### PR TITLE
Makes CDTAbstract/Pull/PushReplication conform to NSCopying.

### DIFF
--- a/Classes/common/CDTReplicator/CDTPullReplication.h
+++ b/Classes/common/CDTReplicator/CDTPullReplication.h
@@ -41,7 +41,7 @@
  
  */
 
-@interface CDTPullReplication : CDTAbstractReplication
+@interface CDTPullReplication : CDTAbstractReplication <NSCopying>
 
 /**
  @name Creating a replication configuration
@@ -143,13 +143,13 @@
  
 
  */
-@property (nonatomic, strong) NSString *filter;
+@property (nonatomic, copy) NSString *filter;
 
 /** The filter function query parameters
  
  @see -filter
  */
-@property (nonatomic, strong) NSDictionary *filterParams;
+@property (nonatomic, copy) NSDictionary *filterParams;
 
 
 @end

--- a/Classes/common/CDTReplicator/CDTPullReplication.m
+++ b/Classes/common/CDTReplicator/CDTPullReplication.m
@@ -35,6 +35,18 @@
     return self;
 }
 
+-(instancetype) copyWithZone:(NSZone *)zone
+{
+    CDTPullReplication *copy = [[CDTPullReplication allocWithZone:zone] initWithSource:self.source
+                                                                                target:self.target];
+    if (copy) {
+        copy.filter = self.filter;
+        copy.filterParams = self.filterParams;
+    }
+    
+    return copy;
+}
+
 -(NSDictionary*) dictionaryForReplicatorDocument:(NSError * __autoreleasing*)error
 {
     NSError *localError;

--- a/Classes/common/CDTReplicator/CDTPushReplication.h
+++ b/Classes/common/CDTReplicator/CDTPushReplication.h
@@ -45,7 +45,7 @@ typedef BOOL (^CDTFilterBlock) (CDTDocumentRevision* revision, NSDictionary* par
  @see CDTAbstractReplication
 */
 
-@interface CDTPushReplication : CDTAbstractReplication
+@interface CDTPushReplication : CDTAbstractReplication <NSCopying>
 
 /**
  @name Creating a replication configuration
@@ -143,7 +143,7 @@ typedef BOOL (^CDTFilterBlock) (CDTDocumentRevision* revision, NSDictionary* par
  
  @see -filter
  */
-@property (nonatomic, strong) NSDictionary *filterParams;
+@property (nonatomic, copy) NSDictionary *filterParams;
 
 
 @end

--- a/Classes/common/CDTReplicator/CDTPushReplication.m
+++ b/Classes/common/CDTReplicator/CDTPushReplication.m
@@ -38,6 +38,19 @@
     return self;
 }
 
+-(instancetype) copyWithZone:(NSZone *)zone
+{
+    CDTPushReplication *copy = [[CDTPushReplication allocWithZone:zone] initWithSource:self.source
+                                                                                target:self.target];
+    if (copy) {
+        copy.filter = self.filter;
+        copy.filterParams = self.filterParams;
+    }
+    
+    return copy;
+}
+
+
 -(NSDictionary*) dictionaryForReplicatorDocument:(NSError * __autoreleasing*)error
 {
     NSError *localError;

--- a/Classes/common/CDTReplicator/CDTReplicator.m
+++ b/Classes/common/CDTReplicator/CDTReplicator.m
@@ -33,7 +33,7 @@ static NSString* const CDTReplicatorErrorDomain = @"CDTReplicatorErrorDomain";
 
 @property (nonatomic, strong) TDReplicatorManager *replicatorManager;
 @property (nonatomic, strong) TDReplicator *tdReplicator;
-@property (nonatomic, strong) CDTAbstractReplication* cdtReplication;
+@property (nonatomic, copy)   CDTAbstractReplication* cdtReplication;
 @property (nonatomic, strong) NSDictionary *replConfig;
 // private readwrite properties
 @property (nonatomic, readwrite) CDTReplicatorState state;
@@ -78,15 +78,18 @@ static NSString* const CDTReplicatorErrorDomain = @"CDTReplicatorErrorDomain";
     self = [super init];
     if (self) {
         _replicatorManager = replicatorManager;
+        _cdtReplication = [replication copy];
+        
         NSError *localError;
-        _replConfig =[replication dictionaryForReplicatorDocument:&localError];
+        _replConfig =[_cdtReplication dictionaryForReplicatorDocument:&localError];
         if (!_replConfig) {
             if(error) *error = localError;
             return nil;
         }
+        
         _state = CDTReplicatorStatePending;
-        _cdtReplication = replication;
         _started = NO;
+        
     }
     return self;
 }


### PR DESCRIPTION
This ensures that the replication configuration cannot change after
the instantiation of the CDTReplicator object, which could cause some
bugs.

The other PRs overlap only a bit with this -- CDTReplicator.m  But it will be easier to wait for the ones before it and rebase after they are merged.
