### PR TITLE
Moves the TD_FilterBlock from TD_Database to TDPusher.

### DIFF
--- a/Classes/common/CDTReplicator/CDTAbstractReplication.m
+++ b/Classes/common/CDTReplicator/CDTAbstractReplication.m
@@ -28,7 +28,6 @@ NSString* const CDTReplicationErrorDomain = @"CDTReplicationErrorDomain";
     return nil;
 }
 
-
 - (NSString *)description
 {
     return [NSString stringWithFormat:@"Replicator Doc: %@",

--- a/Classes/common/CDTReplicator/CDTPushReplication.m
+++ b/Classes/common/CDTReplicator/CDTPushReplication.m
@@ -18,7 +18,6 @@
 #import "TDMisc.h"
 
 @interface CDTPushReplication()
-@property (nonatomic, strong) NSString *filterId;
 @end
 
 @implementation CDTPushReplication
@@ -35,7 +34,6 @@
     if(self = [super init]) {
         _source = source;
         _target = target;
-        _filterId = TDCreateUUID();
     }
     return self;
 }
@@ -68,10 +66,11 @@
         return nil;
     }
 
-    if (self.filter) {
-        [doc setObject:self.filterId forKey:@"filter"];
+
+    if (self.filterParams) {
         [doc setObject:self.filterParams ? : @{} forKey:@"query_params"];
     }
+    
     return doc;
 }
 

--- a/Classes/common/CDTReplicator/CDTReplicator.h
+++ b/Classes/common/CDTReplicator/CDTReplicator.h
@@ -20,6 +20,7 @@
 @class CDTDatastore;
 @class CDTDocumentBody;
 @class TDReplicatorManager;
+@class CDTAbstractReplication;
 
 /**
  * Describes the state of a CDTReplicator at a given moment.
@@ -40,8 +41,7 @@ typedef NS_ENUM(NSInteger, CDTReplicatorState) {
      */
     CDTReplicatorStateStopped,
     /**
-     * -stop has
-     * been called and the replicator is stopping its worker threads.
+     * -stop has been called and the replicator is being removed from the replication thread.
      */
     CDTReplicatorStateStopping,
     /**
@@ -121,7 +121,8 @@ typedef NS_ENUM(NSInteger, CDTReplicatorState) {
  Private so no docs
  */
 -(id)initWithTDReplicatorManager:(TDReplicatorManager*)replicatorManager
-           replicationProperties:(NSDictionary*)properties;
+                     replication:(CDTAbstractReplication*)replication
+                           error:(NSError * __autoreleasing*)error;
 
 
 /**---------------------------------------------------------------------------------------

--- a/Classes/common/CDTReplicator/CDTReplicatorFactory.h
+++ b/Classes/common/CDTReplicator/CDTReplicatorFactory.h
@@ -21,20 +21,6 @@
 @class CDTAbstractReplication;
 
 /**
-* Replication errors.
-*/
-typedef NS_ENUM(NSInteger, CDTReplicatorFactoryErrors) {
-    /**
-     * CDTReplicator was not fully constucted
-     */
-    CDTReplicatorFactoryErrorNilReplicatorObject = 1,
-    /**
-       Error creating a new CDTDocumentBody
-     */
-    CDTReplicatorFactoryErrorNilDocumentBodyForReplication  = 2
-};
-
-/**
  Factory for CDTReplicator objects.
 
  Use CDTReplicatorFactory to create CDTReplicator objects based on the parameters set in a 

--- a/Classes/common/touchdb/TDMisc.h
+++ b/Classes/common/touchdb/TDMisc.h
@@ -57,3 +57,6 @@ NSURL* TDURLWithoutQuery( NSURL* url );
 
 /** Appends path components to a URL. These will NOT be URL-escaped, so you can include queries. */
 NSURL* TDAppendToURL(NSURL* baseURL, NSString* toAppend);
+
+/** Filter block, used in replication. */
+typedef BOOL (^TD_FilterBlock) (TD_Revision* revision, NSDictionary* params);

--- a/Classes/common/touchdb/TDPusher.h
+++ b/Classes/common/touchdb/TDPusher.h
@@ -5,10 +5,11 @@
 //  Created by Jens Alfke on 12/5/11.
 //  Copyright (c) 2011 Couchbase, Inc. All rights reserved.
 //
+//  Modifications for this distribution by Cloudant, Inc., Copyright (c) 2014 Cloudant, Inc.
+//
 
-#import "TDPuller.h"
-#import "TD_Database.h"
-
+#import "TDReplicator.h"
+#import "TDMisc.h"
 
 /** Replicator that pushes to a remote CouchDB. */
 @interface TDPusher : TDReplicator
@@ -30,5 +31,9 @@
 }
 
 @property BOOL createTarget;
+
+/** Block called to filter document revisions that are pushed to the remote server. */
+@property (nonatomic,copy) TD_FilterBlock filter;
+
 
 @end

--- a/Classes/common/touchdb/TD_Database.h
+++ b/Classes/common/touchdb/TD_Database.h
@@ -11,6 +11,7 @@
 
 #import "TD_Revision.h"
 #import "TDStatus.h"
+#import "TDMisc.h"
 
 @class FMDatabase, FMDatabaseQueue, TD_View, TDBlobStore;
 struct TDQueryOptions;      // declared in TD_View.h
@@ -27,9 +28,6 @@ extern NSString* const TD_DatabaseWillCloseNotification;
 /** NSNotification posted when a database is about to be deleted (but before it closes). */
 extern NSString* const TD_DatabaseWillBeDeletedNotification;
 
-
-/** Filter block, used in changes feeds and replication. */
-typedef BOOL (^TD_FilterBlock) (TD_Revision* revision, NSDictionary* params);
 
 
 /** Options for what metadata to include in document bodies */
@@ -71,7 +69,6 @@ extern const TDChangesOptions kDefaultTDChangesOptions;
     int _transactionLevel;
     NSMutableDictionary* _views;
     NSMutableDictionary* _validations;
-    NSMutableDictionary* _filters;
     TDBlobStore* _attachments;
     NSMutableDictionary* _pendingAttachmentsByDigest;
     NSMutableArray* _activeReplicators;
@@ -203,9 +200,6 @@ extern const TDChangesOptions kDefaultTDChangesOptions;
                                   filter: (TD_FilterBlock)filter
                                   params: (NSDictionary*)filterParams;
 
-/** Define or clear a named filter function. These aren't used directly by TD_Database, but they're looked up by TDRouter when a _changes request has a ?filter parameter. */
-- (void) defineFilter: (NSString*)filterName asBlock: (TD_FilterBlock)filterBlock;
 
-- (TD_FilterBlock) filterNamed: (NSString*)filterName;
 
 @end

--- a/Classes/common/touchdb/TD_Database.m
+++ b/Classes/common/touchdb/TD_Database.m
@@ -1143,17 +1143,6 @@ const TDChangesOptions kDefaultTDChangesOptions = {UINT_MAX, 0, NO, NO, YES};
 }
 
 
-- (void) defineFilter: (NSString*)filterName asBlock: (TD_FilterBlock)filterBlock {
-    if (!_filters)
-        _filters = [[NSMutableDictionary alloc] init];
-    [_filters setValue: [filterBlock copy] forKey: filterName];
-}
-
-- (TD_FilterBlock) filterNamed: (NSString*)filterName {
-    return _filters[filterName];
-}
-
-
 #pragma mark - VIEWS:
 
 

--- a/Tests/Tests/CDTReplicationTests.m
+++ b/Tests/Tests/CDTReplicationTests.m
@@ -101,10 +101,8 @@
 
     NSDictionary *pushDoc = [push dictionaryForReplicatorDocument:nil];
     
-    STAssertTrue(pushDoc[@"filter"] != nil, @"No filter field in push replicator document");
+    STAssertTrue(push.filter != nil, @"No filter set in CDTPushReplication");
     STAssertEqualObjects(@{@"param1":@"foo"}, pushDoc[@"query_params"], @"\n%@", pushDoc);
-    STAssertNotNil([tmp.database filterNamed:pushDoc[@"filter"]],
-                   @"no filter called %@", pushDoc[@"filter"]);
     
     [replicatorFactory stop];
 }


### PR DESCRIPTION
Previously, a TD_Database managed all filters associated with that
database in a local NSMutableDictionary. This has been removed and
now the TDPusher class holds a copy of the block which defines the
filter.

These changes are reflected in the CDT\* level classes.

*filterId is removed from CDTPushReplication
*CDTReplicator is now initialized with an instance of an
CDTAbstractReplication class instead of its NSDictionary representation.
(This doesn't affect the API since this is a 'private' instantiation method.)
*CDTReplicator maintains a copy of a CDTFilterBlock
*CDTReplicatorFactory -oneWay was modified accordingly.

Note: Should I remove CDTReplicatorFactoryErrors as these are not used
anymore?
