### PR TITLE
Changes behavior of the conflict resolution framework.

### DIFF
--- a/Classes/common/CDTConflictResolver.h
+++ b/Classes/common/CDTConflictResolver.h
@@ -30,22 +30,23 @@
 
 /**
  * The implementation of this method should examine the conflicted revisions and return
- * a winning CDTDocumentRevision. 
+ * a winning CDTDocumentRevision from the conflicts array. You may not create a new 
+ * CDTDocumentRevision.
  *
  * This method will be called by [CDTDatastore resolveConflictsForDocument:resolver:error:]
  * if there are conflicts found for the document ID.
  *
  * When called by [CDTDatastore resolveConflictsForDocument:resolver:error:],
- * the returned CDTDocumentRevision, barring any errors, will be added to the document 
- * tree as the child of the current winner, and all the other conflicting revisions in the 
- * tree will be deleted.
+ * the returned CDTDocumentRevision is declared the winner and all other conflicting
+ * revisions in the tree will be deleted. This all happens within a single database transaction
+ * in order to ensure atomicity.
  *
  * The output of this method should be deterministic. That is, for the given docId and
- * conflict set, the same revision should be returned for all calls.
+ * conflict set, the same CDTDocumentRevision should be returned for all calls.
  *
  * Additionally, this method should not modify other documents or attempt to query the database
  * (via calls to CDTDatastore methods). Doing so will create a blocking transaction to 
- * the database, the code will never excute and this method will hang indefinitely.
+ * the database; the code will never excute and this method will hang indefinitely.
  *
  * Finally, if `nil` is returned by this method, nothing will be changed in the database and the
  * document will remain conflicted.
@@ -56,9 +57,6 @@
  * object. Additionally, due to this restriction, documents may not yet be deleted with this 
  * conflict resolution mechanism. The future CDTMutableDocumentRevision will provide a flexible 
  * way of merging conflicts.
- *
- * @bug WARNING: Currently (20 May 2014), this does not properly migrate attachments for resolutions 
- * that choose revisions that are not the current winning revision. See CDTDatastore for details.
  *
  * @param docId id of the document with conflicts
  * @param conflicts array of conflicted CDTDocumentRevision, including the current winner

--- a/Classes/common/CDTDatastore+Conflicts.h
+++ b/Classes/common/CDTDatastore+Conflicts.h
@@ -18,8 +18,6 @@
 
 @interface CDTDatastore (Conflicts)
 
-
-
 /**
  * Get all document ids in the datastore that have a conflict in its revision tree.
  *
@@ -31,11 +29,12 @@
  Resolve conflicts for a specific document using an object that conforms to the
  CDTConflictResolver protocol
  
- This method creates an NSArry of CDTDocumentRevision objects for each of the conflicting
+ This method creates an NSArry of CDTDocumentRevision objects representing each of the conflicting
  revisions in a particular document tree and passes that array to the given
  [CDTConflictResolver resolve:conflicts:]. The [CDTConflictResolver resolve:conflicts:] method 
- should return the winning revision from the array. The returned CDTDocumentRevision, if not nil, 
- is appended to the current winning revision and other conflicted revisions are marked as deleted.
+ must return the winning revision chosen from the array. This method checks the returned
+ CDTDocumentRevision and then deletes all other conflicting revisions in the document tree. This 
+ all happens within a single database transaction in order to ensure atomicity.
 
  It is envisioned that this method will be used in conjunction with getConflictedDocumentIds.
  
@@ -49,23 +48,6 @@
                                                            error:&error];
         //check error, didResolve
     }
- 
- @bug WARNING: Currently (20 May 2014), this does not properly migrate attachments. If a 
- CDTConflictResolver object selects a winning revision other than the current winning revision, 
- the attachments for that revision will not propagate. At this time, this ONLY changes the document 
- bodies. For example, consider the following document tree
- 
-    1-a  --- 2-a --- 3-a  (-- 4-a)
-      \
-        ---- 2-b
- 
- with attachments on revision 2-b and revision 3-a. Assume that your [CDTConflictResolver
- resolve:conflicts:] method returns the 2-b revision. The winning revision after this resolution
- process is now 4-a (3-a will be its parent node). The JSON document body will match revision 2-b. 
- However, [CDTDatastore attachmentsForRev:error:]4-a will return the attachments associated with 
- revision 3-a and not for 2-b.
- 
- This issue will be resolved soon.
  
  @param docId id of Document to resolve conflicts
  @param resolver the CDTConflictResolver-conforming object used to resolve conflicts

--- a/Tests/Tests/DatastoreConflictResolvers.h
+++ b/Tests/Tests/DatastoreConflictResolvers.h
@@ -26,7 +26,7 @@
  this class chooses the biggest revision generation
  */
 @interface CDTTestBiggestRevResolver  : NSObject<CDTConflictResolver>
--(NSDictionary *) resolvedDocumentAsDictionary;  //made public for tests
+@property (strong, readonly) NSDictionary* resolvedDocumentAsDictionary;
 @end
 
 
@@ -56,3 +56,31 @@
 */
 @interface CDTTestDoesNoResolutionResolver  : NSObject<CDTConflictResolver>
 @end
+
+/**
+ this class chooses the smallest revision generation
+ */
+@interface CDTTestSmallestRevResolver  : NSObject<CDTConflictResolver>
+@property (strong, readonly) NSDictionary* resolvedDocumentAsDictionary;
+@end
+
+/**
+ this class creates a new CDTDocumentRevision object with the JSON body supplied
+ by resolveDocumentAsDictionary and returns that as the winning revision
+ */
+@interface CDTTestNewRevisionResolver  : NSObject<CDTConflictResolver>
+@property (strong, nonatomic) NSDictionary* resolvedDocumentAsDictionary;
+@end
+
+
+/**
+ This class chooses revisions based upon the content of the JSON body of the revision. For
+ each revision, it calls CDTDocumentRevision -documentAsDictionary and compares it to
+ the NSDictionary object supplied with the init below.
+ */
+@interface CDTTestSpecificJSONDocumentResolver  : NSObject<CDTConflictResolver>
+@property (nonatomic, strong) NSDictionary* documentBody;
+-(instancetype) initWithDictionary:(NSDictionary *)documentBody;
+@end
+
+

--- a/Tests/Tests/DatastoreConflicts.m
+++ b/Tests/Tests/DatastoreConflicts.m
@@ -21,6 +21,7 @@
 
 #import "CDTDatastoreManager.h"
 #import "CDTDatastore+Conflicts.h"
+#import "CDTDatastore+Attachments.h"
 #import "CDTDatastore+Internal.h"
 #import "CDTDocumentBody.h"
 #import "CDTDocumentRevision.h"
@@ -36,6 +37,8 @@
 #import "TD_Body.h"
 #import "CollectionUtils.h"
 #import "DBQueryUtils.h"
+#import "CDTAttachment.h"
+#import <MRDatabaseContentChecker.h>
 
 @interface DatastoreConflicts : CloudantSyncTests
 @property (nonatomic,strong) CDTDatastore *datastore;
@@ -67,19 +70,29 @@
 
 /**
  creates a new document with the following document tree
-
+ 
     ----- 2-c (seq 5, deleted = 1)
   /
  1-a (seq 1) --- 2-a (seq 2) --- 3-a (seq 3)
   \
     ---- 2-b (seq 4)
  
- There are only two conflicting revisions, 3-a and 2-b,
- because 2-c is deleted.
-*/
+ There are only two conflicting revisions, 3-a and 2-b, because 2-c is deleted.
+ 
+ For each revision, the content of the JSON body (the NSDictionary returned by CDTDocumentRevision
+ -documentAsDicitionary), will be {fooN.x:barN.x} where N = 1,2,3 and x = a, b, c.
+ For example, the JSON body for 1-a is {foo1.a:bar1.a}, and the body for 2-c is {foo2.c:bar2.c}.
+ This can be used to check for the content of each revision in the tests.
+ 
+ If withAttachment is YES, an image file is attached to revision 2-a. Note that due to the
+ implementation of attaching data to documents, the document body of 2-a will be {foo1.a:bar1.a}.
+ 
+ */
 -(void) addConflictingDocumentWithId:(NSString *)anId
                          toDatastore:(CDTDatastore*)datastore
+                      withAttachment:(BOOL)attach
 {
+    
     
     STAssertNotNil(anId, @"ID string is nil");
     
@@ -90,13 +103,30 @@
                                       body:body
                                      error:&error];
     
-    
     error = nil;
-    body = [[CDTDocumentBody alloc] initWithDictionary:@{@"foo2.a":@"bar2.a"}];
-    CDTDocumentRevision *rev2a = [datastore updateDocumentWithId:rev1.docId
-                                                         prevRev:rev1.revId
-                                                            body:body
-                                                           error:&error];
+    CDTDocumentRevision *rev2a = nil;
+    if (attach) {
+        
+        NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+        NSString *imagePath = [bundle pathForResource:@"bonsai-boston" ofType:@"jpg"];
+        NSData *data = [NSData dataWithContentsOfFile:imagePath];
+        
+        CDTAttachment *attachment = [[CDTUnsavedDataAttachment alloc] initWithData:data
+                                                                              name:@"bonsai-boston"
+                                                                              type:@"image/jpg"];
+        
+        rev2a = [self.datastore updateAttachments:@[attachment]
+                                           forRev:rev1
+                                            error:nil];
+        
+    }
+    else{
+        body = [[CDTDocumentBody alloc] initWithDictionary:@{@"foo2.a":@"bar2.a"}];
+        rev2a = [datastore updateDocumentWithId:rev1.docId
+                                        prevRev:rev1.revId
+                                           body:body
+                                          error:&error];
+    }
     
     error = nil;
     body = [[CDTDocumentBody alloc] initWithDictionary:@{@"foo3.a":@"bar3.a"}];
@@ -104,7 +134,7 @@
                             prevRev:rev2a.revId
                                body:body
                               error:&error];
-
+    
     error = nil;
     TD_Body *tdbody = [[TD_Body alloc] initWithProperties:@{@"foo2.b":@"bar2.b"}];
     TD_Database *tdstore = datastore.database;
@@ -131,7 +161,7 @@
                                             revID:nil
                                           deleted:YES];
     revision.body = tdbody;
-
+    
     td_rev = [tdstore putRevision:revision
                    prevRevisionID:rev1.revId
                     allowConflict:YES
@@ -143,11 +173,32 @@
     CDTDocumentRevision *rev2c = [[CDTDocumentRevision alloc] initWithTDRevision:td_rev];
     STAssertNotNil(rev2c, @"CDTDocumentRevision object was nil");
     
-    TDStatus statusResults = [tdstore compact];
-    STAssertTrue(statusResults == kTDStatusOK, @"TDStatusAsNSError: %@",
-                 TDStatusToNSError( statusResults, nil));
     
 }
+
+/**
+ creates a new document with the following document tree
+ 
+    ----- 2-c (seq 5, deleted = 1)
+  /
+ 1-a (seq 1) --- 2-a (seq 2) --- 3-a (seq 3)
+  \
+    ---- 2-b (seq 4)
+ 
+ There are only two conflicting revisions, 3-a and 2-b, because 2-c is deleted.
+ 
+ For each revision, the content of the JSON body is {fooN.x:barN.x} where
+ N = 1,2,3 and x = a, b, c. For example, the JSON body for 1-a is {foo1.a:bar1.a},
+ and the body for 2-c is {foo2.c:bar2.c}. This can be used to check for the
+ content of each revision in the tests.
+ */
+-(void) addConflictingDocumentWithId:(NSString *)anId
+                         toDatastore:(CDTDatastore*)datastore
+{
+    
+    [self addConflictingDocumentWithId:anId toDatastore:datastore withAttachment:NO];
+}
+
 
 
 - (CDTDocumentRevision*)addNonConflictingDocumentWithBody:(NSDictionary*)body
@@ -166,6 +217,11 @@
 -(void)testCreateConflict
 {
     [self addConflictingDocumentWithId:@"doc0" toDatastore:self.datastore];
+}
+
+-(void)testCreateConflictWithAttachment
+{
+    [self addConflictingDocumentWithId:@"doc0" toDatastore:self.datastore withAttachment:YES];
 }
 
 -(void)testFindAllConflicts
@@ -266,20 +322,15 @@
 
 - (void) testResolveConflictWithBiggestRev
 {
-    //add a non-conflicting document
-    [self addNonConflictingDocumentWithBody:@{@"conflict":@"no"} toDatastore:self.datastore];
     
-    NSSet *setOfConflictedDocIds = [NSSet setWithArray:@[@"doc0", @"doc1", @"doc2", @"doc3"]];
-    for (NSString *docId in setOfConflictedDocIds) {
-        [self addConflictingDocumentWithId:docId toDatastore:self.datastore];
-    }
-    
-    //add another non-conflicting document
-    [self addNonConflictingDocumentWithBody:@{@"conflict":@"no"} toDatastore:self.datastore];
+    [self addConflictingDocumentWithId:@"doc0" toDatastore:self.datastore];
     
     CDTTestBiggestRevResolver *myResolver = [[CDTTestBiggestRevResolver alloc] init];
-        
-    for (NSString *docId in [self.datastore getConflictedDocumentIds]) {
+    
+    NSArray *conflictedDocs = [self.datastore getConflictedDocumentIds];
+    STAssertEquals(conflictedDocs.count, (NSUInteger)1, @"");
+    
+    for (NSString *docId in conflictedDocs) {
         NSError *error;
         STAssertTrue([self.datastore resolveConflictsForDocument:docId
                                                         resolver:myResolver
@@ -289,66 +340,64 @@
     }
     
     //make sure there are no more conflicting documents
-    NSArray *conflictedDocs = [self.datastore getConflictedDocumentIds];
-    STAssertTrue(conflictedDocs.count == 0,
-                 @"Found %lu conflicted docs", (unsigned long)conflictedDocs.count);
+    conflictedDocs = [self.datastore getConflictedDocumentIds];
+    STAssertEquals(conflictedDocs.count, (NSUInteger)0, @"");
     
-    //make sure that doc0, doc1, doc2 and doc3 all have the proper rev and content
-    //They should have rev prefixes of 4- and should have content of {foo3.a:bar3.a}
-    for (NSString *docId in setOfConflictedDocIds) {
-        //NSLog(adocid);
-        
-        NSError *error = nil;
-        CDTDocumentRevision *rev = [self.datastore getDocumentWithId:docId error:&error];
-        STAssertNil(error, @"Error getting document");
-        STAssertNotNil(rev, @"CDTDocumentRevision object was nil");
-        STAssertTrue([TD_Revision generationFromRevID:rev.revId] == 4,
-                     @"Unexpected RevId: %@", rev.revId);
-        STAssertTrue([[rev documentAsDictionary] isEqualToDictionary:myResolver.resolvedDocumentAsDictionary],
-                     @"Unexpected document: %@", [rev documentAsDictionary]);
-    }
+    //make sure that doc0 has the proper rev and content
+    //They should have rev prefixes of 3-
+    NSError *error = nil;
+    CDTDocumentRevision *rev = [self.datastore getDocumentWithId:@"doc0" error:&error];
+    STAssertNil(error, @"Error getting document");
+    STAssertNotNil(rev, @"CDTDocumentRevision object was nil");
+    STAssertEquals([TD_Revision generationFromRevID:rev.revId], (unsigned)3,
+                   @"Unexpected RevId: %@", rev.revId);
+    STAssertTrue([[rev documentAsDictionary] isEqualToDictionary:myResolver.resolvedDocumentAsDictionary],
+                 @"Unexpected document: %@", [rev documentAsDictionary]);
+
 }
 
-- (void) testResolveByAnnihilation
-{
-    //add a non-conflicting document
-    [self addNonConflictingDocumentWithBody:@{@"conflict":@"no"} toDatastore:self.datastore];
-    
-    NSSet *setOfConflictedDocIds = [NSSet setWithArray:@[@"doc0", @"doc1", @"doc2", @"doc3"]];
-    for (NSString *docId in setOfConflictedDocIds) {
-        [self addConflictingDocumentWithId:docId toDatastore:self.datastore];
-    }
-    
-    //add another non-conflicting document
-    [self addNonConflictingDocumentWithBody:@{@"conflict":@"no"} toDatastore:self.datastore];
-    
-    CDTTestDeleteConflictedDocResolver *myResolver = [[CDTTestDeleteConflictedDocResolver alloc] init];
-    
-    for (NSString *docId in [self.datastore getConflictedDocumentIds]) {
-        NSError *error;
-        STAssertTrue([self.datastore resolveConflictsForDocument:docId
-                                                        resolver:myResolver
-                                                           error:&error],
-                     @"resolve failure: %@", docId);
-        STAssertNil(error, @"Error resolving document. %@", error);
-    }
-    
-    //make sure there are no more conflicting documents
-    NSArray *conflictedDocs = [self.datastore getConflictedDocumentIds];
-    STAssertTrue(conflictedDocs.count == 0,
-                 @"Found %lu conflicted docs", (unsigned long)conflictedDocs.count);
-    
-    //make sure that doc0, doc1, doc2 and doc3 cannot be retrieved
-    for (NSString *docId in setOfConflictedDocIds) {
-        
-        NSError *error = nil;
-        CDTDocumentRevision *rev = [self.datastore getDocumentWithId:docId error:&error];
-        STAssertNotNil(error, @"No Error getting document");
-        STAssertTrue(error.code == 404, @"Error was not a 404. Found %ld", error.code);
-        STAssertNil(rev, @"CDTDocumentRevision object was not nil even though it was deleted.");
-        
-    }
-}
+//
+//commented out until it's possible to delete documents within conflict resolution framework
+//
+//- (void) testResolveByAnnihilation
+//{
+//    //add a non-conflicting document
+//    [self addNonConflictingDocumentWithBody:@{@"conflict":@"no"} toDatastore:self.datastore];
+//    
+//    NSSet *setOfConflictedDocIds = [NSSet setWithArray:@[@"doc0", @"doc1", @"doc2", @"doc3"]];
+//    for (NSString *docId in setOfConflictedDocIds) {
+//        [self addConflictingDocumentWithId:docId toDatastore:self.datastore];
+//    }
+//    
+//    //add another non-conflicting document
+//    [self addNonConflictingDocumentWithBody:@{@"conflict":@"no"} toDatastore:self.datastore];
+//    
+//    CDTTestDeleteConflictedDocResolver *myResolver = [[CDTTestDeleteConflictedDocResolver alloc] init];
+//    
+//    for (NSString *docId in [self.datastore getConflictedDocumentIds]) {
+//        NSError *error;
+//        STAssertTrue([self.datastore resolveConflictsForDocument:docId
+//                                                        resolver:myResolver
+//                                                           error:&error],
+//                     @"resolve failure: %@", docId);
+//        STAssertNil(error, @"Error resolving document. %@", error);
+//    }
+//    
+//    //make sure there are no more conflicting documents
+//    NSArray *conflictedDocs = [self.datastore getConflictedDocumentIds];
+//    STAssertEquals(conflictedDocs.count, (NSUInteger)0, @"");
+//    
+//    //make sure that doc0, doc1, doc2 and doc3 cannot be retrieved
+//    for (NSString *docId in setOfConflictedDocIds) {
+//        
+//        NSError *error = nil;
+//        CDTDocumentRevision *rev = [self.datastore getDocumentWithId:docId error:&error];
+//        STAssertNotNil(error, @"No Error getting document");
+//        STAssertEquals(error.code, (NSInteger)404, @"Error %@", error);
+//        STAssertNil(rev, @"CDTDocumentRevision object was not nil even though it was deleted.");
+//        
+//    }
+//}
 
 - (void) testNoResolution
 {
@@ -376,8 +425,7 @@
     
     //make sure there are the correct number of conflicting documents
     NSArray *conflictedDocs = [self.datastore getConflictedDocumentIds];
-    STAssertTrue(conflictedDocs.count == setOfConflictedDocIds.count,
-                 @"Found %lu conflicted docs", (unsigned long)conflictedDocs.count);
+    STAssertEquals(conflictedDocs.count, setOfConflictedDocIds.count, @"");
     
     //make sure that doc0, doc1, doc2 and doc3 are still retrieved
     for (NSString *docId in setOfConflictedDocIds) {
@@ -416,7 +464,7 @@
     
     //check conflicting documents
     NSArray *conflictedDocs = [self.datastore getConflictedDocumentIds];
-    STAssertTrue(conflictedDocs.count == 2, @"Found %lu conflicted docs", (unsigned long)conflictedDocs.count);
+    STAssertEquals(conflictedDocs.count, (NSUInteger)2, @"");
     
     NSSet *stillConflicted = [NSSet setWithArray:@[@"doc2", @"doc3"]];
     STAssertTrue([stillConflicted isEqualToSet:[NSSet setWithArray:conflictedDocs]],
@@ -428,10 +476,252 @@
         CDTDocumentRevision *rev = [self.datastore getDocumentWithId:docId error:&error];
         STAssertNil(error, @"Error getting document");
         STAssertNotNil(rev, @"CDTDocumentRevision object was nil");
-        STAssertTrue([TD_Revision generationFromRevID:rev.revId] == 4, @"Unexpected RevId: %@", rev.revId);
+        STAssertEquals([TD_Revision generationFromRevID:rev.revId], (unsigned)3,
+                       @"Unexpected RevId: %@", rev.revId);
         STAssertTrue([[rev documentAsDictionary] isEqualToDictionary: myResolver.resolvedDocumentAsDictionary],
                      @"Unexpected document: %@", [rev documentAsDictionary]);
     }
+}
+
+
+- (void) testResolveConflictWithSmallestRev
+{
+    
+    [self addConflictingDocumentWithId:@"doc0" toDatastore:self.datastore];
+    
+    CDTTestSmallestRevResolver *myResolver = [[CDTTestSmallestRevResolver alloc] init];
+    
+    NSArray *conflictedDocs = [self.datastore getConflictedDocumentIds];
+    STAssertEquals(conflictedDocs.count, (NSUInteger)1, @"");
+    
+    for (NSString *docId in conflictedDocs) {
+        NSError *error;
+        STAssertTrue([self.datastore resolveConflictsForDocument:docId
+                                                        resolver:myResolver
+                                                           error:&error],
+                     @"resolve failure: %@", docId);
+        STAssertNil(error, @"Error resolving document. %@", error);
+    }
+    
+    //make sure there are no more conflicting documents
+    conflictedDocs = [self.datastore getConflictedDocumentIds];
+    STAssertEquals(conflictedDocs.count, (NSUInteger)0, @"");
+    
+    //make sure that doc0 has the proper rev and content
+    //They should have rev prefixes of 2-
+    NSError *error = nil;
+    CDTDocumentRevision *rev = [self.datastore getDocumentWithId:@"doc0" error:&error];
+    STAssertNil(error, @"Error getting document");
+    STAssertNotNil(rev, @"CDTDocumentRevision object was nil");
+    STAssertEquals([TD_Revision generationFromRevID:rev.revId], (unsigned)2,
+                   @"Unexpected RevId: %@", rev.revId);
+    STAssertTrue([[rev documentAsDictionary] isEqualToDictionary:myResolver.resolvedDocumentAsDictionary],
+                 @"Unexpected document: %@", [rev documentAsDictionary]);
+    
+}
+
+- (void) testCannotResolveWithNewRevision
+{
+    //this test ensures that when a CDTConflictResolver returns a CDTDocumentRevision
+    //that is not in the conflicts array, the resolveConflictForDocument fails appropriately
+    
+    [self addConflictingDocumentWithId:@"doc0" toDatastore:self.datastore];
+    
+    CDTTestNewRevisionResolver *myResolver = [[CDTTestNewRevisionResolver alloc] init];
+    
+    NSArray *conflictedDocs = [self.datastore getConflictedDocumentIds];
+    STAssertEquals(conflictedDocs.count, (NSUInteger)1, @"");
+    
+    for (NSString *docId in conflictedDocs) {
+        NSError *error;
+        STAssertFalse([self.datastore resolveConflictsForDocument:docId
+                                                        resolver:myResolver
+                                                           error:&error],
+                     @"Expected resolve to fail. %@", docId);
+        NSError *expectError = TDStatusToNSErrorWithInfo(kTDStatusServerError, nil, nil);
+        
+        STAssertEquals(error.code, expectError.code, @"Unexpected Error %@. \n Expected %@ \n", error, expectError);
+    }
+    
+    
+    //make sure there is still a conflicting document
+    conflictedDocs = [self.datastore getConflictedDocumentIds];
+    STAssertEquals(conflictedDocs.count, (NSUInteger)1, @"");
+    
+    //make sure that doc0 still has two conflicting revsions
+    __weak DatastoreConflicts  *weakSelf = self;
+    [[self.dbutil queue] inDatabase:^(FMDatabase *db) {
+        DatastoreConflicts *strongSelf = weakSelf;
+        NSArray *revsArray = [strongSelf.datastore activeRevisionsForDocumentId:@"doc0" database:db];
+        STAssertEquals(revsArray.count, (NSUInteger)2, @"");
+        
+    }];
+    
+    //The winning revision should still have a prefix of 3-
+    NSError *error = nil;
+    CDTDocumentRevision *rev = [self.datastore getDocumentWithId:@"doc0" error:&error];
+    STAssertNil(error, @"Error getting document");
+    STAssertNotNil(rev, @"CDTDocumentRevision object was nil");
+    STAssertEquals([TD_Revision generationFromRevID:rev.revId], (unsigned)3,
+                   @"Unexpected RevId: %@", rev.revId);
+    STAssertTrue([[rev documentAsDictionary] isEqualToDictionary:@{@"foo3.a":@"bar3.a"}],
+                 @"Unexpected document: %@", [rev documentAsDictionary]);
+    
+}
+
+-(void) testResolveConflictWithAttachmentWithBiggestRev
+{
+    //this tests that the conflict resolution retains the revisions association with an attachment
+    // before
+    //    ----- 2-c (seq 5, deleted = 1)
+    //    /
+    //    1-a (seq 1) --- 2-a (seq 2, attachment here) --- 3-a (seq 3, attachment here)
+    //    \
+    //    ---- 2-b (seq 4)
+    //
+    // after
+    //    ----- 2-c (seq 5, deleted = 1)
+    //    /
+    //    1-a (seq 1) --- 2-a (seq 2, attachment here) --- 3-a (seq 3, attachment here)
+    //    \
+    //    ---- 2-b (seq 4) -- 3-b(seq 6, deleted = 1)
+    //
+    // and then we check to ensure that 3-a has the attachment still.
+    // this test made more sense when we had different behavior in conflict resolution, but
+    // I suppose it's still good to ensure we're not blowing away attachments.
+    
+    
+    //add conflicting document with attachement
+    [self addConflictingDocumentWithId:@"doc0" toDatastore:self.datastore withAttachment:YES];
+    
+    CDTTestBiggestRevResolver *myResolver = [[CDTTestBiggestRevResolver alloc] init];
+    
+    for (NSString *docId in [self.datastore getConflictedDocumentIds]) {
+        NSError *error;
+        STAssertTrue([self.datastore resolveConflictsForDocument:docId
+                                                        resolver:myResolver
+                                                           error:&error],
+                     @"resolve failure: %@", docId);
+        STAssertNil(error, @"Error resolving document. %@", error);
+    }
+    
+    //make sure there are no more conflicted documents
+    NSArray *conflictedDocs = [self.datastore getConflictedDocumentIds];
+    STAssertEquals(conflictedDocs.count, (NSUInteger)0, @"");
+    
+    //make sure that doc0 has the proper rev and content
+    //The winning rev should be generation 3 and should have content of {foo3.a:bar3.a}
+    //It should also have the bonsai-boston attached image.
+    NSError *error = nil;
+    CDTDocumentRevision *rev = [self.datastore getDocumentWithId:@"doc0" error:&error];
+    STAssertNil(error, @"Error getting document");
+    STAssertNotNil(rev, @"CDTDocumentRevision object was nil");
+    STAssertEquals([TD_Revision generationFromRevID:rev.revId], (unsigned)3,
+                   @"Unexpected RevId: %@", rev.revId);
+    STAssertTrue([[rev documentAsDictionary] isEqualToDictionary:myResolver.resolvedDocumentAsDictionary],
+                 @"Unexpected document: %@", [rev documentAsDictionary]);
+    
+    NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+    NSString *imagePath = [bundle pathForResource:@"bonsai-boston" ofType:@"jpg"];
+    NSData *imageData = [NSData dataWithContentsOfFile:imagePath];
+    
+    [self.dbutil.queue inDatabase:^(FMDatabase *db ) {
+        NSArray *expectedRows = @[
+                                  @[@"sequence", @"filename", @"type", @"length", @"revpos", @"encoding", @"encoded_length"],
+                                  @[@2, @"bonsai-boston", @"image/jpg", @(imageData.length), @2, @0, @(imageData.length)],
+                                  @[@3, @"bonsai-boston", @"image/jpg", @(imageData.length), @2, @0, @(imageData.length)]
+                                  ];
+        
+        MRDatabaseContentChecker *dc = [[MRDatabaseContentChecker alloc] init];
+        NSError *validationError;
+        STAssertTrue([dc checkDatabase:db
+                                 table:@"attachments"
+                               hasRows:expectedRows
+                                 error:&validationError],
+                     [dc formattedErrors:validationError]);
+    }];
+    
+}
+
+
+- (void) testResolveConflictWithAttachmentForRev2b
+{
+    //this tests that the conflict resolution retains the revision associations with attachments
+    // before
+    //    ----- 2-c (seq 5, deleted = 1)
+    //    /
+    //    1-a (seq 1) --- 2-a (seq 2, attachment here) --- 3-a (seq 3, attachment here)
+    //    \
+    //    ---- 2-b (seq 4)
+    //
+    // after
+    //    ----- 2-c (seq 5, deleted = 1)
+    //    /
+    //    1-a (seq 1) --- 2-a (seq 2, attachment here) --- 3-a (seq 3, attachment here) --- 4-b (seq 6, deleted=1)
+    //    \
+    //    ---- 2-b (seq 4)
+    //
+    // and then we check to ensure that GETing the document returns 2-b without an attachment.
+
+    //add conflicting document with attachement
+    [self addConflictingDocumentWithId:@"doc0" toDatastore:self.datastore withAttachment:YES];
+    
+    CDTTestSpecificJSONDocumentResolver *myResolver = [[CDTTestSpecificJSONDocumentResolver alloc]
+                                                       initWithDictionary:@{@"foo2.b":@"bar2.b"}];
+    
+    for (NSString *docId in [self.datastore getConflictedDocumentIds]) {
+        NSError *error;
+        STAssertTrue([self.datastore resolveConflictsForDocument:docId
+                                                        resolver:myResolver
+                                                           error:&error],
+                     @"resolve failure: %@", docId);
+        STAssertNil(error, @"Error resolving document. %@", error);
+    }
+    
+    
+    //make sure there are no more conflicting documents
+    NSArray *conflictedDocs = [self.datastore getConflictedDocumentIds];
+    STAssertEquals(conflictedDocs.count, (NSUInteger)0, @"");
+    
+    //make sure that doc0 has the proper rev and content
+    //The winning rev should be generation 2 and should have content of {foo2.b:bar2.b}
+    //It should NOT have the bonsai-boston attached image.
+    NSError *error = nil;
+    CDTDocumentRevision *rev = [self.datastore getDocumentWithId:@"doc0" error:&error];
+    STAssertNil(error, @"Error getting document");
+    STAssertNotNil(rev, @"CDTDocumentRevision object was nil");
+    STAssertEquals([TD_Revision generationFromRevID:rev.revId], (unsigned)2,
+                   @"Unexpected RevId: %@", rev.revId);
+    STAssertTrue([[rev documentAsDictionary] isEqualToDictionary:@{@"foo2.b":@"bar2.b"}],
+                 @"Unexpected document: %@", [rev documentAsDictionary]);
+    
+    NSArray *attachments = [self.datastore attachmentsForRev:rev
+                                                       error:nil];
+    
+    STAssertEquals((NSUInteger)0, [attachments count], @"Wrong number of attachments");
+    
+    
+    NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+    NSString *imagePath = [bundle pathForResource:@"bonsai-boston" ofType:@"jpg"];
+    NSData *imageData = [NSData dataWithContentsOfFile:imagePath];
+    
+    [self.dbutil.queue inDatabase:^(FMDatabase *db ) {
+        NSArray *expectedRows = @[
+                                  @[@"sequence", @"filename", @"type", @"length", @"revpos", @"encoding", @"encoded_length"],
+                                  @[@2, @"bonsai-boston", @"image/jpg", @(imageData.length), @2, @0, @(imageData.length)],
+                                  @[@3, @"bonsai-boston", @"image/jpg", @(imageData.length), @2, @0, @(imageData.length)]
+                                  ];
+        
+        MRDatabaseContentChecker *dc = [[MRDatabaseContentChecker alloc] init];
+        NSError *validationError;
+        STAssertTrue([dc checkDatabase:db
+                                 table:@"attachments"
+                               hasRows:expectedRows
+                                 error:&validationError],
+                     [dc formattedErrors:validationError]);
+    }];
+
+    
 }
 
 


### PR DESCRIPTION
Previously, the conflict resolution framework would append the
CDTDocumentRevision object returned by CDTConflictResolver -resovle:conflicts:
to the current winning revision in a document's tree and then
delete all other conflicting revisions.

This update makes the following changes:
- Restricts the CDTConflictResolver -resolve:conflicts: method to
  return one of the CDTDocumentRevision objects found in the conflicts
  array it was given. This completely forbids any new CDTDocumentRevision to
  become the new winning revision (this is temporary).
- The CDTDocumentRevision returned by CDTConflictResolver -resolve:conflicts:
  becomes the new winning revision by deleting all other conflicting revisions
  in the document tree.

In addition, this solves the problem with attachments not properly migrating
the the new winning revision since we no longer create any new revisions to the
document tree. (Cloudant FogBugz 31053)

CDTDatastore+Conflicts is modified accordingly.
CDTConflictResolver.h documentation is modified.

Tests are modified and created in DatastoreConflictResolvers and DatastoreConflicts.m
In addition, tests for conflict resolution of documents with attachments are added.
