### PR TITLE
TD_DatabaseManager initWithDirectory no longer sets NSError* to nil.

### DIFF
--- a/Classes/common/touchdb/TD_DatabaseManager.m
+++ b/Classes/common/touchdb/TD_DatabaseManager.m
@@ -69,7 +69,7 @@ static NSCharacterSet* kIllegalNameChars;
                  options: (const TD_DatabaseManagerOptions*)options
                    error: (NSError**)outError
 {
-    if (outError) *outError = nil;
+
     self = [super init];
     if (self) {
         _dir = [dirPath copy];


### PR DESCRIPTION
The conventions is for methods never to set NSError\* to nil.
