### PR TITLE
Adds support for filtered pull replication.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,15 +10,14 @@
 *.perspectivev3
 !default.perspectivev3
 xcuserdata
+*.xccheckout
 profile
 *.moved-aside
 DerivedData
 .idea/
 *.hmap
-CDTDatastore.xcworkspace/xcshareddata/CDTDatastore.xccheckout
+build
 
 #CocoaPods
 Pods
-build
-contents.xcworkspacedata
 Podfile.lock

--- a/CDTDatastore.xcworkspace/contents.xcworkspacedata
+++ b/CDTDatastore.xcworkspace/contents.xcworkspacedata
@@ -58,6 +58,24 @@
             location = "group:CDTReplicator"
             name = "CDTReplicator">
             <FileRef
+               location = "group:CDTAbstractReplication.h">
+            </FileRef>
+            <FileRef
+               location = "group:CDTAbstractReplication.m">
+            </FileRef>
+            <FileRef
+               location = "group:CDTPullReplication.h">
+            </FileRef>
+            <FileRef
+               location = "group:CDTPullReplication.m">
+            </FileRef>
+            <FileRef
+               location = "group:CDTPushReplication.h">
+            </FileRef>
+            <FileRef
+               location = "group:CDTPushReplication.m">
+            </FileRef>
+            <FileRef
                location = "group:CDTReplicationErrorInfo.h">
             </FileRef>
             <FileRef

--- a/Classes/common/CDTReplicator/CDTAbstractReplication.h
+++ b/Classes/common/CDTReplicator/CDTAbstractReplication.h
@@ -1,0 +1,110 @@
+//
+//  CDTAbstractReplication.h
+//  
+//
+//  Created by Adam Cox on 4/8/14.
+//  Copyright (c) 2014 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+@class CDTDatastore;
+
+extern NSString* const CDTReplicationErrorDomain;
+
+/**
+ * Replication errors.
+ */
+typedef NS_ENUM(NSInteger, CDTReplicationErrors) {
+    /**
+     No source is defined.
+     */
+    CDTReplicationErrorUndefinedSource,
+    /**
+     No target is defined
+     */
+    CDTReplicationErrorUndefinedTarget,
+    /**
+     Unsupported protocol. Only 'http' or 'https'.
+     */
+    CDTReplicationErrorInvalidScheme,
+    /**
+     Missing either a username or password.
+     */
+    CDTReplicationErrorIncompleteCredentials
+};
+
+
+/**
+ This is an abstract base class for the CDTPushReplication and CDTPullReplication subclasses.
+ Do not create instances of this class.
+ 
+ CDTAbstractReplication objects encapsulate the parameters necessary
+ for the CDTReplicationFactory to create a CDTReplicator object, which
+ is used to start individual replication tasks.
+ 
+ All replications require a remote datasource URL and a local CDTDatastore.
+ These are specified with the -target and -source properties found in the subclasses.
+ 
+ */
+@interface CDTAbstractReplication : NSObject
+
+
+/*
+ ---------------------------------------------------------------------------------------
+ The following methods/properties may be accessed instances of the CDTPushReplication
+ and CDTPullReplication classes.
+ 
+ These methods and properties are common to both push and pull replications and are used
+ to set various replication options.
+ 
+ http://docs.couchdb.org/en/latest/json-structure.html#replication-settings
+ 
+ ---------------------------------------------------------------------------------------
+ */
+
+
+/*
+ ---------------------------------------------------------------------------------------
+ The following methods should not be accessed by a user of this class or the subclasses. 
+ The only exception may be the dictionaryForReplicatorDocument method, in special circumstances.
+ */
+
+/** --------------------------------------------------------------------------------------
+ @name For internal use only
+ ---------------------------------------------------------------------------------------
+ */
+
+/** The NSDictionary is used by CDTReplicatorFactory to generate the proper document for the 
+ _replicator database.
+ 
+ @param error reports error information
+ @return The NSDictionary that represents the JSON document to be written to the _replicator
+ database.
+ @warning This method is for internal use only. The CDTPushReplication and CDTPullReplication
+     classes implement this method.
+
+ */
+-(NSDictionary*) dictionaryForReplicatorDocument:(NSError * __autoreleasing*)error;
+
+
+
+/** Checks the content and format of the remoteDatastore URL to ensure that it uses a proper protocol (http or https) and has both a username and password (or neither).
+ 
+ @warning This method is for internal use only. 
+ @param url the URL to be validated
+ @param error reports error information
+ @return YES on valid URL.
+ 
+ */
+-(BOOL)validateRemoteDatastoreURL:(NSURL *)url error:(NSError * __autoreleasing*)error;
+
+
+@end

--- a/Classes/common/CDTReplicator/CDTAbstractReplication.m
+++ b/Classes/common/CDTReplicator/CDTAbstractReplication.m
@@ -1,0 +1,83 @@
+//
+//  CDTAbstractReplication.m
+//
+//  Created by Adam Cox on 4/8/14.
+//  Copyright (c) 2014 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+#import "CDTAbstractReplication.h"
+#import "TD_DatabaseManager.h"
+
+NSString* const CDTReplicationErrorDomain = @"CDTReplicationErrorDomain";
+
+@implementation CDTAbstractReplication
+
+/**
+ This method sets all of the common replication parameters. The subclasses,
+ CDTPushReplication and CDTPullReplication add source, target and filter. 
+ */
+-(NSDictionary*) dictionaryForReplicatorDocument:(NSError * __autoreleasing*)error
+{
+    return nil;
+}
+
+
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"Replicator Doc: %@",
+            [self dictionaryForReplicatorDocument:nil]];
+}
+
+-(BOOL)validateRemoteDatastoreURL:(NSURL *)url error:(NSError * __autoreleasing*)error
+{
+    NSString *scheme = [url.scheme lowercaseString];
+    NSArray *validSchemes = @[@"http", @"https"];
+    if (![validSchemes containsObject:scheme]) {
+        if (error) {
+            Warn(@"%@ -validateRemoteDatastoreURL Error. "
+                  @"Invalid scheme: %@", [self class], url.scheme);
+            
+            NSString *msg = @"Cannot sync data. Invalid Remote Database URL";
+            
+            NSDictionary *userInfo = @{NSLocalizedDescriptionKey: NSLocalizedString(msg, nil)};
+            *error = [NSError errorWithDomain:CDTReplicationErrorDomain
+                                         code:CDTReplicationErrorInvalidScheme
+                                     userInfo:userInfo];
+        }
+        return NO;
+
+    }
+    
+    // username and password must be supplied together
+    BOOL usernameSupplied = url.user != nil && ![url.user isEqualToString:@""];
+    BOOL passwordSupplied = url.password != nil && ![url.password isEqualToString:@""];
+    
+    if ( (!usernameSupplied && passwordSupplied) ||
+         (usernameSupplied && !passwordSupplied)) {
+        if (error) {
+            Warn(@"%@ -validateRemoteDatastoreURL Error. "
+                  @"Must have both username and password, or neither. ", [self class]);
+            
+            NSString *msg = [NSString stringWithFormat:@"Cannot sync data. Missing %@",
+                             usernameSupplied ? @"password" : @"username"];
+            
+            NSDictionary *userInfo = @{NSLocalizedDescriptionKey: NSLocalizedString(msg, nil)};
+            *error = [NSError errorWithDomain:CDTReplicationErrorDomain
+                                         code:CDTReplicationErrorIncompleteCredentials
+                                     userInfo:userInfo];
+        }
+        return NO;
+    }
+    
+    
+    return YES;
+}
+
+@end

--- a/Classes/common/CDTReplicator/CDTPullReplication.h
+++ b/Classes/common/CDTReplicator/CDTPullReplication.h
@@ -1,0 +1,150 @@
+//
+//  CDTPullReplication.h
+//  
+//
+//  Created by Adam Cox on 4/8/14.
+//  Copyright (c) 2014 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+#import "CDTAbstractReplication.h"
+
+/**
+ 
+ CDTPullReplication objects are used to configure a replication of a
+ remote Cloudant/CouchDB datastore to a local CDTDatastore. At minimum, source
+ and target must be specified.
+ 
+ Example usage:
+
+    CDTDatastoreManager *manager = [...];
+    CDTDatastore *datastore = [...];
+    CDTReplicatorFactory *replicatorFactory = [...];
+ 
+    NSURL *remote = [NSURL URLwithString:@"https://user:password@account.cloudant.com/myremotedb"];
+ 
+    CDTPullReplication* pull = [CDTPullReplication replicationWithSource:remote
+                                                                  target:datastore];
+ 
+    NSError *error;
+    CDTReplicator *rep = [replicatorFactory oneWay:pull error:&error];
+ 
+    //check for error
+    [rep start];
+ 
+ */
+
+@interface CDTPullReplication : CDTAbstractReplication
+
+/**
+ @name Creating a replication configuration
+ */
+
+/** All CDTPullReplication objects must have a source and target.
+ 
+ @param source the remote server URL from which the data is replicated.
+ @param target the local datastore to which the data is replicated.
+ @return a CDTPullReplication object.
+ 
+ */
++(instancetype) replicationWithSource:(NSURL *)source
+                               target:(CDTDatastore *)target;
+
+
+/**
+ @name Accessing the replication source and target
+ */
+
+/** The CDTDatastore to which the data is replicated.
+ */
+@property (nonatomic, strong, readonly) CDTDatastore* target;
+
+/** The NSURL for the remote datastore:
+ 
+     protocol://[user:password@]host[:port]/remoteDatabaseName
+ 
+ Only _http_ and _https_ are valid protocols.
+ 
+ Consider using NSURLComponents if you need to set each component individually.
+ 
+ @see CDTAbstractReplication.
+ */
+@property (nonatomic, strong, readonly) NSURL *source;
+
+/**
+ @name Using filtered replication
+ */
+
+/** The name of the filter to be used on the remote source.
+ 
+ If this property is nil, the default, then no filter is used in the replication.
+ 
+ See the Cloudant/CouchDB documentation on replication and filter functions.
+ 
+ * [http://docs.cloudant.com/guides/replication/replication.html#filtered-replication](http://docs.cloudant.com/guides/replication/replication.html#filtered-replication)
+ * [http://docs.couchdb.org/en/latest/couchapp/ddocs.html#filter-functions](http://docs.couchdb.org/en/latest/couchapp/ddocs.html#filter-functions)
+ * [http://docs.couchdb.org/en/latest/json-structure.html#replication-settings](http://docs.couchdb.org/en/latest/json-structure.html#replication-settings)
+ 
+ Filter functions in Cloudant/CouchDB are passed two arguments: a document revision and a 
+ request header.
+ 
+    function(doc, request){ ... }
+ 
+ Additional parameters to the filter function may be passed in via the `request.query` object.
+ In CloudantSync, these parameters are specified with the [CDTPullReplication filterParams] 
+ property.
+ 
+ Consider a design document on the remote server called "_design/users" with a filter function
+ called "by_age_range":
+ 
+    function(doc, req){
+        var age = doc['user']['age'];
+        
+        if (age >= req.query.min && age <= req.query.max)
+            return true;
+        else 
+            return false;
+    }
+ 
+ 
+ To replicate from the remote database to the local 
+ datastore using this filter, specify:
+ 
+    pull.filter = @"users/by_age_range";
+    pull.filterParams = @{@"min":@23, @"max":@43};
+ 
+ before calling:
+    
+    CDTReplicator *rep = [replicatorFactory oneWay:pull error:&error];
+ 
+ The filter function acts on the document revisions found in the _changes feed, 
+ filtering the entries that appear.
+ 
+ See the following for more information:
+ 
+ * http://docs.couchdb.org/en/latest/replication/protocol.html
+ * http://docs.couchdb.org/en/latest/api/database/changes.html
+ 
+
+ */
+@property (nonatomic, strong) NSString *filter;
+
+/** Specify filter function parameters using an NSDictionary
+ 
+ For example, one may specify filter parameters like:
+ 
+     CDTPullReplication* pull = [[CDTPullReplication alloc] init];
+     pull.filterParams = @{@"min":@23, @"max":@43};
+ 
+ @see -filter
+ */
+@property (nonatomic, strong) NSDictionary *filterParams;
+
+
+@end

--- a/Classes/common/CDTReplicator/CDTPullReplication.m
+++ b/Classes/common/CDTReplicator/CDTPullReplication.m
@@ -1,0 +1,95 @@
+//
+//  CDTPullReplication.m
+//  
+//
+//  Created by Adam Cox on 4/8/14.
+//  Copyright (c) 2014 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+#import "CDTPullReplication.h"
+#import "CDTDatastore.h"
+
+
+@implementation CDTPullReplication
+
++(instancetype) replicationWithSource:(NSURL *)source
+                               target:(CDTDatastore *)target
+{
+    return [[self alloc] initWithSource:source target:target];
+}
+
+-(instancetype) initWithSource:(NSURL *)source
+                        target:(CDTDatastore *)target
+{
+    if(self = [super init]) {
+        _source = source;
+        _target = target;
+    }
+    return self;
+}
+
+-(NSDictionary*) dictionaryForReplicatorDocument:(NSError * __autoreleasing*)error
+{
+    NSError *localError;
+    if (![self validateRemoteDatastoreURL:self.source error:&localError]) {
+        if (error) {
+            *error = localError;
+            return nil;
+        }
+    }
+    
+    NSMutableDictionary *doc = [[NSMutableDictionary alloc] init];
+
+    [doc setObject:self.source.absoluteString forKey:@"source"];
+    
+    if (self.target) {
+        [doc setObject:self.target.name forKey:@"target"];
+    } else {
+        if (error) {
+            Warn(@"CDTPullReplication -dictionaryForReplicatorDocument Error: target is nil.");
+            NSString *msg = @"Cannot sync data. Remote server not specified.";
+            NSDictionary *userInfo = @{NSLocalizedDescriptionKey: NSLocalizedString(msg, nil)};
+            *error = [NSError errorWithDomain:CDTReplicationErrorDomain
+                                         code:CDTReplicationErrorUndefinedTarget
+                                     userInfo:userInfo];
+        }
+        return nil;
+    }
+   
+    if (self.filter) {
+        [doc setObject:self.filter forKey:@"filter"];
+        if (self.filterParams) {
+            [doc setObject:self.filterParams forKey:@"query_params"];
+        }
+    }
+    
+    return doc;
+}
+
+//This is method is overridden and this code placed here so we can provide a better error message
+-(BOOL)validateRemoteDatastoreURL:(NSURL *)url error:(NSError * __autoreleasing*)error
+{
+    if (url == nil) {
+        if (error) {
+            Warn(@"CDTPullReplication -dictionaryForReplicatorDocument Error: source is nil.");
+            NSString *msg = @"Cannot sync data. Local data source not specified.";
+            NSDictionary *userInfo = @{NSLocalizedDescriptionKey: NSLocalizedString(msg, nil)};
+            *error = [NSError errorWithDomain:CDTReplicationErrorDomain
+                                         code:CDTReplicationErrorUndefinedSource
+                                     userInfo:userInfo];
+        }
+        return NO;
+    }
+    
+    return [super validateRemoteDatastoreURL:url error:error];
+}
+
+        
+@end

--- a/Classes/common/CDTReplicator/CDTPushReplication.h
+++ b/Classes/common/CDTReplicator/CDTPushReplication.h
@@ -1,0 +1,83 @@
+//
+//  CDTPushReplication.h
+//  
+//
+//  Created by Adam Cox on 4/8/14.
+//  Copyright (c) 2014 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+#import "CDTAbstractReplication.h"
+
+/**
+ CDTPushReplication objects are used to configure a replication of a local
+ CDTDatastore to a remote Cloudant/CouchDB datastore. At minimum, source and
+ target must be specified.
+
+ Filtered push replication is not yet implemented.
+ 
+ Example usage:
+
+    CDTDatastoreManager *manager = [...];
+    CDTDatastore *datastore = [...];
+    CDTReplicatorFactory *replicatorFactory = [...];
+    
+    NSURL *remote = [NSURL URLwithString:@"https://user:password@account.cloudant.com/myremotedb"];
+    
+    CDTPushReplication* push = [CDTPushReplication replicationWithSource:datastore
+                                                                  target:remote];
+ 
+    NSError *error;
+    CDTReplicator *myrep = [replicatorFactory oneWay:push error:&error];
+ 
+    //check for error
+ 
+    [myrep start];
+
+ @see CDTAbstractReplication
+*/
+
+@interface CDTPushReplication : CDTAbstractReplication
+
+/**
+ @name Creating a replication configuration
+ */
+
+/** All CDTPushReplication objects must have a source and target.
+ 
+ @param source the local datastore from which the data is replicated.
+ @param target the remote server URL to which the data is replicated.
+ @return a CDTPushReplication object.
+ 
+ */
++(instancetype) replicationWithSource:(CDTDatastore *)source
+                               target:(NSURL *)target;
+
+/**
+ @name Accessing the replication source and target
+ */
+
+/** The NSURL for the target remote datastore
+ 
+     protocol://[user:password@]host[:port]/remoteDatabaseName
+ 
+ Only _http_ and _https_ are valid protocols.
+ 
+ Consider using NSURLComponents if you need to set each component individually.
+ 
+ @see CDTAbstractReplication.
+ */
+@property (nonatomic, strong, readonly) NSURL* target;
+
+/**
+ The CDTDatastore from which the data is replicated.
+ */
+@property (nonatomic, strong, readonly) CDTDatastore *source;
+
+@end

--- a/Classes/common/CDTReplicator/CDTPushReplication.m
+++ b/Classes/common/CDTReplicator/CDTPushReplication.m
@@ -1,0 +1,88 @@
+//
+//  CDTPushReplication.m
+//  
+//
+//  Created by Adam Cox on 4/8/14.
+//  Copyright (c) 2014 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+#import "CDTPushReplication.h"
+#import "CDTDatastore.h"
+
+
+@implementation CDTPushReplication
+
++(instancetype) replicationWithSource:(CDTDatastore *)source
+                               target:(NSURL *)target
+{
+    return [[self alloc] initWithSource:source target:target];
+}
+
+-(instancetype) initWithSource:(CDTDatastore *)source
+                        target:(NSURL *)target
+{
+    if(self = [super init]) {
+        _source = source;
+        _target = target;
+    }
+    return self;
+}
+
+-(NSDictionary*) dictionaryForReplicatorDocument:(NSError * __autoreleasing*)error
+{
+    NSError *localError;
+    if (![self validateRemoteDatastoreURL:self.target error:&localError]) {
+        if (error) {
+            *error = localError;
+            return nil;
+        }
+    }
+    
+    NSMutableDictionary *doc = [[NSMutableDictionary alloc] init];
+    
+    [doc setObject:self.target.absoluteString forKey:@"target"];
+    
+    if (self.source) {
+        [doc setObject:self.source.name forKey:@"source"];
+    } else {
+        if (error) {
+            Warn(@"CDTPullReplication -dictionaryForReplicatorDocument Error: source is nil.");
+            NSString *msg = @"Cannot sync data. Local data source not specified.";
+            NSDictionary *userInfo = @{NSLocalizedDescriptionKey: NSLocalizedString(msg, nil)};
+            *error = [NSError errorWithDomain:CDTReplicationErrorDomain
+                                         code:CDTReplicationErrorUndefinedSource
+                                     userInfo:userInfo];
+        }
+        return nil;
+    }
+
+    return doc;
+}
+
+//This is method is overridden and this code placed here so we can provide a better error message
+-(BOOL)validateRemoteDatastoreURL:(NSURL *)url error:(NSError * __autoreleasing*)error
+{
+    if (url == nil) {
+        if (error) {
+            Warn(@"CDTPullReplication -dictionaryForReplicatorDocument Error: target is nil.");
+            NSString *msg = @"Cannot sync data. Remote server not specified.";
+            NSDictionary *userInfo = @{NSLocalizedDescriptionKey: NSLocalizedString(msg, nil)};
+            *error = [NSError errorWithDomain:CDTReplicationErrorDomain
+                                         code:CDTReplicationErrorUndefinedTarget
+                                     userInfo:userInfo];
+        }
+        return NO;
+    }
+    
+    return [super validateRemoteDatastoreURL:url error:error];
+}
+
+
+@end

--- a/Classes/common/CDTReplicator/CDTReplicatorFactory.h
+++ b/Classes/common/CDTReplicator/CDTReplicatorFactory.h
@@ -18,6 +18,21 @@
 @class CDTDatastore;
 @class CDTReplicator;
 @class CDTDatastoreManager;
+@class CDTAbstractReplication;
+
+/**
+* Replication errors.
+*/
+typedef NS_ENUM(NSInteger, CDTReplicatorFactoryErrors) {
+    /**
+     * CDTReplicator was not fully constucted
+     */
+    CDTReplicatorFactoryErrorNilReplicatorObject = 1,
+    /**
+       Error creating a new CDTDocumentBody
+     */
+    CDTReplicatorFactoryErrorNilDocumentBodyForReplication  = 2
+};
 
 /**
  Factory for CDTReplicator objects.
@@ -68,6 +83,27 @@
  *  --------------------------------------------------------------------------------------
  */
 
+/**
+ * Create a CDTReplicator object set up to replicate changes from the
+ * local datastore to a remote database.
+ *
+ * CDTPullReplication and CDTPushReplication (subclasses of CDTAbstractReplication)
+ * provide configuration parameters for the construction of the CDTReplicator.
+ *
+ * @param replication a CDTPullReplication or CDTPushReplication
+ * @param error report error information
+ *
+ * @return a CDTReplicator instance which can be used to start and
+ *  stop the replication itself.
+ */
+- (CDTReplicator*)oneWay:(CDTAbstractReplication*)replication
+                   error:(NSError * __autoreleasing *)error;
+
+
+/**
+ The following methods will soon be deprecated. 
+ @see CDTReplicatorFactor -oneWay:(CDTAbstractReplication*).
+*/
 /**
  * Create a CDTReplicator object set up to replicate changes from the
  * local datastore to a remote database.

--- a/Classes/common/CloudantSync.h
+++ b/Classes/common/CloudantSync.h
@@ -23,6 +23,8 @@
 #import "CDTAttachment.h"
 
 #import "CDTReplicator.h"
+#import "CDTPushReplication.h"
+#import "CDTPullReplication.h"
 #import "CDTReplicatorFactory.h"
 #import "CDTReplicatorDelegate.h"
 #import "CDTReplicationErrorInfo.h"

--- a/Project/Project.xcworkspace/contents.xcworkspacedata
+++ b/Project/Project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,1 @@
+<?xml version='1.0' encoding='UTF-8'?><Workspace version='1.0'><FileRef location='group:Project.xcodeproj'/><FileRef location='group:Pods/Pods.xcodeproj'/></Workspace>

--- a/README.md
+++ b/README.md
@@ -129,10 +129,12 @@ NSURL *remoteDatabaseURL = [NSURL URLWithString:s];
 CDTDatastore *datastore = [manager datastoreNamed:@"my_datastore"];
 
 // Replicate from the local to remote database
-CDTReplicator *replicator =
-[replicatorFactory onewaySourceDatastore:datastore
-                               targetURI:remoteDatabaseURL];
+CDTPushReplication *pushReplication = [CDTPushReplication replicationWithSource:datastore
+                                                                         target:remoteDatabaseURL];
+NSError *error;
+CDTReplicator *replicator = [replicatorFactory oneWay:pushReplication error:&error];
 
+//check error
 
 // Fire-and-forget (there are easy ways to monitor the state too)
 [replicator start];

--- a/ReplicationAcceptance/ReplicationAcceptance.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/ReplicationAcceptance/ReplicationAcceptance.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:ReplicationAcceptance.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/ReplicationAcceptance/ReplicationAcceptance.xcworkspace/contents.xcworkspacedata
+++ b/ReplicationAcceptance/ReplicationAcceptance.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,1 @@
+<?xml version='1.0' encoding='UTF-8'?><Workspace version='1.0'><FileRef location='group:ReplicationAcceptance.xcodeproj'/><FileRef location='group:Pods/Pods.xcodeproj'/></Workspace>

--- a/ReplicationAcceptance/ReplicationAcceptance/ReplicationAcceptance+CRUD.h
+++ b/ReplicationAcceptance/ReplicationAcceptance/ReplicationAcceptance+CRUD.h
@@ -25,6 +25,7 @@
 
 -(void) createRemoteDocs:(NSInteger)count;
 -(void) createRemoteDocWithId:(NSString*)docId revs:(NSInteger)n_revs;
+-(NSString*) createRemoteDocWithId:(NSString *)ddocid body:(NSDictionary*)ddocbody;
 
 -(NSDictionary*) remoteDbMetadata;
 

--- a/Tests/Tests.xcodeproj/project.pbxproj
+++ b/Tests/Tests.xcodeproj/project.pbxproj
@@ -66,6 +66,8 @@
 		9FAAB00218DCEB2C00E70F51 /* DatastoreConflicts.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FAAB00018DCEB2C00E70F51 /* DatastoreConflicts.m */; };
 		9FC082981913378F0024EA1E /* DatastoreConflictResolvers.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FC082971913378F0024EA1E /* DatastoreConflictResolvers.m */; };
 		9FC082991913378F0024EA1E /* DatastoreConflictResolvers.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FC082971913378F0024EA1E /* DatastoreConflictResolvers.m */; };
+		9FA839CB18FC474F0054512E /* CDTReplicationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FA839CA18FC474F0054512E /* CDTReplicationTests.m */; };
+		9FA839CC18FC474F0054512E /* CDTReplicationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FA839CA18FC474F0054512E /* CDTReplicationTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -114,6 +116,7 @@
 		9FAAB00018DCEB2C00E70F51 /* DatastoreConflicts.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DatastoreConflicts.m; sourceTree = "<group>"; };
 		9FC082961913378F0024EA1E /* DatastoreConflictResolvers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DatastoreConflictResolvers.h; sourceTree = "<group>"; };
 		9FC082971913378F0024EA1E /* DatastoreConflictResolvers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DatastoreConflictResolvers.m; sourceTree = "<group>"; };
+		9FA839CA18FC474F0054512E /* CDTReplicationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTReplicationTests.m; sourceTree = "<group>"; };
 		B8C5CE07530A44358897106E /* Pods-ios.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ios.xcconfig"; path = "Pods/Pods-ios.xcconfig"; sourceTree = "<group>"; };
 		BBD8D50209E84CD981F3FA7A /* libPods-osx.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-osx.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C0D0295E40984E2788387EEE /* libPods-ios.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ios.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -208,6 +211,7 @@
 				9FC082971913378F0024EA1E /* DatastoreConflictResolvers.m */,
 				9FAAB00018DCEB2C00E70F51 /* DatastoreConflicts.m */,
 				27389E3418534E050027A404 /* SetUpDatastore.m */,
+				9FA839CA18FC474F0054512E /* CDTReplicationTests.m */,
 				27B34A5A18C0B204009F18E6 /* IndexManagerTests.h */,
 				8E3377D418ABF36E003E3D93 /* IndexManagerTests.m */,
 				27389E16185345FD0027A404 /* Supporting Files */,
@@ -433,6 +437,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9FA839CB18FC474F0054512E /* CDTReplicationTests.m in Sources */,
 				8E3377D518ABF36E003E3D93 /* IndexManagerTests.m in Sources */,
 				9F0D2408188E378700D3D04E /* TDCanonicalJSONTests.m in Sources */,
 				9F0D23F1188B4FA900D3D04E /* TDMultipartReaderTests.m in Sources */,
@@ -463,6 +468,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9FA839CC18FC474F0054512E /* CDTReplicationTests.m in Sources */,
 				8E3377D618ABF42A003E3D93 /* IndexManagerTests.m in Sources */,
 				9F0D2409188E378700D3D04E /* TDCanonicalJSONTests.m in Sources */,
 				9F0D23F2188B4FA900D3D04E /* TDMultipartReaderTests.m in Sources */,

--- a/Tests/Tests/CDTReplicationTests.m
+++ b/Tests/Tests/CDTReplicationTests.m
@@ -1,0 +1,199 @@
+//
+//  CDTReplicationTests.m
+//  Tests
+//
+//  Created by Adam Cox on 4/14/14.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+#import <SenTestingKit/SenTestingKit.h>
+#import "CDTPullReplication.h"
+#import "CDTPushReplication.h"
+#import "CloudantSyncTests.h"
+#import "CDTDatastoreManager.h"
+
+@interface CDTReplicationTests : CloudantSyncTests
+
+@end
+
+@implementation CDTReplicationTests
+
+-(void)testDictionaryForPullReplicationDocument
+{
+    NSString *remoteUrl = @"https://adam:cox@myaccount.cloudant.com/mydb";
+    NSDictionary *expectedDictionary = @{@"target":@"test_database",
+                                         @"source": remoteUrl,
+                                         @"filter": @"myddoc/myfilter",
+                                         @"query_params":@{@"min":@23, @"max":@43}};
+
+    
+    NSError *error;
+    CDTDatastore *tmp = [self.factory datastoreNamed:@"test_database" error:&error];
+    CDTPullReplication *pull = [CDTPullReplication replicationWithSource:[NSURL URLWithString:remoteUrl]
+                                                                  target:tmp];
+    
+    pull.filter = @"myddoc/myfilter";
+    pull.filterParams = @{@"min":@23, @"max":@43};
+    
+    error = nil;
+    NSDictionary *pullDict = [pull dictionaryForReplicatorDocument:&error];
+    STAssertNil(error, @"Error creating dictionary. %@. Replicator: %@", error, pull);
+    STAssertEqualObjects(pullDict, expectedDictionary, @"pull dictionary: %@", pullDict);
+}
+
+-(void)testDictionaryForPushReplicationDocument
+{
+    NSString *remoteUrl = @"https://adam:cox@myaccount.cloudant.com/mydb";
+    NSDictionary *expectedDictionary = @{@"source":@"test_database",
+                                         @"target": remoteUrl};
+    
+    NSError *error;
+    CDTDatastore *tmp = [self.factory datastoreNamed:@"test_database" error:&error];
+    
+    CDTPushReplication *push = [CDTPushReplication replicationWithSource:tmp
+                                                                  target:[NSURL URLWithString:remoteUrl]];
+
+    
+    error = nil;
+    NSDictionary *pushDict = [push dictionaryForReplicatorDocument:&error];
+    STAssertNil(error, @"Error creating dictionary. %@. Replicator: %@", error, push);
+    STAssertEqualObjects(pushDict, expectedDictionary, @"push dictionary: %@", pushDict);
+}
+
+
+-(CDTAbstractReplication *)buildReplicationObject:(Class)aClass remoteUrl:(NSURL *)url
+{
+    CDTDatastore *tmp = [self.factory datastoreNamed:@"test_database" error:nil];
+    
+    //this feels wrong...
+    if (aClass == [CDTPushReplication class]) {
+        
+        return [CDTPushReplication replicationWithSource:tmp target:url];
+    
+    } else if (aClass == [CDTPullReplication class]) {
+    
+        return [CDTPullReplication replicationWithSource:url target:tmp];
+    
+    } else {
+        
+        return nil;
+    }
+}
+
+-(void)urlTestExpectTrue:(Class)prClass
+                     url:(NSURL*)url
+{
+    CDTAbstractReplication *pr = [self buildReplicationObject:prClass remoteUrl:url];
+    NSError *error = nil;
+    STAssertTrue([pr validateRemoteDatastoreURL:url error:&error], @"\nerror: %@ \nurl: %@", error, url);
+}
+
+-(void)urlTestExpectFalse:(Class)prClass
+                      url:(NSURL*)url
+            withErrorCode:(NSInteger)code
+{
+    NSError *error = nil;
+    CDTAbstractReplication *pr = [self buildReplicationObject:prClass remoteUrl:url];
+    
+    STAssertFalse([pr validateRemoteDatastoreURL:url error:&error], @"\nerror: %@ \nurl: %@", error, url);
+    STAssertTrue(error.code == code, @"\nerror: %@  \nurl: %@", error, url);
+}
+
+-(void)runUrlTestFor:(Class)prClass
+{
+
+    //expect to pass
+    [self urlTestExpectTrue:prClass
+                        url:[NSURL URLWithString:@"https://myaccount.cloudant.com/foo"]];
+    [self urlTestExpectTrue:prClass
+                        url:[NSURL URLWithString:@"https://adam:pass@myaccount.cloudant.com/foo"]];
+    [self urlTestExpectTrue:prClass
+                        url:[NSURL URLWithString:@"http://adam:pass@myaccount.cloudant.com/foo"]];
+    [self urlTestExpectTrue:prClass
+                        url:[NSURL URLWithString:@"http://adam:pass@myaccount.cloudant.com:5000/foo"]];
+    [self urlTestExpectTrue:prClass
+                        url:[NSURL URLWithString:@"http://myaccount.cloudant.com:5000/foo"]];
+    [self urlTestExpectTrue:prClass
+                        url:[NSURL URLWithString:@"https://myaccount.cloudant.com:5000/foo"]];
+    [self urlTestExpectTrue:prClass
+                        url:[NSURL URLWithString:@"https://myaccount.cloudant.com/foo%2Fbar%2Fbam"]];
+    [self urlTestExpectTrue:prClass
+                        url:[NSURL URLWithString:@"https://myaccount.cloudant.com:5000/foo%2Fbar%2Fbam"]];
+    [self urlTestExpectTrue:prClass
+                        url:[NSURL URLWithString:@"https://adam:pass@myaccount.cloudant.com:5000/foo%2Fbar%2Fbam"]];
+    [self urlTestExpectTrue:prClass
+                        url:[NSURL URLWithString:@"http://adam:pass@myaccount.cloudant.com:5000/foo%2Fbar%2Fbam"]];
+    
+    //even though this path shouldn't exist in normal situations, we can't restrict the URL because
+    //it could be a CNAME record or other type of redirect.
+    [self urlTestExpectTrue:prClass
+                        url:[NSURL URLWithString:@"https://someurl.com/foo/bar/bam"]];
+    
+    //build a URL with NSURLComponents
+    NSURLComponents *urlc = [[NSURLComponents alloc] init];
+    urlc.scheme = @"https";
+    urlc.host = @"myaccount.cloudant.com";
+    urlc.percentEncodedPath = @"/foo%2Fbar%2Fbam";
+    [self urlTestExpectTrue:prClass  url:[urlc URL]];
+    
+    urlc.user = @"adam";
+    [self urlTestExpectFalse:prClass
+                         url:[urlc URL]
+               withErrorCode:CDTReplicationErrorIncompleteCredentials];
+    
+    urlc.user = nil;
+    urlc.password = @"password";
+    [self urlTestExpectFalse:prClass
+                         url:[urlc URL]
+               withErrorCode:CDTReplicationErrorIncompleteCredentials];
+    
+    urlc.user = @"adam";
+    [self urlTestExpectTrue:prClass url:[urlc URL]];
+    
+    //expect to fail
+    [self urlTestExpectFalse:prClass
+                         url:[NSURL URLWithString:@"ftp://myaccount.cloudant.com/foo"]
+               withErrorCode:CDTReplicationErrorInvalidScheme];
+    
+    [self urlTestExpectFalse:prClass
+                         url:[NSURL URLWithString:@"ftp://myaccount.cloudant.com/foo/bar"]
+               withErrorCode:CDTReplicationErrorInvalidScheme];
+    
+    [self urlTestExpectFalse:prClass
+                         url:[NSURL URLWithString:@"https://adam@myaccount.cloudant.com/foo"]
+               withErrorCode:CDTReplicationErrorIncompleteCredentials];
+    
+    [self urlTestExpectFalse:prClass
+                         url:[NSURL URLWithString:@"https://:password@myaccount.cloudant.com/foo"]
+               withErrorCode:CDTReplicationErrorIncompleteCredentials];
+    
+}
+
+-(void)testRemoteURL
+{
+    
+    //tests for the pull replication class
+    [self runUrlTestFor:[CDTPullReplication class]];
+    
+    [self urlTestExpectFalse:[CDTPullReplication class]
+                         url:nil
+               withErrorCode:CDTReplicationErrorUndefinedSource];
+
+    
+    //tests for the push replication class
+    [self runUrlTestFor:[CDTPushReplication class]];
+
+    [self urlTestExpectFalse:[CDTPushReplication class]
+                         url:nil
+               withErrorCode:CDTReplicationErrorUndefinedTarget];
+    
+}
+
+
+@end

--- a/doc/replication.md
+++ b/doc/replication.md
@@ -44,9 +44,11 @@ CDTDatastore ds = [manager datastoreNamed:@"my_datastore"];
 
 // Create a replicator that replicates changes from the local
 // datastore to the remote database.
-CDTReplicator *replicator =
-[self.replicatorFactory onewaySourceDatastore:datastore
-                                    targetURI:remoteDatabaseURL];
+CDTPushReplication *pushReplication = [CDTPushReplication replicationWithSource:datastore
+                                                                         target:remoteDatabaseURL];
+NSError *error;
+CDTReplicator *replicator = [replicatorFactory oneWay:pushReplication error:&error];
+//check error
 
 // Start the replication and wait for it to complete
 [replicator start];
@@ -73,9 +75,11 @@ CDTDatastore ds = [manager datastoreNamed:@"my_datastore"];
 
 // Create a replicator that replicates changes from the local
 // datastore to the remote database.
-CDTReplicator *replicator =
-[self.replicatorFactory onewaySourceURI:remoteDatabaseURL
-                        targetDatastore:datastore];
+CDTPullReplication *pushReplication = [CDTPullReplication replicationWithSource:remoteDatabaseURL
+                                                                         target:datastore];
+NSError *error;
+CDTReplicator *replicator = [replicatorFactory oneWay:pullReplication error:&error];
+//check error
 
 // Start the replication and wait for it to complete
 [replicator start];


### PR DESCRIPTION
Adds support for filtered pull replication and reorganizes the
way replications are specified and initiated.

Adds CDTReplication, CDTPushReplication and CDTPullReplication, which
are used to encapsulate the data necessary to start a replication. CDTReplication
is an "abstract" base class for CDTPushReplication and CDTPullReplication.

Adds CDTReplicatorFactory -oneWay:(CDTReplicaiton *), which accepts
a CDTReplication object to specify the replication. This method returns a
CDTReplicator, which actually begins the execution of the replication when called
(CDTReplicator -start).

CDTReplicatorFactory -onewaySourceDatatore:targetURI and -onewaySoureURI:targetDatatore
will soon be deprecated in favor of -oneWay, which is documented in this commit.

CDTPullReplication supports filtered replication from the remote server.

This code does not make any query to the remote server to
ensure the existence of the filter function. (Perhaps this should be
done?)

A test (and supporting methods) was added to the ReplicationAcceptance
project.
