### PR TITLE
Adding tests for CREATE and UPDATE operations (and modified one DELETE test)

### DIFF
--- a/Classes/common/CDTDocumentBody.m
+++ b/Classes/common/CDTDocumentBody.m
@@ -17,6 +17,7 @@
 
 #import "TD_Body.h"
 #import "TD_Revision.h"
+#import "TDJSON.h"
 
 @implementation CDTDocumentBody
 
@@ -33,7 +34,12 @@
 {
     self = [super init];
     if (self) {
+        
+        if(![TDJSON isValidJSONObject: dict])
+            return nil;
+        
         _td_body = [[TD_Body alloc] initWithProperties:dict];
+
     }
     return self;
 }

--- a/Classes/common/touchdb/TDJSON.h
+++ b/Classes/common/touchdb/TDJSON.h
@@ -5,6 +5,7 @@
 //  Created by Jens Alfke on 2/27/12.
 //  Copyright (c) 2012 Couchbase, Inc. All rights reserved.
 //
+//  Modifications for this distribution by Cloudant, Inc., Copyright (c) 2014 Cloudant, Inc.
 
 #import <Foundation/Foundation.h>
 
@@ -53,6 +54,9 @@ typedef NSUInteger TDJSONWritingOptions;
 + (id)JSONObjectWithData:(NSData *)data
                  options:(TDJSONReadingOptions)opt
                    error:(NSError **)error;
+
++ (BOOL) isValidJSONObject:(id)obj;
+
 @end
 
 #endif // USE_NSJSON

--- a/Classes/common/touchdb/TDJSON.m
+++ b/Classes/common/touchdb/TDJSON.m
@@ -12,6 +12,8 @@
 //  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
 //  either express or implied. See the License for the specific language governing permissions
 //  and limitations under the License.
+//
+//  Modifications for this distribution by Cloudant, Inc., Copyright (c) 2014 Cloudant, Inc.
 
 #import "TDJSON.h"
 
@@ -67,6 +69,10 @@
         return [data objectFromJSONDataWithParseOptions: 0 error: error];
 }
 
++ (BOOL) isValidJSONObject:(id)obj
+{
+    return [self dataWithJSONObject:obj options:0 error:NULL] != nil;
+}
 
 #endif // USE_NSJSON
 

--- a/Classes/common/touchdb/TD_Database+Insertion.m
+++ b/Classes/common/touchdb/TD_Database+Insertion.m
@@ -14,6 +14,8 @@
 //  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
 //  either express or implied. See the License for the specific language governing permissions
 //  and limitations under the License.
+//
+//  Modifications for this distribution by Cloudant, Inc., Copyright (c) 2014 Cloudant, Inc.
 
 #import "TD_Database+Insertion.h"
 #import "TD_Database+Attachments.h"
@@ -289,6 +291,11 @@ NSString* const TD_DatabaseChangeNotification = @"TD_DatabaseChange";
     if (!revToInsert || (previousRevID && !docIdToInsert) || (deleted && !docIdToInsert)
              || (docIdToInsert && ![TD_Database isValidDocumentID: docIdToInsert])) {
         *outStatus = kTDStatusBadID;
+        return nil;
+    }
+    
+    if(revToInsert.body == nil  && !deleted){
+        *outStatus = kTDStatusBadJSON;
         return nil;
     }
 

--- a/Tests/Tests/CloudantSyncTests.h
+++ b/Tests/Tests/CloudantSyncTests.h
@@ -17,11 +17,14 @@
 
 @class CDTDatastoreManager;
 
+#define kDBExtension @"touchdb"  //in TD_DatabaseManager.m. Move it into .h?
+
 @interface CloudantSyncTests : SenTestCase
 
 @property (nonatomic,strong) CDTDatastoreManager *factory;
 @property (nonatomic,strong) NSString *factoryPath;
+@property (nonatomic, readonly) NSSet *sqlTables;
 
 - (NSString*)createTemporaryDirectoryAndReturnPath;
-
+- (NSString *)pathForDBName:(NSString *)name;
 @end

--- a/Tests/Tests/CloudantSyncTests.m
+++ b/Tests/Tests/CloudantSyncTests.m
@@ -18,7 +18,14 @@
 #import "CDTDatastoreManager.h"
 #import "CDTDatastore.h"
 
+#import "FMDatabaseAdditions.h"
+#import "FMDatabaseQueue.h"
+#import "FMResultSet.h"
+
 @interface CloudantSyncTests ()
+
+@property (nonatomic, readwrite) NSSet *sqlTables;
+
 
 @end
 
@@ -46,6 +53,52 @@
     return path;
 }
 
+- (NSSet*)sqlTables
+{
+    if(_sqlTables)
+        return _sqlTables;
+    
+    NSError *error;
+    NSString *localFactoryPath = [self createTemporaryDirectoryAndReturnPath];
+    CDTDatastoreManager *localFactory = [[CDTDatastoreManager alloc] initWithDirectory:localFactoryPath error:&error];
+    STAssertNil(error, @"CDTDatastoreManager had error");
+    STAssertNotNil(localFactory, @"Factory is nil");
+    
+    NSString *dbName = @"temptogettables";
+    CDTDatastore *datastore = [localFactory datastoreNamed:dbName error:&error];
+    
+    [datastore documentCount]; //internally, this calls ensureDatabaseOpen, which calls TD_Database open:, which
+    //creates the tables in the sqlite db. otherwise, the database would be empty.
+    
+    NSString *dbPath = [localFactoryPath stringByAppendingPathComponent:[dbName stringByAppendingPathExtension:kDBExtension]];
+    
+    FMDatabaseQueue *queue = [FMDatabaseQueue databaseQueueWithPath:dbPath];
+    STAssertNotNil(queue, @"FMDatabaseQueue was nil: %@", queue);
+    __block NSMutableArray *tables = [[NSMutableArray alloc] init];
+    
+    [queue inDatabase:^(FMDatabase *db){
+        NSString *sql = @"select name from sqlite_master where type='table' and name not in ('sqlite_sequence')";
+        FMResultSet  *result = [db executeQuery:sql];
+        while([result next]){
+            [tables addObject:[result stringForColumn:@"name"]];
+        }
+        [result close];
+    }];
+    
+    error = nil;
+    [[NSFileManager defaultManager] removeItemAtPath:localFactoryPath error:&error];
+    STAssertNil(error, @"Error deleting temporary directory.");
+    
+    _sqlTables = [NSSet setWithArray:tables];
+    return _sqlTables;
+}
+
+- (NSString *)pathForDBName:(NSString *)name
+{
+    return [self.factoryPath stringByAppendingPathComponent:[name stringByAppendingPathExtension:kDBExtension]];
+}
+
+
 - (void)setUp
 {
     [super setUp];
@@ -58,6 +111,8 @@
     
     STAssertNil(error, @"CDTDatastoreManager had error");
     STAssertNotNil(self.factory, @"Factory is nil");
+    
+    _sqlTables = nil;
 }
 
 - (void)tearDown

--- a/Tests/Tests/DatastoreActions.m
+++ b/Tests/Tests/DatastoreActions.m
@@ -20,6 +20,11 @@
 #import "CDTDatastore.h"
 #import "CDTDatastoreManager.h"
 
+#import "FMDatabaseAdditions.h"
+#import "TDJSON.h"
+#import "FMResultSet.h"
+#import "FMDatabaseQueue.h"
+
 @interface DatastoreActions : CloudantSyncTests
 
 @end
@@ -37,8 +42,7 @@
 
 - (NSString*)createTemporaryFileAndReturnPath
 {
-    NSString *tempFileTemplate =
-    [NSTemporaryDirectory() stringByAppendingPathComponent:@"cloudant_sync_ios_tests.tempfile.XXXXXX"];
+    NSString *tempFileTemplate = [NSTemporaryDirectory() stringByAppendingPathComponent:@"cloudant_sync_ios_tests.tempfile.XXXXXX"];
     const char *tempFileTemplateCString = [tempFileTemplate fileSystemRepresentation];
     char *tempFileNameCString =  (char *)malloc(strlen(tempFileTemplateCString) + 1);
     strcpy(tempFileNameCString, tempFileTemplateCString);
@@ -90,5 +94,31 @@
     
 }
 
+-(void)testForSQLTables
+{
+    NSError *error;
+    CDTDatastore *datastore = [self.factory datastoreNamed:@"test" error:&error];
+    
+    [datastore documentCount]; //this calls ensureDatabaseOpen, which calls TD_Database open:, which
+    //creates the tables in the sqlite db. otherwise, the database would be empty.
+    
+    NSString *dbPath = [self pathForDBName:datastore.name];
+    
+    FMDatabaseQueue *queue = [FMDatabaseQueue databaseQueueWithPath:dbPath];
+    STAssertNotNil(queue, @"FMDatabaseQueue was nil: %@", queue);
+    
+    NSSet *tables = [self sqlTables];
+    for ( id table in tables ){
+        if(![table isKindOfClass:[NSString class]]){
+            STFail(@"not an NSString: %@", table);
+            continue;
+        }
+        [queue inDatabase:^(FMDatabase *db) {
+            STAssertTrue([db tableExists:table], @"%@ table doesn't exist", table);
+        }];
+    }
+    //should we bother with testing the schema of these tables? 
+    
+}
 
 @end

--- a/Tests/Tests/DatastoreCrud.m
+++ b/Tests/Tests/DatastoreCrud.m
@@ -14,6 +14,7 @@
 //  and limitations under the License.
 
 #import <SenTestingKit/SenTestingKit.h>
+#import <Foundation/Foundation.h>
 
 #import "CloudantSyncTests.h"
 
@@ -21,6 +22,14 @@
 #import "CDTDatastore.h"
 #import "CDTDocumentBody.h"
 #import "CDTDocumentRevision.h"
+
+#import "FMDatabaseAdditions.h"
+#import "FMDatabaseQueue.h"
+#import "TDJSON.h"
+#import "FMResultSet.h"
+
+#import "TD_Body.h"
+#import "CollectionUtils.h"
 
 @interface DatastoreCrud : CloudantSyncTests
 
@@ -52,6 +61,253 @@
 
 
 
+#pragma mark - helper methods
+
+-(void)printFMResult:(FMResultSet *)result ignorecolumns:(NSSet *)ignored
+{
+    for(int i = 0; i < [result columnCount]; i++){
+        NSString *resultString = [result stringForColumnIndex:i];
+        NSString *columnName =[result columnNameForIndex:i];
+        if([ignored member:columnName])
+            continue;
+        
+        if([columnName isEqualToString:@"json"]){
+            NSDictionary* jsonDoc = [TDJSON JSONObjectWithData: [result dataForColumnIndex: i]
+                                                       options: TDJSONReadingMutableContainers
+                                                         error: NULL];
+            resultString = [NSString stringWithFormat:@"%@", jsonDoc];
+            
+        }
+        
+        NSLog(@"%@ : %@",[result columnNameForIndex:i], resultString);
+    }
+}
+
+-(void)printAllRows:(FMDatabaseQueue *)queue forTable:(NSString *)table
+{
+    NSString *sql = [NSString stringWithFormat:@"select * from %@", table];
+    [self printResults:queue forQuery:sql];
+}
+
+-(void)printResults:(FMDatabaseQueue *)queue forQuery:(NSString *)sql
+{
+    __weak DatastoreCrud  *weakSelf = self;
+    [queue inDatabase:^(FMDatabase *db) {
+        DatastoreCrud *strongSelf = weakSelf;
+        FMResultSet *result = [db executeQuery:sql];
+        
+        NSLog(@"results for query: %@", sql);
+        
+        while([result next])
+            [strongSelf printFMResult:result ignorecolumns:nil];
+        
+        
+        [result close];
+    }];
+    
+}
+
+-(int)rowCountForTable:(NSString *)table inDatabase:(FMDatabaseQueue *)queue
+{
+    __block int count = 0;
+    [queue inDatabase:^(FMDatabase *db) {
+        NSString *sql = [NSString stringWithFormat:@"select count(*) as counts from %@", table];
+        FMResultSet *result = [db executeQuery:sql];
+        [result next];
+        count =  [result intForColumn:@"counts"];
+        [result close];
+    }];
+    
+    return count;
+    
+}
+
+
+-(NSMutableDictionary *)getAllTablesRowCountWithQueue:(FMDatabaseQueue *)queue
+{
+    NSSet *tables = [self sqlTables];
+    NSMutableDictionary *rowCount = [[NSMutableDictionary alloc] init];
+    for(NSString *table in tables){
+        [rowCount setValue:[NSNumber numberWithInt:[self rowCountForTable:table inDatabase:queue]] forKey:table];
+    }
+    return rowCount;
+}
+
+/*
+ Both dictionaries should contain keys that are the names of tables and values that are NSNumbers.
+ The values of initialRowCount are the "initial" number of rows in each table.
+ The values of modifiedRows should be the expected number of news rows found in each table.
+*/
+-(void)checkTableRowCount:(NSDictionary *)initialRowCount modifiedBy:(NSDictionary *)modifiedRowCount withQueue:(FMDatabaseQueue *)queue
+{
+    
+    for(NSString* table in initialRowCount){
+        
+        NSLog(@"testing for modification to %@", table);
+        NSInteger initCount = [initialRowCount[table] integerValue];
+        NSInteger expectCount = initCount;
+        
+        if([modifiedRowCount[table] respondsToSelector:@selector(integerValue)])
+            expectCount += [modifiedRowCount[table] integerValue];  //we expect there to be one new row in the modifiedTables
+        
+        NSInteger foundCount = [self rowCountForTable:table inDatabase:queue];
+        STAssertTrue( foundCount == expectCount,
+                     @"For table %@: row count mismatch. initial number of rows %d expected %d found %d.",
+                     table, initCount, expectCount, foundCount);
+        
+    }
+}
+
+-(CDTDocumentBody *)createNilDocument
+{
+    NSDictionary *myDoc = @{@"hello": [NSSet setWithArray:@[@"world"]]};
+    
+    //require that myDoc is not JSON serializable
+    STAssertFalse([TDJSON isValidJSONObject:myDoc],
+                  @"My Non-serializable dictionary turned out to be serializable!");
+    
+    //require that CDTDocumentBody fails
+    CDTDocumentBody *body = [[CDTDocumentBody alloc] initWithDictionary:myDoc];
+    STAssertNil(body, @"Able to instantiate CDTDocument Body with non-serializable NSDictionary");
+    return body;
+}
+
+#pragma mark - CREATE tests
+
+
+-(void)testCreateOneDocumentSQLEntries
+{
+    NSError *error;
+    NSString *key = @"hello";
+    NSString *value = @"world";
+    NSString *testDocId = @"document_id_for_CreateOneDocumentSQLEntries";
+    
+    [self.datastore documentCount]; //this calls ensureDatabaseOpen, which calls TD_Database open:, which
+    //creates the tables in the sqlite db. otherwise, the database would be empty.
+
+    NSString *dbPath = [self pathForDBName:self.datastore.name];
+    
+    FMDatabaseQueue *queue = [FMDatabaseQueue databaseQueueWithPath:dbPath];
+    STAssertNotNil(queue, @"FMDatabaseQueue was nil: %@", queue);
+
+    NSMutableDictionary *initialRowCount = [self getAllTablesRowCountWithQueue:queue];
+    
+    CDTDocumentBody *body = [[CDTDocumentBody alloc] initWithDictionary:@{key: value}];
+    CDTDocumentRevision *ob = [self.datastore createDocumentWithId:testDocId
+                                                              body:body
+                                                             error:&error];
+    STAssertNil(error, @"Error creating document");
+    STAssertNotNil(ob, @"CDTDocumentRevision object was nil");
+    
+    NSDictionary *modifiedCount = @{@"docs": @1, @"revs": @1};
+    
+    [self checkTableRowCount:initialRowCount modifiedBy:modifiedCount withQueue:queue];
+    
+    
+    //now test the content of docs/revs
+
+    NSString *sql = @"select * from docs";
+    __block int doc_id;
+    [queue inDatabase:^(FMDatabase *db) {
+        FMResultSet *result = [db executeQuery:sql];
+        [result next];
+        NSLog(@"testing content of docs table");
+        
+        STAssertEqualObjects(testDocId, [result stringForColumn:@"docid"], @"doc id doesn't match. should be %@. found %@", testDocId, [result stringForColumn:@"docid"]);
+        doc_id = [result intForColumn:@"doc_id"];
+        
+        STAssertEqualObjects([result stringForColumn:@"docid"], [ob docId],
+                             @"database docid (%@) doesn't match CDTDocumentRevision.docId (%@)",
+                             [result stringForColumn:@"docid"], [ob docId]);
+
+        STAssertFalse([result next], @"There are too many rows in docs");
+
+        [result close];
+    }];
+    
+    
+    sql = @"select * from revs";
+    [queue inDatabase:^(FMDatabase *db) {
+        FMResultSet *result = [db executeQuery:sql];
+        [result next];
+        
+        NSLog(@"testing content of revs table");
+        STAssertEquals(doc_id, [result intForColumn:@"doc_id"], @"doc_id in revs (%d) doesn't match doc_id in docs (%d).", doc_id, [result intForColumn:@"doc_id"]);
+        STAssertEquals(1, [result intForColumn:@"sequence"], @"sequence is not 1");
+        STAssertFalse([[result stringForColumn:@"revid"] isEqualToString:@""], @"revid string isEqual to empty string");
+        STAssertTrue([result boolForColumn:@"current"], @"document current should be YES");
+        STAssertFalse([result boolForColumn:@"deleted"], @"document deleted should be NO");
+        
+        NSDictionary* jsonDoc = [TDJSON JSONObjectWithData: [result dataForColumn:@"json"]
+                                                   options: TDJSONReadingMutableContainers
+                                                     error: NULL];
+        STAssertTrue([jsonDoc isEqualToDictionary:@{key: value}], @"JSON document from revs.json not equal to original key-value pair. Found %@. Expected %@", jsonDoc, @{key: value});
+        
+        STAssertEqualObjects([ob documentAsDictionary], jsonDoc, @"JSON document from CDTDocumentRevision not to revs.json. Found %@. Expected %@", [ob documentAsDictionary], jsonDoc);
+        
+        STAssertFalse([result next], @"There are too many rows in revs");
+        STAssertNil([result stringForColumn:@"doc_id"], @"after [result next], doc_id not nil");
+        STAssertNil([result stringForColumn:@"revid"], @"after [result next],  revid not nil");
+        
+        [result close];
+    }];
+}
+
+-(void)testCannotCreateInvalidDocument
+{
+    [self createNilDocument];
+}
+
+-(void)testCannotInsertNil
+{
+    NSError *error;
+    NSString *testDocId = @"document_id_for_cannotInsertNil";
+
+    CDTDocumentBody *body = [self createNilDocument];
+    STAssertNil(body, @"CDTDocumentBody was not nil");
+
+    [self.datastore documentCount]; //this calls ensureDatabaseOpen, which calls TD_Database open:, which
+    //creates the tables in the sqlite db. otherwise, the database would be empty.
+    
+    NSString *dbPath = [self pathForDBName:self.datastore.name];
+    FMDatabaseQueue *queue = [FMDatabaseQueue databaseQueueWithPath:dbPath];
+    STAssertNotNil(queue, @"FMDatabaseQueue was nil: %@", queue);
+    NSMutableDictionary *initialRowCount = [self getAllTablesRowCountWithQueue:queue];
+    
+    CDTDocumentRevision *ob = [self.datastore createDocumentWithId:testDocId
+                                                              body:body
+                                                             error:&error];
+    STAssertNotNil(error, @"No Error creating document!");
+    STAssertTrue(error.code == 400, @"Error was not a 400. Found %ld", error.code);
+    STAssertNil(ob, @"CDTDocumentRevision object was not nil");
+    
+    [self checkTableRowCount:initialRowCount modifiedBy:nil withQueue:queue];
+
+}
+
+-(void)testCannotCreateNewDocWithoutUniqueID
+{
+    NSError *error;
+    NSString *key = @"hello";
+    NSString *value = @"world";
+    NSString *testDocId = @"document_id_for_CannotCreateNewDocWithoutUniqueID";
+        
+    CDTDocumentBody *body = [[CDTDocumentBody alloc] initWithDictionary:@{key: value}];
+    CDTDocumentRevision *ob = [self.datastore createDocumentWithId:testDocId
+                                                              body:body
+                                                             error:&error];
+    STAssertNil(error, @"Error creating document");
+    STAssertNotNil(ob, @"CDTDocumentRevision object was nil");
+    
+    body = [[CDTDocumentBody alloc] initWithDictionary:@{key: value}];
+    ob = [self.datastore createDocumentWithId:testDocId
+                                         body:body
+                                        error:&error];
+    STAssertNotNil(error, @"Error was nil when creating second doc with same doc_id");
+    STAssertTrue(error.code == 409, @"Error was not a 409. Found %ld", error.code);
+    STAssertNil(ob, @"CDTDocumentRevision object was not nil when creating second doc with same doc_id");
+}
+
 -(void)testAddDocument
 {
     NSError *error;
@@ -71,7 +327,7 @@
                                                              error:&error];
     
     STAssertNil(error, @"Error creating document");
-    STAssertNotNil(ob, @"Datastore object was nil");
+    STAssertNotNil(ob, @"CDTDocumentRevision object was nil");
     STAssertEqualObjects(@"document_id_for_test", ob.docId, @"Document ID was not as set in test");
     
     NSString *docId = ob.docId;
@@ -86,6 +342,8 @@
     STAssertEqualObjects(ob.documentAsDictionary[@"hello"], @"world", @"Object from database has wrong data");
 }
 
+#pragma mark - READ tests
+
 -(void)testGetDocument
 {
     NSError *error;
@@ -93,7 +351,7 @@
     CDTDocumentRevision *ob = [self.datastore createDocumentWithBody:body error:&error];
     
     STAssertNil(error, @"Error creating document");
-    STAssertNotNil(ob, @"Datastore object was nil");
+    STAssertNotNil(ob, @"CDTDocumentRevision object was nil");
     
     NSString *docId = ob.docId;
     CDTDocumentRevision *retrieved = [self.datastore getDocumentWithId:docId error:&error];
@@ -161,79 +419,7 @@
     }
 }
 
--(void)testUpdatingSingleDocument
-{
-    NSError *error;
-    CDTDocumentBody *body = [[CDTDocumentBody alloc] initWithDictionary:@{@"hello": @"world"}];
-    CDTDocumentRevision *ob = [self.datastore createDocumentWithBody:body error:&error];
-    STAssertNil(error, @"Error creating document");
-    STAssertNotNil(ob, @"Datastore object was nil");
-    
-    NSString *docId = ob.docId;
-    
-    CDTDocumentBody *body2 = [[CDTDocumentBody alloc] initWithDictionary:@{@"hi": @"mike"}];
-    CDTDocumentRevision *ob2 = [self.datastore updateDocumentWithId:docId
-                                                            prevRev:ob.revId
-                                                               body:body2
-                                                              error:&error];
-    STAssertNil(error, @"Error updating document");
-    STAssertNotNil(ob2, @"Datastore object was nil");
-    
-    // Check new revision
-    const NSUInteger expected_count = 1;
-    CDTDocumentRevision *retrieved;
-    
-    retrieved = [self.datastore getDocumentWithId:docId error:&error];
-    STAssertNil(error, @"Error getting document");
-    STAssertNotNil(retrieved, @"retrieved object was nil");
-    STAssertEqualObjects(ob.docId, retrieved.docId, @"Object retrieved from database has wrong docid");
-    STAssertEqualObjects(ob2.revId, retrieved.revId, @"Object retrieved from database has wrong revid");
-    STAssertEquals(retrieved.documentAsDictionary.count, expected_count, @"Object from database has != 1 key");
-    STAssertEqualObjects(retrieved.documentAsDictionary[@"hi"], @"mike", @"Object from database has wrong data");
-    
-    // Check we can get old revision
-    retrieved = [self.datastore getDocumentWithId:docId rev:ob.revId error:&error];
-    STAssertNil(error, @"Error getting document using old rev");
-    STAssertNotNil(retrieved, @"retrieved object was nil");
-    STAssertEqualObjects(ob.docId, retrieved.docId, @"Object retrieved from database has wrong docid");
-    STAssertEqualObjects(ob.revId, retrieved.revId, @"Object retrieved from database has wrong revid");
-    STAssertEquals(retrieved.documentAsDictionary.count, expected_count, @"Object from database has != 1 key");
-    STAssertEqualObjects(retrieved.documentAsDictionary[@"hello"], @"world", @"Object from database has wrong data");
-}
-
--(void)testDeleteDocument
-{
-    NSError *error;
-    CDTDocumentBody *body = [[CDTDocumentBody alloc] initWithDictionary:@{@"hello": @"world"}];
-    CDTDocumentRevision *ob = [self.datastore createDocumentWithBody:body error:&error];
-    STAssertNil(error, @"Error creating document");
-    STAssertNotNil(ob, @"Datastore object was nil");
-    
-    NSString *docId = ob.docId;
-    Boolean deleted = [self.datastore deleteDocumentWithId:docId
-                                                       rev:ob.revId
-                                                     error:&error];
-    STAssertNil(error, @"Error deleting document");
-    STAssertTrue(deleted, @"Object wasn't deleted successfully");
-    
-    // Check new revision isn't found
-    CDTDocumentRevision *retrieved;
-    retrieved = [self.datastore getDocumentWithId:docId error:&error];
-    STAssertNotNil(error, @"Error getting document");
-    STAssertNil(retrieved, @"retrieved object was nil");
-    
-    error = nil;
-    
-    // Check we can get old revision
-    const NSUInteger expected_count = 1;
-    retrieved = [self.datastore getDocumentWithId:docId rev:ob.revId error:&error];
-    STAssertNil(error, @"Error getting document");
-    STAssertNotNil(retrieved, @"retrieved object was nil");
-    STAssertEqualObjects(ob.docId, retrieved.docId, @"Object retrieved from database has wrong docid");
-    STAssertEqualObjects(ob.revId, retrieved.revId, @"Object retrieved from database has wrong revid");
-    STAssertEquals(retrieved.documentAsDictionary.count, expected_count, @"Object from database has != 1 key");
-    STAssertEqualObjects(retrieved.documentAsDictionary[@"hello"], @"world", @"Object from database has wrong data");
-}
+#pragma mark READ ALL tests
 
 -(void)test_getAllDocumentsOffsetLimitDescending
 {
@@ -248,7 +434,7 @@
         STAssertNil(error, @"Error creating document");
         [dbObjects addObject:ob];
     }
-//    NSArray* reversedObjects = [[dbObjects reverseObjectEnumerator] allObjects];
+    //    NSArray* reversedObjects = [[dbObjects reverseObjectEnumerator] allObjects];
     
     // Test count and offsets for descending and ascending
     [self getAllDocuments_testCountAndOffset:objectCount expectedDbObjects:dbObjects descending:NO];
@@ -363,27 +549,27 @@
                                          offset:0];
     
     // Error cases
-//    try {
-//        offset = 0; count = -10;
-//        core.getAllDocuments(offset, count, descending);
-//        Assert.fail("IllegalArgumentException not thrown");
-//    } catch (IllegalArgumentException ex) {
-//        // All fine
-//    }
-//    try {
-//        offset = -10; count = 10;
-//        core.getAllDocuments(offset, count, descending);
-//        Assert.fail("IllegalArgumentException not thrown");
-//    } catch (IllegalArgumentException ex) {
-//        // All fine
-//    }
-//    try {
-//        offset = 50; count = -10;
-//        core.getAllDocuments(offset, count, descending);
-//        Assert.fail("IllegalArgumentException not thrown");
-//    } catch (IllegalArgumentException ex) {
-//        // All fine
-//    }
+    //    try {
+    //        offset = 0; count = -10;
+    //        core.getAllDocuments(offset, count, descending);
+    //        Assert.fail("IllegalArgumentException not thrown");
+    //    } catch (IllegalArgumentException ex) {
+    //        // All fine
+    //    }
+    //    try {
+    //        offset = -10; count = 10;
+    //        core.getAllDocuments(offset, count, descending);
+    //        Assert.fail("IllegalArgumentException not thrown");
+    //    } catch (IllegalArgumentException ex) {
+    //        // All fine
+    //    }
+    //    try {
+    //        offset = 50; count = -10;
+    //        core.getAllDocuments(offset, count, descending);
+    //        Assert.fail("IllegalArgumentException not thrown");
+    //    } catch (IllegalArgumentException ex) {
+    //        // All fine
+    //    }
 }
 
 -(void)getAllDocuments_compareResultExpected:(NSArray*)expectedDbObjects actual:(NSArray*)result count:(int)count offset:(int)offset
@@ -396,5 +582,654 @@
         [self assertIdAndRevisionAndShallowContentExpected:expected actual:actual];
     }
 }
+
+
+#pragma mark - UPDATE tests
+
+-(void)testUpdateWithBadRev
+{
+    [self.datastore documentCount]; //this calls ensureDatabaseOpen, which calls TD_Database open:, which
+    //creates the tables in the sqlite db. otherwise, the database would be empty.
+    
+    NSString *dbPath = [self pathForDBName:self.datastore.name];
+    
+    FMDatabaseQueue *queue = [FMDatabaseQueue databaseQueueWithPath:dbPath];
+    STAssertNotNil(queue, @"FMDatabaseQueue was nil: %@", queue);
+    
+    
+    NSError *error;
+    NSString *key1 = @"hello";
+    NSString *value1 = @"world";
+    
+    CDTDocumentBody *body = [[CDTDocumentBody alloc] initWithDictionary:@{key1:value1}];
+    CDTDocumentRevision *ob = [self.datastore createDocumentWithBody:body error:&error];
+    STAssertNil(error, @"Error creating document");
+    STAssertNotNil(ob, @"CDTDocumentRevision object was nil");
+    
+    NSString *key2 = @"hi";
+    NSString *value2 = @"mike";
+    NSString *badRev = @"2-abcdef1234567890abcdef9876543210";
+
+    NSMutableDictionary *initialRowCount = [self getAllTablesRowCountWithQueue:queue];
+
+    CDTDocumentBody *body2 = [[CDTDocumentBody alloc] initWithDictionary:@{key2:value2}];
+    CDTDocumentRevision *ob2 = [self.datastore updateDocumentWithId:ob.docId
+                                                            prevRev:badRev
+                                                               body:body2
+                                                              error:&error];
+    STAssertNotNil(error, @"Error was nil");
+    STAssertTrue(error.code == 409, @"Error was not a 409. Found %ld", error.code);
+    STAssertNil(ob2, @"CDTDocumentRevision object was not nil");
+    error = nil;
+    
+    //expect the database to be unmodified
+    [self checkTableRowCount:initialRowCount modifiedBy:nil withQueue:queue];
+    
+    badRev = [ob.revId stringByAppendingString:@"a"];
+    
+    body2 = [[CDTDocumentBody alloc] initWithDictionary:@{key2:value2}];
+    ob2 = [self.datastore updateDocumentWithId:ob.docId
+                                       prevRev:badRev
+                                          body:body2
+                                         error:&error];
+    STAssertNotNil(error, @"Error was nil");
+    STAssertTrue(error.code == 409, @"Error was not a 409. Found %ld", error.code);
+    STAssertNil(ob2, @"CDTDocumentRevision object was not nil");
+    error = nil;
+    
+    //expect the database to be unmodified
+    [self checkTableRowCount:initialRowCount modifiedBy:nil withQueue:queue];
+
+    
+    //now update the document with the proper ID
+    //then try to update the document again with the rev 1-x.
+    body2 = [[CDTDocumentBody alloc] initWithDictionary:@{key2:value2}];
+    ob2 = [self.datastore updateDocumentWithId:ob.docId
+                                       prevRev:ob.revId
+                                          body:body2
+                                         error:&error];
+    
+    STAssertNil(error, @"Error creating document. %@", error);
+    STAssertNotNil(ob2, @"CDTDocumentRevision object was nil");
+    
+    NSDictionary *modifiedCount = @{@"revs": @1};  //expect just one additional entry in revs
+    [self checkTableRowCount:initialRowCount modifiedBy:modifiedCount withQueue:queue];
+    
+    initialRowCount = [self getAllTablesRowCountWithQueue:queue];
+    
+    NSString *key3 = @"howdy";
+    NSString *value3 = @"adam";
+    
+    CDTDocumentBody *body3 = [[CDTDocumentBody alloc] initWithDictionary:@{key3:value3}];
+    CDTDocumentRevision *ob3 = [self.datastore updateDocumentWithId:ob.docId
+                                                            prevRev:ob.revId  //this is the bad revision
+                                                               body:body3
+                                                              error:&error];
+    STAssertNotNil(error, @"No error when updating document with bad rev");
+    STAssertTrue(error.code == 409, @"Error was not a 409. Found %ld", error.code);
+    STAssertNil(ob3, @"CDTDocumentRevision object was not nil after update with bad rev");
+    
+    //expect the database to be unmodified
+    [self checkTableRowCount:initialRowCount modifiedBy:nil withQueue:queue];
+
+    
+}
+
+-(void)testUpdateBadDocId
+{
+    NSError *error;
+    NSString *key1 = @"hello";
+    NSString *value1 = @"world";
+    
+    CDTDocumentBody *body = [[CDTDocumentBody alloc] initWithDictionary:@{key1:value1}];
+    CDTDocumentRevision *ob = [self.datastore createDocumentWithBody:body error:&error];
+    STAssertNil(error, @"Error creating document");
+    STAssertNotNil(ob, @"CDTDocumentRevision object was nil");
+    
+    NSString *dbPath = [self pathForDBName:self.datastore.name];
+    FMDatabaseQueue *queue = [FMDatabaseQueue databaseQueueWithPath:dbPath];
+    STAssertNotNil(queue, @"FMDatabaseQueue was nil: %@", queue);
+    NSMutableDictionary *initialRowCount = [self getAllTablesRowCountWithQueue:queue];
+
+    NSString *key2 = @"hi";
+    NSString *value2 = @"mike";
+    
+    body = [[CDTDocumentBody alloc] initWithDictionary:@{key2:value2}];
+    CDTDocumentRevision *ob2 = [self.datastore updateDocumentWithId:@"idonotexist"
+                                                            prevRev:ob.revId
+                                                               body:body
+                                                              error:&error];
+    
+    STAssertNotNil(error, @"No error when updating document with bad id");
+    STAssertTrue(error.code == 404, @"Error was not a 404. Found %ld", error.code);
+    STAssertNil(ob2, @"CDTDocumentRevision object was not nil after update with bad rev");
+    
+    //expect the database to be unmodified
+    [self checkTableRowCount:initialRowCount modifiedBy:nil withQueue:queue];
+    
+}
+
+-(void)testUpdatingSingleDocument
+{
+    [self.datastore documentCount]; //this calls ensureDatabaseOpen, which calls TD_Database open:, which
+    //creates the tables in the sqlite db. otherwise, the database would be empty.
+    
+    NSString *dbPath = [self pathForDBName:self.datastore.name];
+    FMDatabaseQueue *queue = [FMDatabaseQueue databaseQueueWithPath:dbPath];
+    STAssertNotNil(queue, @"FMDatabaseQueue was nil: %@", queue);
+    NSMutableDictionary *initialRowCount = [self getAllTablesRowCountWithQueue:queue];
+    
+    NSError *error;
+    NSString *key1 = @"hello";
+    NSString *value1 = @"world";
+    
+    CDTDocumentBody *body = [[CDTDocumentBody alloc] initWithDictionary:@{key1:value1}];
+    CDTDocumentRevision *ob = [self.datastore createDocumentWithBody:body error:&error];
+    STAssertNil(error, @"Error creating document");
+    STAssertNotNil(ob, @"CDTDocumentRevision object was nil");
+    
+    
+    NSString *docId = ob.docId;
+    NSString *key2 = @"hi";
+    NSString *value2 = @"mike";
+    
+    CDTDocumentBody *body2 = [[CDTDocumentBody alloc] initWithDictionary:@{key2:value2}];
+    CDTDocumentRevision *ob2 = [self.datastore updateDocumentWithId:docId
+                                                            prevRev:ob.revId
+                                                               body:body2
+                                                              error:&error];
+    STAssertNil(error, @"Error updating document");
+    STAssertNotNil(ob2, @"CDTDocumentRevision object was nil");
+    
+    // Check new revision
+    const NSUInteger expected_count = 1;
+    CDTDocumentRevision *retrieved;
+    
+    retrieved = [self.datastore getDocumentWithId:docId error:&error];
+    STAssertNil(error, @"Error getting document");
+    STAssertNotNil(retrieved, @"retrieved object was nil");
+    STAssertEqualObjects(ob.docId, retrieved.docId, @"Object retrieved from database has wrong docid");
+    STAssertEqualObjects(ob2.revId, retrieved.revId, @"Object retrieved from database has wrong revid");
+    STAssertEquals(retrieved.documentAsDictionary.count, expected_count, @"Object from database has != 1 key");
+    STAssertEqualObjects(retrieved.documentAsDictionary[key2], value2, @"Object from database has wrong data");
+    
+    // Check we can get old revision
+    retrieved = [self.datastore getDocumentWithId:docId rev:ob.revId error:&error];
+    STAssertNil(error, @"Error getting document using old rev");
+    STAssertNotNil(retrieved, @"retrieved object was nil");
+    STAssertEqualObjects(ob.docId, retrieved.docId, @"Object retrieved from database has wrong docid");
+    STAssertEqualObjects(ob.revId, retrieved.revId, @"Object retrieved from database has wrong revid");
+    STAssertEquals(retrieved.documentAsDictionary.count, expected_count, @"Object from database has != 1 key");
+    STAssertEqualObjects(retrieved.documentAsDictionary[key1], value1, @"Object from database has wrong data");
+    
+    
+    //now test the content of docs/revs tables explicitely.
+    
+    NSDictionary *modifiedCount = @{@"docs": @1, @"revs": @2};
+    [self checkTableRowCount:initialRowCount modifiedBy:modifiedCount withQueue:queue];
+    
+    NSString *sql = @"select * from docs";
+    __block int doc_id_inDocsTable;
+    [queue inDatabase:^(FMDatabase *db) {
+        FMResultSet *result = [db executeQuery:sql];
+        [result next];
+        NSLog(@"testing content of docs table");
+        
+        STAssertEqualObjects(docId, [result stringForColumn:@"docid"], @"doc id doesn't match. should be %@. found %@", docId,
+                             [result stringForColumn:@"docid"]);
+        
+        doc_id_inDocsTable = [result intForColumn:@"doc_id"];
+        
+        STAssertFalse([result next], @"There are too many rows in docs");
+        
+        [result close];
+    }];
+    
+    
+    sql = @"select * from revs";
+    [queue inDatabase:^(FMDatabase *db) {
+        FMResultSet *result = [db executeQuery:sql];
+        [result next];
+        
+        NSLog(@"testing content of revs table");
+        STAssertEquals(doc_id_inDocsTable, [result intForColumn:@"doc_id"],
+                       @"doc_id in revs (%d) doesn't match doc_id in docs (%d).", doc_id_inDocsTable, [result intForColumn:@"doc_id"]);
+        
+        STAssertEquals(1, [result intForColumn:@"sequence"], @"sequence is not 1");
+        STAssertFalse([[result stringForColumn:@"revid"] isEqualToString:@""], @"revid string isEqual to empty string");
+        STAssertFalse([result boolForColumn:@"current"], @"document current should be NO");
+        STAssertFalse([result boolForColumn:@"deleted"], @"document deleted should be NO");
+        
+        NSDictionary* jsonDoc = [TDJSON JSONObjectWithData: [result dataForColumn:@"json"]
+                                                   options: TDJSONReadingMutableContainers
+                                                     error: NULL];
+        STAssertTrue([jsonDoc isEqualToDictionary:@{key1: value1}], @"JSON document from revs.json not equal to original key-value pair. Found %@. Expected %@", jsonDoc, @{key1: value1});
+
+        //next row
+        STAssertTrue([result next], @"Didn't find the second row in the revs table");
+
+        STAssertEquals(doc_id_inDocsTable, [result intForColumn:@"doc_id"],
+                       @"doc_id in revs (%d) doesn't match doc_id in docs (%d).", doc_id_inDocsTable, [result intForColumn:@"doc_id"]);
+        
+        STAssertEquals(2, [result intForColumn:@"sequence"], @"sequence is not 1");
+        STAssertFalse([[result stringForColumn:@"revid"] isEqualToString:@""], @"revid string isEqual to empty string");
+        STAssertTrue([result boolForColumn:@"current"], @"document current should be YES");
+        STAssertFalse([result boolForColumn:@"deleted"], @"document deleted should be NO");
+        
+        jsonDoc = [TDJSON JSONObjectWithData: [result dataForColumn:@"json"]
+                                                   options: TDJSONReadingMutableContainers
+                                                     error: NULL];
+        STAssertTrue([jsonDoc isEqualToDictionary:@{key2: value2}], @"JSON document from revs.json not equal to original key-value pair. Found %@. Expected %@", jsonDoc, @{key2: value2});
+
+        
+        STAssertFalse([result next], @"There are too many rows in revs");
+        STAssertNil([result stringForColumn:@"doc_id"], @"after [result next], doc_id not nil");
+        STAssertNil([result stringForColumn:@"revid"], @"after [result next],  revid not nil");
+        
+        [result close];
+    }];
+
+}
+
+-(void)testUpdateWithNilDocumentBody
+{
+    [self.datastore documentCount]; //this calls ensureDatabaseOpen, which calls TD_Database open:, which
+    //creates the tables in the sqlite db. otherwise, the database would be empty.
+    
+    NSError *error;
+    CDTDocumentBody *body = [[CDTDocumentBody alloc] initWithDictionary:@{@"hello":@"world"}];
+    CDTDocumentRevision *ob = [self.datastore createDocumentWithBody:body error:&error];
+    STAssertNil(error, @"Error creating document");
+    STAssertNotNil(ob, @"CDTDocumentRevision object was nil");
+    
+    NSString *dbPath = [self pathForDBName:self.datastore.name];
+    FMDatabaseQueue *queue = [FMDatabaseQueue databaseQueueWithPath:dbPath];
+    STAssertNotNil(queue, @"FMDatabaseQueue was nil: %@", queue);
+    NSMutableDictionary *initialRowCount = [self getAllTablesRowCountWithQueue:queue];
+    
+    NSString *docId = ob.docId;
+    
+    CDTDocumentBody *body2 = [self createNilDocument];
+    CDTDocumentRevision *ob2 = [self.datastore updateDocumentWithId:docId
+                                                            prevRev:ob.revId
+                                                               body:body2
+                                                              error:&error];
+    STAssertNotNil(error, @"No Error updating document with nil CDTDocumentBody");
+    STAssertTrue(error.code == 400, @"Error was not a 400. Found %ld", error.code);
+    STAssertNil(ob2, @"CDTDocumentRevision object was not nil when updating with nil CDTDocumentBody");
+    
+    NSDictionary *modifiedCount = nil;
+    [self checkTableRowCount:initialRowCount modifiedBy:modifiedCount withQueue:queue];
+}
+
+
+-(NSInteger)getRevPrefix:(NSString *)revString
+{
+    return [[revString componentsSeparatedByString:@"-"][0] integerValue];
+}
+
+-(void)testMultipleUpdates
+{
+    [self.datastore documentCount]; //this calls ensureDatabaseOpen, which calls TD_Database open:, which
+    //creates the tables in the sqlite db. otherwise, the database would be empty.
+    
+    NSString *dbPath = [self pathForDBName:self.datastore.name];
+    
+    FMDatabaseQueue *queue = [FMDatabaseQueue databaseQueueWithPath:dbPath];
+    STAssertNotNil(queue, @"FMDatabaseQueue was nil: %@", queue);
+    
+    NSMutableDictionary *initialRowCount = [self getAllTablesRowCountWithQueue:queue];
+
+    NSError *error;
+    int numOfUpdates = 1001;
+
+    NSArray *bodies = [self generateDocuments:numOfUpdates + 1];
+    
+    CDTDocumentRevision *ob = [self.datastore createDocumentWithBody:bodies[0] error:&error];
+    STAssertNil(error, @"Error creating document");
+    STAssertNotNil(ob, @"CDTDocumentRevision object was nil");
+    
+    for(int i = 0; i < numOfUpdates; i++){
+
+        ob = [self.datastore updateDocumentWithId:ob.docId
+                                     prevRev:ob.revId
+                                        body:bodies[i+1]
+                                       error:&error];
+        STAssertNil(error, @"Error creating document. Update Number %d", i);
+        STAssertNotNil(ob, @"CDTDocumentRevision object was nil. Update Number %d", i);
+    }
+    
+    NSDictionary *modifiedCount = @{@"docs": @1, @"revs": [[NSNumber alloc] initWithInt:numOfUpdates + 1]};
+    NSLog(@"checking table counts");
+    [self checkTableRowCount:initialRowCount modifiedBy:modifiedCount withQueue:queue];
+    NSLog(@"done checking table counts");
+    
+    NSLog(@"Checking revs and docs tables");
+    [queue inDatabase:^(FMDatabase *db) {
+        FMResultSet  *result = [db executeQuery:@"select * from docs"];
+        [result next];
+        STAssertEqualObjects(ob.docId, [result stringForColumn:@"docid"], @"doc id doesn't match. should be %@. found %@", ob.docId,
+                             [result stringForColumn:@"docid"]);
+        STAssertEquals(1, [result intForColumn:@"doc_id"], @"Expected first row in docs to have doc_id == 1");
+        STAssertFalse([result next], @"There are too many rows in docs");
+        [result close];
+
+        result = [db executeQuery:@"select * from revs, docs where revs.doc_id = docs.doc_id"];
+        int counter = 0;
+        while([result next]){
+            NSDictionary *expectedDict = [[bodies[counter] td_body] properties];
+            
+            counter++;
+            
+            STAssertEquals(counter, [result intForColumn:@"sequence"],
+                           @"Revs bad sequence. Expected %d. Found %d", counter, [result intForColumn:@"sequence"]);
+            STAssertEquals(counter-1, [result intForColumn:@"parent"],
+                           @"Expected revs.parent to be %d. Found%d", counter-1, [result intForColumn:@"parent"]);
+            
+            if(counter == 1)
+                STAssertTrue([result objectForColumnName:@"parent"] == [NSNull null], @"Expected revs.parent to be NULL. Found %@ counter %d", [result objectForColumnName:@"parent"], counter);
+            
+            if(counter == numOfUpdates + 1)
+                STAssertTrue([result boolForColumn:@"current"], @"expected last entry in rows to be current version");
+        
+            STAssertFalse([result boolForColumn:@"deleted"], @"did not expect 'deleted' to be true");
+            
+            NSInteger revNumber = [self getRevPrefix:[result stringForColumn:@"revid"]];
+            STAssertEquals([[NSNumber numberWithInt:counter] integerValue], revNumber, @"expected rev integer to be %d. Found %d. counter %d. From rev %@", counter, revNumber, counter, [result stringForColumn:@"revid"] );
+            
+            NSDictionary* jsonDoc = [TDJSON JSONObjectWithData: [result dataForColumn:@"json"]
+                                                       options: TDJSONReadingMutableContainers
+                                                         error: NULL];
+            STAssertTrue([jsonDoc isEqualToDictionary:expectedDict],
+                         @"JSON document from revs.json not equal to expected. Found %@. Expected %@",
+                         jsonDoc, expectedDict);
+            
+        }
+        
+        STAssertEquals(counter, numOfUpdates + 1, @"Expected %d rows in results. Found %d", numOfUpdates + 1, counter);
+        [result close];
+    }];
+
+
+}
+
+//
+// The following testUpdateDelete was to check the behavior when a "_deleted":true
+// key-value pair was added to the JSON document. It is expected that when
+// updateDocumentWithId is called, the document would be deleted from the DB.
+// This is a method of deleting documents in Cloudant/CouchDB; it's the
+// only way to delete documents in bulk. (We don't yet have a '_bulk_docs' call in CloudantSync,
+// however, and not sure if we will...).
+//
+// In the code below, when "_deleted":true is added to the document and updateDocumentWithId
+// is called, this key-value pair is simply thrown away and the document is inserted into
+// the database as the next revision.
+//
+// This behavior should be different. Either we support _delete:true, or we return
+// nil and report an NSError.
+//
+//-(void)testUpdateDelete
+//{
+//    [self.datastore documentCount]; //this calls ensureDatabaseOpen, which calls TD_Database open:, which
+//    //creates the tables in the sqlite db. otherwise, the database would be empty.
+//    
+//    NSString *dbPath = [self pathForDBName:self.datastore.name];
+//    
+//    FMDatabaseQueue *queue = [FMDatabaseQueue databaseQueueWithPath:dbPath];
+//    STAssertNotNil(queue, @"FMDatabaseQueue was nil: %@", queue);
+//    
+//    NSMutableDictionary *initialRowCount = [self getAllTablesRowCountWithQueue:queue];
+//    
+//    NSError *error;
+//    NSString *key1 = @"hello";
+//    NSString *value1 = @"world";
+//    
+//    CDTDocumentBody *body = [[CDTDocumentBody alloc] initWithDictionary:@{key1:value1}];
+//    CDTDocumentRevision *ob = [self.datastore createDocumentWithBody:body error:&error];
+//    STAssertNil(error, @"Error creating document");
+//    STAssertNotNil(ob, @"CDTDocumentRevision object was nil");
+//    
+//    
+//    NSString *docId = ob.docId;
+//    NSString *delkey = @"_deleted";
+//    NSNumber *delvalue= [NSNumber numberWithBool:YES];
+//    NSString *key2 = @"hi";
+//    NSString *value2 = @"adam";
+//    //id value2 = $true;
+//    NSDictionary *body2dict =@{key1:value1, key2:value2, delkey:delvalue};
+//    
+//    CDTDocumentBody *body2 = [[CDTDocumentBody alloc] initWithDictionary:body2dict];
+//    STAssertNotNil(body2, @"CDTDocumentBody with _deleted:true was nil. Dict: %@", body2dict);
+//    CDTDocumentRevision *ob2 = [self.datastore updateDocumentWithId:docId
+//                                                            prevRev:ob.revId
+//                                                               body:body2
+//                                                              error:&error];
+//
+//    STAssertNil(error, @"Error deleting document with update");
+//    STAssertNotNil(ob2, @"CDTDocumentRevision object was nil");
+//    
+//    // Check new revision
+//    const NSUInteger expected_count = 1;
+//    CDTDocumentRevision *retrieved;
+//    retrieved = [self.datastore getDocumentWithId:docId error:&error];
+//    STAssertNotNil(error, @"No Error getting deleted document");
+//    STAssertNil(retrieved, @"retrieved object was not nil");
+//    
+//    error = nil;
+//    
+//    // Check we can get old revision
+//    retrieved = [self.datastore getDocumentWithId:docId rev:ob.revId error:&error];
+//    STAssertNil(error, @"Error getting document using old rev");
+//    STAssertNotNil(retrieved, @"retrieved object was nil");
+//    STAssertEqualObjects(ob.docId, retrieved.docId, @"Object retrieved from database has wrong docid");
+//    STAssertEqualObjects(ob.revId, retrieved.revId, @"Object retrieved from database has wrong revid");
+//    STAssertEquals(retrieved.documentAsDictionary.count, expected_count, @"Object from database has != 1 key");
+//    STAssertEqualObjects(retrieved.documentAsDictionary[key1], value1, @"Object from database has wrong data");
+//    
+//    
+//    //now test the content of docs/revs tables explicitely.
+//    
+//    NSDictionary *modifiedCount = @{@"docs": @1, @"revs": @2};
+//    [self checkTableRowCount:initialRowCount modifiedBy:modifiedCount withQueue:queue];
+//    
+//    [self printAllRows:queue forTable:@"docs"];
+//    [self printAllRows:queue forTable:@"revs"];
+//    
+////    NSString *sql = @"select * from docs";
+////    __block int doc_id_inDocsTable;
+////    [queue inDatabase:^(FMDatabase *db) {
+////        FMResultSet *result = [db executeQuery:sql];
+////        [result next];
+////        NSLog(@"testing content of docs table");
+////        
+////        STAssertEqualObjects(docId, [result stringForColumn:@"docid"], @"doc id doesn't match. should be %@. found %@", docId,
+////                             [result stringForColumn:@"docid"]);
+////        
+////        doc_id_inDocsTable = [result intForColumn:@"doc_id"];
+////        
+////        STAssertFalse([result next], @"There are too many rows in docs");
+////        
+////        [result close];
+////    }];
+////    
+////    
+////    sql = @"select * from revs";
+////    [queue inDatabase:^(FMDatabase *db) {
+////        FMResultSet *result = [db executeQuery:sql];
+////        [result next];
+////        
+////        NSLog(@"testing content of revs table");
+////        STAssertEquals(doc_id_inDocsTable, [result intForColumn:@"doc_id"],
+////                       @"doc_id in revs (%d) doesn't match doc_id in docs (%d).", doc_id_inDocsTable, [result intForColumn:@"doc_id"]);
+////        
+////        STAssertEquals(1, [result intForColumn:@"sequence"], @"sequence is not 1");
+////        STAssertFalse([[result stringForColumn:@"revid"] isEqualToString:@""], @"revid string isEqual to empty string");
+////        STAssertFalse([result boolForColumn:@"current"], @"document current should be NO");
+////        STAssertTrue([result boolForColumn:@"deleted"], @"document deleted should be NO");
+////        
+////        NSDictionary* jsonDoc = [TDJSON JSONObjectWithData: [result dataForColumn:@"json"]
+////                                                   options: TDJSONReadingMutableContainers
+////                                                     error: NULL];
+////        STAssertTrue([jsonDoc isEqualToDictionary:@{key1: value1}], @"JSON document from revs.json not equal to original key-value pair. Found %@. Expected %@", jsonDoc, @{key1: value1});
+////        
+////        //next row
+////        STAssertTrue([result next], @"Didn't find the second row in the revs table");
+////        
+////        STAssertEquals(doc_id_inDocsTable, [result intForColumn:@"doc_id"],
+////                       @"doc_id in revs (%d) doesn't match doc_id in docs (%d).", doc_id_inDocsTable, [result intForColumn:@"doc_id"]);
+////        
+////        STAssertEquals(2, [result intForColumn:@"sequence"], @"sequence is not 1");
+////        STAssertFalse([[result stringForColumn:@"revid"] isEqualToString:@""], @"revid string isEqual to empty string");
+////        STAssertTrue([result boolForColumn:@"current"], @"document current should be YES");
+////        STAssertFalse([result boolForColumn:@"deleted"], @"document deleted should be NO");
+////        
+////        jsonDoc = [TDJSON JSONObjectWithData: [result dataForColumn:@"json"]
+////                                     options: TDJSONReadingMutableContainers
+////                                       error: NULL];
+////        STAssertTrue([jsonDoc isEqualToDictionary:@{key2: value2}], @"JSON document from revs.json not equal to original key-value pair. Found %@. Expected %@", jsonDoc, @{key2: value2});
+////        
+////        
+////        STAssertFalse([result next], @"There are too many rows in revs");
+////        STAssertNil([result stringForColumn:@"doc_id"], @"after [result next], doc_id not nil");
+////        STAssertNil([result stringForColumn:@"revid"], @"after [result next],  revid not nil");
+////        
+////        [result close];
+////    }];
+//    
+//
+//    
+//}
+
+
+#pragma mark - DELETE tests
+
+-(void)testDeleteDocument
+{
+    [self.datastore documentCount]; //this calls ensureDatabaseOpen, which calls TD_Database open:, which
+    //creates the tables in the sqlite db. otherwise, the database would be empty.
+    
+    NSString *dbPath = [self pathForDBName:self.datastore.name];
+    
+    FMDatabaseQueue *queue = [FMDatabaseQueue databaseQueueWithPath:dbPath];
+    STAssertNotNil(queue, @"FMDatabaseQueue was nil: %@", queue);
+    
+    NSMutableDictionary *initialRowCount = [self getAllTablesRowCountWithQueue:queue];
+
+    
+    NSError *error;
+    CDTDocumentBody *body = [[CDTDocumentBody alloc] initWithDictionary:@{@"hello": @"world"}];
+    CDTDocumentRevision *ob = [self.datastore createDocumentWithBody:body error:&error];
+    STAssertNil(error, @"Error creating document");
+    STAssertNotNil(ob, @"CDTDocumentRevision object was nil");
+    
+    NSString *docId = ob.docId;
+    Boolean deleted = [self.datastore deleteDocumentWithId:docId
+                                                       rev:ob.revId
+                                                     error:&error];
+    STAssertNil(error, @"Error deleting document");
+    STAssertTrue(deleted, @"Object wasn't deleted successfully");
+    
+    // Check new revision isn't found
+    CDTDocumentRevision *retrieved;
+    retrieved = [self.datastore getDocumentWithId:docId error:&error];
+    STAssertNotNil(error, @"No Error getting deleted document");
+    STAssertTrue(error.code == 404, @"Error was not a 404. Found %ld", error.code);
+    STAssertNil(retrieved, @"retrieved object was not nil");
+    
+    error = nil;
+    
+    // Check we can get old revision
+    const NSUInteger expected_count = 1;
+    retrieved = [self.datastore getDocumentWithId:docId rev:ob.revId error:&error];
+    STAssertNil(error, @"Error getting document");
+    STAssertNotNil(retrieved, @"retrieved object was nil");
+    STAssertEqualObjects(ob.docId, retrieved.docId, @"Object retrieved from database has wrong docid");
+    STAssertEqualObjects(ob.revId, retrieved.revId, @"Object retrieved from database has wrong revid");
+    STAssertEquals(retrieved.documentAsDictionary.count, expected_count, @"Object from database has != 1 key");
+    STAssertEqualObjects(retrieved.documentAsDictionary[@"hello"], @"world", @"Object from database has wrong data");
+    
+    
+    NSDictionary *modifiedCount = @{@"docs": @1, @"revs": @2};
+    NSLog(@"checking table counts");
+    [self checkTableRowCount:initialRowCount modifiedBy:modifiedCount withQueue:queue];
+    NSLog(@"done checking table count");
+    
+    //explicit check of docs/revs tables
+    NSString *sql = @"select * from docs";
+    __block int doc_id_inDocsTable;
+    [queue inDatabase:^(FMDatabase *db) {
+        FMResultSet *result = [db executeQuery:sql];
+        [result next];
+        NSLog(@"testing content of docs table");
+        
+        STAssertEqualObjects(docId, [result stringForColumn:@"docid"], @"doc id doesn't match. should be %@. found %@", docId,
+                             [result stringForColumn:@"docid"]);
+        
+        doc_id_inDocsTable = [result intForColumn:@"doc_id"];
+        
+        STAssertFalse([result next], @"There are too many rows in docs");
+        
+        [result close];
+    }];
+    
+    
+    sql = @"select * from revs";
+    [queue inDatabase:^(FMDatabase *db) {
+        FMResultSet *result = [db executeQuery:sql];
+        [result next];
+        
+        NSLog(@"testing content of revs table");
+        STAssertEquals(doc_id_inDocsTable, [result intForColumn:@"doc_id"],
+                       @"doc_id in revs (%d) doesn't match doc_id in docs (%d).", doc_id_inDocsTable, [result intForColumn:@"doc_id"]);
+        
+        STAssertEquals(1, [result intForColumn:@"sequence"], @"sequence is not 1");
+        NSInteger revNumber = [self getRevPrefix:[result stringForColumn:@"revid"]];
+        STAssertEquals([[NSNumber numberWithInt:1] integerValue], revNumber,
+                       @"expected rev integer to be %d. Found %d. From rev %@", 1, revNumber, [result stringForColumn:@"revid"] );
+        
+        STAssertFalse([result boolForColumn:@"current"], @"document current should be false");
+        STAssertFalse([result boolForColumn:@"deleted"], @"document deleted should be false");
+        STAssertEqualObjects([result objectForColumnName:@"parent"], [NSNull null],
+                     @"Expected revs.parent to be NULL. Found %@", [result objectForColumnName:@"parent"]);
+        
+        NSDictionary* jsonDoc = [TDJSON JSONObjectWithData: [result dataForColumn:@"json"]
+                                                   options: TDJSONReadingMutableContainers
+                                                     error: NULL];
+        STAssertTrue([jsonDoc isEqualToDictionary:@{@"hello": @"world"}],
+                     @"JSON document from revs.json not equal to original key-value pair. Found %@. Expected %@", jsonDoc, @{@"hello":@"world"});
+        
+        //next row
+        STAssertTrue([result next], @"Didn't find the second row in the revs table");
+        
+        STAssertEquals(doc_id_inDocsTable, [result intForColumn:@"doc_id"],
+                       @"doc_id in revs (%d) doesn't match doc_id in docs (%d).", doc_id_inDocsTable, [result intForColumn:@"doc_id"]);
+        
+        revNumber = [self getRevPrefix:[result stringForColumn:@"revid"]];
+        STAssertEquals([[NSNumber numberWithInt:2] integerValue], revNumber,
+                       @"expected rev integer to be %d. Found %d. From rev %@", 2, revNumber, [result stringForColumn:@"revid"] );
+
+        STAssertTrue([result boolForColumn:@"current"], @"document current should be false");
+        STAssertTrue([result boolForColumn:@"deleted"], @"document deleted should be true");
+        STAssertTrue([result intForColumn:@"parent"] == 1, @"Expected revs.parent to be 1. Found %@", [result intForColumn:@"parent"]);
+        
+        //TD_Database+Insertion inserts an empty NSData object instead of NSNull
+        STAssertEqualObjects([result objectForColumnName:@"json"], [NSData data],
+                     @"Expected revs.json to be empty NSData. Found %@", [result objectForColumnName:@"json"]);
+        
+        jsonDoc = [TDJSON JSONObjectWithData: [result dataForColumn:@"json"]
+                                     options: TDJSONReadingMutableContainers
+                                       error: NULL];
+        STAssertNil(jsonDoc, @"Expected revs.json to be nil: %@",jsonDoc);
+        
+        
+        STAssertFalse([result next], @"There are too many rows in revs");
+        STAssertNil([result stringForColumn:@"doc_id"], @"after [result next], doc_id is %@", [result stringForColumn:@"doc_id"]);
+        STAssertNil([result stringForColumn:@"revid"], @"after [result next],  revid is %@", [result stringForColumn:@"revid"]);
+        
+        [result close];
+    }];
+
+}
+
 
 @end


### PR DESCRIPTION
- Add test to ensures underlying SQL database looks as expected
  after inserting a single 'hello world' document.
- Add protection against non-serializable dictionaries.
  Ensure that non-serializable dictionaries cannot successfully
  be used to create CDTDocumentBody objects.
- Change was made in TD_Database+Insertion to check
  for nil pointer to TD_Revision.body before insertion begins.
- The method isValidJSONObject was added to TDJSON to support JSONKit.
- Add test for creating second document with same _id.
- Add tests for updates with bad/old revision values and examines the
  underlying SQLite database for lots of updates (>1000) to a single
  document.
- Modified testDeleteDocument to examine the SQLite tables
- Add CloudantSyncTest setOfSqlTables: method
- Add testUpdateWithNilDocument
- Adds testUpdateDelete, but this is entirely commented out at the moment
  because the test does not pass.
- Organizing code and adding pragma mark statements
