### PR TITLE
Use MRDatabaseContentChecker to simplify database validation

### DIFF
--- a/Tests/Podfile
+++ b/Tests/Podfile
@@ -3,6 +3,7 @@
 
 def import_pods
     pod "CDTDatastore", :path => "../"
+    pod "MRDatabaseContentChecker", :git => "https://github.com/mikerhodes/MRDatabaseContentChecker.git"
 end
 
 target :ios do


### PR DESCRIPTION
This helps make our tests less verbose, and should make it
simpler to check database content more quickly, especially
more complicated databases.

Help on MRDatabaseContentChecker:

https://github.com/mikerhodes/MRDatabaseContentChecker
