### PR TITLE
Fixes CDTDatastore -getRevisionHistory, which was returning an empty array

### DIFF
--- a/Classes/common/CDTDatastore.m
+++ b/Classes/common/CDTDatastore.m
@@ -447,7 +447,7 @@ NSString* const CDTDatastoreChangeNotification = @"CDTDatastoreChangeNotificatio
     for (TD_Revision *td_rev in td_revs) {
         CDTDocumentRevision *ob = [[CDTDocumentRevision alloc]initWithDocId:td_rev.docID
                                                                  revisionId:td_rev.revID
-                                                                       body:td_rev.body.properties
+                                                                       body:@{}
                                                                     deleted:td_rev.deleted
                                                                 attachments:@{}
                                                                    sequence:td_rev.sequence];


### PR DESCRIPTION
Fixes CDTDatastore -getRevisionHistory, which was returning an empty array
Passes empty body to CDTDocumentRevision init method so that it doesn't return nil.
