### PR TITLE
34405 remote attachment

### DIFF
--- a/Classes/common/Attachments/CDTAttachment.h
+++ b/Classes/common/Attachments/CDTAttachment.h
@@ -118,3 +118,32 @@
                         type:(NSString*)type;
 
 @end
+
+@interface CDTRemoteAttachment : CDTAttachment
+
+/**
+ 
+ Creates a CDTRemoteAttachment object from the parameters given.
+ 
+ @param name The name of the attachment eg example.txt
+ @param jsonData The decoded jsonData reccived from couchdb / cloudant
+ @param document the URL of the document this attachment is attached to
+ @param error will point to an NSError object in case of error
+ 
+ */
++(CDTRemoteAttachment *)createAttachmentForName:(NSString *)name
+                                   withJSONData:(NSDictionary *) jsonData
+                                    forDocument:(NSURL*)document
+                                          error:(NSError * __autoreleasing *) error;
+
+/**
+ 
+ Returns the data for an attachment. If attachment data requries downloading, (ie it was not provided
+ in the JSON with the document download) it will block while downloading the data from the remote 
+ server
+ 
+ @return the attachments data
+ 
+ */
+-(NSData*)dataFromAttachmentContent;
+@end

--- a/Classes/common/CDTDocumentRevision.h
+++ b/Classes/common/CDTDocumentRevision.h
@@ -42,11 +42,14 @@
  cloudant or a CouchDB instance.
  
  @param json Json data to create an object from
+ @param documentURL the url of the document
  @param error points to an NSError in case of error
  
  @return new CDTDocument Revision instance
 */
-+(CDTDocumentRevision*)createRevisionFromJson:(NSData*)json error:(NSError * __autoreleasing *) error;
++(CDTDocumentRevision*)createRevisionFromJson:(NSData*)json
+                                  forDocument:(NSURL *)documentURL
+                                        error:(NSError * __autoreleasing *) error;
 
 -(id)initWithDocId:(NSString *)docId
         revisionId:(NSString *) revId

--- a/Tests/Tests/Attachments/AttachmentCRUDMutableDocument.m
+++ b/Tests/Tests/Attachments/AttachmentCRUDMutableDocument.m
@@ -95,6 +95,116 @@
 
 #pragma mark Tests
 
+-(void)testDocumentRevisionFactoryWithAttachmentDataIncluded
+{
+    NSError * error;
+    
+    NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+    NSString *imagePath = [bundle pathForResource:@"bonsai-boston" ofType:@"jpg"];
+    NSData *data = [NSData dataWithContentsOfFile:imagePath];
+    NSString *encoded = [data base64EncodedStringWithOptions:0];
+    
+    NSDictionary * dict = @{@"_id":@"someIdHere",
+                            @"_rev":@"3-750dac460a6cc41e6999f8943b8e603e",
+                            @"aKey":@"aValue",
+                            @"_attachments":@{@"bonsai-boston.jpg":@{@"stub":[NSNumber numberWithBool:NO],
+                                                                     @"length":[NSNumber numberWithLong:[encoded length]],
+                                                                     @"digest":@"thisisahashiswear1234",
+                                                                     @"revpos":[NSNumber numberWithInt:1],
+                                                                     @"content_type":@"image/jpeg",
+                                                                     @"data":encoded
+                                                                     }
+                                              },
+                            @"_conflicts":@[],
+                            @"_deleted_conflicts":@[],
+                            @"_local_seq":@1,
+                            @"_revs_info":@{},
+                            @"_revisions":@[],
+                            @"hello":@"world"
+                            };
+    NSDictionary * body = @{@"aKey":@"aValue",@"hello":@"world"};
+    
+    NSData * jsonData = [NSJSONSerialization dataWithJSONObject:dict options:0 error:&error];
+    
+    STAssertNil(error, @"Error should have been nil");
+    
+    CDTDocumentRevision * rev = [CDTDocumentRevision createRevisionFromJson:jsonData
+                                                                forDocument:[NSURL
+                                                                             URLWithString:@"http://localhost:5984/temp/doc"]
+                                                                      error:&error];
+    
+    STAssertNil(error, @"Error occured creating document with valid data");
+    STAssertNotNil(rev, @"Revision was nil");
+    STAssertEqualObjects(@"someIdHere",
+                         rev.docId,
+                         @"docId was different, expected someIdHere actual %@",
+                         rev.docId);
+    STAssertEqualObjects(@"3-750dac460a6cc41e6999f8943b8e603e",
+                         rev.revId,
+                         @"Revision was different expected 3-750dac460a6cc41e6999f8943b8e603e actual %@",
+                         rev.revId);
+    
+    STAssertEqualObjects(body, rev.body, @"Body was different");
+    STAssertFalse(rev.deleted, @"Document is not marked as deleted");
+    STAssertEquals([rev.attachments count], (NSUInteger) 1, @"Attachment count is wrong, expected 1 actual %d", [rev.attachments count]);
+    
+}
+
+-(void)testDocumentRevisionFactoryWithAttachmentDataExcluded
+{
+    NSError * error;
+    
+    NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+    NSString *imagePath = [bundle pathForResource:@"bonsai-boston" ofType:@"jpg"];
+    NSData *data = [NSData dataWithContentsOfFile:imagePath];
+    NSString *encoded = [data base64EncodedStringWithOptions:0];
+    NSURL * attachmentDir = [bundle resourceURL];
+    
+    NSDictionary * dict = @{@"_id":@"someIdHere",
+                            @"_rev":@"3-750dac460a6cc41e6999f8943b8e603e",
+                            @"aKey":@"aValue",
+                            @"_attachments":@{@"bonsai-boston.jpg":@{@"stub":[NSNumber numberWithBool:YES],
+                                                                     @"length":[NSNumber numberWithLong:[encoded length]],
+                                                                     @"digest":@"thisisahashiswear1234",
+                                                                     @"revpos":[NSNumber numberWithInt:1],
+                                                                     @"content_type":@"image/jpeg",
+                                                                     }
+                                              },
+                            @"_conflicts":@[],
+                            @"_deleted_conflicts":@[],
+                            @"_local_seq":@1,
+                            @"_revs_info":@{},
+                            @"_revisions":@[],
+                            @"hello":@"world"
+                            };
+    NSDictionary * body = @{@"aKey":@"aValue",@"hello":@"world"};
+    
+    NSData * jsonData = [NSJSONSerialization dataWithJSONObject:dict options:0 error:&error];
+    
+    STAssertNil(error, @"Error should have been nil");
+    
+    CDTDocumentRevision * rev = [CDTDocumentRevision createRevisionFromJson:jsonData
+                                                                forDocument:attachmentDir
+                                                                      error:&error];
+    
+    STAssertNil(error, @"Error occured creating document with valid data");
+    STAssertNotNil(rev, @"Revision was nil");
+    STAssertEqualObjects(@"someIdHere",
+                         rev.docId,
+                         @"docId was different, expected someIdHere actual %@",
+                         rev.docId);
+    STAssertEqualObjects(@"3-750dac460a6cc41e6999f8943b8e603e",
+                         rev.revId,
+                         @"Revision was different expected 3-750dac460a6cc41e6999f8943b8e603e actual %@",
+                         rev.revId);
+    
+    STAssertEqualObjects(body, rev.body, @"Body was different");
+    STAssertFalse(rev.deleted, @"Document is not marked as deleted");
+    STAssertEquals([rev.attachments count], (NSUInteger) 1, @"Attachment count is wrong, expected 1 actual %d", [rev.attachments count]);
+    STAssertEqualObjects(data, [[rev.attachments objectForKey:@"bonsai-boston.jpg"]dataFromAttachmentContent],@"data was not the same");
+    
+}
+
 - (void)testCreate
 {
     NSError *error = nil;

--- a/Tests/Tests/DatastoreMutableDocumentCrud.m
+++ b/Tests/Tests/DatastoreMutableDocumentCrud.m
@@ -97,7 +97,10 @@
     
     STAssertNil(error, @"Error should have been nil");
     
-    CDTDocumentRevision * rev = [CDTDocumentRevision createRevisionFromJson:jsonData error:&error];
+    CDTDocumentRevision * rev = [CDTDocumentRevision createRevisionFromJson:jsonData
+                                                                forDocument:[NSURL
+                                                                             URLWithString:@"http://localhost:5984/temp/doc"]
+                                                                      error:&error];
     
     STAssertNil(error, @"Error occured creating document with valid data");
     STAssertNotNil(rev, @"Revision was nil");
@@ -123,7 +126,10 @@
     
     STAssertNil(error, @"Error should have been nil");
     
-    CDTDocumentRevision * rev = [CDTDocumentRevision createRevisionFromJson:jsonData error:&error];
+    CDTDocumentRevision * rev = [CDTDocumentRevision createRevisionFromJson:jsonData
+                                                                forDocument:[NSURL
+                                                                             URLWithString:@"http://localhost:5984/temp/doc"]
+                                                                      error:&error];
     
     STAssertNil(error, @"Error occured creating document with valid data");
     STAssertNotNil(rev, @"Revision was nil");
@@ -145,7 +151,10 @@
     
     STAssertNil(error, @"Error should have been nil");
     
-    CDTDocumentRevision * rev = [CDTDocumentRevision createRevisionFromJson:jsonData error:&error];
+    CDTDocumentRevision * rev = [CDTDocumentRevision createRevisionFromJson:jsonData
+                                                                forDocument:[NSURL
+                                                                             URLWithString:@"http://localhost:5984/temp/doc"]
+                                                                      error:&error];
     
     STAssertNil(error, @"Error occured creating document with valid data");
     STAssertNotNil(rev, @"Revision was nil");
@@ -169,7 +178,10 @@
     
     STAssertNil(error, @"Error should have been nil");
     
-    CDTDocumentRevision * rev = [CDTDocumentRevision createRevisionFromJson:jsonData error:&error];
+    CDTDocumentRevision * rev = [CDTDocumentRevision createRevisionFromJson:jsonData
+                                                                forDocument:[NSURL
+                                                                             URLWithString:@"http://localhost:5984/temp/doc"]
+                                                                      error:&error];
     
     STAssertNotNil(error, @"Error did not occur whencreating document with invalid data");
     STAssertNil(rev, @"Revision was not nil");
@@ -182,7 +194,7 @@
     NSDictionary * dict = @{@"_id":@"someIdHere",
                             @"_rev":@"3-750dac460a6cc41e6999f8943b8e603e",
                             @"aKey":@"aValue",
-                            @"_attachments":@[],
+                            @"_attachments":@{},
                             @"_conflicts":@[],
                             @"_deleted_conflicts":@[],
                             @"_local_seq":@1,
@@ -196,7 +208,10 @@
     
     STAssertNil(error, @"Error should have been nil");
     
-    CDTDocumentRevision * rev = [CDTDocumentRevision createRevisionFromJson:jsonData error:&error];
+    CDTDocumentRevision * rev = [CDTDocumentRevision createRevisionFromJson:jsonData
+                                                                forDocument:[NSURL
+                                                                             URLWithString:@"http://localhost:5984/temp/doc"]
+                                                                      error:&error];
     
     STAssertNil(error, @"Error occured creating document with valid data");
     STAssertNotNil(rev, @"Revision was nil");
@@ -220,7 +235,11 @@
     NSData* data = [jsonString dataUsingEncoding:NSUTF8StringEncoding];
    
     NSError *error;
-    CDTDocumentRevision * rev = [CDTDocumentRevision createRevisionFromJson:data error:&error];
+    CDTDocumentRevision * rev = [CDTDocumentRevision createRevisionFromJson:data
+                                                                forDocument:[
+                                                                             NSURL
+                                                                             URLWithString:@"http://localhost:5984/temp/doc"]
+                                                                      error:&error];
     STAssertNil(rev, @"Revision should be nil with invalid json");
     STAssertNotNil(error, @"Error should be set");
 }


### PR DESCRIPTION
Implemented CDTRemoteAttachment, which represents an attachment in a remote server. 

The data is kept in memory if it is downloaded via a GET document request that includes attachment data. I'm not sure if this is the best approach for memory management for a large number of attachments. If the data was not included, the Remote attachment will download the data using a synchronous call, this is probably not the best approach, but it does guarantee that an NSData object with populated data is returned.

The CDTDocumentRevision factory method has also been changed to take an URL of the document that has been downloaded e.g. https://exmaple.cloudant.com/exampledb/exampledoc/
