### PR TITLE
29187 update indexes on create/update/delete of documents

### DIFF
--- a/Classes/common/Indexing/CDTIndexManager.m
+++ b/Classes/common/Indexing/CDTIndexManager.m
@@ -60,6 +60,8 @@ static const int VERSION = 1;
 
 -(BOOL)updateSchema:(int)currentVersion;
 
+-(void)dbChanged:(NSNotification*)n;
+
 @end
 
 
@@ -107,6 +109,10 @@ static const int VERSION = 1;
             }
             return nil;
         }
+        [[NSNotificationCenter defaultCenter] addObserver: self
+                                                 selector: @selector(dbChanged:)
+                                                     name: CDTDatastoreChangeNotification
+                                                   object: datastore];
     }
     return self;
 }
@@ -739,6 +745,12 @@ static const int VERSION = 1;
     return YES;
 }
 
+-(void)dbChanged:(NSNotification*)n
+{
+    // we received a CDTDatastoreChangeNotification, so a document has been created, updated,
+    // or deleted. So we should update all the indexes.
+    [self updateAllIndexes:nil];
+}
 
 @end
 


### PR DESCRIPTION
Currently one needs to run updateAllIndexes before querying the datastore. This PR fixes that by making each update to the datastore run updateAllIndexes in the background.
