### PR TITLE
33513 pull replication by document id

### DIFF
--- a/Classes/common/CDTReplicator/CDTAbstractReplication.h
+++ b/Classes/common/CDTReplicator/CDTAbstractReplication.h
@@ -128,6 +128,14 @@ typedef NS_ENUM(NSInteger, CDTReplicationErrors) {
 @property (nonatomic, copy) NSDictionary* optionalHeaders;
 
 /**
+ If non-nil, this block is executed before -startWithError returns.
+
+ This allows the Replication configuration to be customized just
+ before the replicator starts.
+ */
+@property (nonatomic, copy) void(^onStart)(CDTAbstractReplication*);
+
+/**
  Returns the default "User-Agent" header value used in HTTP requests made during replication.
 */
 + (NSString*)defaultUserAgentHTTPHeader;

--- a/Classes/common/CDTReplicator/CDTAbstractReplication.m
+++ b/Classes/common/CDTReplicator/CDTAbstractReplication.m
@@ -28,6 +28,7 @@ NSString *const CDTReplicationErrorDomain = @"CDTReplicationErrorDomain";
     CDTAbstractReplication *copy = [[[self class] allocWithZone:zone] init];
     if (copy) {
         copy.optionalHeaders = self.optionalHeaders;
+        copy.onStart = self.onStart;
     }
 
     return copy;

--- a/Classes/common/CDTReplicator/CDTPullReplication.h
+++ b/Classes/common/CDTReplicator/CDTPullReplication.h
@@ -152,4 +152,24 @@
  */
 @property (nonatomic, copy) NSDictionary *filterParams;
 
+/** The list of document IDs to pull during a replication.
+
+ All other documents are filtered out and not included in the replication.
+
+ Modifying the example above, in order to replicate a subset of known document 
+ IDs, specify:
+ 
+    pull.clientFilterDocIds = @[@"doc-1", @"doc-2", @"doc-12"];
+ 
+ before calling:
+ 
+    CDTReplicator *rep = [replicatorFactory oneWay:pull error:&error];
+ 
+ Now only the documents already extant in the database will be updated, and 
+ any additional documents with the specified IDs (if present) will be pulled.
+ 
+ */
+@property (nonatomic, copy) NSArray *clientFilterDocIds;
+
+
 @end

--- a/Classes/common/CDTReplicator/CDTPullReplication.m
+++ b/Classes/common/CDTReplicator/CDTPullReplication.m
@@ -46,6 +46,7 @@
         copy.target = self.target;
         copy.filter = self.filter;
         copy.filterParams = self.filterParams;
+        copy.clientFilterDocIds = self.clientFilterDocIds;
     }
 
     return copy;
@@ -95,7 +96,11 @@
             [doc setObject:self.filterParams forKey:@"query_params"];
         }
     }
-
+    
+    if (self.clientFilterDocIds) {
+        [doc setObject:self.clientFilterDocIds forKey:@"client_filter_doc_ids"];
+    }
+    
     return doc;
 }
 

--- a/Classes/common/touchdb/TDPuller.h
+++ b/Classes/common/touchdb/TDPuller.h
@@ -16,15 +16,22 @@
 @interface TDPuller : TDReplicator {
    @private
     TDChangeTracker* _changeTracker;
-    BOOL _caughtUp;                      // Have I received all current _changes entries?
-    TDSequenceMap* _pendingSequences;    // Received but not yet copied into local DB
-    NSMutableArray* _revsToPull;         // Queue of TDPulledRevisions to download
-    NSMutableArray* _deletedRevsToPull;  // Separate lower-priority of deleted TDPulledRevisions
-    NSMutableArray* _bulkRevsToPull;     // TDPulledRevisions that can be fetched in bulk
-    NSUInteger _httpConnectionCount;     // Number of active NSURLConnections
-    TDBatcher* _downloadsToInsert;       // Queue of TDPulledRevisions, with bodies, to insert in DB
+    BOOL _caughtUp;                     // Have I received all current _changes entries?
+    TDSequenceMap* _pendingSequences;   // Received but not yet copied into local DB
+    NSMutableArray* _revsToPull;        // Queue of TDPulledRevisions to download
+    NSMutableArray* _deletedRevsToPull; // Separate lower-priority of deleted TDPulledRevisions
+    NSMutableArray* _bulkRevsToPull;    // TDPulledRevisions that can be fetched in bulk
+    NSUInteger _httpConnectionCount;    // Number of active NSURLConnections
+    TDBatcher* _downloadsToInsert;      // Queue of TDPulledRevisions, with bodies, to insert in DB
+    NSArray* _clientFilterDocIds;       // If set, only pull this subset of doc ids
+    NSMutableSet *_clientFilterNewDocIds; // The set difference: _clientFilterDocIds - all doc ids in DB
 }
 
+// overriden from TDReplicator
+- (NSString*) remoteCheckpointDocID;
+// overriden from TDReplicator
+- (void) addToInbox: (TD_Revision*)rev;
+- (void) setClientFilterDocIds:(NSArray *)clientFilterDocIds;
 @end
 
 /** A revision received from a remote server during a pull. Tracks the opaque remote sequence ID. */

--- a/Classes/common/touchdb/TDPuller.m
+++ b/Classes/common/touchdb/TDPuller.m
@@ -29,6 +29,7 @@
 #import "ExceptionUtils.h"
 #import "TDJSON.h"
 #import "CDTLogging.h"
+#import "TDCanonicalJSON.h"
 
 // Maximum number of revisions to fetch simultaneously. (CFNetwork will only send about 5
 // simultaneous requests, but by keeping a larger number in its queue we ensure that it doesn't
@@ -55,8 +56,17 @@ static NSString* joinQuotedEscaped(NSArray* strings);
 
 - (void)dealloc { [_changeTracker stop]; }
 
-- (void)beginReplicating
-{
+- (void) beginReplicating {
+    
+    // download the missing documents according to the doc id filter
+    if (_clientFilterNewDocIds) {
+        for (NSString *docId in _clientFilterNewDocIds) {
+            TD_Revision *rev = [[TD_Revision alloc] initWithDocID:docId revID:nil deleted:FALSE];
+            rev.sequence = -1; // fake sequence number means "don't track sequence numbers"
+            [self pullRemoteRevision:rev ignoreMissingDocs:YES immediatelyInsert:YES];
+        }
+    }
+    
     if (!_downloadsToInsert) {
         // Note: This is a ref cycle, because the block has a (retained) reference to 'self',
         // and _downloadsToInsert retains the block, and of course I retain _downloadsToInsert.
@@ -319,15 +329,17 @@ static NSString* joinQuotedEscaped(NSArray* strings);
                 queue = _deletedRevsToPull;
                 if (queue.count == 0) break;  // both queues are empty
             }
-            [self pullRemoteRevision:queue[0]];
-            [queue removeObjectAtIndex:0];
+            [self pullRemoteRevision: queue[0] ignoreMissingDocs:NO immediatelyInsert:NO];
+            [queue removeObjectAtIndex: 0];
         }
     }
 }
 
 // Fetches the contents of a revision from the remote db, including its parent revision ID.
 // The contents are stored into rev.properties.
-- (void)pullRemoteRevision:(TD_Revision*)rev
+- (void) pullRemoteRevision: (TD_Revision*)rev
+          ignoreMissingDocs:(BOOL)ignoreMissingDocs
+          immediatelyInsert:(BOOL)immediatelyInsert
 {
     [self asyncTaskStarted];
     ++_httpConnectionCount;
@@ -336,9 +348,16 @@ static NSString* joinQuotedEscaped(NSArray* strings);
     // been added since the latest revisions we have locally.
     // See: http://wiki.apache.org/couchdb/HTTP_Document_API#GET
     // See: http://wiki.apache.org/couchdb/HTTP_Document_API#Getting_Attachments_With_a_Document
-    NSString* path = $sprintf(@"%@?rev=%@&revs=true&attachments=true", TDEscapeID(rev.docID),
-                              TDEscapeID(rev.revID));
-    NSArray* knownRevs = [_db getPossibleAncestorRevisionIDs:rev limit:kMaxNumberOfAttsSince];
+    NSString* path;
+    // if revID isn't supplied, get the latest revision
+    if (rev.revID) {
+        path = $sprintf(@"%@?rev=%@&revs=true&attachments=true",
+                              TDEscapeID(rev.docID), TDEscapeID(rev.revID));
+    } else {
+        path = $sprintf(@"%@?revs=true&attachments=true",
+                        TDEscapeID(rev.docID));
+    }
+    NSArray* knownRevs = [_db getPossibleAncestorRevisionIDs: rev limit: kMaxNumberOfAttsSince];
     if (knownRevs.count > 0)
         path = [path stringByAppendingFormat:@"&atts_since=%@", joinQuotedEscaped(knownRevs)];
     CDTLogVerbose(CDTREPLICATION_LOG_CONTEXT, @"%@: GET %@", self, path);
@@ -347,35 +366,41 @@ static NSString* joinQuotedEscaped(NSArray* strings);
     // results in compiler error (could be undefined variable)
     __weak TDPuller* weakSelf = self;
     TDMultipartDownloader* dl;
-    dl = [[TDMultipartDownloader alloc] initWithURL:TDAppendToURL(_remote, path)
-                                           database:_db
-                                     requestHeaders:self.requestHeaders
-                                       onCompletion:^(TDMultipartDownloader* dl, NSError* error) {
-                                           __strong TDPuller* strongSelf = weakSelf;
-                                           // OK, now we've got the response revision:
-                                           if (error) {
-                                               strongSelf.error = error;
-                                               [strongSelf revisionFailed];
-                                               strongSelf.changesProcessed++;
-                                           } else {
-                                               TD_Revision* gotRev =
-                                                   [TD_Revision revisionWithProperties:dl.document];
-                                               gotRev.sequence = rev.sequence;
-                                               // Add to batcher ... eventually it will be fed to
-                                               // -insertRevisions:.
-                                               [_downloadsToInsert queueObject:gotRev];
-                                               [strongSelf asyncTaskStarted];
-                                           }
-
-                                           // Note that we've finished this task:
-                                           [strongSelf removeRemoteRequest:dl];
-                                           [strongSelf asyncTasksFinished:1];
-                                           --_httpConnectionCount;
-                                           // Start another task if there are still revisions
-                                           // waiting to be pulled:
-                                           [strongSelf pullRemoteRevisions];
-                                       }];
-    [self addRemoteRequest:dl];
+    dl = [[TDMultipartDownloader alloc] initWithURL: TDAppendToURL(_remote, path)
+                                           database: _db
+                                     requestHeaders: self.requestHeaders
+                                       onCompletion:
+        ^(TDMultipartDownloader* dl, NSError *error) {
+            __strong TDPuller *strongSelf = weakSelf;
+            // OK, now we've got the response revision:
+            if (error) {
+                // if ignoreMissingDocs is true, we know that some requests might 404
+                if (!(ignoreMissingDocs && error.code == 404)) {
+                    strongSelf.error = error;
+                    [strongSelf revisionFailed];
+                }
+                strongSelf.changesProcessed++;
+            } else {
+                TD_Revision* gotRev = [TD_Revision revisionWithProperties: dl.document];
+                gotRev.sequence = rev.sequence;
+                // Add to batcher ... eventually it will be fed to -insertRevisions:.
+                if (immediatelyInsert) {
+                    [strongSelf insertDownloads:@[gotRev]];
+                } else {
+                    [_downloadsToInsert queueObject: gotRev];
+                }
+                [strongSelf asyncTaskStarted];
+            }
+            
+            // Note that we've finished this task:
+            [strongSelf removeRemoteRequest:dl];
+            [strongSelf asyncTasksFinished:1];
+            --_httpConnectionCount;
+            // Start another task if there are still revisions waiting to be pulled:
+            [strongSelf pullRemoteRevisions];
+        }
+     ];
+    [self addRemoteRequest: dl];
     dl.authorizer = _authorizer;
     [dl start];
 }
@@ -484,7 +509,9 @@ static NSString* joinQuotedEscaped(NSArray* strings);
                 }
 
                 // Mark this revision's fake sequence as processed:
-                [_pendingSequences removeSequence:fakeSequence];
+                if (fakeSequence != -1) {
+                    [_pendingSequences removeSequence: fakeSequence];
+                }
             }
         }
 
@@ -508,6 +535,60 @@ static NSString* joinQuotedEscaped(NSArray* strings);
     self.changesProcessed += downloads.count;
     [self asyncTasksFinished:downloads.count];
 }
+
+/* over-ride implementation in TDReplicator */
+- (NSString*) remoteCheckpointDocID {
+    if (_clientFilterDocIds) {
+        NSMutableDictionary* spec = $mdict({@"localUUID", _db.privateUUID},
+                                           {@"remoteURL", _remote.absoluteString},
+                                           {@"push", @(self.isPush)},
+                                           {@"cloudantSyncDocIdSubset", @YES});
+        return TDHexSHA1Digest([TDCanonicalJSON canonicalData: spec]);
+    } else {
+        return [super remoteCheckpointDocID];
+    }
+}
+
+/* over-ride implementation in TDReplicator,
+   to allow filtering by doc id if needed
+ */
+- (void) addToInbox: (TD_Revision*)rev {
+    if (_clientFilterDocIds != nil) {
+        // if we're client filtering, only pull revisions for doc ids we already have
+        TDStatus status;
+        [self.db getDocumentWithID:rev.docID revisionID:nil options:kTDNoBody status:&status];
+        if (status == kTDStatusNotFound)
+            return;
+    }
+    [super addToInbox:rev];
+}
+
+- (void) setClientFilterDocIds:(NSArray *)clientFilterDocIds
+{
+    if (clientFilterDocIds != nil) {
+        
+        _clientFilterDocIds = clientFilterDocIds;
+        
+        struct TDQueryOptions query = {
+            .limit = (unsigned int)_db.documentCount,
+            .inclusiveEnd = YES,
+            .skip = 0,
+            .descending = NO,
+            .includeDocs = NO,
+            .content = 0
+        };
+
+        // work out which documents we don't have but want
+        _clientFilterNewDocIds = [NSMutableSet set];
+        for (NSDictionary *doc in [[_db getDocsWithIDs:_clientFilterDocIds options:&query] objectForKey:@"rows"]) {
+            if ([doc[@"error"] isEqualToString:@"not_found"]) {
+                [_clientFilterNewDocIds addObject:[doc objectForKey:@"key"]];
+            }
+        }
+    }
+
+}
+
 
 @end
 

--- a/Classes/common/touchdb/TDReplicator.h
+++ b/Classes/common/touchdb/TDReplicator.h
@@ -84,6 +84,9 @@ extern NSString* TDReplicatorStoppedNotification;
     TDReplicatorStoppedNotification will be posted when it finally stops. */
 - (void)stop;
 
+/** Internal method, declared for sub-classes to over-ride */
+- (NSString*) remoteCheckpointDocID;
+
 /** Is the replicator running? (Observable) */
 @property (readonly, nonatomic) BOOL running;
 

--- a/Classes/common/touchdb/TD_DatabaseManager.m
+++ b/Classes/common/touchdb/TD_DatabaseManager.m
@@ -20,6 +20,7 @@
 #import "TD_DatabaseManager.h"
 #import "TD_Database.h"
 #import "TDPusher.h"
+#import "TDPuller.h"
 #import "TDReplicatorManager.h"
 #import "TDInternal.h"
 #import "TDMisc.h"
@@ -280,7 +281,8 @@ static NSDictionary* parseSourceOrTarget(NSDictionary* properties, NSString* key
                                 authorizer:NULL];
 }
 
-- (TDReplicator*)replicatorWithProperties:(NSDictionary*)properties status:(TDStatus*)outStatus
+- (TDReplicator*) replicatorWithProperties: (NSDictionary*)properties
+                                    status: (TDStatus*)outStatus
 {
     // Extract the parameters from the JSON request body:
     // http://wiki.apache.org/couchdb/Replication
@@ -316,9 +318,14 @@ static NSDictionary* parseSourceOrTarget(NSDictionary* properties, NSString* key
     repl.options = properties;
     repl.requestHeaders = headers;
     repl.authorizer = authorizer;
-    if (push) ((TDPusher*)repl).createTarget = createTarget;
 
-    if (outStatus) *outStatus = kTDStatusOK;
+    if (push)
+        ((TDPusher*)repl).createTarget = createTarget;
+    if (!push)
+        [(TDPuller*)repl setClientFilterDocIds:$castIf(NSArray, properties[@"client_filter_doc_ids"])];
+    
+    if (outStatus)
+        *outStatus = kTDStatusOK;
     return repl;
 }
 

--- a/ReplicationAcceptance/ReplicationAcceptance/ReplicationAcceptance+CRUD.m
+++ b/ReplicationAcceptance/ReplicationAcceptance/ReplicationAcceptance+CRUD.m
@@ -125,10 +125,16 @@
 
 -(void) createRemoteDocs:(NSInteger)count suffixFrom:(NSInteger)start
 {
+    [self createRemoteDocs:1 count:count];
+}
+
+-(void) createRemoteDocs:(NSInteger)start
+                   count:(NSInteger)count
+{
     NSMutableArray *docs = [NSMutableArray array];
-    NSUInteger currentIndex = start;
-    for (long i = 1; i < count+1; i++) {
-        currentIndex++;
+    NSUInteger currentIndex;
+    for (long i = 0; i < count; i++) {
+        currentIndex = start+i;
         NSString *docId = [NSString stringWithFormat:@"doc-%li", currentIndex];
         NSDictionary *dict = @{@"_id": docId, 
                                @"hello": @"world", 

--- a/ReplicationAcceptance/ReplicationAcceptance/ReplicationAcceptance+CRUD.m
+++ b/ReplicationAcceptance/ReplicationAcceptance/ReplicationAcceptance+CRUD.m
@@ -120,16 +120,10 @@
 
 - (void)createRemoteDocs:(NSInteger)count
 {
-    [self createRemoteDocs:count suffixFrom:0];
+    [self createRemoteDocs:count suffixFrom:1];
 }
 
 -(void) createRemoteDocs:(NSInteger)count suffixFrom:(NSInteger)start
-{
-    [self createRemoteDocs:1 count:count];
-}
-
--(void) createRemoteDocs:(NSInteger)start
-                   count:(NSInteger)count
 {
     NSMutableArray *docs = [NSMutableArray array];
     NSUInteger currentIndex;

--- a/ReplicationAcceptance/ReplicationAcceptance/ReplicationAcceptance.m
+++ b/ReplicationAcceptance/ReplicationAcceptance/ReplicationAcceptance.m
@@ -96,16 +96,25 @@ static NSUInteger largeRevTreeSize = 1500;
  Create a new replicator, and wait for replication from the remote database to complete.
  */
 -(CDTReplicator *) pullFromRemote {
-    return [self pullFromRemoteWithFilter:nil params:nil];
+    return [self pullFromRemoteWithFilter:nil params:nil clientFilterDocIds:nil];
 }
 
--(CDTReplicator *) pullFromRemoteWithFilter:(NSString*)filterName params:(NSDictionary*)params
+-(CDTReplicator *) pullFromRemoteWithFilter:(NSString*)filterName
+                                     params:(NSDictionary*)params
+{
+    return [self pullFromRemoteWithFilter:filterName params:params clientFilterDocIds:nil];
+}
+
+-(CDTReplicator *) pullFromRemoteWithFilter:(NSString*)filterName
+                                     params:(NSDictionary*)params
+                         clientFilterDocIds:(NSArray*)filterDocIds
 {
     CDTPullReplication *pull = [CDTPullReplication replicationWithSource:self.primaryRemoteDatabaseURL
                                                                   target:self.datastore];
     
     pull.filter = filterName;
     pull.filterParams = params;
+    pull.clientFilterDocIds = filterDocIds;
     
     NSError *error;
     CDTReplicator *replicator =  [self.replicatorFactory oneWay:pull error:&error];
@@ -124,6 +133,11 @@ static NSUInteger largeRevTreeSize = 1500;
     
     return replicator;
 }
+
+-(CDTReplicator *) pullFromRemoteWithClientFilterDocIds:(NSArray*)clientFilterDocIds {
+    return [self pullFromRemoteWithFilter:nil params:nil clientFilterDocIds:clientFilterDocIds];
+}
+
 
 
 /**
@@ -860,6 +874,213 @@ static NSUInteger largeRevTreeSize = 1500;
     [self deleteRemoteDatabase:thirdDatabaseName instanceURL:self.remoteRootURL];
 }
 
+
+-(void) testPullClientFilteredLots {
+    // Create large number of documents locally and remotely
+    // ensure all updated documents on remote side are pulled
+    // ensure new documents on remote side matching id list are pulled
+    
+    // Create docs in remote database
+    NSLog(@"Creating documents...");
+    
+    int localdocs = 5000;
+    int remotedocs = 5000;
+    
+    // 0..5000 local
+    // 5001..10000 remote
+    // then upload 2-rev 0..5000 remote
+    
+    [self createLocalDocs:localdocs];
+    [self createRemoteDocs:localdocs+1 count:remotedocs];
+    // now do some updates
+    for (CDTDocumentRevision *rev in [self.datastore getAllDocuments]) {
+        // 2-rev, with the 1-rev as parent
+        NSMutableDictionary *dict = [rev.body mutableCopy];
+        NSString *localRevId = [rev revId];
+        [dict setValue:localRevId forKey:@"_rev"];
+        [dict setValue:@YES forKey:@"updated"];
+        [self createRemoteDocWithId:rev.docId body:dict];
+    }
+    
+    NSMutableArray *filterDocIds = [NSMutableArray array];
+    int i;
+    for (i=0; i<localdocs+remotedocs; i++) {
+        if (i % 2 == 1) {
+            [filterDocIds addObject:[NSString stringWithFormat:@"doc-%i", i+1]];
+        }
+    }
+  
+    [self pullFromRemoteWithClientFilterDocIds:filterDocIds];
+    
+    //5000 local + 5000/2 remote = 7500
+    STAssertEquals(self.datastore.documentCount, (unsigned long)(localdocs+remotedocs/2),
+                   @"Incorrect number of documents created");
+
+    //5000 local + 5000/2 remote + 5000 remote copies of local (rev-2)
+    STAssertEquals(self.datastore.database.lastSequence, (long long)(localdocs+remotedocs/2+localdocs),
+                   @"Incorrect sequence number");
+
+    // document checks:
+    // 0..5000 all have 2-rev
+    // 5000..10000 are all even numbers and have a 1-rev
+    for (CDTDocumentRevision *rev in [self.datastore getAllDocuments]) {
+        long docNo = [[rev.docId substringFromIndex:4] integerValue];
+        if (docNo <= localdocs+1) {
+            STAssertTrue([rev.revId hasPrefix:@"2-"], @"rev id %@ does not start 2- for doc id %@", rev.revId, rev.docId);
+        }
+        if (docNo > localdocs && docNo <= localdocs+remotedocs+1) {
+            STAssertTrue(docNo %2 == 0, @"document number must be even");
+            STAssertTrue([rev.revId hasPrefix:@"1-"], @"rev id does not start 1-");
+        }
+    }
+}
+
+-(void) testPullClientFiltered {
+    // Create n docs and pull a subset of them, filtered by ID
+    
+    // Create docs in remote database
+    NSLog(@"Creating documents...");
+    
+    int ndocs = 50; //don't need 100k docs
+    
+    [self createRemoteDocs:ndocs];
+    
+    NSArray *filterDocIds = @[[NSString stringWithFormat:@"doc-%i", 1],
+                        [NSString stringWithFormat:@"doc-%i", 3],
+                        [NSString stringWithFormat:@"doc-%i", 13],
+                        [NSString stringWithFormat:@"doc-%i", 23]];
+
+    [self pullFromRemoteWithClientFilterDocIds:filterDocIds];
+    STAssertTrue(filterDocIds.count == [self.datastore documentCount], @"unexpected number of docs: %@",[self.datastore documentCount]);
+    
+    NSArray *localDocs = [self.datastore getDocumentsWithIds:filterDocIds];
+    
+    STAssertNotNil(localDocs, @"nil");
+    STAssertTrue(localDocs.count == filterDocIds.count, @"unexpected number of docs: %@",localDocs.count);
+    STAssertTrue(self.datastore.documentCount == filterDocIds.count,
+                 @"Incorrect number of documents created %lu", self.datastore.documentCount);
+}
+
+-(void) testPullClientFilteredNewDocsAppear {
+    // Create n docs and pull a subset of them, filtered by ID
+    // then create another n docs, some of which are also included in the filter
+    
+    // Create docs in remote database
+    NSLog(@"Creating documents...");
+    
+    int ndocs = 50; //don't need 100k docs
+    
+    [self createRemoteDocs:ndocs];
+    
+    NSArray *filterDocIds = @[[NSString stringWithFormat:@"doc-%i", 1],
+                              [NSString stringWithFormat:@"doc-%i", 3],
+                              [NSString stringWithFormat:@"doc-%i", 13],
+                              [NSString stringWithFormat:@"doc-%i", 23],
+                              [NSString stringWithFormat:@"doc-%i", 70]];
+    
+    [self pullFromRemoteWithClientFilterDocIds:filterDocIds];
+
+    STAssertEquals([self.datastore.database lastSequence], 4ll, @"Incorrect sequence number");
+    STAssertEquals(self.datastore.documentCount, 4ul,
+                   @"Incorrect number of documents created");
+    
+    // 50 more
+    [self createRemoteDocs:51 count:ndocs];
+
+    [self pullFromRemoteWithClientFilterDocIds:filterDocIds];
+
+    STAssertEquals([self.datastore.database lastSequence], 5ll, @"Incorrect sequence number");
+    STAssertEquals(self.datastore.documentCount, 5ul,
+                 @"Incorrect number of documents created");
+
+    
+    NSArray *localDocs = [self.datastore getAllDocuments];
+    
+    STAssertEquals(localDocs.count, filterDocIds.count, @"unexpected number of docs");
+    STAssertEquals(self.datastore.documentCount, filterDocIds.count,
+                 @"Incorrect number of documents created");
+}
+
+-(void) testPullClientFilterLargeRevTree {
+    // create n docs with m revisions and pull a subset of them, filtered by ID
+    
+    int ndocs = 50;
+    
+    NSArray *filterDocIds = @[[NSString stringWithFormat:@"doc-%i", 1],
+                              [NSString stringWithFormat:@"doc-%i", 3],
+                              [NSString stringWithFormat:@"doc-%i", 13],
+                              [NSString stringWithFormat:@"doc-%i", 23],
+                              [NSString stringWithFormat:@"doc-%i", 70]];
+    
+    for(int i=0; i<ndocs; i++) {
+        // Create the initial rev in remote datastore
+        NSString *docId = [NSString stringWithFormat:@"doc-%i", i];
+        [self createRemoteDocWithId:docId revs:50];
+    }
+    
+    [self pullFromRemoteWithClientFilterDocIds:filterDocIds];
+
+    // 50 * 4 docs
+    STAssertEquals([self.datastore.database lastSequence], 200ll, @"Incorrect sequence number");
+    STAssertEquals(self.datastore.documentCount, 4ul,
+                 @"Incorrect number of documents created");
+
+    // 50 more
+    for(int i=50; i<ndocs+50; i++) {
+        // Create the initial rev in remote datastore
+        NSString *docId = [NSString stringWithFormat:@"doc-%i", i];
+        [self createRemoteDocWithId:docId revs:50];
+    }
+    
+    [self pullFromRemoteWithClientFilterDocIds:filterDocIds];
+    
+    STAssertEquals([self.datastore.database lastSequence], 250ll, @"Incorrect sequence number");
+    STAssertEquals(self.datastore.documentCount, 5ul,
+                 @"Incorrect number of documents created");
+
+}
+
+-(void) testPullClientFilterUpdates {
+    // create n docs and pull a subset of them, filtered by ID
+    // update them and pull the same subset, filtered by ID
+    
+    // Create docs in remote database
+    NSLog(@"Creating documents...");
+    
+    int ndocs = 50; //don't need 100k docs
+    
+    [self createRemoteDocs:ndocs];
+    
+    NSArray *filterDocIds = @[[NSString stringWithFormat:@"doc-%i", 1],
+                              [NSString stringWithFormat:@"doc-%i", 3],
+                              [NSString stringWithFormat:@"doc-%i", 13],
+                              [NSString stringWithFormat:@"doc-%i", 23],
+                              [NSString stringWithFormat:@"doc-%i", 70]];
+    
+    [self pullFromRemoteWithClientFilterDocIds:filterDocIds];
+
+    STAssertEquals([self.datastore.database lastSequence], 4ll, @"Incorrect sequence number");
+    STAssertEquals(self.datastore.documentCount, 4ul,
+                 @"Incorrect number of documents created");
+    
+    // now do some updates
+    for (CDTDocumentRevision *rev in [self.datastore getAllDocuments]) {
+        NSMutableDictionary *dict = [rev.body mutableCopy];
+        [dict setValue:rev.revId forKey:@"_rev"];
+        [dict setValue:@YES forKey:@"updated"];
+        [self createRemoteDocWithId:rev.docId body:dict];
+    }
+
+    [self pullFromRemoteWithClientFilterDocIds:filterDocIds];
+    
+    for (CDTDocumentRevision *rev in [self.datastore getAllDocuments]) {
+        STAssertTrue([rev.revId hasPrefix:@"2-"], @"rev id does not start 2-");
+    }
+
+    STAssertEquals([self.datastore.database lastSequence], 8ll, @"Incorrect sequence number");
+    STAssertEquals(self.datastore.documentCount, 4ul,
+                 @"Incorrect number of documents updated");
+}
 
 /**
  Reproduce reported issue:

--- a/ReplicationAcceptance/ReplicationAcceptance/ReplicationAcceptance.m
+++ b/ReplicationAcceptance/ReplicationAcceptance/ReplicationAcceptance.m
@@ -891,7 +891,7 @@ static NSUInteger largeRevTreeSize = 1500;
     // then upload 2-rev 0..5000 remote
     
     [self createLocalDocs:localdocs];
-    [self createRemoteDocs:localdocs+1 count:remotedocs];
+    [self createRemoteDocs:remotedocs suffixFrom:localdocs+1];
     // now do some updates
     for (CDTDocumentRevision *rev in [self.datastore getAllDocuments]) {
         // 2-rev, with the 1-rev as parent
@@ -985,7 +985,7 @@ static NSUInteger largeRevTreeSize = 1500;
                    @"Incorrect number of documents created");
     
     // 50 more
-    [self createRemoteDocs:51 count:ndocs];
+    [self createRemoteDocs:ndocs suffixFrom:51];
 
     [self pullFromRemoteWithClientFilterDocIds:filterDocIds];
 


### PR DESCRIPTION
Do pull replication with a subset of document IDs.

The user configures clientFilterDocIds on the CDTPullReplication object; this is an array of document IDs.

Internally, the sets clientFilterCurrentSetDocIds (doc IDs for inclusion during pull, for which we already have at least one rev in the database), and clientFilterNewDocIds (doc IDs for inclusion during pull, which we don't yet have in the database) are used.

Lots of things are missing right now, especially an updated remoteCheckpointDocID method whose input to the hash function should the doc ID list.