### PR TITLE
27716 TD_DatabaseManager initWithDirectory check for file in path

### DIFF
--- a/Classes/common/CDTDatastoreManager.m
+++ b/Classes/common/CDTDatastoreManager.m
@@ -28,6 +28,8 @@ NSString* const CDTDatastoreErrorDomain = @"CDTDatastoreErrorDomain";
         _manager = [[TD_DatabaseManager alloc] initWithDirectory:directoryPath
                                                          options:nil
                                                            error:outError];
+        if(!_manager)
+            return nil;
     }
     return self;
 }

--- a/Classes/common/touchdb/TD_DatabaseManager.m
+++ b/Classes/common/touchdb/TD_DatabaseManager.m
@@ -82,7 +82,10 @@ static NSCharacterSet* kIllegalNameChars;
                                        withIntermediateDirectories: NO
                                                         attributes: nil
                                                              error: &error]) {
-            if (!TDIsFileExistsError(error)) {
+            
+            BOOL isDir;
+            if( !TDIsFileExistsError(error) ||
+               ([[NSFileManager defaultManager] fileExistsAtPath:_dir isDirectory:&isDir] && !isDir) ){
                 if (outError) *outError = error;
                 return nil;
             }

--- a/Tests/Tests/CloudantSyncTests.h
+++ b/Tests/Tests/CloudantSyncTests.h
@@ -15,4 +15,6 @@
 @property (nonatomic,strong) CDTDatastoreManager *factory;
 @property (nonatomic,strong) NSString *factoryPath;
 
+- (NSString*)createTemporaryDirectoryAndReturnPath;
+
 @end

--- a/Tests/Tests/DatastoreActions.m
+++ b/Tests/Tests/DatastoreActions.m
@@ -19,6 +19,7 @@
 
 @implementation DatastoreActions
 
+
 - (void)testGetADatabase
 {
     NSError *error;
@@ -26,5 +27,61 @@
     STAssertNotNil(tmp, @"Could not create test database");
     STAssertTrue([tmp isKindOfClass:[CDTDatastore class]], @"Returned database not CDTDatastore");
 }
+
+- (NSString*)createTemporaryFileAndReturnPath
+{
+    NSString *tempFileTemplate =
+    [NSTemporaryDirectory() stringByAppendingPathComponent:@"cloudant_sync_ios_tests.tempfile.XXXXXX"];
+    const char *tempFileTemplateCString = [tempFileTemplate fileSystemRepresentation];
+    char *tempFileNameCString =  (char *)malloc(strlen(tempFileTemplateCString) + 1);
+    strcpy(tempFileNameCString, tempFileTemplateCString);
+    
+    char *result = mktemp(tempFileNameCString);
+    if (!result)
+    {
+        STFail(@"Couldn't create temporary file");
+    }
+    
+    NSString *path = [[NSFileManager defaultManager]
+                      stringWithFileSystemRepresentation:tempFileNameCString
+                      length:strlen(result)];
+    
+    BOOL fileCreated = [[NSFileManager defaultManager] createFileAtPath:path contents:nil attributes:nil];
+    
+    STAssertTrue(fileCreated, @"File %@ not created in %s", path, __PRETTY_FUNCTION__);
+    
+    free(tempFileNameCString);
+    
+    return path;
+}
+
+- (void)testFailToCreateFactoryWithPreExistingFile
+{
+    NSError *error;
+    NSString *localFilePath = [self createTemporaryFileAndReturnPath];
+    
+    CDTDatastoreManager *localFactory = [[CDTDatastoreManager alloc] initWithDirectory:localFilePath error:&error];
+    STAssertNil(localFactory, @"CDTDatastoreManager should fail with a pre-existing file at path in %s", __PRETTY_FUNCTION__);
+
+    error = nil;
+    [[NSFileManager defaultManager] removeItemAtPath:localFilePath error:&error];
+    STAssertNil(error, @"Error deleting temporary directory.");
+    
+}
+
+- (void)testCreateFactoryWithPreExistingDirectory
+{
+    NSError *error;
+    NSString *localDirPath = [self createTemporaryDirectoryAndReturnPath];
+    
+    CDTDatastoreManager *localFactory = [[CDTDatastoreManager alloc] initWithDirectory:localDirPath error:&error];
+    STAssertNotNil(localFactory, @"CDTDatastoreManager should not fail with a pre-existing directory at path in %s", __PRETTY_FUNCTION__);
+    
+    error = nil;
+    [[NSFileManager defaultManager] removeItemAtPath:localDirPath error:&error];
+    STAssertNil(error, @"Error deleting temporary directory.");
+    
+}
+
 
 @end


### PR DESCRIPTION
This adds additional checks in TD_DatabaseManager initWithDirectory:(NSString *)path to fail when path points to a file and not a directory. Additionally, CDTDatastoreManager initWithDirectory fails to initialize when TD_DatabaseManager returns nil. 

Tests for these scenarios were added to the Tests project. 
