### PR TITLE
28017 and 28015 -- Using Delegate in example Project and fixing .pbxproj files

### DIFF
--- a/Classes/common/CloudantSync.h
+++ b/Classes/common/CloudantSync.h
@@ -15,5 +15,5 @@
 
 #import "CDTReplicator.h"
 #import "CDTReplicatorFactory.h"
-#import "CDTReplicatorListener.h"
+#import "CDTReplicatorDelegate.h"
 #import "CDTReplicationErrorInfo.h"

--- a/Project/Project.xcodeproj/project.pbxproj
+++ b/Project/Project.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		27C1CDF0184E2D9C000604EF /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 27C1CDEE184E2D9C000604EF /* InfoPlist.strings */; };
 		27C1CDF2184E2D9C000604EF /* ProjectTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 27C1CDF1184E2D9C000604EF /* ProjectTests.m */; };
 		27E16BDE187D6FBA00F8A3B2 /* CDTReplicateController.m in Sources */ = {isa = PBXBuildFile; fileRef = 27E16BDD187D6FBA00F8A3B2 /* CDTReplicateController.m */; };
+		9F954F9F18AB5B5A00368057 /* libPods-ios.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F954F9E18AB5B5A00368057 /* libPods-ios.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -56,8 +57,9 @@
 		27C1CDF1184E2D9C000604EF /* ProjectTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ProjectTests.m; sourceTree = "<group>"; };
 		27E16BDC187D6FBA00F8A3B2 /* CDTReplicateController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDTReplicateController.h; sourceTree = "<group>"; };
 		27E16BDD187D6FBA00F8A3B2 /* CDTReplicateController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTReplicateController.m; sourceTree = "<group>"; };
-		27FD647C187D684A0095AFC4 /* libPods-ios.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libPods-ios.a"; path = "../Tests/Pods/build/Debug-iphoneos/libPods-ios.a"; sourceTree = "<group>"; };
 		4D0E3AC9C50B4EBE8CF4AF2B /* Pods.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.xcconfig; path = Pods/Pods.xcconfig; sourceTree = "<group>"; };
+		9F954F9E18AB5B5A00368057 /* libPods-ios.a */ = {isa = PBXFileReference; lastKnownFileType = file; name = "libPods-ios.a"; path = "../Tests/Pods/build/Debug-iphoneos/libPods-ios.a"; sourceTree = "<group>"; };
+		C4042E7D26A74D4D86B965BA /* Pods-ios.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ios.xcconfig"; path = "Pods/Pods-ios.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -65,6 +67,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9F954F9F18AB5B5A00368057 /* libPods-ios.a in Frameworks */,
 				27C1CDC9184E2D9C000604EF /* CoreGraphics.framework in Frameworks */,
 				27C1CDCB184E2D9C000604EF /* UIKit.framework in Frameworks */,
 				27C1CDC7184E2D9C000604EF /* Foundation.framework in Frameworks */,
@@ -92,6 +95,7 @@
 				27C1CDC5184E2D9C000604EF /* Frameworks */,
 				27C1CDC4184E2D9C000604EF /* Products */,
 				4D0E3AC9C50B4EBE8CF4AF2B /* Pods.xcconfig */,
+				C4042E7D26A74D4D86B965BA /* Pods-ios.xcconfig */,
 			);
 			sourceTree = "<group>";
 		};
@@ -107,7 +111,7 @@
 		27C1CDC5184E2D9C000604EF /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				27FD647C187D684A0095AFC4 /* libPods-ios.a */,
+				9F954F9E18AB5B5A00368057 /* libPods-ios.a */,
 				27C1CDC6184E2D9C000604EF /* Foundation.framework */,
 				27C1CDC8184E2D9C000604EF /* CoreGraphics.framework */,
 				27C1CDCA184E2D9C000604EF /* UIKit.framework */,
@@ -269,7 +273,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Pods-resources.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Pods-ios-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		4ADBB1B5AB1D4D69833BDD14 /* Check Pods Manifest.lock */ = {
@@ -421,7 +425,7 @@
 		};
 		27C1CDF6184E2D9C000604EF /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4D0E3AC9C50B4EBE8CF4AF2B /* Pods.xcconfig */;
+			baseConfigurationReference = C4042E7D26A74D4D86B965BA /* Pods-ios.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -435,7 +439,7 @@
 		};
 		27C1CDF7184E2D9C000604EF /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4D0E3AC9C50B4EBE8CF4AF2B /* Pods.xcconfig */;
+			baseConfigurationReference = C4042E7D26A74D4D86B965BA /* Pods-ios.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;

--- a/Project/Project/CDTReplicateController.h
+++ b/Project/Project/CDTReplicateController.h
@@ -9,7 +9,7 @@
 #import <UIKit/UIKit.h>
 #import <CloudantSync.h>
 
-@interface CDTReplicateController : UIViewController<CDTReplicatorListener>
+@interface CDTReplicateController : UIViewController<CDTReplicatorDelegate>
 
 @property (nonatomic,strong) IBOutlet UITextView *logView;
 

--- a/Project/Project/CDTReplicateController.m
+++ b/Project/Project/CDTReplicateController.m
@@ -82,7 +82,7 @@
     NSString *state = [CDTReplicator stringForReplicatorState:replicator.state];
     [self log:@"%@ state: %@ (%d)", label, state, replicator.state];
 
-    [replicator setListener:self];
+    [replicator setDelegate:self];
     [replicator start];
 
     state = [CDTReplicator stringForReplicatorState:replicator.state];
@@ -106,9 +106,9 @@
 
         dispatch_async(dispatch_get_main_queue(), ^{
             if (replicator.state == CDTReplicatorStateComplete || replicator.state == CDTReplicatorStateStopped) {
-                [weakSelf complete:replicator];
+                [weakSelf replicatorDidComplete:replicator];
             } else if (replicator.state == CDTReplicatorStateError) {
-                [weakSelf error:replicator info:nil];
+                [weakSelf replicatorDidError:replicator info:nil];
             }
         });
     });
@@ -116,11 +116,11 @@
 
 #pragma mark CDTReplicatorListener delegate
 
--(void)complete:(CDTReplicator *)replicator {
+-(void)replicatorDidComplete:(CDTReplicator *)replicator {
     [self log:@"complete"];
 }
 
--(void)error:(CDTReplicator *)replicator info:(CDTReplicationErrorInfo *)info {
+-(void)replicatorDidError:(CDTReplicator *)replicator info:(CDTReplicationErrorInfo *)info {
     [self log:@"error: %@", info];
 }
 

--- a/Tests/Tests.xcodeproj/project.pbxproj
+++ b/Tests/Tests.xcodeproj/project.pbxproj
@@ -1,661 +1,1670 @@
-// !$*UTF8*$!
-{
-	archiveVersion = 1;
-	classes = {
-	};
-	objectVersion = 46;
-	objects = {
-
-/* Begin PBXBuildFile section */
-		27389E10185345FD0027A404 /* SenTestingKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 27389E0F185345FD0027A404 /* SenTestingKit.framework */; };
-		27389E12185345FD0027A404 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 27389E11185345FD0027A404 /* Foundation.framework */; };
-		27389E14185345FD0027A404 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 27389E13185345FD0027A404 /* UIKit.framework */; };
-		27389E1A185345FD0027A404 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 27389E18185345FD0027A404 /* InfoPlist.strings */; };
-		27389E3518534E050027A404 /* CloudantSyncTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 27389E2E18534E050027A404 /* CloudantSyncTests.m */; };
-		27389E3618534E050027A404 /* DatastoreActions.m in Sources */ = {isa = PBXBuildFile; fileRef = 27389E3018534E050027A404 /* DatastoreActions.m */; };
-		27389E3718534E050027A404 /* DatastoreCrud.m in Sources */ = {isa = PBXBuildFile; fileRef = 27389E3218534E050027A404 /* DatastoreCrud.m */; };
-		27389E3818534E050027A404 /* SetUpDatastore.m in Sources */ = {isa = PBXBuildFile; fileRef = 27389E3418534E050027A404 /* SetUpDatastore.m */; };
-		27CCEDC7187AD64F006F3C66 /* SenTestingKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 27389E0F185345FD0027A404 /* SenTestingKit.framework */; };
-		27CCEDCD187AD64F006F3C66 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 27CCEDCB187AD64F006F3C66 /* InfoPlist.strings */; };
-		27CCEDD6187AD70C006F3C66 /* CloudantSyncTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 27389E2E18534E050027A404 /* CloudantSyncTests.m */; };
-		27CCEDD7187AD719006F3C66 /* DatastoreActions.m in Sources */ = {isa = PBXBuildFile; fileRef = 27389E3018534E050027A404 /* DatastoreActions.m */; };
-		27CCEDD8187AD719006F3C66 /* DatastoreCrud.m in Sources */ = {isa = PBXBuildFile; fileRef = 27389E3218534E050027A404 /* DatastoreCrud.m */; };
-		27CCEDD9187AD719006F3C66 /* SetUpDatastore.m in Sources */ = {isa = PBXBuildFile; fileRef = 27389E3418534E050027A404 /* SetUpDatastore.m */; };
-		9F0D23E918888C6C00D3D04E /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F0D23E818888C6C00D3D04E /* Foundation.framework */; };
-		9F0D23F1188B4FA900D3D04E /* TDMultipartReaderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F0D23F0188B4FA900D3D04E /* TDMultipartReaderTests.m */; };
-		9F0D23F2188B4FA900D3D04E /* TDMultipartReaderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F0D23F0188B4FA900D3D04E /* TDMultipartReaderTests.m */; };
-		9F0D23F4188B4FFF00D3D04E /* TDMultipartWriterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F0D23F3188B4FFF00D3D04E /* TDMultipartWriterTests.m */; };
-		9F0D23F5188B4FFF00D3D04E /* TDMultipartWriterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F0D23F3188B4FFF00D3D04E /* TDMultipartWriterTests.m */; };
-		9F0D23F7188DF30D00D3D04E /* TDMultiStreamWriterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F0D23F6188DF30D00D3D04E /* TDMultiStreamWriterTests.m */; };
-		9F0D23F8188DF30D00D3D04E /* TDMultiStreamWriterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F0D23F6188DF30D00D3D04E /* TDMultiStreamWriterTests.m */; };
-		9F0D23FA188DF36800D3D04E /* TD_DatabaseTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F0D23F9188DF36800D3D04E /* TD_DatabaseTests.m */; };
-		9F0D23FB188DF36800D3D04E /* TD_DatabaseTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F0D23F9188DF36800D3D04E /* TD_DatabaseTests.m */; };
-		9F0D23FF188DF96600D3D04E /* TD_DatabaseManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F0D23FE188DF96600D3D04E /* TD_DatabaseManagerTests.m */; };
-		9F0D2400188DF96600D3D04E /* TD_DatabaseManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F0D23FE188DF96600D3D04E /* TD_DatabaseManagerTests.m */; };
-		9F0D2402188DFE8600D3D04E /* TD_RevisionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F0D2401188DFE8600D3D04E /* TD_RevisionTests.m */; };
-		9F0D2403188DFE8600D3D04E /* TD_RevisionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F0D2401188DFE8600D3D04E /* TD_RevisionTests.m */; };
-		9F0D2408188E378700D3D04E /* TDCanonicalJSONTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F0D2407188E378700D3D04E /* TDCanonicalJSONTests.m */; };
-		9F0D2409188E378700D3D04E /* TDCanonicalJSONTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F0D2407188E378700D3D04E /* TDCanonicalJSONTests.m */; };
-		9F0D240B188E3C3A00D3D04E /* TDCollateJSONTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F0D240A188E3C3A00D3D04E /* TDCollateJSONTests.m */; };
-		9F0D240C188E3C3A00D3D04E /* TDCollateJSONTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F0D240A188E3C3A00D3D04E /* TDCollateJSONTests.m */; };
-		9F0D240E188F01DD00D3D04E /* TDMiscTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F0D240D188F01DD00D3D04E /* TDMiscTests.m */; };
-		9F0D240F188F01DD00D3D04E /* TDMiscTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F0D240D188F01DD00D3D04E /* TDMiscTests.m */; };
-		9F0D24111890AD0C00D3D04E /* TDMultipartDownloaderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F0D24101890AD0C00D3D04E /* TDMultipartDownloaderTests.m */; };
-		9F0D24121890AD0C00D3D04E /* TDMultipartDownloaderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F0D24101890AD0C00D3D04E /* TDMultipartDownloaderTests.m */; };
-		9F0D24141892E9B800D3D04E /* TDPusherTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F0D24131892E9B800D3D04E /* TDPusherTests.m */; };
-		9F0D24151892E9B800D3D04E /* TDPusherTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F0D24131892E9B800D3D04E /* TDPusherTests.m */; };
-		9F0D24171893161000D3D04E /* TDReachabilityTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F0D24161893161000D3D04E /* TDReachabilityTests.m */; };
-		9F0D24181893161000D3D04E /* TDReachabilityTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F0D24161893161000D3D04E /* TDReachabilityTests.m */; };
-		9F0D241A18932DA700D3D04E /* TDSequenceMapTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F0D241918932DA700D3D04E /* TDSequenceMapTests.m */; };
-		9F0D241B18932DA700D3D04E /* TDSequenceMapTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F0D241918932DA700D3D04E /* TDSequenceMapTests.m */; };
-/* End PBXBuildFile section */
-
-/* Begin PBXFileReference section */
-		27389E0C185345FD0027A404 /* Tests.octest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Tests.octest; sourceTree = BUILT_PRODUCTS_DIR; };
-		27389E0F185345FD0027A404 /* SenTestingKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SenTestingKit.framework; path = Library/Frameworks/SenTestingKit.framework; sourceTree = DEVELOPER_DIR; };
-		27389E11185345FD0027A404 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		27389E13185345FD0027A404 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
-		27389E17185345FD0027A404 /* Tests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Tests-Info.plist"; sourceTree = "<group>"; };
-		27389E19185345FD0027A404 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		27389E1D185345FD0027A404 /* Tests-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Tests-Prefix.pch"; sourceTree = "<group>"; };
-		27389E2D18534E050027A404 /* CloudantSyncTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CloudantSyncTests.h; sourceTree = "<group>"; };
-		27389E2E18534E050027A404 /* CloudantSyncTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CloudantSyncTests.m; sourceTree = "<group>"; };
-		27389E3018534E050027A404 /* DatastoreActions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DatastoreActions.m; sourceTree = "<group>"; };
-		27389E3218534E050027A404 /* DatastoreCrud.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DatastoreCrud.m; sourceTree = "<group>"; };
-		27389E3418534E050027A404 /* SetUpDatastore.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SetUpDatastore.m; sourceTree = "<group>"; };
-		27CCEDC6187AD64F006F3C66 /* Tests OSX.octest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Tests OSX.octest"; sourceTree = BUILT_PRODUCTS_DIR; };
-		27CCEDCA187AD64F006F3C66 /* Tests OSX-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Tests OSX-Info.plist"; sourceTree = "<group>"; };
-		27CCEDCC187AD64F006F3C66 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		27CCEDCE187AD64F006F3C66 /* Tests_OSX.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Tests_OSX.m; sourceTree = "<group>"; };
-		27CCEDD0187AD64F006F3C66 /* Tests OSX-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Tests OSX-Prefix.pch"; sourceTree = "<group>"; };
-		2996853CB13542679108F845 /* Pods-osx.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-osx.xcconfig"; path = "Pods/Pods-osx.xcconfig"; sourceTree = "<group>"; };
-		635BE7F70A3A4DFFA9455CDC /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		9F0D23E818888C6C00D3D04E /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
-		9F0D23F0188B4FA900D3D04E /* TDMultipartReaderTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TDMultipartReaderTests.m; sourceTree = "<group>"; };
-		9F0D23F3188B4FFF00D3D04E /* TDMultipartWriterTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TDMultipartWriterTests.m; sourceTree = "<group>"; };
-		9F0D23F6188DF30D00D3D04E /* TDMultiStreamWriterTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TDMultiStreamWriterTests.m; sourceTree = "<group>"; };
-		9F0D23F9188DF36800D3D04E /* TD_DatabaseTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TD_DatabaseTests.m; sourceTree = "<group>"; };
-		9F0D23FE188DF96600D3D04E /* TD_DatabaseManagerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TD_DatabaseManagerTests.m; sourceTree = "<group>"; };
-		9F0D2401188DFE8600D3D04E /* TD_RevisionTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TD_RevisionTests.m; sourceTree = "<group>"; };
-		9F0D2407188E378700D3D04E /* TDCanonicalJSONTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TDCanonicalJSONTests.m; sourceTree = "<group>"; };
-		9F0D240A188E3C3A00D3D04E /* TDCollateJSONTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TDCollateJSONTests.m; sourceTree = "<group>"; };
-		9F0D240D188F01DD00D3D04E /* TDMiscTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TDMiscTests.m; sourceTree = "<group>"; };
-		9F0D24101890AD0C00D3D04E /* TDMultipartDownloaderTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TDMultipartDownloaderTests.m; sourceTree = "<group>"; };
-		9F0D24131892E9B800D3D04E /* TDPusherTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TDPusherTests.m; sourceTree = "<group>"; };
-		9F0D24161893161000D3D04E /* TDReachabilityTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TDReachabilityTests.m; sourceTree = "<group>"; };
-		9F0D241918932DA700D3D04E /* TDSequenceMapTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TDSequenceMapTests.m; sourceTree = "<group>"; };
-		B8C5CE07530A44358897106E /* Pods-ios.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ios.xcconfig"; path = "Pods/Pods-ios.xcconfig"; sourceTree = "<group>"; };
-		BBD8D50209E84CD981F3FA7A /* libPods-osx.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-osx.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		C0D0295E40984E2788387EEE /* libPods-ios.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ios.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		EE84F28F860D431381668D04 /* Pods.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.xcconfig; path = Pods/Pods.xcconfig; sourceTree = "<group>"; };
-/* End PBXFileReference section */
-
-/* Begin PBXFrameworksBuildPhase section */
-		27389E09185345FD0027A404 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				27389E10185345FD0027A404 /* SenTestingKit.framework in Frameworks */,
-				27389E14185345FD0027A404 /* UIKit.framework in Frameworks */,
-				27389E12185345FD0027A404 /* Foundation.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		27CCEDC3187AD64F006F3C66 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				9F0D23E918888C6C00D3D04E /* Foundation.framework in Frameworks */,
-				27CCEDC7187AD64F006F3C66 /* SenTestingKit.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXFrameworksBuildPhase section */
-
-/* Begin PBXGroup section */
-		27389E01185345DA0027A404 = {
-			isa = PBXGroup;
-			children = (
-				27389E15185345FD0027A404 /* Tests */,
-				27CCEDC8187AD64F006F3C66 /* Tests OSX */,
-				27389E0E185345FD0027A404 /* Frameworks */,
-				27389E0D185345FD0027A404 /* Products */,
-				EE84F28F860D431381668D04 /* Pods.xcconfig */,
-				B8C5CE07530A44358897106E /* Pods-ios.xcconfig */,
-				2996853CB13542679108F845 /* Pods-osx.xcconfig */,
-			);
-			sourceTree = "<group>";
-		};
-		27389E0D185345FD0027A404 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				27389E0C185345FD0027A404 /* Tests.octest */,
-				27CCEDC6187AD64F006F3C66 /* Tests OSX.octest */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		27389E0E185345FD0027A404 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				9F0D23E818888C6C00D3D04E /* Foundation.framework */,
-				27389E0F185345FD0027A404 /* SenTestingKit.framework */,
-				27389E11185345FD0027A404 /* Foundation.framework */,
-				27389E13185345FD0027A404 /* UIKit.framework */,
-				635BE7F70A3A4DFFA9455CDC /* libPods.a */,
-				C0D0295E40984E2788387EEE /* libPods-ios.a */,
-				BBD8D50209E84CD981F3FA7A /* libPods-osx.a */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		27389E15185345FD0027A404 /* Tests */ = {
-			isa = PBXGroup;
-			children = (
-				9F0D2407188E378700D3D04E /* TDCanonicalJSONTests.m */,
-				9F0D24131892E9B800D3D04E /* TDPusherTests.m */,
-				9F0D24161893161000D3D04E /* TDReachabilityTests.m */,
-				9F0D241918932DA700D3D04E /* TDSequenceMapTests.m */,
-				9F0D240D188F01DD00D3D04E /* TDMiscTests.m */,
-				9F0D240A188E3C3A00D3D04E /* TDCollateJSONTests.m */,
-				9F0D23F9188DF36800D3D04E /* TD_DatabaseTests.m */,
-				9F0D23FE188DF96600D3D04E /* TD_DatabaseManagerTests.m */,
-				9F0D2401188DFE8600D3D04E /* TD_RevisionTests.m */,
-				9F0D24101890AD0C00D3D04E /* TDMultipartDownloaderTests.m */,
-				9F0D23F0188B4FA900D3D04E /* TDMultipartReaderTests.m */,
-				9F0D23F3188B4FFF00D3D04E /* TDMultipartWriterTests.m */,
-				9F0D23F6188DF30D00D3D04E /* TDMultiStreamWriterTests.m */,
-				27389E2D18534E050027A404 /* CloudantSyncTests.h */,
-				27389E2E18534E050027A404 /* CloudantSyncTests.m */,
-				27389E3018534E050027A404 /* DatastoreActions.m */,
-				27389E3218534E050027A404 /* DatastoreCrud.m */,
-				27389E3418534E050027A404 /* SetUpDatastore.m */,
-				27389E16185345FD0027A404 /* Supporting Files */,
-			);
-			path = Tests;
-			sourceTree = "<group>";
-		};
-		27389E16185345FD0027A404 /* Supporting Files */ = {
-			isa = PBXGroup;
-			children = (
-				27389E17185345FD0027A404 /* Tests-Info.plist */,
-				27389E18185345FD0027A404 /* InfoPlist.strings */,
-				27389E1D185345FD0027A404 /* Tests-Prefix.pch */,
-			);
-			name = "Supporting Files";
-			sourceTree = "<group>";
-		};
-		27CCEDC8187AD64F006F3C66 /* Tests OSX */ = {
-			isa = PBXGroup;
-			children = (
-				27CCEDCE187AD64F006F3C66 /* Tests_OSX.m */,
-				27CCEDC9187AD64F006F3C66 /* Supporting Files */,
-			);
-			path = "Tests OSX";
-			sourceTree = "<group>";
-		};
-		27CCEDC9187AD64F006F3C66 /* Supporting Files */ = {
-			isa = PBXGroup;
-			children = (
-				27CCEDCA187AD64F006F3C66 /* Tests OSX-Info.plist */,
-				27CCEDCB187AD64F006F3C66 /* InfoPlist.strings */,
-				27CCEDD0187AD64F006F3C66 /* Tests OSX-Prefix.pch */,
-			);
-			name = "Supporting Files";
-			sourceTree = "<group>";
-		};
-/* End PBXGroup section */
-
-/* Begin PBXNativeTarget section */
-		27389E0B185345FD0027A404 /* Tests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 27389E1E185345FD0027A404 /* Build configuration list for PBXNativeTarget "Tests" */;
-			buildPhases = (
-				095CA0EFFBC84C0EB3464C5A /* Check Pods Manifest.lock */,
-				27389E08185345FD0027A404 /* Sources */,
-				27389E09185345FD0027A404 /* Frameworks */,
-				27389E0A185345FD0027A404 /* Resources */,
-				08B95EDB86F54BC99DEF0C13 /* Copy Pods Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = Tests;
-			productName = Tests;
-			productReference = 27389E0C185345FD0027A404 /* Tests.octest */;
-			productType = "com.apple.product-type.bundle";
-		};
-		27CCEDC5187AD64F006F3C66 /* Tests OSX */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 27CCEDD3187AD64F006F3C66 /* Build configuration list for PBXNativeTarget "Tests OSX" */;
-			buildPhases = (
-				708AFFBE12E945969103B2AF /* Check Pods Manifest.lock */,
-				27CCEDC2187AD64F006F3C66 /* Sources */,
-				27CCEDC3187AD64F006F3C66 /* Frameworks */,
-				27CCEDC4187AD64F006F3C66 /* Resources */,
-				E63BC4B0310E42E0AC6C6072 /* Copy Pods Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "Tests OSX";
-			productName = "Tests OSX";
-			productReference = 27CCEDC6187AD64F006F3C66 /* Tests OSX.octest */;
-			productType = "com.apple.product-type.bundle";
-		};
-/* End PBXNativeTarget section */
-
-/* Begin PBXProject section */
-		27389E02185345DA0027A404 /* Project object */ = {
-			isa = PBXProject;
-			attributes = {
-				LastUpgradeCheck = 0500;
-				TargetAttributes = {
-					27CCEDC5187AD64F006F3C66 = {
-						TestTargetID = 27389E0B185345FD0027A404;
-					};
-				};
-			};
-			buildConfigurationList = 27389E05185345DA0027A404 /* Build configuration list for PBXProject "Tests" */;
-			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
-			hasScannedForEncodings = 0;
-			knownRegions = (
-				en,
-			);
-			mainGroup = 27389E01185345DA0027A404;
-			productRefGroup = 27389E0D185345FD0027A404 /* Products */;
-			projectDirPath = "";
-			projectRoot = "";
-			targets = (
-				27389E0B185345FD0027A404 /* Tests */,
-				27CCEDC5187AD64F006F3C66 /* Tests OSX */,
-			);
-		};
-/* End PBXProject section */
-
-/* Begin PBXResourcesBuildPhase section */
-		27389E0A185345FD0027A404 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				27389E1A185345FD0027A404 /* InfoPlist.strings in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		27CCEDC4187AD64F006F3C66 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				27CCEDCD187AD64F006F3C66 /* InfoPlist.strings in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		08B95EDB86F54BC99DEF0C13 /* Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Pods-ios-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		095CA0EFFBC84C0EB3464C5A /* Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Check Pods Manifest.lock";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		708AFFBE12E945969103B2AF /* Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Check Pods Manifest.lock";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		E63BC4B0310E42E0AC6C6072 /* Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Pods-osx-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-/* End PBXShellScriptBuildPhase section */
-
-/* Begin PBXSourcesBuildPhase section */
-		27389E08185345FD0027A404 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				9F0D2408188E378700D3D04E /* TDCanonicalJSONTests.m in Sources */,
-				9F0D23F1188B4FA900D3D04E /* TDMultipartReaderTests.m in Sources */,
-				9F0D23FF188DF96600D3D04E /* TD_DatabaseManagerTests.m in Sources */,
-				9F0D240E188F01DD00D3D04E /* TDMiscTests.m in Sources */,
-				9F0D23F7188DF30D00D3D04E /* TDMultiStreamWriterTests.m in Sources */,
-				27389E3618534E050027A404 /* DatastoreActions.m in Sources */,
-				27389E3518534E050027A404 /* CloudantSyncTests.m in Sources */,
-				9F0D24111890AD0C00D3D04E /* TDMultipartDownloaderTests.m in Sources */,
-				9F0D241A18932DA700D3D04E /* TDSequenceMapTests.m in Sources */,
-				9F0D23FA188DF36800D3D04E /* TD_DatabaseTests.m in Sources */,
-				9F0D2402188DFE8600D3D04E /* TD_RevisionTests.m in Sources */,
-				9F0D240B188E3C3A00D3D04E /* TDCollateJSONTests.m in Sources */,
-				27389E3818534E050027A404 /* SetUpDatastore.m in Sources */,
-				9F0D24171893161000D3D04E /* TDReachabilityTests.m in Sources */,
-				27389E3718534E050027A404 /* DatastoreCrud.m in Sources */,
-				9F0D23F4188B4FFF00D3D04E /* TDMultipartWriterTests.m in Sources */,
-				9F0D24141892E9B800D3D04E /* TDPusherTests.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		27CCEDC2187AD64F006F3C66 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				9F0D2409188E378700D3D04E /* TDCanonicalJSONTests.m in Sources */,
-				9F0D23F2188B4FA900D3D04E /* TDMultipartReaderTests.m in Sources */,
-				9F0D2400188DF96600D3D04E /* TD_DatabaseManagerTests.m in Sources */,
-				9F0D240F188F01DD00D3D04E /* TDMiscTests.m in Sources */,
-				9F0D23F8188DF30D00D3D04E /* TDMultiStreamWriterTests.m in Sources */,
-				27CCEDD7187AD719006F3C66 /* DatastoreActions.m in Sources */,
-				27CCEDD8187AD719006F3C66 /* DatastoreCrud.m in Sources */,
-				9F0D24121890AD0C00D3D04E /* TDMultipartDownloaderTests.m in Sources */,
-				9F0D241B18932DA700D3D04E /* TDSequenceMapTests.m in Sources */,
-				9F0D23FB188DF36800D3D04E /* TD_DatabaseTests.m in Sources */,
-				9F0D2403188DFE8600D3D04E /* TD_RevisionTests.m in Sources */,
-				9F0D240C188E3C3A00D3D04E /* TDCollateJSONTests.m in Sources */,
-				27CCEDD9187AD719006F3C66 /* SetUpDatastore.m in Sources */,
-				9F0D24181893161000D3D04E /* TDReachabilityTests.m in Sources */,
-				27CCEDD6187AD70C006F3C66 /* CloudantSyncTests.m in Sources */,
-				9F0D23F5188B4FFF00D3D04E /* TDMultipartWriterTests.m in Sources */,
-				9F0D24151892E9B800D3D04E /* TDPusherTests.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXSourcesBuildPhase section */
-
-/* Begin PBXVariantGroup section */
-		27389E18185345FD0027A404 /* InfoPlist.strings */ = {
-			isa = PBXVariantGroup;
-			children = (
-				27389E19185345FD0027A404 /* en */,
-			);
-			name = InfoPlist.strings;
-			sourceTree = "<group>";
-		};
-		27CCEDCB187AD64F006F3C66 /* InfoPlist.strings */ = {
-			isa = PBXVariantGroup;
-			children = (
-				27CCEDCC187AD64F006F3C66 /* en */,
-			);
-			name = InfoPlist.strings;
-			sourceTree = "<group>";
-		};
-/* End PBXVariantGroup section */
-
-/* Begin XCBuildConfiguration section */
-		27389E06185345DA0027A404 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				MACOSX_DEPLOYMENT_TARGET = 10.8;
-			};
-			name = Debug;
-		};
-		27389E07185345DA0027A404 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				MACOSX_DEPLOYMENT_TARGET = 10.8;
-			};
-			name = Release;
-		};
-		27389E1F185345FD0027A404 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = B8C5CE07530A44358897106E /* Pods-ios.xcconfig */;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = NO;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-					"$(DEVELOPER_FRAMEWORKS_DIR)",
-				);
-				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "Tests/Tests-Prefix.pch";
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				INFOPLIST_FILE = "Tests/Tests-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
-				MACOSX_DEPLOYMENT_TARGET = 10.8;
-				ONLY_ACTIVE_ARCH = YES;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				WRAPPER_EXTENSION = octest;
-			};
-			name = Debug;
-		};
-		27389E20185345FD0027A404 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = B8C5CE07530A44358897106E /* Pods-ios.xcconfig */;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = YES;
-				ENABLE_NS_ASSERTIONS = NO;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-					"$(DEVELOPER_FRAMEWORKS_DIR)",
-				);
-				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "Tests/Tests-Prefix.pch";
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				INFOPLIST_FILE = "Tests/Tests-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
-				MACOSX_DEPLOYMENT_TARGET = 10.8;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				VALIDATE_PRODUCT = YES;
-				WRAPPER_EXTENSION = octest;
-			};
-			name = Release;
-		};
-		27CCEDD4187AD64F006F3C66 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2996853CB13542679108F845 /* Pods-osx.xcconfig */;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = NO;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(DEVELOPER_FRAMEWORKS_DIR)",
-					"$(inherited)",
-				);
-				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "Tests OSX/Tests OSX-Prefix.pch";
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				INFOPLIST_FILE = "Tests OSX/Tests OSX-Info.plist";
-				MACOSX_DEPLOYMENT_TARGET = 10.8;
-				ONLY_ACTIVE_ARCH = YES;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = macosx;
-				WRAPPER_EXTENSION = octest;
-			};
-			name = Debug;
-		};
-		27CCEDD5187AD64F006F3C66 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2996853CB13542679108F845 /* Pods-osx.xcconfig */;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = YES;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				ENABLE_NS_ASSERTIONS = NO;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(DEVELOPER_FRAMEWORKS_DIR)",
-					"$(inherited)",
-				);
-				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "Tests OSX/Tests OSX-Prefix.pch";
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				INFOPLIST_FILE = "Tests OSX/Tests OSX-Info.plist";
-				MACOSX_DEPLOYMENT_TARGET = 10.8;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = macosx;
-				WRAPPER_EXTENSION = octest;
-			};
-			name = Release;
-		};
-/* End XCBuildConfiguration section */
-
-/* Begin XCConfigurationList section */
-		27389E05185345DA0027A404 /* Build configuration list for PBXProject "Tests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				27389E06185345DA0027A404 /* Debug */,
-				27389E07185345DA0027A404 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		27389E1E185345FD0027A404 /* Build configuration list for PBXNativeTarget "Tests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				27389E1F185345FD0027A404 /* Debug */,
-				27389E20185345FD0027A404 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		27CCEDD3187AD64F006F3C66 /* Build configuration list for PBXNativeTarget "Tests OSX" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				27CCEDD4187AD64F006F3C66 /* Debug */,
-				27CCEDD5187AD64F006F3C66 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-/* End XCConfigurationList section */
-	};
-	rootObject = 27389E02185345DA0027A404 /* Project object */;
-}
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>archiveVersion</key>
+	<string>1</string>
+	<key>classes</key>
+	<dict/>
+	<key>objectVersion</key>
+	<string>46</string>
+	<key>objects</key>
+	<dict>
+		<key>009D4E71AED34A54853B7F51</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BBD8D50209E84CD981F3FA7A</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>08B95EDB86F54BC99DEF0C13</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array/>
+			<key>inputPaths</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXShellScriptBuildPhase</string>
+			<key>name</key>
+			<string>Copy Pods Resources</string>
+			<key>outputPaths</key>
+			<array/>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+			<key>shellPath</key>
+			<string>/bin/sh</string>
+			<key>shellScript</key>
+			<string>"${SRCROOT}/Pods/Pods-ios-resources.sh"
+</string>
+			<key>showEnvVarsInLog</key>
+			<string>0</string>
+		</dict>
+		<key>095CA0EFFBC84C0EB3464C5A</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array/>
+			<key>inputPaths</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXShellScriptBuildPhase</string>
+			<key>name</key>
+			<string>Check Pods Manifest.lock</string>
+			<key>outputPaths</key>
+			<array/>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+			<key>shellPath</key>
+			<string>/bin/sh</string>
+			<key>shellScript</key>
+			<string>diff "${PODS_ROOT}/../Podfile.lock" "${PODS_ROOT}/Manifest.lock" &gt; /dev/null
+if [[ $? != 0 ]] ; then
+    cat &lt;&lt; EOM
+error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.
+EOM
+    exit 1
+fi
+</string>
+			<key>showEnvVarsInLog</key>
+			<string>0</string>
+		</dict>
+		<key>27389E01185345DA0027A404</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>27389E15185345FD0027A404</string>
+				<string>27CCEDC8187AD64F006F3C66</string>
+				<string>27389E0E185345FD0027A404</string>
+				<string>27389E0D185345FD0027A404</string>
+				<string>EE84F28F860D431381668D04</string>
+				<string>B8C5CE07530A44358897106E</string>
+				<string>2996853CB13542679108F845</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27389E02185345DA0027A404</key>
+		<dict>
+			<key>attributes</key>
+			<dict>
+				<key>LastUpgradeCheck</key>
+				<string>0500</string>
+				<key>TargetAttributes</key>
+				<dict>
+					<key>27CCEDC5187AD64F006F3C66</key>
+					<dict>
+						<key>TestTargetID</key>
+						<string>27389E0B185345FD0027A404</string>
+					</dict>
+				</dict>
+			</dict>
+			<key>buildConfigurationList</key>
+			<string>27389E05185345DA0027A404</string>
+			<key>compatibilityVersion</key>
+			<string>Xcode 3.2</string>
+			<key>developmentRegion</key>
+			<string>English</string>
+			<key>hasScannedForEncodings</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXProject</string>
+			<key>knownRegions</key>
+			<array>
+				<string>en</string>
+			</array>
+			<key>mainGroup</key>
+			<string>27389E01185345DA0027A404</string>
+			<key>productRefGroup</key>
+			<string>27389E0D185345FD0027A404</string>
+			<key>projectDirPath</key>
+			<string></string>
+			<key>projectReferences</key>
+			<array/>
+			<key>projectRoot</key>
+			<string></string>
+			<key>targets</key>
+			<array>
+				<string>27389E0B185345FD0027A404</string>
+				<string>27CCEDC5187AD64F006F3C66</string>
+			</array>
+		</dict>
+		<key>27389E05185345DA0027A404</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>27389E06185345DA0027A404</string>
+				<string>27389E07185345DA0027A404</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>27389E06185345DA0027A404</key>
+		<dict>
+			<key>buildSettings</key>
+			<dict>
+				<key>MACOSX_DEPLOYMENT_TARGET</key>
+				<string>10.8</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>27389E07185345DA0027A404</key>
+		<dict>
+			<key>buildSettings</key>
+			<dict>
+				<key>MACOSX_DEPLOYMENT_TARGET</key>
+				<string>10.8</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>27389E08185345FD0027A404</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>9F0D2408188E378700D3D04E</string>
+				<string>9F0D23F1188B4FA900D3D04E</string>
+				<string>9F0D23FF188DF96600D3D04E</string>
+				<string>9F0D240E188F01DD00D3D04E</string>
+				<string>9F0D23F7188DF30D00D3D04E</string>
+				<string>27389E3618534E050027A404</string>
+				<string>27389E3518534E050027A404</string>
+				<string>9F0D24111890AD0C00D3D04E</string>
+				<string>9F0D241A18932DA700D3D04E</string>
+				<string>9F0D23FA188DF36800D3D04E</string>
+				<string>9F0D2402188DFE8600D3D04E</string>
+				<string>9F0D240B188E3C3A00D3D04E</string>
+				<string>27389E3818534E050027A404</string>
+				<string>9F0D24171893161000D3D04E</string>
+				<string>27389E3718534E050027A404</string>
+				<string>9F0D23F4188B4FFF00D3D04E</string>
+				<string>9F0D24141892E9B800D3D04E</string>
+			</array>
+			<key>isa</key>
+			<string>PBXSourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>27389E09185345FD0027A404</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>27389E10185345FD0027A404</string>
+				<string>27389E14185345FD0027A404</string>
+				<string>27389E12185345FD0027A404</string>
+				<string>640AB8661E6344B98E64E18E</string>
+			</array>
+			<key>isa</key>
+			<string>PBXFrameworksBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>27389E0A185345FD0027A404</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>27389E1A185345FD0027A404</string>
+			</array>
+			<key>isa</key>
+			<string>PBXResourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>27389E0B185345FD0027A404</key>
+		<dict>
+			<key>buildConfigurationList</key>
+			<string>27389E1E185345FD0027A404</string>
+			<key>buildPhases</key>
+			<array>
+				<string>095CA0EFFBC84C0EB3464C5A</string>
+				<string>27389E08185345FD0027A404</string>
+				<string>27389E09185345FD0027A404</string>
+				<string>27389E0A185345FD0027A404</string>
+				<string>08B95EDB86F54BC99DEF0C13</string>
+			</array>
+			<key>buildRules</key>
+			<array/>
+			<key>dependencies</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXNativeTarget</string>
+			<key>name</key>
+			<string>Tests</string>
+			<key>productName</key>
+			<string>Tests</string>
+			<key>productReference</key>
+			<string>27389E0C185345FD0027A404</string>
+			<key>productType</key>
+			<string>com.apple.product-type.bundle</string>
+		</dict>
+		<key>27389E0C185345FD0027A404</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>wrapper.cfbundle</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>Tests.octest</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>27389E0D185345FD0027A404</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>27389E0C185345FD0027A404</string>
+				<string>27CCEDC6187AD64F006F3C66</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Products</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27389E0E185345FD0027A404</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>9F0D23E818888C6C00D3D04E</string>
+				<string>27389E0F185345FD0027A404</string>
+				<string>27389E11185345FD0027A404</string>
+				<string>27389E13185345FD0027A404</string>
+				<string>635BE7F70A3A4DFFA9455CDC</string>
+				<string>C0D0295E40984E2788387EEE</string>
+				<string>BBD8D50209E84CD981F3FA7A</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Frameworks</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27389E0F185345FD0027A404</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>wrapper.framework</string>
+			<key>name</key>
+			<string>SenTestingKit.framework</string>
+			<key>path</key>
+			<string>Library/Frameworks/SenTestingKit.framework</string>
+			<key>sourceTree</key>
+			<string>DEVELOPER_DIR</string>
+		</dict>
+		<key>27389E10185345FD0027A404</key>
+		<dict>
+			<key>fileRef</key>
+			<string>27389E0F185345FD0027A404</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>27389E11185345FD0027A404</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>wrapper.framework</string>
+			<key>name</key>
+			<string>Foundation.framework</string>
+			<key>path</key>
+			<string>Library/Frameworks/Foundation.framework</string>
+			<key>sourceTree</key>
+			<string>DEVELOPER_DIR</string>
+		</dict>
+		<key>27389E12185345FD0027A404</key>
+		<dict>
+			<key>fileRef</key>
+			<string>27389E11185345FD0027A404</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>27389E13185345FD0027A404</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>wrapper.framework</string>
+			<key>name</key>
+			<string>UIKit.framework</string>
+			<key>path</key>
+			<string>Library/Frameworks/UIKit.framework</string>
+			<key>sourceTree</key>
+			<string>DEVELOPER_DIR</string>
+		</dict>
+		<key>27389E14185345FD0027A404</key>
+		<dict>
+			<key>fileRef</key>
+			<string>27389E13185345FD0027A404</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>27389E15185345FD0027A404</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>9F0D2407188E378700D3D04E</string>
+				<string>9F0D24131892E9B800D3D04E</string>
+				<string>9F0D24161893161000D3D04E</string>
+				<string>9F0D241918932DA700D3D04E</string>
+				<string>9F0D240D188F01DD00D3D04E</string>
+				<string>9F0D240A188E3C3A00D3D04E</string>
+				<string>9F0D23F9188DF36800D3D04E</string>
+				<string>9F0D23FE188DF96600D3D04E</string>
+				<string>9F0D2401188DFE8600D3D04E</string>
+				<string>9F0D24101890AD0C00D3D04E</string>
+				<string>9F0D23F0188B4FA900D3D04E</string>
+				<string>9F0D23F3188B4FFF00D3D04E</string>
+				<string>9F0D23F6188DF30D00D3D04E</string>
+				<string>27389E2D18534E050027A404</string>
+				<string>27389E2E18534E050027A404</string>
+				<string>27389E3018534E050027A404</string>
+				<string>27389E3218534E050027A404</string>
+				<string>27389E3418534E050027A404</string>
+				<string>27389E16185345FD0027A404</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>Tests</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27389E16185345FD0027A404</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>27389E17185345FD0027A404</string>
+				<string>27389E18185345FD0027A404</string>
+				<string>27389E1D185345FD0027A404</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Supporting Files</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27389E17185345FD0027A404</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.xml</string>
+			<key>path</key>
+			<string>Tests-Info.plist</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27389E18185345FD0027A404</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>27389E19185345FD0027A404</string>
+			</array>
+			<key>isa</key>
+			<string>PBXVariantGroup</string>
+			<key>name</key>
+			<string>InfoPlist.strings</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27389E19185345FD0027A404</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.strings</string>
+			<key>name</key>
+			<string>en</string>
+			<key>path</key>
+			<string>en.lproj/InfoPlist.strings</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27389E1A185345FD0027A404</key>
+		<dict>
+			<key>fileRef</key>
+			<string>27389E18185345FD0027A404</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>27389E1D185345FD0027A404</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>Tests-Prefix.pch</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27389E1E185345FD0027A404</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>27389E1F185345FD0027A404</string>
+				<string>27389E20185345FD0027A404</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>27389E1F185345FD0027A404</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>B8C5CE07530A44358897106E</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>ALWAYS_SEARCH_USER_PATHS</key>
+				<string>NO</string>
+				<key>ARCHS</key>
+				<string>$(ARCHS_STANDARD_INCLUDING_64_BIT)</string>
+				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
+				<string>gnu++0x</string>
+				<key>CLANG_CXX_LIBRARY</key>
+				<string>libc++</string>
+				<key>CLANG_ENABLE_MODULES</key>
+				<string>YES</string>
+				<key>CLANG_ENABLE_OBJC_ARC</key>
+				<string>YES</string>
+				<key>CLANG_WARN_BOOL_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
+				<string>YES_ERROR</string>
+				<key>CLANG_WARN_EMPTY_BODY</key>
+				<string>YES</string>
+				<key>CLANG_WARN_ENUM_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_INT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
+				<string>YES_ERROR</string>
+				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
+				<string>YES</string>
+				<key>COPY_PHASE_STRIP</key>
+				<string>NO</string>
+				<key>FRAMEWORK_SEARCH_PATHS</key>
+				<array>
+					<string>$(SDKROOT)/Developer/Library/Frameworks</string>
+					<string>$(inherited)</string>
+					<string>$(DEVELOPER_FRAMEWORKS_DIR)</string>
+				</array>
+				<key>GCC_C_LANGUAGE_STANDARD</key>
+				<string>gnu99</string>
+				<key>GCC_DYNAMIC_NO_PIC</key>
+				<string>NO</string>
+				<key>GCC_OPTIMIZATION_LEVEL</key>
+				<string>0</string>
+				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
+				<string>YES</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>Tests/Tests-Prefix.pch</string>
+				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
+				<array>
+					<string>DEBUG=1</string>
+					<string>$(inherited)</string>
+				</array>
+				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
+				<string>NO</string>
+				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
+				<string>YES</string>
+				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
+				<string>YES_ERROR</string>
+				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNUSED_FUNCTION</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNUSED_VARIABLE</key>
+				<string>YES</string>
+				<key>INFOPLIST_FILE</key>
+				<string>Tests/Tests-Info.plist</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>7.0</string>
+				<key>MACOSX_DEPLOYMENT_TARGET</key>
+				<string>10.8</string>
+				<key>ONLY_ACTIVE_ARCH</key>
+				<string>YES</string>
+				<key>PRODUCT_NAME</key>
+				<string>$(TARGET_NAME)</string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+				<key>WRAPPER_EXTENSION</key>
+				<string>octest</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>27389E20185345FD0027A404</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>B8C5CE07530A44358897106E</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>ALWAYS_SEARCH_USER_PATHS</key>
+				<string>NO</string>
+				<key>ARCHS</key>
+				<string>$(ARCHS_STANDARD_INCLUDING_64_BIT)</string>
+				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
+				<string>gnu++0x</string>
+				<key>CLANG_CXX_LIBRARY</key>
+				<string>libc++</string>
+				<key>CLANG_ENABLE_MODULES</key>
+				<string>YES</string>
+				<key>CLANG_ENABLE_OBJC_ARC</key>
+				<string>YES</string>
+				<key>CLANG_WARN_BOOL_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
+				<string>YES_ERROR</string>
+				<key>CLANG_WARN_EMPTY_BODY</key>
+				<string>YES</string>
+				<key>CLANG_WARN_ENUM_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_INT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
+				<string>YES_ERROR</string>
+				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
+				<string>YES</string>
+				<key>COPY_PHASE_STRIP</key>
+				<string>YES</string>
+				<key>ENABLE_NS_ASSERTIONS</key>
+				<string>NO</string>
+				<key>FRAMEWORK_SEARCH_PATHS</key>
+				<array>
+					<string>$(SDKROOT)/Developer/Library/Frameworks</string>
+					<string>$(inherited)</string>
+					<string>$(DEVELOPER_FRAMEWORKS_DIR)</string>
+				</array>
+				<key>GCC_C_LANGUAGE_STANDARD</key>
+				<string>gnu99</string>
+				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
+				<string>YES</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>Tests/Tests-Prefix.pch</string>
+				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
+				<string>YES</string>
+				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
+				<string>YES_ERROR</string>
+				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNUSED_FUNCTION</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNUSED_VARIABLE</key>
+				<string>YES</string>
+				<key>INFOPLIST_FILE</key>
+				<string>Tests/Tests-Info.plist</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>7.0</string>
+				<key>MACOSX_DEPLOYMENT_TARGET</key>
+				<string>10.8</string>
+				<key>PRODUCT_NAME</key>
+				<string>$(TARGET_NAME)</string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+				<key>VALIDATE_PRODUCT</key>
+				<string>YES</string>
+				<key>WRAPPER_EXTENSION</key>
+				<string>octest</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>27389E2D18534E050027A404</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>CloudantSyncTests.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27389E2E18534E050027A404</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>CloudantSyncTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27389E3018534E050027A404</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>DatastoreActions.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27389E3218534E050027A404</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>DatastoreCrud.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27389E3418534E050027A404</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>SetUpDatastore.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27389E3518534E050027A404</key>
+		<dict>
+			<key>fileRef</key>
+			<string>27389E2E18534E050027A404</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>27389E3618534E050027A404</key>
+		<dict>
+			<key>fileRef</key>
+			<string>27389E3018534E050027A404</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>27389E3718534E050027A404</key>
+		<dict>
+			<key>fileRef</key>
+			<string>27389E3218534E050027A404</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>27389E3818534E050027A404</key>
+		<dict>
+			<key>fileRef</key>
+			<string>27389E3418534E050027A404</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>27CCEDC2187AD64F006F3C66</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>9F0D2409188E378700D3D04E</string>
+				<string>9F0D23F2188B4FA900D3D04E</string>
+				<string>9F0D2400188DF96600D3D04E</string>
+				<string>9F0D240F188F01DD00D3D04E</string>
+				<string>9F0D23F8188DF30D00D3D04E</string>
+				<string>27CCEDD7187AD719006F3C66</string>
+				<string>27CCEDD8187AD719006F3C66</string>
+				<string>9F0D24121890AD0C00D3D04E</string>
+				<string>9F0D241B18932DA700D3D04E</string>
+				<string>9F0D23FB188DF36800D3D04E</string>
+				<string>9F0D2403188DFE8600D3D04E</string>
+				<string>9F0D240C188E3C3A00D3D04E</string>
+				<string>27CCEDD9187AD719006F3C66</string>
+				<string>9F0D24181893161000D3D04E</string>
+				<string>27CCEDD6187AD70C006F3C66</string>
+				<string>9F0D23F5188B4FFF00D3D04E</string>
+				<string>9F0D24151892E9B800D3D04E</string>
+			</array>
+			<key>isa</key>
+			<string>PBXSourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>27CCEDC3187AD64F006F3C66</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>9F0D23E918888C6C00D3D04E</string>
+				<string>27CCEDC7187AD64F006F3C66</string>
+				<string>009D4E71AED34A54853B7F51</string>
+			</array>
+			<key>isa</key>
+			<string>PBXFrameworksBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>27CCEDC4187AD64F006F3C66</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>27CCEDCD187AD64F006F3C66</string>
+			</array>
+			<key>isa</key>
+			<string>PBXResourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>27CCEDC5187AD64F006F3C66</key>
+		<dict>
+			<key>buildConfigurationList</key>
+			<string>27CCEDD3187AD64F006F3C66</string>
+			<key>buildPhases</key>
+			<array>
+				<string>708AFFBE12E945969103B2AF</string>
+				<string>27CCEDC2187AD64F006F3C66</string>
+				<string>27CCEDC3187AD64F006F3C66</string>
+				<string>27CCEDC4187AD64F006F3C66</string>
+				<string>E63BC4B0310E42E0AC6C6072</string>
+			</array>
+			<key>buildRules</key>
+			<array/>
+			<key>dependencies</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXNativeTarget</string>
+			<key>name</key>
+			<string>Tests OSX</string>
+			<key>productName</key>
+			<string>Tests OSX</string>
+			<key>productReference</key>
+			<string>27CCEDC6187AD64F006F3C66</string>
+			<key>productType</key>
+			<string>com.apple.product-type.bundle</string>
+		</dict>
+		<key>27CCEDC6187AD64F006F3C66</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>wrapper.cfbundle</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>Tests OSX.octest</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>27CCEDC7187AD64F006F3C66</key>
+		<dict>
+			<key>fileRef</key>
+			<string>27389E0F185345FD0027A404</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>27CCEDC8187AD64F006F3C66</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>27CCEDCE187AD64F006F3C66</string>
+				<string>27CCEDC9187AD64F006F3C66</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>Tests OSX</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27CCEDC9187AD64F006F3C66</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>27CCEDCA187AD64F006F3C66</string>
+				<string>27CCEDCB187AD64F006F3C66</string>
+				<string>27CCEDD0187AD64F006F3C66</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Supporting Files</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27CCEDCA187AD64F006F3C66</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.xml</string>
+			<key>path</key>
+			<string>Tests OSX-Info.plist</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27CCEDCB187AD64F006F3C66</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>27CCEDCC187AD64F006F3C66</string>
+			</array>
+			<key>isa</key>
+			<string>PBXVariantGroup</string>
+			<key>name</key>
+			<string>InfoPlist.strings</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27CCEDCC187AD64F006F3C66</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.strings</string>
+			<key>name</key>
+			<string>en</string>
+			<key>path</key>
+			<string>en.lproj/InfoPlist.strings</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27CCEDCD187AD64F006F3C66</key>
+		<dict>
+			<key>fileRef</key>
+			<string>27CCEDCB187AD64F006F3C66</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>27CCEDCE187AD64F006F3C66</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>Tests_OSX.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27CCEDD0187AD64F006F3C66</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>Tests OSX-Prefix.pch</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27CCEDD3187AD64F006F3C66</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>27CCEDD4187AD64F006F3C66</string>
+				<string>27CCEDD5187AD64F006F3C66</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>27CCEDD4187AD64F006F3C66</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>2996853CB13542679108F845</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>ALWAYS_SEARCH_USER_PATHS</key>
+				<string>NO</string>
+				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
+				<string>gnu++0x</string>
+				<key>CLANG_CXX_LIBRARY</key>
+				<string>libc++</string>
+				<key>CLANG_ENABLE_OBJC_ARC</key>
+				<string>YES</string>
+				<key>CLANG_WARN_BOOL_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
+				<string>YES_ERROR</string>
+				<key>CLANG_WARN_EMPTY_BODY</key>
+				<string>YES</string>
+				<key>CLANG_WARN_ENUM_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_INT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
+				<string>YES_ERROR</string>
+				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
+				<string>YES</string>
+				<key>COPY_PHASE_STRIP</key>
+				<string>NO</string>
+				<key>FRAMEWORK_SEARCH_PATHS</key>
+				<array>
+					<string>$(DEVELOPER_FRAMEWORKS_DIR)</string>
+					<string>$(inherited)</string>
+				</array>
+				<key>GCC_C_LANGUAGE_STANDARD</key>
+				<string>gnu99</string>
+				<key>GCC_DYNAMIC_NO_PIC</key>
+				<string>NO</string>
+				<key>GCC_ENABLE_OBJC_EXCEPTIONS</key>
+				<string>YES</string>
+				<key>GCC_OPTIMIZATION_LEVEL</key>
+				<string>0</string>
+				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
+				<string>YES</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>Tests OSX/Tests OSX-Prefix.pch</string>
+				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
+				<array>
+					<string>DEBUG=1</string>
+					<string>$(inherited)</string>
+				</array>
+				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
+				<string>NO</string>
+				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
+				<string>YES</string>
+				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
+				<string>YES_ERROR</string>
+				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNUSED_FUNCTION</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNUSED_VARIABLE</key>
+				<string>YES</string>
+				<key>INFOPLIST_FILE</key>
+				<string>Tests OSX/Tests OSX-Info.plist</string>
+				<key>MACOSX_DEPLOYMENT_TARGET</key>
+				<string>10.8</string>
+				<key>ONLY_ACTIVE_ARCH</key>
+				<string>YES</string>
+				<key>PRODUCT_NAME</key>
+				<string>$(TARGET_NAME)</string>
+				<key>SDKROOT</key>
+				<string>macosx</string>
+				<key>WRAPPER_EXTENSION</key>
+				<string>octest</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>27CCEDD5187AD64F006F3C66</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>2996853CB13542679108F845</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>ALWAYS_SEARCH_USER_PATHS</key>
+				<string>NO</string>
+				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
+				<string>gnu++0x</string>
+				<key>CLANG_CXX_LIBRARY</key>
+				<string>libc++</string>
+				<key>CLANG_ENABLE_OBJC_ARC</key>
+				<string>YES</string>
+				<key>CLANG_WARN_BOOL_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
+				<string>YES_ERROR</string>
+				<key>CLANG_WARN_EMPTY_BODY</key>
+				<string>YES</string>
+				<key>CLANG_WARN_ENUM_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_INT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
+				<string>YES_ERROR</string>
+				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
+				<string>YES</string>
+				<key>COPY_PHASE_STRIP</key>
+				<string>YES</string>
+				<key>DEBUG_INFORMATION_FORMAT</key>
+				<string>dwarf-with-dsym</string>
+				<key>ENABLE_NS_ASSERTIONS</key>
+				<string>NO</string>
+				<key>FRAMEWORK_SEARCH_PATHS</key>
+				<array>
+					<string>$(DEVELOPER_FRAMEWORKS_DIR)</string>
+					<string>$(inherited)</string>
+				</array>
+				<key>GCC_C_LANGUAGE_STANDARD</key>
+				<string>gnu99</string>
+				<key>GCC_ENABLE_OBJC_EXCEPTIONS</key>
+				<string>YES</string>
+				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
+				<string>YES</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>Tests OSX/Tests OSX-Prefix.pch</string>
+				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
+				<string>YES</string>
+				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
+				<string>YES_ERROR</string>
+				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNUSED_FUNCTION</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNUSED_VARIABLE</key>
+				<string>YES</string>
+				<key>INFOPLIST_FILE</key>
+				<string>Tests OSX/Tests OSX-Info.plist</string>
+				<key>MACOSX_DEPLOYMENT_TARGET</key>
+				<string>10.8</string>
+				<key>PRODUCT_NAME</key>
+				<string>$(TARGET_NAME)</string>
+				<key>SDKROOT</key>
+				<string>macosx</string>
+				<key>WRAPPER_EXTENSION</key>
+				<string>octest</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>27CCEDD6187AD70C006F3C66</key>
+		<dict>
+			<key>fileRef</key>
+			<string>27389E2E18534E050027A404</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>27CCEDD7187AD719006F3C66</key>
+		<dict>
+			<key>fileRef</key>
+			<string>27389E3018534E050027A404</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>27CCEDD8187AD719006F3C66</key>
+		<dict>
+			<key>fileRef</key>
+			<string>27389E3218534E050027A404</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>27CCEDD9187AD719006F3C66</key>
+		<dict>
+			<key>fileRef</key>
+			<string>27389E3418534E050027A404</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>2996853CB13542679108F845</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>name</key>
+			<string>Pods-osx.xcconfig</string>
+			<key>path</key>
+			<string>Pods/Pods-osx.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>635BE7F70A3A4DFFA9455CDC</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>archive.ar</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>libPods.a</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>640AB8661E6344B98E64E18E</key>
+		<dict>
+			<key>fileRef</key>
+			<string>C0D0295E40984E2788387EEE</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>708AFFBE12E945969103B2AF</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array/>
+			<key>inputPaths</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXShellScriptBuildPhase</string>
+			<key>name</key>
+			<string>Check Pods Manifest.lock</string>
+			<key>outputPaths</key>
+			<array/>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+			<key>shellPath</key>
+			<string>/bin/sh</string>
+			<key>shellScript</key>
+			<string>diff "${PODS_ROOT}/../Podfile.lock" "${PODS_ROOT}/Manifest.lock" &gt; /dev/null
+if [[ $? != 0 ]] ; then
+    cat &lt;&lt; EOM
+error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.
+EOM
+    exit 1
+fi
+</string>
+			<key>showEnvVarsInLog</key>
+			<string>0</string>
+		</dict>
+		<key>9F0D23E818888C6C00D3D04E</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>wrapper.framework</string>
+			<key>name</key>
+			<string>Foundation.framework</string>
+			<key>path</key>
+			<string>System/Library/Frameworks/Foundation.framework</string>
+			<key>sourceTree</key>
+			<string>SDKROOT</string>
+		</dict>
+		<key>9F0D23E918888C6C00D3D04E</key>
+		<dict>
+			<key>fileRef</key>
+			<string>9F0D23E818888C6C00D3D04E</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>9F0D23F0188B4FA900D3D04E</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>TDMultipartReaderTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>9F0D23F1188B4FA900D3D04E</key>
+		<dict>
+			<key>fileRef</key>
+			<string>9F0D23F0188B4FA900D3D04E</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>9F0D23F2188B4FA900D3D04E</key>
+		<dict>
+			<key>fileRef</key>
+			<string>9F0D23F0188B4FA900D3D04E</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>9F0D23F3188B4FFF00D3D04E</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>TDMultipartWriterTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>9F0D23F4188B4FFF00D3D04E</key>
+		<dict>
+			<key>fileRef</key>
+			<string>9F0D23F3188B4FFF00D3D04E</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>9F0D23F5188B4FFF00D3D04E</key>
+		<dict>
+			<key>fileRef</key>
+			<string>9F0D23F3188B4FFF00D3D04E</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>9F0D23F6188DF30D00D3D04E</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>TDMultiStreamWriterTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>9F0D23F7188DF30D00D3D04E</key>
+		<dict>
+			<key>fileRef</key>
+			<string>9F0D23F6188DF30D00D3D04E</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>9F0D23F8188DF30D00D3D04E</key>
+		<dict>
+			<key>fileRef</key>
+			<string>9F0D23F6188DF30D00D3D04E</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>9F0D23F9188DF36800D3D04E</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>TD_DatabaseTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>9F0D23FA188DF36800D3D04E</key>
+		<dict>
+			<key>fileRef</key>
+			<string>9F0D23F9188DF36800D3D04E</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>9F0D23FB188DF36800D3D04E</key>
+		<dict>
+			<key>fileRef</key>
+			<string>9F0D23F9188DF36800D3D04E</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>9F0D23FE188DF96600D3D04E</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>TD_DatabaseManagerTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>9F0D23FF188DF96600D3D04E</key>
+		<dict>
+			<key>fileRef</key>
+			<string>9F0D23FE188DF96600D3D04E</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>9F0D2400188DF96600D3D04E</key>
+		<dict>
+			<key>fileRef</key>
+			<string>9F0D23FE188DF96600D3D04E</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>9F0D2401188DFE8600D3D04E</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>TD_RevisionTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>9F0D2402188DFE8600D3D04E</key>
+		<dict>
+			<key>fileRef</key>
+			<string>9F0D2401188DFE8600D3D04E</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>9F0D2403188DFE8600D3D04E</key>
+		<dict>
+			<key>fileRef</key>
+			<string>9F0D2401188DFE8600D3D04E</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>9F0D2407188E378700D3D04E</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>TDCanonicalJSONTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>9F0D2408188E378700D3D04E</key>
+		<dict>
+			<key>fileRef</key>
+			<string>9F0D2407188E378700D3D04E</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>9F0D2409188E378700D3D04E</key>
+		<dict>
+			<key>fileRef</key>
+			<string>9F0D2407188E378700D3D04E</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>9F0D240A188E3C3A00D3D04E</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>TDCollateJSONTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>9F0D240B188E3C3A00D3D04E</key>
+		<dict>
+			<key>fileRef</key>
+			<string>9F0D240A188E3C3A00D3D04E</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>9F0D240C188E3C3A00D3D04E</key>
+		<dict>
+			<key>fileRef</key>
+			<string>9F0D240A188E3C3A00D3D04E</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>9F0D240D188F01DD00D3D04E</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>TDMiscTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>9F0D240E188F01DD00D3D04E</key>
+		<dict>
+			<key>fileRef</key>
+			<string>9F0D240D188F01DD00D3D04E</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>9F0D240F188F01DD00D3D04E</key>
+		<dict>
+			<key>fileRef</key>
+			<string>9F0D240D188F01DD00D3D04E</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>9F0D24101890AD0C00D3D04E</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>TDMultipartDownloaderTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>9F0D24111890AD0C00D3D04E</key>
+		<dict>
+			<key>fileRef</key>
+			<string>9F0D24101890AD0C00D3D04E</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>9F0D24121890AD0C00D3D04E</key>
+		<dict>
+			<key>fileRef</key>
+			<string>9F0D24101890AD0C00D3D04E</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>9F0D24131892E9B800D3D04E</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>TDPusherTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>9F0D24141892E9B800D3D04E</key>
+		<dict>
+			<key>fileRef</key>
+			<string>9F0D24131892E9B800D3D04E</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>9F0D24151892E9B800D3D04E</key>
+		<dict>
+			<key>fileRef</key>
+			<string>9F0D24131892E9B800D3D04E</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>9F0D24161893161000D3D04E</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>TDReachabilityTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>9F0D24171893161000D3D04E</key>
+		<dict>
+			<key>fileRef</key>
+			<string>9F0D24161893161000D3D04E</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>9F0D24181893161000D3D04E</key>
+		<dict>
+			<key>fileRef</key>
+			<string>9F0D24161893161000D3D04E</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>9F0D241918932DA700D3D04E</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>TDSequenceMapTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>9F0D241A18932DA700D3D04E</key>
+		<dict>
+			<key>fileRef</key>
+			<string>9F0D241918932DA700D3D04E</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>9F0D241B18932DA700D3D04E</key>
+		<dict>
+			<key>fileRef</key>
+			<string>9F0D241918932DA700D3D04E</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>B8C5CE07530A44358897106E</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>name</key>
+			<string>Pods-ios.xcconfig</string>
+			<key>path</key>
+			<string>Pods/Pods-ios.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>BBD8D50209E84CD981F3FA7A</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>archive.ar</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>libPods-osx.a</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>C0D0295E40984E2788387EEE</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>archive.ar</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>libPods-ios.a</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>E63BC4B0310E42E0AC6C6072</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array/>
+			<key>inputPaths</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXShellScriptBuildPhase</string>
+			<key>name</key>
+			<string>Copy Pods Resources</string>
+			<key>outputPaths</key>
+			<array/>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+			<key>shellPath</key>
+			<string>/bin/sh</string>
+			<key>shellScript</key>
+			<string>"${SRCROOT}/Pods/Pods-osx-resources.sh"
+</string>
+			<key>showEnvVarsInLog</key>
+			<string>0</string>
+		</dict>
+		<key>EE84F28F860D431381668D04</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>name</key>
+			<string>Pods.xcconfig</string>
+			<key>path</key>
+			<string>Pods/Pods.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+	</dict>
+	<key>rootObject</key>
+	<string>27389E02185345DA0027A404</string>
+</dict>
+</plist>


### PR DESCRIPTION
This fixes bugs reported in FB 28015 and 28017. The fix needs to
be done simultaneously (from what I can tell) because the example
Project has a dependency on the Tests project (the Pods project
in the CDTDatastore workspace doesn't seem to be fully populated
until you run 'pod install' inside of Tests).

The example Project was verified to run in the simulator.
