### PR TITLE
FB 32172 introduce deleteDatastoreNamed method 

### DIFF
--- a/Classes/common/CDTDatastoreManager.h
+++ b/Classes/common/CDTDatastoreManager.h
@@ -52,4 +52,21 @@ extern NSString* const CDTDatastoreErrorDomain;
 -(CDTDatastore *)datastoreNamed:(NSString*)name
                           error:(NSError * __autoreleasing *)error;
 
+
+/**
+ Deletes a datastore for the given name.
+ 
+ All datastore files, including attachments and extensions, are deleted.
+ 
+ Currently it is the responsibility of the caller to ensure that extensions should be shutdown (and
+ their underlying databases closed) before calling this method.
+ 
+ @param name datastore name
+ @param error will point to an NSError object in case of error.
+
+ */
+-(BOOL)deleteDatastoreNamed:(NSString*)name
+                      error:(NSError * __autoreleasing *)error;
+
+
 @end

--- a/Classes/common/touchdb/TD_DatabaseManager.m
+++ b/Classes/common/touchdb/TD_DatabaseManager.m
@@ -109,7 +109,8 @@ static NSCharacterSet* kIllegalNameChars;
 
 + (BOOL) isValidDatabaseName: (NSString*)name {
     if (name.length > 0 && [name rangeOfCharacterFromSet: kIllegalNameChars].length == 0
-                        && islower([name characterAtIndex: 0]))
+                        && islower([name characterAtIndex: 0])
+                        && ![name hasSuffix:@"_extensions"])
         return YES;
     return $equal(name, kTDReplicatorDatabaseName);
 }


### PR DESCRIPTION
Method and test cases.

This will delete the datastore and all associated files, including attachments and extensions.

Also disallow datastores to have the suffix _extensions, to avoid confusion with the
${datastore}_extensions directory.
