### PR TITLE
Fixes bug introduced in a previous merge when the CDTDatastore -conflictsForDocument method was removed.

### DIFF
--- a/Classes/common/CDTDatastore+Internal.h
+++ b/Classes/common/CDTDatastore+Internal.h
@@ -48,5 +48,9 @@
  */
 -(NSArray*) activeRevisionsForDocumentId:(NSString*)docId database:(FMDatabase *)db;
 
+/**
+ This method is the same as above, but opens a separate database transaction
+ */
+-(NSArray*) activeRevisionsForDocumentId:(NSString *)docId;
 
 @end

--- a/Classes/common/CDTDatastore+Internal.m
+++ b/Classes/common/CDTDatastore+Internal.m
@@ -44,5 +44,15 @@
     return results;
 }
 
+-(NSArray*) activeRevisionsForDocumentId:(NSString *)docId
+{
+    __block NSArray *revs = nil;
+    [self.database inTransaction:^TDStatus(FMDatabase *db) {
+        revs = [self activeRevisionsForDocumentId:docId database:db];
+        return kTDStatusOK;
+    }];
+    
+    return revs;
+}
 
 @end

--- a/ReplicationAcceptance/ReplicationAcceptance/Attachments.m
+++ b/ReplicationAcceptance/ReplicationAcceptance/Attachments.m
@@ -598,9 +598,10 @@
     CDTAttachment *attachment = [[CDTUnsavedDataAttachment alloc] initWithData:data
                                                                           name:attachmentName
                                                                           type:@"text/plain"];    
+    NSError *error = nil;
     rev = [self.datastore updateAttachments:@[attachment]
                                      forRev:rev
-                                      error:nil];
+                                      error:&error];
     STAssertNotNil(rev, @"Unable to add attachments to document");
     
     [self pushTo:remoteDbURL from:self.datastore];

--- a/ReplicationAcceptance/ReplicationAcceptance/CloudantReplicationBase+CompareDb.m
+++ b/ReplicationAcceptance/ReplicationAcceptance/CloudantReplicationBase+CompareDb.m
@@ -9,6 +9,7 @@
 #import "CloudantReplicationBase+CompareDb.h"
 
 #import <CloudantSync.h>
+#import <CDTDatastore+Internal.h>
 #import <SenTestingKit/SenTestingKit.h>
 #import <UNIRest.h>
 #import <CommonCrypto/CommonDigest.h>
@@ -123,7 +124,7 @@
         CDTDocumentRevision *document = (CDTDocumentRevision*)ob;
 
         // This returns all the `current` revisions for a given document.
-        NSArray *allRevisions = [local conflictsForDocument:document];
+        NSArray *allRevisions = [local activeRevisionsForDocumentId:document.docId];
 
         // Make sure the history for each conflict is correct
         for (CDTDocumentRevision *currentRevision in allRevisions) {


### PR DESCRIPTION
Adds -conflictsForDocumentId to CDTDatastore+Internals.
Modifies CloudantReplicationBase+CompareDb -compareDocIdsAndAllRevs:withDatabase
to call -conflictsForDocumentId.
