### PR TITLE
32613 - inaccurate CDTReplicator changesProcessed after pull replication

### DIFF
--- a/Classes/common/touchdb/TDPuller.m
+++ b/Classes/common/touchdb/TDPuller.m
@@ -522,8 +522,8 @@ static NSString* joinQuotedEscaped(NSArray* strings);
     LogTo(Sync, @"%@ inserted %u revs in %.3f sec (%.1f/sec)",
           self, (unsigned)downloads.count, time, downloads.count/time);
     
-    [self asyncTasksFinished: downloads.count];
     self.changesProcessed += downloads.count;
+    [self asyncTasksFinished: downloads.count];
 }
 
 

--- a/ReplicationAcceptance/ReplicationAcceptance/ReplicationAcceptance.m
+++ b/ReplicationAcceptance/ReplicationAcceptance/ReplicationAcceptance.m
@@ -26,6 +26,7 @@
 #import "CDTPullReplication.h"
 #import "CDTPushReplication.h"
 #import "TDReplicatorManager.h"
+#import "TDReplicator.h"
 
 @interface ReplicationAcceptance ()
 
@@ -206,9 +207,8 @@ static NSUInteger largeRevTreeSize = 1500;
     STAssertTrue(same, @"Remote and local databases differ");
     
     STAssertEquals(n_docs, (NSUInteger)replicator.changesTotal, @"total number of changes mismatch");
-    //todo.
-    //STAssertEquals(n_docs, (NSUInteger)replicator.changesProcessed, @"processed number of changes mismatch");
-
+    
+    STAssertEquals(n_docs, (NSUInteger)replicator.changesProcessed, @"processed number of changes mismatch");
 }
 
 


### PR DESCRIPTION
Fixes bug where TDPuller notified listeners of a stopped replication before updating its changesProcessed property. This caused CDTReplicator not to have the correct value.

Modifies test in ReplicationAcceptance that verifies this now works.
