### PR TITLE
34404 create rev from json

### DIFF
--- a/Classes/common/Attachments/CDTAttachment.h
+++ b/Classes/common/Attachments/CDTAttachment.h
@@ -118,3 +118,49 @@
                         type:(NSString*)type;
 
 @end
+
+@interface CDTSavedHTTPAttachment : CDTAttachment
+
+/**
+ 
+ Creates a CDTRemoteAttachment object from information obtained from
+ the _attachments object in a couch get request
+ 
+ @param name The name of the attachment eg example.txt
+ @param jsonData The decoded jsonData reccived from couchdb / cloudant
+ @param document the URL of the document this attachment is attached to
+ @param error will point to an NSError object in case of error
+ 
+ */
++(CDTSavedHTTPAttachment *)createAttachmentWithName:(NSString *)name
+                                           JSONData:(NSDictionary *) jsonData
+                                      attachmentURL:(NSURL*)attachmentURL
+                                              error:(NSError * __autoreleasing *) error;
+/**
+ 
+ Creates an attachment that represents a remote HTTP accessed attachment
+ 
+ @param attachmentURL the URL to the attachment file
+ @param name the name of the attachment
+ @param type the mime type of the attachment eg image/jpeg
+ @param size the size of the file in bytes (-1 if unkown)
+ @param data attschment data if it has already been downloaded
+ 
+ */
+-(id)initWithDocumentURL:(NSURL*)attachmentURL
+                    name:(NSString *)name
+                    type:(NSString *)type
+                    size:(NSInteger)size
+                    data:(NSData*)data;
+
+/**
+ 
+ Returns the data for an attachment. If attachment data requries downloading, (ie it was not provided
+ in the JSON with the document download) it will block while downloading the data from the remote 
+ server
+ 
+ @return the attachments data
+ 
+ */
+-(NSData*)dataFromAttachmentContent;
+@end

--- a/Classes/common/CDTDocumentRevision.h
+++ b/Classes/common/CDTDocumentRevision.h
@@ -35,7 +35,6 @@
 
 @property (nonatomic,readonly) SequenceNumber sequence;
 
-
 -(id)initWithDocId:(NSString *)docId
         revisionId:(NSString *) revId
               body:(NSDictionary *)body
@@ -48,6 +47,20 @@
        attachments:(NSDictionary *)attachments
           sequence:(SequenceNumber)sequence;
 
+/**
+ Creates an CDTDocumentRevision from JSON Data
+ The json data is expected to come from
+ Cloudant or a CouchDB instance.
+ 
+ @param json JSON data to create an object from
+ @param documentURL the url of the document
+ @param error points to an NSError in case of error
+ 
+ @return new CDTDocumentRevision instance
+*/
++(CDTDocumentRevision*)createRevisionFromJson:(NSDictionary*)jsonDict
+                                  forDocument:(NSURL *)documentURL
+                                        error:(NSError * __autoreleasing *) error;
 
 /** 
  Return document content as an NSData object.

--- a/Tests/Tests.xcodeproj/project.pbxproj
+++ b/Tests/Tests.xcodeproj/project.pbxproj
@@ -38,6 +38,8 @@
 		985FF00019CC597400EA5392 /* IndexManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 985FEFFE19CC597400EA5392 /* IndexManagerTests.m */; };
 		989E6E22198799AE00FB8510 /* DatastoreCRUD.m in Sources */ = {isa = PBXBuildFile; fileRef = 989E6E21198799AE00FB8510 /* DatastoreCRUD.m */; };
 		989E6E23198799AE00FB8510 /* DatastoreCRUD.m in Sources */ = {isa = PBXBuildFile; fileRef = 989E6E21198799AE00FB8510 /* DatastoreCRUD.m */; };
+		8E3377D518ABF36E003E3D93 /* IndexManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E3377D418ABF36E003E3D93 /* IndexManagerTests.m */; };
+		8E3377D618ABF42A003E3D93 /* IndexManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E3377D418ABF36E003E3D93 /* IndexManagerTests.m */; };
 		9985C74919AE5D8300636AB6 /* CDTQueryBuilderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9985C74819AE5D8300636AB6 /* CDTQueryBuilderTests.m */; };
 		9F0D23E918888C6C00D3D04E /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F0D23E818888C6C00D3D04E /* Foundation.framework */; };
 		9F0D23F1188B4FA900D3D04E /* TDMultipartReaderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F0D23F0188B4FA900D3D04E /* TDMultipartReaderTests.m */; };
@@ -103,6 +105,7 @@
 		985FEFFD19CC597400EA5392 /* IndexManagerTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IndexManagerTests.h; sourceTree = "<group>"; };
 		985FEFFE19CC597400EA5392 /* IndexManagerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IndexManagerTests.m; sourceTree = "<group>"; };
 		989E6E21198799AE00FB8510 /* DatastoreCRUD.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DatastoreCRUD.m; sourceTree = "<group>"; };
+		8E3377D418ABF36E003E3D93 /* IndexManagerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IndexManagerTests.m; sourceTree = "<group>"; };
 		9985C74819AE5D8300636AB6 /* CDTQueryBuilderTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTQueryBuilderTests.m; sourceTree = "<group>"; };
 		9F0D23E818888C6C00D3D04E /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		9F0D23F0188B4FA900D3D04E /* TDMultipartReaderTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TDMultipartReaderTests.m; sourceTree = "<group>"; };
@@ -206,6 +209,10 @@
 				9F95D60E18CF6A580006D349 /* DBQueryUtils.h */,
 				9F95D60F18CF6A580006D349 /* DBQueryUtils.m */,
 				27ACD1EC193DDDCC00658EC2 /* Events */,
+				27389E3418534E050027A404 /* SetUpDatastore.m */,
+				9FA839CA18FC474F0054512E /* CDTReplicationTests.m */,
+				27B34A5A18C0B204009F18E6 /* IndexManagerTests.h */,
+				8E3377D418ABF36E003E3D93 /* IndexManagerTests.m */,
 				27F43D4618E99C31003E8422 /* osx-aws-toolkit */,
 				27389E3418534E050027A404 /* SetUpDatastore.m */,
 				9FA839CA18FC474F0054512E /* CDTReplicationTests.m */,
@@ -479,6 +486,7 @@
 				985FEFFF19CC597400EA5392 /* IndexManagerTests.m in Sources */,
 				9F95D61018CF6A580006D349 /* DBQueryUtils.m in Sources */,
 				9F0D23F4188B4FFF00D3D04E /* TDMultipartWriterTests.m in Sources */,
+				27ACD1EE193DDDF000658EC2 /* CDTDatastoreEvents.m in Sources */,
 				9F0D24141892E9B800D3D04E /* TDPusherTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -512,6 +520,7 @@
 				9F95D61118CF6A580006D349 /* DBQueryUtils.m in Sources */,
 				27CCEDD6187AD70C006F3C66 /* CloudantSyncTests.m in Sources */,
 				9F0D23F5188B4FFF00D3D04E /* TDMultipartWriterTests.m in Sources */,
+				27ACD1EF193DDDF000658EC2 /* CDTDatastoreEvents.m in Sources */,
 				9F0D24151892E9B800D3D04E /* TDPusherTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Tests/Tests/DatastoreCRUD.m
+++ b/Tests/Tests/DatastoreCRUD.m
@@ -70,8 +70,6 @@
 #pragma mark - helper methods
 
 
-
-
 -(NSArray*)generateDocuments:(int)count
 {
     NSMutableArray *result = [NSMutableArray arrayWithCapacity:count];
@@ -85,6 +83,148 @@
 
 #pragma mark - CREATE tests
 
+-(void)testDocumentRevisionFactoryValidData
+{
+    NSError * error;
+    NSDictionary * dict = @{@"_id":@"someIdHere",
+                            @"_rev":@"3-750dac460a6cc41e6999f8943b8e603e",
+                            @"aKey":@"aValue",
+                            @"hello":@"world"
+                            };
+    NSDictionary * body = @{@"aKey":@"aValue",@"hello":@"world"};
+    
+    
+    STAssertNil(error, @"Error should have been nil");
+    
+    CDTDocumentRevision * rev = [CDTDocumentRevision createRevisionFromJson:dict
+                                                                forDocument:[NSURL
+                                                                             URLWithString:@"http://localhost:5984/temp/doc"]
+                                                                      error:&error];
+    
+    STAssertNil(error, @"Error occured creating document with valid data");
+    STAssertNotNil(rev, @"Revision was nil");
+    STAssertEqualObjects(@"someIdHere", rev.docId, @"docId was different, expected someIdHere actual %@",rev.docId);
+    STAssertEqualObjects(@"3-750dac460a6cc41e6999f8943b8e603e", rev.revId, @"Revision was different expected 3-750dac460a6cc41e6999f8943b8e603e actual %@",rev.revId);
+
+    STAssertEqualObjects(body, rev.body, @"Body was different");
+    STAssertFalse(rev.deleted, @"Document is not marked as deleted");
+    
+}
+
+-(void)testDocumentRevisionValidDataDeletedDocWithBody
+{
+    NSError * error;
+    NSDictionary *body = @{ @"aKey":@"aValue",
+                            @"hello":@"world"
+                            };
+    
+    NSDictionary * dict = @{@"_id":@"someIdHere",
+                            @"_rev":@"3-750dac460a6cc41e6999f8943b8e603e",
+                            @"_deleted":[NSNumber numberWithBool:YES],
+                            @"aKey":@"aValue",
+                            @"hello":@"world"
+                            };
+
+    
+    STAssertNil(error, @"Error should have been nil");
+    
+    CDTDocumentRevision * rev = [CDTDocumentRevision createRevisionFromJson:dict
+                                                                forDocument:[NSURL
+                                                                             URLWithString:@"http://localhost:5984/temp/doc"]
+                                                                      error:&error];
+    
+    STAssertNil(error, @"Error occured creating document with valid data");
+    STAssertNotNil(rev, @"Revision was nil");
+    STAssertEqualObjects(@"someIdHere", rev.docId, @"docId was different, expected someIdHere actual %@",rev.docId);
+    STAssertEqualObjects(@"3-750dac460a6cc41e6999f8943b8e603e", rev.revId, @"Revision was different expected 3-750dac460a6cc41e6999f8943b8e603e actual %@",rev.revId);
+    
+    STAssertEqualObjects(@{}, rev.body, @"Body should be empty");
+    STAssertTrue(rev.deleted, @"Document is not marked as deleted");
+}
+
+-(void)testDocumentRevisionValidDataDeletedDocWithoutBody{
+    NSError * error;
+    NSDictionary * dict = @{@"_id":@"someIdHere",
+                            @"_rev":@"3-750dac460a6cc41e6999f8943b8e603e",
+                            @"_deleted":[NSNumber numberWithBool:YES]
+                            };
+    
+    
+    STAssertNil(error, @"Error should have been nil");
+    
+    CDTDocumentRevision * rev = [CDTDocumentRevision createRevisionFromJson:dict
+                                                                forDocument:[NSURL
+                                                                             URLWithString:@"http://localhost:5984/temp/doc"]
+                                                                      error:&error];
+    
+    STAssertNil(error, @"Error occured creating document with valid data");
+    STAssertNotNil(rev, @"Revision was nil");
+    STAssertEqualObjects(@"someIdHere", rev.docId, @"docId was different, expected someIdHere actual %@",rev.docId);
+    STAssertEqualObjects(@"3-750dac460a6cc41e6999f8943b8e603e", rev.revId, @"Revision was different expected 3-750dac460a6cc41e6999f8943b8e603e actual %@",rev.revId);
+    
+    STAssertEqualObjects([NSDictionary dictionary], rev.body, @"Body should be empty");
+    STAssertTrue(rev.deleted, @"Document is not marked as deleted");
+}
+
+-(void) testDocumentRevisionInvalidData{
+    NSError * error;
+    NSDictionary * dict = @{@"_id":@"someIdHere",
+                            @"_rev":@"3-750dac460a6cc41e6999f8943b8e603e",
+                            @"aKey":@"aValue",
+                            @"hello":@"world",
+                            @"_invalidKey":@"someValue"
+                            };
+    
+    STAssertNil(error, @"Error should have been nil");
+    
+    CDTDocumentRevision * rev = [CDTDocumentRevision createRevisionFromJson:dict
+                                                                forDocument:[NSURL
+                                                                             URLWithString:@"http://localhost:5984/temp/doc"]
+                                                                      error:&error];
+    
+    STAssertNotNil(error, @"Error did not occur whencreating document with invalid data");
+    STAssertNil(rev, @"Revision was not nil");
+
+}
+
+-(void)testDocumentRevisionFactoryWithValidValuesAll_prefixs
+{
+    NSError * error;
+    NSDictionary * dict = @{@"_id":@"someIdHere",
+                            @"_rev":@"3-750dac460a6cc41e6999f8943b8e603e",
+                            @"aKey":@"aValue",
+                            @"_attachments":@{},
+                            @"_conflicts":@[],
+                            @"_deleted_conflicts":@[],
+                            @"_local_seq":@1,
+                            @"_revs_info":@{},
+                            @"_revisions":@[],
+                            @"hello":@"world"
+                            };
+    NSDictionary * body = @{@"aKey":@"aValue",@"hello":@"world"};
+    
+    STAssertNil(error, @"Error should have been nil");
+    
+    CDTDocumentRevision * rev = [CDTDocumentRevision createRevisionFromJson:dict
+                                                                forDocument:[NSURL
+                                                                             URLWithString:@"http://localhost:5984/temp/doc"]
+                                                                      error:&error];
+    
+    STAssertNil(error, @"Error occured creating document with valid data");
+    STAssertNotNil(rev, @"Revision was nil");
+    STAssertEqualObjects(@"someIdHere",
+                         rev.docId,
+                         @"docId was different, expected someIdHere actual %@",
+                         rev.docId);
+    STAssertEqualObjects(@"3-750dac460a6cc41e6999f8943b8e603e",
+                         rev.revId,
+                         @"Revision was different expected 3-750dac460a6cc41e6999f8943b8e603e actual %@",
+                         rev.revId);
+    
+    STAssertEqualObjects(body, rev.body, @"Body was different");
+    STAssertFalse(rev.deleted, @"Document is not marked as deleted");
+    
+}
 
 -(void)testCreateOneDocumentSQLEntries
 {

--- a/Tests/Tests/DatastoreConflictResolvers.m
+++ b/Tests/Tests/DatastoreConflictResolvers.m
@@ -55,7 +55,8 @@
                                                  body:@{}
                                               deleted:YES
                                           attachments:@{}
-                                             sequence:0];
+                                             sequence:0
+            ];
 }
 @end
 


### PR DESCRIPTION
Allow creating CDTDocumentRevision objects for use with remote data sources

Create factory method which takes an NSDictionary and document URL.
- Reject dictionary if it contains any _prefixed values which are not couchdb properties
- Create any attachments as CDTRemoteAttachments defined in _attachments

The bugs likely to occur from this are using the API with NSDictionary objects containing incomplete data.
