### PR TITLE
FB 32224. Removes the _replicator database

### DIFF
--- a/Classes/common/CDTReplicator/CDTReplicator.h
+++ b/Classes/common/CDTReplicator/CDTReplicator.h
@@ -19,6 +19,7 @@
 
 @class CDTDatastore;
 @class CDTDocumentBody;
+@class TDReplicatorManager;
 
 /**
  * Describes the state of a CDTReplicator at a given moment.
@@ -108,7 +109,6 @@ typedef NS_ENUM(NSInteger, CDTReplicatorState) {
  */
 -(BOOL)isActive;
 
-
 /**
  Returns a string representation of a CDTReplicatorState value.
 
@@ -120,8 +120,8 @@ typedef NS_ENUM(NSInteger, CDTReplicatorState) {
 /*
  Private so no docs
  */
--(id)initWithReplicatorDatastore:(CDTDatastore*)replicatorDb
-         replicationDocumentBody:(CDTDocumentBody*)body;
+-(id)initWithTDReplicatorManager:(TDReplicatorManager*)replicatorManager
+           replicationProperties:(NSDictionary*)properties;
 
 
 /**---------------------------------------------------------------------------------------

--- a/Classes/common/CDTReplicator/CDTReplicatorFactory.m
+++ b/Classes/common/CDTReplicator/CDTReplicatorFactory.m
@@ -94,32 +94,9 @@ static NSString* const CDTReplicatorFactoryErrorDomain = @"CDTReplicatorFactoryE
         return nil;
     }
     
-    CDTDocumentBody *body = [[CDTDocumentBody alloc] initWithDictionary:repdoc];
-    if (body == nil) {
-        if (error) {
-            NSDictionary *userInfo =
-            @{NSLocalizedDescriptionKey: NSLocalizedString(@"Data sync failed.", nil)};
-            *error = [NSError errorWithDomain:CDTReplicatorFactoryErrorDomain
-                                         code:CDTReplicatorFactoryErrorNilDocumentBodyForReplication
-                                     userInfo:userInfo];
-            NSLog(@"CDTReplicatorFactory -oneWay:error: Error. Unable to create CDTDocumentBody. "
-                  @"%@\n %@.", [replication class], replication);
-
-        }
-        return nil;
-
-    }
-    
-    NSError *localError = nil;
-    CDTDatastore *datastore = [self.manager datastoreNamed:kTDReplicatorDatabaseName
-                                                     error:&localError];
-    if (localError != nil) {
-        if (error) *error = localError;
-        return nil;
-    }
-    
-    CDTReplicator *replicator = [[CDTReplicator alloc] initWithReplicatorDatastore:datastore
-                                                           replicationDocumentBody:body];
+    CDTReplicator *replicator = [[CDTReplicator alloc]
+                                 initWithTDReplicatorManager:self.replicatorManager
+                                 replicationProperties:repdoc];
     
     if (replicator == nil) {
         if (error) {

--- a/Classes/common/touchdb/TDReplicator.h
+++ b/Classes/common/touchdb/TDReplicator.h
@@ -13,6 +13,8 @@
 @class TD_Database, TD_RevisionList, TDBatcher, TDReachability;
 @protocol TDAuthorizer;
 
+/** Posted when replicator starts running. */
+extern NSString* TDReplicatorStartedNotification;
 
 /** Posted when changesProcessed or changesTotal changes. */
 extern NSString* TDReplicatorProgressChangedNotification;
@@ -108,7 +110,7 @@ extern NSString* TDReplicatorStoppedNotification;
 @property (readonly, nonatomic) NSUInteger changesProcessed;
 
 /** Approximate total number of changes to transfer.
-    This is only an estimate and its value will change during replication. It starts at zero and returns to zero when replication stops. */
+    This is only an estimate and its value will change during replication. */
 @property (readonly, nonatomic) NSUInteger changesTotal;
 
 /** JSON-compatible array of status info about active remote HTTP requests. */

--- a/Classes/common/touchdb/TDReplicator.m
+++ b/Classes/common/touchdb/TDReplicator.m
@@ -42,6 +42,7 @@
 
 NSString* TDReplicatorProgressChangedNotification = @"TDReplicatorProgressChanged";
 NSString* TDReplicatorStoppedNotification = @"TDReplicatorStopped";
+NSString* TDReplicatorStartedNotification = @"TDReplicatorStarted";
 
 
 @interface TDReplicator ()
@@ -236,6 +237,9 @@ NSString* TDReplicatorStoppedNotification = @"TDReplicatorStopped";
     self.running = YES;
     _startTime = CFAbsoluteTimeGetCurrent();
     
+    [[NSNotificationCenter defaultCenter] postNotificationName: TDReplicatorStartedNotification
+                                                        object: self];
+    
 #if TARGET_OS_IPHONE
     // Register for foreground/background transition notifications, on iOS:
     [[NSNotificationCenter defaultCenter] addObserver: self selector: @selector(appBackgrounding:)
@@ -291,7 +295,8 @@ NSString* TDReplicatorStoppedNotification = @"TDReplicatorStopped";
     Log(@"Replication: %@ took %.3f sec; error=%@",
         self, CFAbsoluteTimeGetCurrent()-_startTime, _error);
     self.running = NO;
-    self.changesProcessed = self.changesTotal = 0;
+    
+    
     [[NSNotificationCenter defaultCenter]
         postNotificationName: TDReplicatorStoppedNotification object: self];
     [self saveLastSequence];

--- a/Classes/common/touchdb/TDReplicatorManager.h
+++ b/Classes/common/touchdb/TDReplicatorManager.h
@@ -10,21 +10,18 @@
 
 #import "TD_Database.h"
 @class TD_DatabaseManager;
+@class TDReplicator;
 @protocol TDAuthorizer;
 
-
-extern NSString* const kTDReplicatorDatabaseName;
-
-
-/** Manages the _replicator database for persistent replications.
-    It doesn't really have an API; it works on its own by monitoring the '_replicator' database, and docs in it, for changes. Applications use the regular document APIs to manage replications.
-    A TD_Server owns an instance of this class. */
+/** Manages the creation and queueing of TDReplicator objects on a separate replication thread.
+One must -start (-stop) the TDReplicatorManager in order to setup (destroy) the replication
+ thread on which individual TDReplicators execute.
+*/
 @interface TDReplicatorManager : NSObject
 {
     TD_DatabaseManager* _dbManager;
-    TD_Database* _replicatorDB;
     NSThread* _thread;
-    NSMutableDictionary* _replicatorsByDocID;
+    NSMutableDictionary* _replicatorsBySessionID;
     BOOL _updateInProgress;
 
     NSThread* _serverThread;
@@ -35,5 +32,8 @@ extern NSString* const kTDReplicatorDatabaseName;
 
 - (void) start;
 - (void) stop;
+
+- (TDReplicator* ) createReplicatorWithProperties: (NSDictionary*) properties;
+- (void) startReplicator: (TDReplicator*) repl;
 
 @end

--- a/Classes/common/touchdb/TDReplicatorManager.m
+++ b/Classes/common/touchdb/TDReplicatorManager.m
@@ -33,16 +33,6 @@
 #import <UIKit/UIApplication.h>
 #endif
 
-
-NSString* const kTDReplicatorDatabaseName = @"_replicator";
-
-
-@interface TDReplicatorManager ()
-- (BOOL) validateRevision: (TD_Revision*)newRev context: (id<TD_ValidationContext>)context;
-- (void) processAllDocs;
-@end
-
-
 @implementation TDReplicatorManager
 
 
@@ -50,12 +40,8 @@ NSString* const kTDReplicatorDatabaseName = @"_replicator";
     self = [super init];
     if (self) {
         _dbManager = dbManager;
-        _replicatorDB = [dbManager databaseNamed: kTDReplicatorDatabaseName];
-        if (!_replicatorDB) {
-            return nil;
-        }
-        Assert(_replicatorDB);
         _thread = [NSThread currentThread];
+        _replicatorsBySessionID = [[NSMutableDictionary alloc] init];
     }
     return self;
 }
@@ -67,44 +53,33 @@ NSString* const kTDReplicatorDatabaseName = @"_replicator";
 
 
 - (void) start {
+    
+    if (_serverThread)
+        return;  //we're already running a thread.
+    
     _serverThread = [[NSThread alloc] initWithTarget: self
                                             selector: @selector(runServerThread)
                                               object: nil];
     LogTo(Sync, @"Starting TDReplicatorManager thread %@ ...", _serverThread);
     [_serverThread start];
 
-    [_replicatorDB defineValidation: @"TDReplicatorManager" asBlock:
-         ^BOOL(TD_Revision *newRevision, id<TD_ValidationContext> context) {
-             return [self validateRevision: newRevision context: context];
-         }];
-    [[NSNotificationCenter defaultCenter] addObserver: self selector: @selector(dbChanged:) 
-                                                 name: TD_DatabaseChangeNotification
-                                               object: _replicatorDB];
     [[NSNotificationCenter defaultCenter] addObserver: self selector: @selector(someDbDeleted:)
                                                  name: TD_DatabaseWillBeDeletedNotification
                                                object: nil];
-#if TARGET_OS_IPHONE
-    // Register for foreground/background transition notifications, on iOS:
-    [[NSNotificationCenter defaultCenter] addObserver: self selector: @selector(appForegrounding:)
-                                                 name: UIApplicationWillEnterForegroundNotification
-                                               object: nil];
-#endif
-
-    [self processAllDocs];
 }
 
 
 - (void) stop {
     LogTo(Sync, @"STOP %@", self);
-    [_replicatorDB defineValidation: @"TDReplicatorManager" asBlock: nil];    [[NSNotificationCenter defaultCenter] removeObserver: self];
-    _replicatorsByDocID = nil;
+    [[NSNotificationCenter defaultCenter] removeObserver: self];
+    _replicatorsBySessionID = nil;
     _stopRunLoop = YES;
     _serverThread = nil;
 }
 
 
 - (NSString*) docIDForReplicator: (TDReplicator*)repl {
-    return [[_replicatorsByDocID allKeysForObject: repl] lastObject];
+    return [[_replicatorsBySessionID allKeysForObject: repl] lastObject];
 }
 
 #pragma mark - Replication thread management
@@ -140,278 +115,47 @@ NSString* const kTDReplicatorDatabaseName = @"_replicator";
     MYOnThread(_serverThread, block);
 }
 
-
-#pragma mark - CRUD:
-
-
-// Validation function for the _replicator database:
-- (BOOL) validateRevision: (TD_Revision*)newRev context: (id<TD_ValidationContext>)context {
-    // Ignore the change if it's one I'm making myself, or if it's a deletion:
-    if (_updateInProgress || newRev.deleted)
-        return YES;
-    
-    // First make sure the basic properties are valid:
-    NSDictionary* newProperties = newRev.properties;
-    LogTo(Sync, @"ReplicatorManager: Validating %@: %@", newRev, newProperties);
-    if ([_dbManager validateReplicatorProperties: newProperties] >= 300) {
-        context.errorMessage = @"Invalid replication parameters";
-        return NO;
-    }
-    
-    // Only certain keys can be changed or removed:
-    NSSet* deletableProperties = [NSSet setWithObjects: @"_replication_state", nil];
-    NSSet* mutableProperties = [NSSet setWithObjects: @"filter", @"query_params",
-                                                      @"heartbeat", @"feed", @"reset", nil];
-    NSSet* partialMutableProperties = [NSSet setWithObjects:@"target", @"source", nil];
-    return [context enumerateChanges: ^BOOL(NSString *key, id oldValue, id newValue) {
-        if (![context currentRevision])
-            return ![key hasPrefix: @"_"];
-        
-        // allow change of 'headers' and 'auth' in target and source
-        if ([partialMutableProperties containsObject:key]) {
-            NSDictionary *old = $castIf(NSDictionary, oldValue);
-            NSDictionary *nuu = $castIf(NSDictionary, newValue);
-            if ([oldValue isKindOfClass:[NSString class]]) {
-                old = @{@"url": oldValue};
-            }
-            if ([newValue isKindOfClass:[NSString class]]) {
-                nuu = @{@"url": newValue};
-            }
-            NSMutableSet* changedKeys = [NSMutableSet set];
-            for (NSString *subKey in old.allKeys) {
-                if (!$equal(old[subKey], nuu[subKey])) {
-                    [changedKeys addObject:subKey];
-                }
-            }
-            for (NSString *subKey in nuu.allKeys) {
-                if (!old[subKey]) {
-                    [changedKeys addObject:subKey];
-                }
-            }
-            NSSet* mutableSubProperties = [NSSet setWithObjects:@"headers", @"auth", nil];
-            [changedKeys minusSet:mutableSubProperties];
-            return [changedKeys count] == 0;
-        }
-
-        return [mutableProperties containsObject: key] ||
-                (newValue == nil && [deletableProperties containsObject: key]);
-    }];
-}
-
-
-// PUT a change to a replication document, retrying if there are conflicts:
-- (TDStatus) updateDoc: (TD_Revision*)currentRev
-        withProperties: (NSDictionary*)updates 
+- (TDReplicator* ) createReplicatorWithProperties: (NSDictionary*) properties
 {
-    LogTo(Sync, @"ReplicatorManager: Updating %@ with %@", currentRev, updates);
-    Assert(currentRev.revID);
-    TDStatus status;
-    do {
-        // Create an updated revision by merging in the updates:
-        NSDictionary* currentProperties = currentRev.properties;
-        NSMutableDictionary* updatedProperties = [currentProperties mutableCopy];
-        [updatedProperties addEntriesFromDictionary: updates];
-        [updatedProperties removeObjectForKey: @"reset"];   // reset is one-shot, so take it out now
-        
-        if ($equal(updatedProperties, currentProperties)) {
-            status = kTDStatusOK;     // this is a no-op change
-            break;
-        }
-        TD_Revision* updatedRev = [TD_Revision revisionWithProperties: updatedProperties];
-        
-        // Attempt to PUT the updated revision:
-        _updateInProgress = YES;
-        @try {
-            [_replicatorDB putRevision: updatedRev prevRevisionID: currentRev.revID
-                         allowConflict: NO status: &status];
-        } @finally {
-            _updateInProgress = NO;
-        }
-        
-        if (status == kTDStatusConflict) {
-            // Conflict -- doc has been updated, get the latest revision & try again:
-            TDStatus status2;
-            currentRev = [_replicatorDB getDocumentWithID: currentRev.docID
-                                               revisionID: nil options: 0
-                                                   status: &status2];
-            if (!currentRev)
-                status = status2;
-        }
-    } while (status == kTDStatusConflict);
     
-    if (TDStatusIsError(status))
-        Warn(@"TDReplicatorManager: Error %d updating _replicator doc %@", status, currentRev);
-    return status;
-}
-
-
-- (void) updateDoc: (TD_Revision*)rev forReplicator: (TDReplicator*)repl {
-    NSString* state;
-    if (repl.running)
-        state = @"triggered";
-    else if (repl.error)
-        state = @"error";
-    else
-        state = @"completed";
-    
-    NSMutableDictionary* update = $mdict({@"_replication_id", repl.sessionID});
-    if (!$equal(state, rev[@"_replication_state"])) {
-        update[@"_replication_state"] = state;
-        update[@"_replication_state_time"] = @(time(NULL));
+    TDReplicator* repl = [_dbManager replicatorWithProperties: properties status: NULL];
+    if (!repl) {
+        Warn(@"ReplicatorManager: Can't create replicator for %@", properties);
+        return nil;
     }
-
-    update[@"_replication_stats"] = @{
-                                     @"changesProcessed": @(repl.changesProcessed),
-                                     @"changesTotal": @(repl.changesTotal)
-                                     };
-
-    [self updateDoc: rev withProperties: update];
+    repl.sessionID = TDCreateUUID();
+    
+    _replicatorsBySessionID[repl.sessionID] = repl;
+    
+    return repl;
 }
 
-
-// A replication document has been created, so create the matching TDReplicator:
-- (void) processInsertion: (TD_Revision*)rev {
-    __weak TDReplicatorManager *weakSelf = self;
+- (void) startReplicator: (TDReplicator*) repl
+{
+    if (![_replicatorsBySessionID objectForKey:repl.sessionID]) {
+        Warn(@"ReplicatorManager: You must create TDReplicators with "
+             @"TDReplicatorManager -createReplicatorWithProperties. "
+             @"Replicator not started");
+        return;
+    }
+    
     [self queue:^{
-        TDReplicatorManager *strongSelf = weakSelf;
-        if (_replicatorsByDocID[rev.docID])
-            return;
-        LogTo(Sync, @"ReplicatorManager: %@ was created", rev);
-        NSDictionary* properties = rev.properties;
-        TDReplicator* repl = [_dbManager replicatorWithProperties: properties status: NULL];
-        if (!repl) {
-            Warn(@"TDReplicatorManager: Can't create replicator for %@", properties);
-            return;
-        }
-        NSString* replicationID = properties[@"_replication_id"] ?: TDCreateUUID();
-        repl.sessionID = replicationID;
-
-        if (!_replicatorsByDocID)
-            _replicatorsByDocID = [[NSMutableDictionary alloc] init];
-        _replicatorsByDocID[rev.docID] = repl;
-
-        [[NSNotificationCenter defaultCenter] addObserver: strongSelf
-                                                 selector: @selector(replicatorChanged:)
-                                                     name: nil
-                                                   object: repl];
+        
+        LogTo(Sync, @"ReplicatorManager: %@ (%@) was queued.",
+              [repl class], repl.sessionID );
         
         [repl start];
-        [strongSelf updateDoc: rev forReplicator: repl];
     }];
+    
 }
-
-
-// A replication document has been changed:
-- (void) processUpdate: (TD_Revision*)rev {
-    if (!rev[@"_replication_state"]) {
-        // Client deleted the _replication_state property; restart the replicator:
-        LogTo(Sync, @"ReplicatorManager: Restarting replicator for %@", rev);
-        TDReplicator* repl = _replicatorsByDocID[rev.docID];
-        if (repl) {
-            [repl.db stopAndForgetReplicator: repl];
-            [_replicatorsByDocID removeObjectForKey: rev.docID];
-        }
-        [self processInsertion: rev];
-    }
-}
-
-
-// A replication document has been deleted:
-- (void) processDeletion: (TD_Revision*)rev ofReplicator: (TDReplicator*)repl {
-    LogTo(Sync, @"ReplicatorManager: %@ was deleted", rev);
-    [_replicatorsByDocID removeObjectForKey: rev.docID];
-    [repl stop];
-}
-
 
 #pragma mark - NOTIFICATIONS:
 
-
-- (void) processRevision: (TD_Revision*)rev {
-    if (rev.generation == 1)
-        [self processInsertion: rev];
-    else
-        [self processUpdate: rev];
-}
-
-
-// Create TDReplications for all documents at startup:
-- (void) processAllDocs {
-    if (!_replicatorDB.exists)
-        return;
-    [_replicatorDB open];
-    LogTo(Sync, @"ReplicatorManager scanning existing _replicator docs...");
-    TDQueryOptions options = kDefaultTDQueryOptions;
-    options.includeDocs = YES;
-    NSArray* allDocs = [_replicatorDB getAllDocs: &options][@"rows"];
-    for (NSDictionary* row in allDocs) {
-        NSDictionary* docProps = row[@"doc"];
-        NSString* state = docProps[@"_replication_state"];
-        if (state==nil || $equal(state, @"triggered") ||
-                    [docProps[@"continuous"] boolValue]) {
-            [self processInsertion: [TD_Revision revisionWithProperties: docProps]];
-        }
-    }
-    LogTo(Sync, @"ReplicatorManager done scanning.");
-}
-
-
-- (void) appForegrounding: (NSNotification*)n {
-    // Danger: This is called on the main thread!
-    MYOnThread(_thread, ^{
-        LogTo(Sync, @"App activated -- restarting all replications");
-        [self processAllDocs];
-    });
-}
-
-
 #pragma mark - NSNotifcationCenter handlers
-
-// Notified that a _replicator database document has been created/updated/deleted:
-- (void) dbChanged: (NSNotification*)n {
-    if (_updateInProgress)
-        return;
-    TD_Revision* rev = (n.userInfo)[@"rev"];
-    LogTo(SyncVerbose, @"ReplicatorManager: %@ %@", n.name, rev);
-    NSString* docID = rev.docID;
-    if ([docID hasPrefix: @"_"])
-        return;
-    if (rev.deleted) {
-        TDReplicator* repl = _replicatorsByDocID[docID];
-        if (repl)
-            [self processDeletion: rev ofReplicator: repl];
-    } else {
-        if ([_replicatorDB loadRevisionBody: rev options: 0])
-            [self processRevision: rev];
-        else
-            Warn(@"Unable to load body of %@", rev);
-    }
-}
-
-
-// Notified that a TDReplicator has changed status or stopped:
-- (void) replicatorChanged: (NSNotification*)n {
-    TDReplicator* repl = n.object;
-    LogTo(SyncVerbose, @"ReplicatorManager: %@ %@", n.name, repl);
-    NSString* docID = [self docIDForReplicator: repl];
-    if (!docID)
-        return;  // If it's not a persistent replicator
-    TD_Revision* rev = [_replicatorDB getDocumentWithID: docID revisionID: nil];
-    
-    [self updateDoc: rev forReplicator: repl];
-    
-    if ($equal(n.name, TDReplicatorStoppedNotification)) {
-        // Replicator has stopped:
-        [[NSNotificationCenter defaultCenter] removeObserver: self name: nil object: repl];
-        [_replicatorsByDocID removeObjectForKey: docID];
-    }
-}
-
 
 // Notified that some database is being deleted; delete any associated replication document:
 - (void) someDbDeleted: (NSNotification*)n {
-    if (!_replicatorDB.exists)
-        return;
+
     TD_Database* db = n.object;
     if ([_dbManager.allOpenDatabases indexOfObjectIdenticalTo: db] == NSNotFound)
         return;
@@ -419,22 +163,15 @@ NSString* const kTDReplicatorDatabaseName = @"_replicator";
     
     TDQueryOptions options = kDefaultTDQueryOptions;
     options.includeDocs = YES;
-    NSArray* allDocs = [_replicatorDB getAllDocs: &options][@"rows"];
-    for (NSDictionary* row in allDocs) {
-        NSDictionary* docProps = row[@"doc"];
-        NSString* source = $castIf(NSString, docProps[@"source"]);
-        NSString* target = $castIf(NSString, docProps[@"target"]);
-        if ([source isEqualToString: dbName] || [target isEqualToString: dbName]) {
-            // Replication doc involves this database -- delete it:
-            LogTo(Sync, @"ReplicatorManager deleting replication %@", docProps);
-            TD_Revision* delRev = [[TD_Revision alloc] initWithDocID: docProps[@"_id"]
-                                                             revID: nil deleted: YES];
-            TDStatus status;
-            if (![_replicatorDB putRevision: delRev
-                             prevRevisionID: docProps[@"_rev"]
-                              allowConflict: NO status: &status]) {
-                Warn(@"TDReplicatorManager: Couldn't delete replication doc %@", docProps);
-            }
+    
+    //loop through all replicators to see if any of them are pushing/pulling from
+    //the deleted local database.
+    for (NSString *replicationId in [_replicatorsBySessionID allKeys]) {
+        TDReplicator *repl = [_replicatorsBySessionID objectForKey:replicationId];
+        if ([repl.db.name isEqualToString:dbName]) {
+            LogTo(Sync, @"ReplicatorManager: %@ (%@) was stopped", [repl class], replicationId);
+            [_replicatorsBySessionID removeObjectForKey: replicationId];
+            [repl stop];
         }
     }
 }

--- a/Classes/common/touchdb/TD_DatabaseManager.m
+++ b/Classes/common/touchdb/TD_DatabaseManager.m
@@ -110,9 +110,12 @@ static NSCharacterSet* kIllegalNameChars;
 + (BOOL) isValidDatabaseName: (NSString*)name {
     if (name.length > 0 && [name rangeOfCharacterFromSet: kIllegalNameChars].length == 0
                         && islower([name characterAtIndex: 0])
-                        && ![name hasSuffix:@"_extensions"])
+                        && ![name hasSuffix:@"_extensions"]) {
         return YES;
-    return $equal(name, kTDReplicatorDatabaseName);
+    }
+    else {
+        return NO;
+    }
 }
 
 

--- a/Tests/Tests/CDTReplicationTests.m
+++ b/Tests/Tests/CDTReplicationTests.m
@@ -106,35 +106,8 @@
     STAssertNotNil([tmp.database filterNamed:pushDoc[@"filter"]],
                    @"no filter called %@", pushDoc[@"filter"]);
     
-    [replicator start];  //this should put the doc on the DB.
-    
-    NSString *replicationDocumentId = [self replicationDocumentIdForReplicator:replicator];
-
-    CDTDatastore *replicatorDB = [self.factory datastoreNamed:kTDReplicatorDatabaseName 
-                                                        error:nil];
-    error = nil;
-    CDTDocumentRevision *pushRev = [replicatorDB getDocumentWithId:replicationDocumentId
-                                                             error:&error];
-    STAssertNotNil(pushRev, @"Replication doc doesn't exist: %@", replicationDocumentId);
-    STAssertNil(error, @"%@", error);
-    
-    [replicator stop];
     [replicatorFactory stop];
 }
-
-
-- (NSString*)replicationDocumentIdForReplicator:(CDTReplicator*)replicator
-{
-    // Diddle inside the object to get the replication doc name. Bad practice to get
-    // around private property.
-    SEL selector = NSSelectorFromString(@"replicationDocumentId");
-    IMP imp = [replicator methodForSelector:selector];
-    NSString* (*func)(id, SEL) = (void *)imp;
-    NSString *replicationDocumentId = func(replicator, selector);
-    return replicationDocumentId;
-}
-
-
 
 -(CDTAbstractReplication *)buildReplicationObject:(Class)aClass remoteUrl:(NSURL *)url
 {


### PR DESCRIPTION
This commit removes the _replicator database that was used to control
and monitor replication processes. With this update, the TDReplicator
objects are created directly with TDReplicatorManager. The CDReplicator
objects are conceptually no longer wrappers around _replicator documents,
but instead are wrappers around the TDReplicator objects directly.

The CDTReplicator is initialized with TDReplicatorManager object and
a NSDictionary that specifies the properties of the replication when
created by the CDTReplicatorFactory. There are significant changes to
CDTReplicator.m to make it reflect and monitor the state of the underlying
TDReplicator.

References to the _replicator database are removed from TD_DatabaseManager.
Removes support of "touchdb" protocol for a remote URL from TD_DatabaseManager.
Adds TDReplicatorStartedNotification to TDReplicator.
Adds -createReplicatorWithProperties: and -startReplicator: to
TDReplicatorManager.

By removing the _replicator database, however, there is now no support
to restart replications after the application returns from the background
or is restarted/crashed.
