### PR TITLE
34404 remove td revision from CDTDocumentRevision

### DIFF
--- a/Classes/common/CDTDatastore+Conflicts.m
+++ b/Classes/common/CDTDatastore+Conflicts.m
@@ -130,8 +130,14 @@
             //start with the new ones
             for(NSDictionary * attachment in downloadedAttachments){
                 if(![strongSelf addAttachment:attachment
-                                        toRev:[[CDTDocumentRevision alloc]initWithTDRevision:winner]
+                                        toRev:[[CDTDocumentRevision alloc] initWithDocId:winner.docID
+                                                                             revisionId:winner.revID
+                                                                                    body:winner.body.properties
+                                                                                 deleted:winner.deleted
+                                                                             attachments:@{}
+                                                                                sequence:winner.sequence]
                                    inDatabase:db]){
+                    
                     localError = TDStatusToNSError(kTDStatusAttachmentError, nil);
                     return kTDStatusAttachmentError;
                 }

--- a/Classes/common/CDTDatastore+Internal.m
+++ b/Classes/common/CDTDatastore+Internal.m
@@ -17,6 +17,7 @@
 #import "CDTDatastore+Attachments.h"
 #import "CDTAttachment.h"
 #import "TD_Database.h"
+#import "TD_Body.h"
 #import "CDTDocumentRevision.h"
 
 @implementation CDTDatastore (Internal)
@@ -39,7 +40,14 @@
     for (TD_Revision *tdRev in revs) {
         [self.database loadRevisionBody:tdRev options:0 database:db];
         
-        CDTDocumentRevision *ob = [[CDTDocumentRevision alloc] initWithTDRevision:tdRev];
+        CDTDocumentRevision *ob = [[CDTDocumentRevision alloc]initWithDocId:tdRev.docID
+                                                                 revisionId:tdRev.revID
+                                                                       body:tdRev.body.properties
+                                                                    deleted:tdRev.deleted
+                                                                attachments:@{} 
+                                                                   sequence:tdRev.sequence];
+        
+        //[[CDTDocumentRevision alloc] initWithTDRevision:tdRev];
         
         NSArray * attachmentArray = [self attachmentsForRev:ob  inTransaction:db error:nil];
         NSMutableDictionary * attachments = [NSMutableDictionary dictionary];
@@ -48,7 +56,13 @@
             [attachments setObject:attachment forKey:attachment.name];
         }
         
-        ob = [[CDTDocumentRevision alloc] initWithTDRevision:tdRev andAttachments:attachments];
+        ob = [[CDTDocumentRevision alloc]initWithDocId:tdRev.docID
+                                            revisionId:tdRev.revID
+                                                  body:tdRev.body.properties
+                                               deleted:tdRev.deleted
+                                           attachments:attachments
+                                              sequence:tdRev.sequence];
+        
         
         [results addObject:ob];
     }

--- a/Classes/common/CDTDatastore.m
+++ b/Classes/common/CDTDatastore.m
@@ -113,13 +113,23 @@ NSString* const CDTDatastoreChangeNotification = @"CDTDatastoreChangeNotificatio
     NSMutableDictionary *userInfo = [NSMutableDictionary dictionary];
     
     if (nil != nUserInfo[@"rev"]) {
-        userInfo[@"rev"] = [[CDTDocumentRevision alloc]
-                            initWithTDRevision:nUserInfo[@"rev"]];
+        TD_Revision *tdRev = nUserInfo[@"rev"];
+        userInfo[@"rev"] = [[CDTDocumentRevision alloc]initWithDocId:tdRev.docID
+                                                          revisionId:tdRev.revID
+                                                                body:tdRev.body.properties
+                                                             deleted:tdRev.deleted
+                                                         attachments:@{}
+                                                            sequence:tdRev.sequence];
     }
     
     if (nil != nUserInfo[@"winner"]) {
-        userInfo[@"winner"] = [[CDTDocumentRevision alloc]
-                               initWithTDRevision:nUserInfo[@"rev"]];
+        TD_Revision *tdRev = nUserInfo[@"rev"];
+        userInfo[@"winner"] = [[CDTDocumentRevision alloc]initWithDocId:tdRev.docID
+                                                             revisionId:tdRev.revID
+                                                                   body:tdRev.body.properties
+                                                                deleted:tdRev.deleted
+                                                            attachments:@{}
+                                                               sequence:tdRev.sequence];
     }
     
     if (nil != nUserInfo[@"source"]) {
@@ -173,7 +183,12 @@ NSString* const CDTDatastoreChangeNotification = @"CDTDatastoreChangeNotificatio
         return nil;
     }
     
-    return [[CDTDocumentRevision alloc] initWithTDRevision:new];
+    return [[CDTDocumentRevision alloc]initWithDocId:new.docID
+                                          revisionId:new.revID
+                                                body:new.body.properties
+                                             deleted:new.deleted
+                                         attachments:@{}
+                                            sequence:new.sequence];
 }
 
 
@@ -200,7 +215,12 @@ NSString* const CDTDatastoreChangeNotification = @"CDTDatastoreChangeNotificatio
         return nil;
     }
     
-    return [[CDTDocumentRevision alloc] initWithTDRevision:new];
+    return [[CDTDocumentRevision alloc]initWithDocId:new.docID
+                                          revisionId:new.revID
+                                                body:new.body.properties
+                                             deleted:new.deleted
+                                         attachments:@{}
+                                            sequence:new.sequence];
 }
 
 
@@ -232,7 +252,12 @@ NSString* const CDTDatastoreChangeNotification = @"CDTDatastoreChangeNotificatio
         return nil;
     }
     
-    CDTDocumentRevision *revision = [[CDTDocumentRevision alloc] initWithTDRevision:rev];
+    CDTDocumentRevision *revision = [[CDTDocumentRevision alloc]initWithDocId:rev.docID
+                                                                   revisionId:rev.revID
+                                                                         body:rev.body.properties
+                                                                      deleted:rev.deleted
+                                                                  attachments:@{}
+                                                                     sequence:rev.sequence];
     NSArray * attachments = [self attachmentsForRev:revision error:error];
     
     NSMutableDictionary * attachmentsDict =  [NSMutableDictionary dictionary];
@@ -241,7 +266,12 @@ NSString* const CDTDatastoreChangeNotification = @"CDTDatastoreChangeNotificatio
         [attachmentsDict setObject:attachment forKey:attachment.name];
     }
     
-    revision = [[CDTDocumentRevision alloc]initWithTDRevision:rev andAttachments:attachmentsDict];
+    revision = [[CDTDocumentRevision alloc]initWithDocId:rev.docID
+                                              revisionId:rev.revID
+                                                    body:rev.body.properties
+                                                 deleted:rev.deleted
+                                             attachments:attachmentsDict
+                                                sequence:rev.sequence];
     
     return revision;
 }
@@ -285,15 +315,24 @@ NSString* const CDTDatastoreChangeNotification = @"CDTDatastoreChangeNotificatio
             revision.body = [[TD_Body alloc] initWithProperties:row[@"doc"]];
             revision.sequence = [row[@"doc"][@"_local_seq"] longLongValue];
             
-            CDTDocumentRevision *ob = [[CDTDocumentRevision alloc] initWithTDRevision:revision];
+            CDTDocumentRevision *ob = [[CDTDocumentRevision alloc]initWithDocId:revision.docID
+                                                                     revisionId:revision.revID
+                                                                           body:revision.body.properties
+                                                                        deleted:revision.deleted
+                                                                    attachments:@{}
+                                                                       sequence:revision.sequence];
             
             NSArray * attachments = [self attachmentsForRev:ob error:&error];
             NSMutableDictionary *dict = [NSMutableDictionary dictionary];
             for (CDTAttachment * attachment in attachments){
                 [dict setObject:attachment forKey:attachment.name];
             }
-            [batch addObject:[[CDTDocumentRevision alloc] initWithTDRevision:revision
-                                                              andAttachments:dict ]];
+            [batch addObject:[[CDTDocumentRevision alloc]initWithDocId:revision.docID
+                                                            revisionId:revision.revID
+                                                                  body:revision.body.properties
+                                                               deleted:revision.deleted
+                                                           attachments:dict
+                                                              sequence:revision.sequence]];
         }
         
         result = [result arrayByAddingObjectsFromArray:batch];
@@ -365,14 +404,23 @@ NSString* const CDTDatastoreChangeNotification = @"CDTDatastoreChangeNotificatio
             revision.body = [[TD_Body alloc] initWithProperties:row[@"doc"]];
         }
         
-        CDTDocumentRevision *ob = [[CDTDocumentRevision alloc] initWithTDRevision:revision];
+        CDTDocumentRevision *ob = [[CDTDocumentRevision alloc]initWithDocId:revision.docID
+                                                                 revisionId:revision.revID
+                                                                       body:revision.body.properties
+                                                                    deleted:revision.deleted
+                                                                attachments:@{}
+                                                                   sequence:revision.sequence];
         NSArray * attachments = [self attachmentsForRev:ob error:&error];
         NSMutableDictionary *dict = [NSMutableDictionary dictionary];
         for (CDTAttachment * attachment in attachments){
             [dict setObject:attachment forKey:attachment.name];
         }
-        [result addObject:[[CDTDocumentRevision alloc] initWithTDRevision:revision
-                                                           andAttachments:dict ]];
+        [result addObject:[[CDTDocumentRevision alloc]initWithDocId:revision.docID
+                                                         revisionId:revision.revID
+                                                               body:revision.body.properties
+                                                            deleted:revision.deleted
+                                                        attachments:dict
+                                                           sequence:revision.sequence]];
     }
     
     return result;
@@ -388,10 +436,21 @@ NSString* const CDTDatastoreChangeNotification = @"CDTDatastoreChangeNotificatio
     NSMutableArray *result = [NSMutableArray array];
     
     // Array of TD_Revision
-    NSArray *td_revs = [self.database getRevisionHistory:revision.td_rev];
+    TD_Revision *converted = [[TD_Revision alloc]initWithDocID:revision.docId
+                                                         revID:revision.revId
+                                                       deleted:revision.deleted];
+
+    
+    
+    NSArray *td_revs = [self.database getRevisionHistory:converted];
     
     for (TD_Revision *td_rev in td_revs) {
-        CDTDocumentRevision *ob = [[CDTDocumentRevision alloc] initWithTDRevision:td_rev];
+        CDTDocumentRevision *ob = [[CDTDocumentRevision alloc]initWithDocId:td_rev.docID
+                                                                 revisionId:td_rev.revID
+                                                                       body:td_rev.body.properties
+                                                                    deleted:td_rev.deleted
+                                                                attachments:@{}
+                                                                   sequence:td_rev.sequence];
         [result addObject:ob];
     }
     
@@ -514,7 +573,12 @@ NSString* const CDTDatastoreChangeNotification = @"CDTDatastoreChangeNotificatio
         return nil;
     }
     
-    return [[CDTDocumentRevision alloc] initWithTDRevision:new];
+    return [[CDTDocumentRevision alloc]initWithDocId:new.docID
+                                          revisionId:new.revID
+                                                body:new.body.properties
+                                             deleted:new.deleted
+                                         attachments:@{}
+                                            sequence:new.sequence];
 }
 
 -(NSString*) extensionDataFolder:(NSString*)extensionName
@@ -610,7 +674,12 @@ NSString* const CDTDatastoreChangeNotification = @"CDTDatastoreChangeNotificatio
             saved = nil;
             return;
         }else {
-            saved = [[CDTDocumentRevision alloc] initWithTDRevision:new];
+            saved = [[CDTDocumentRevision alloc]initWithDocId:new.docID
+                                                   revisionId:new.revID
+                                                         body:new.body.properties
+                                                      deleted:new.deleted
+                                                  attachments:@{}
+                                                     sequence:new.sequence];
             for(NSDictionary * attachment in downloadedAttachments){
                 //insert each attchment into the database, if this fails rollback
                 if(![datastore addAttachment:attachment toRev:saved inDatabase:db]){
@@ -635,7 +704,12 @@ NSString* const CDTDatastoreChangeNotification = @"CDTDatastoreChangeNotificatio
                 
             }
             
-            saved = [[CDTDocumentRevision alloc]initWithTDRevision:new];
+            saved = [[CDTDocumentRevision alloc]initWithDocId:new.docID
+                                                   revisionId:new.revID
+                                                         body:new.body.properties
+                                                      deleted:new.deleted
+                                                  attachments:@{}
+                                                     sequence:new.sequence];
         }
     }];
     
@@ -647,8 +721,12 @@ NSString* const CDTDatastoreChangeNotification = @"CDTDatastoreChangeNotificatio
             [attachmentDict setObject:attachment forKey:attachment.name];
         }
         
-        saved = [[CDTDocumentRevision alloc] initWithTDRevision:saved.td_rev
-                                                  andAttachments:attachmentDict];
+        saved = [[CDTDocumentRevision alloc] initWithDocId:saved.docId
+                                                revisionId:saved.revId
+                                                      body:saved.body
+                                                   deleted:saved.deleted
+                                               attachments:attachmentDict
+                                                  sequence:saved.sequence];
     }
     return saved;
     
@@ -753,8 +831,12 @@ NSString* const CDTDatastoreChangeNotification = @"CDTDatastoreChangeNotificatio
             [attachmentDict setObject:attachment forKey:attachment.name];
         }
         
-        result = [[CDTDocumentRevision alloc] initWithTDRevision:result.td_rev
-                                                   andAttachments:attachmentDict];
+        result = [[CDTDocumentRevision alloc] initWithDocId:result.docId
+                                                revisionId:result.revId
+                                                      body:result.body
+                                                   deleted:result.deleted
+                                               attachments:attachmentDict
+                                                   sequence:result.sequence];
         
         NSDictionary* userInfo = $dict({@"rev", result},
                                        {@"winner", result});
@@ -829,7 +911,12 @@ NSString* const CDTDatastoreChangeNotification = @"CDTDatastoreChangeNotificatio
         }
     }
     
-    return [[CDTDocumentRevision alloc] initWithTDRevision:new];
+    return [[CDTDocumentRevision alloc]initWithDocId:new.docID
+                                          revisionId:new.revID
+                                                body:new.body.properties
+                                             deleted:new.deleted
+                                         attachments:@{}
+                                            sequence:new.sequence];
 }
 
 -(CDTDocumentRevision*)deleteDocumentFromRevision:(CDTDocumentRevision *)revision
@@ -853,7 +940,12 @@ NSString* const CDTDatastoreChangeNotification = @"CDTDatastoreChangeNotificatio
         return nil;
     }
     
-    return [[CDTDocumentRevision alloc] initWithTDRevision:new];
+    return [[CDTDocumentRevision alloc]initWithDocId:new.docID
+                                          revisionId:new.revID
+                                                body:new.body.properties
+                                             deleted:new.deleted
+                                         attachments:@{}
+                                            sequence:new.sequence];
 }
 
 -(NSArray*)deleteDocumentWithId:(NSString *)docId
@@ -888,7 +980,12 @@ NSString* const CDTDatastoreChangeNotification = @"CDTDatastoreChangeNotificatio
                 *rollback = YES;
                 return;
             }
-            deleted = [[CDTDocumentRevision alloc] initWithTDRevision:new];
+            deleted = [[CDTDocumentRevision alloc]initWithDocId:new.docID
+                                                     revisionId:new.revID
+                                                           body:new.body.properties
+                                                        deleted:new.deleted
+                                                    attachments:@{}
+                                                       sequence:new.sequence];
             [deletedDocs addObject:deleted];
 
         }

--- a/Classes/common/CDTDocumentRevision.h
+++ b/Classes/common/CDTDocumentRevision.h
@@ -35,12 +35,19 @@
 
 @property (nonatomic,readonly) SequenceNumber sequence;
 
-@property (nonatomic,strong,readonly) TD_Revision *td_rev;
 
--(id)initWithTDRevision:(TD_Revision*)rev ;
+-(id)initWithDocId:(NSString *)docId
+        revisionId:(NSString *) revId
+              body:(NSDictionary *)body
+       attachments:(NSDictionary *) attachments;
 
--(id)initWithTDRevision:(TD_Revision*)rev
-         andAttachments: (NSDictionary *) attachments;
+-(id)initWithDocId:(NSString *)docId
+        revisionId:(NSString *)revId
+              body:(NSDictionary *)body
+           deleted:(BOOL)deleted
+       attachments:(NSDictionary *)attachments
+          sequence:(SequenceNumber)sequence;
+
 
 /** 
  Return document content as an NSData object.

--- a/Classes/common/CDTReplicator/CDTReplicator.m
+++ b/Classes/common/CDTReplicator/CDTReplicator.m
@@ -22,6 +22,7 @@
 
 #import "TD_Revision.h"
 #import "TD_Database.h"
+#import "TD_Body.h"
 #import "TDPusher.h"
 #import "TDPuller.h"
 #import "TDReplicatorManager.h"
@@ -160,7 +161,12 @@ static NSString* const CDTReplicatorErrorDomain = @"CDTReplicatorErrorDomain";
             CDTFilterBlock cdtfilter = [pushRep.filter copy];
             
             tdpusher.filter = ^(TD_Revision *rev, NSDictionary* params){
-                return cdtfilter([[CDTDocumentRevision alloc] initWithTDRevision:rev], params);
+                return cdtfilter([[CDTDocumentRevision alloc]initWithDocId:rev.docID
+                                                                revisionId:rev.revID
+                                                                      body:rev.body.properties
+                                                                   deleted:rev.deleted
+                                                               attachments:@{}
+                                                                  sequence:rev.sequence], params);
             };
             
         }

--- a/Classes/common/Indexing/CDTFieldIndexer.m
+++ b/Classes/common/Indexing/CDTFieldIndexer.m
@@ -38,7 +38,7 @@
 -(NSArray*)valuesForRevision:(CDTDocumentRevision*)revision
                    indexName:(NSString*)indexName
 {
-    NSObject *value = [[[[revision td_rev] body] properties] valueForKey:_fieldName];
+    NSObject *value = [[revision body] valueForKey:_fieldName];
     
     // only index strings, numbers, or arrays
     if ([value isKindOfClass: [NSString class]] || [value isKindOfClass: [NSNumber class]]) {

--- a/Classes/common/Indexing/CDTIndexManager.m
+++ b/Classes/common/Indexing/CDTIndexManager.m
@@ -22,6 +22,7 @@
 #import "CDTDatastore.h"
 
 #import "TD_Database.h"
+#import "TD_Body.h"
 
 #import "FMResultSet.h"
 #import "FMDatabase.h"
@@ -597,8 +598,13 @@ static const int VERSION = 1;
 
             // Insert new values if the rev isn't deleted
             if (!rev.deleted) {
-                NSArray *valuesInsert = [f valuesForRevision:[[CDTDocumentRevision alloc]
-                                                              initWithTDRevision:rev]
+                CDTDocumentRevision * docRev = [[CDTDocumentRevision alloc]initWithDocId:rev.docID
+                                                                              revisionId:rev.revID
+                                                                                    body:rev.body.properties
+                                                                                 deleted:rev.deleted
+                                                                             attachments:@{}
+                                                                                sequence:rev.sequence];
+                NSArray *valuesInsert = [f valuesForRevision:docRev
                                                    indexName:[index indexName]];
                 for (NSObject *rawValue in valuesInsert) {
                     NSObject *convertedValue = [helper convertIndexValue:rawValue];

--- a/Tests/Tests/DatastoreConflictResolvers.m
+++ b/Tests/Tests/DatastoreConflictResolvers.m
@@ -53,7 +53,12 @@
     TD_Revision *revision = [[TD_Revision alloc] initWithDocID:docId
                                                          revID:nil
                                                        deleted:YES];
-    return [[CDTDocumentRevision alloc] initWithTDRevision:revision];
+    return [[CDTDocumentRevision alloc]initWithDocId:revision.docID
+                                          revisionId:revision.revID
+                                                body:revision.body.properties
+                                             deleted:revision.deleted
+                                         attachments:@{}
+                                            sequence:revision.sequence];
 }
 @end
 
@@ -132,7 +137,11 @@
                                                       revID:old.revId
                                                     deleted:NO];
     tdrev.body = tdbody;
-    CDTDocumentRevision *theReturn = [[CDTDocumentRevision alloc] initWithTDRevision:tdrev];
+    CDTDocumentRevision *theReturn = [[CDTDocumentRevision alloc]initWithDocId:tdrev.docID
+                                                                    revisionId:tdrev.revID
+                                                                          body:tdrev.body.properties
+                                                                       deleted:tdrev.deleted attachments:@{}
+                                                                      sequence:tdrev.sequence];
     
     return theReturn;
     

--- a/Tests/Tests/DatastoreConflicts.m
+++ b/Tests/Tests/DatastoreConflicts.m
@@ -152,7 +152,12 @@
         error = TDStatusToNSError(status, nil);
     }
     STAssertNil(error, @"Error creating conflict %@", error);
-    CDTDocumentRevision *rev2b = [[CDTDocumentRevision alloc] initWithTDRevision:td_rev];
+    CDTDocumentRevision *rev2b = [[CDTDocumentRevision alloc]initWithDocId:td_rev.docID
+                                                                revisionId:td_rev.revID
+                                                                      body:td_rev.body.properties
+                                                                   deleted:td_rev.deleted
+                                                               attachments:@{}
+                                                                  sequence:td_rev.sequence];
     STAssertNotNil(rev2b, @"CDTDocumentRevision object was nil");
     
     error = nil;
@@ -170,7 +175,12 @@
         error = TDStatusToNSError(status, nil);
     }
     STAssertNil(error, @"Error creating conflict %@", error);
-    CDTDocumentRevision *rev2c = [[CDTDocumentRevision alloc] initWithTDRevision:td_rev];
+    CDTDocumentRevision *rev2c = [[CDTDocumentRevision alloc]initWithDocId:td_rev.docID
+                                                                revisionId:td_rev.revID
+                                                                      body:td_rev.body.properties
+                                                                   deleted:td_rev.deleted
+                                                               attachments:@{}
+                                                                  sequence:td_rev.sequence];
     STAssertNotNil(rev2c, @"CDTDocumentRevision object was nil");
     
     

--- a/Tests/Tests/DatastoreConflictsMutableDocs.m
+++ b/Tests/Tests/DatastoreConflictsMutableDocs.m
@@ -148,7 +148,10 @@
         error = TDStatusToNSError(status, nil);
     }
     STAssertNil(error, @"Error creating conflict %@", error);
-    CDTDocumentRevision *rev2b = [[CDTDocumentRevision alloc] initWithTDRevision:td_rev];
+    CDTDocumentRevision *rev2b = [[CDTDocumentRevision alloc]initWithDocId:td_rev.docID
+                                                                revisionId:td_rev.revID
+                                                                      body:td_rev.body.properties
+                                                                   deleted:td_rev.deleted];
     STAssertNotNil(rev2b, @"CDTDocumentRevision object was nil");
     
     error = nil;
@@ -166,7 +169,10 @@
         error = TDStatusToNSError(status, nil);
     }
     STAssertNil(error, @"Error creating conflict %@", error);
-    CDTDocumentRevision *rev2c = [[CDTDocumentRevision alloc] initWithTDRevision:td_rev];
+    CDTDocumentRevision *rev2c = [[CDTDocumentRevision alloc]initWithDocId:td_rev.docID
+                                                                revisionId:td_rev.revID
+                                                                      body:td_rev.body.properties
+                                                                   deleted:td_rev.deleted];
     STAssertNotNil(rev2c, @"CDTDocumentRevision object was nil");
     
     

--- a/Tests/Tests/IndexManagerTests.m
+++ b/Tests/Tests/IndexManagerTests.m
@@ -458,7 +458,7 @@
     STAssertTrue([[res documentIds] count] > 0, @"Query yielded nothing!");
     
     for(CDTDocumentRevision *doc in res) {
-        NSNumber *val = [[[[doc td_rev] body] properties] objectForKey:@"area"];
+        NSNumber *val = [[doc body] objectForKey:@"area"];
         int valInt = [val intValue];
         STAssertTrue(valInt <= lastVal, @"Not sorted");
         lastVal = valInt;
@@ -485,7 +485,7 @@
     STAssertTrue([[res documentIds] count] > 0, @"Query yielded nothing!");
     
     for(CDTDocumentRevision *doc in res) {
-        NSString *val = [[[[doc td_rev] body] properties] objectForKey:@"name"];
+        NSString *val = [[doc body] objectForKey:@"name"];
 
         STAssertTrue([val compare:lastName] < 0, @"Not sorted correctly");
         lastName = val;
@@ -1061,7 +1061,7 @@
                    indexName:(NSString*)indexName
 
 {
-    NSString *value = [[[[revision td_rev] body] properties] valueForKey:indexName];
+    NSString *value = [[revision body] valueForKey:indexName];
 
     NSString *prefix1 = [value substringToIndex:1];
     NSString *prefix2 = [value substringToIndex:2];


### PR DESCRIPTION
Remove TD_Revision from CDTDocumentRevisions

-Change constructors to take the information provided by TD_Revision as a parameters
-Remove TD_Revision property

Constructor changes should only effect the internal creation of the CDTDocumentRevisions 
