### PR TITLE
Fix references in the Tests project

### DIFF
--- a/Tests/Tests.xcodeproj/project.pbxproj
+++ b/Tests/Tests.xcodeproj/project.pbxproj
@@ -15,14 +15,12 @@
 		27389E1A185345FD0027A404 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 27389E18185345FD0027A404 /* InfoPlist.strings */; };
 		27389E3518534E050027A404 /* CloudantSyncTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 27389E2E18534E050027A404 /* CloudantSyncTests.m */; };
 		27389E3618534E050027A404 /* DatastoreActions.m in Sources */ = {isa = PBXBuildFile; fileRef = 27389E3018534E050027A404 /* DatastoreActions.m */; };
-		27389E3818534E050027A404 /* SetUpDatastore.m in Sources */ = {isa = PBXBuildFile; fileRef = 27389E3418534E050027A404 /* SetUpDatastore.m */; };
 		27651C6419001B54006FEF7F /* bonsai-boston.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 27651C6319001B54006FEF7F /* bonsai-boston.jpg */; };
 		27651C6519001B54006FEF7F /* bonsai-boston.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 27651C6319001B54006FEF7F /* bonsai-boston.jpg */; };
 		27CCEDC7187AD64F006F3C66 /* SenTestingKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 27389E0F185345FD0027A404 /* SenTestingKit.framework */; };
 		27CCEDCD187AD64F006F3C66 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 27CCEDCB187AD64F006F3C66 /* InfoPlist.strings */; };
 		27CCEDD6187AD70C006F3C66 /* CloudantSyncTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 27389E2E18534E050027A404 /* CloudantSyncTests.m */; };
 		27CCEDD7187AD719006F3C66 /* DatastoreActions.m in Sources */ = {isa = PBXBuildFile; fileRef = 27389E3018534E050027A404 /* DatastoreActions.m */; };
-		27CCEDD9187AD719006F3C66 /* SetUpDatastore.m in Sources */ = {isa = PBXBuildFile; fileRef = 27389E3418534E050027A404 /* SetUpDatastore.m */; };
 		27D96E4418E1E0D400DEA006 /* lorem.txt in Resources */ = {isa = PBXBuildFile; fileRef = 27D96E4218E1E0D400DEA006 /* lorem.txt */; };
 		27D96E4518E1E0D400DEA006 /* lorem.txt in Resources */ = {isa = PBXBuildFile; fileRef = 27D96E4218E1E0D400DEA006 /* lorem.txt */; };
 		27F43D4918E99C31003E8422 /* AmazonMD5Util.m in Sources */ = {isa = PBXBuildFile; fileRef = 27F43D4818E99C31003E8422 /* AmazonMD5Util.m */; };
@@ -38,8 +36,6 @@
 		985FF00019CC597400EA5392 /* IndexManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 985FEFFE19CC597400EA5392 /* IndexManagerTests.m */; };
 		989E6E22198799AE00FB8510 /* DatastoreCRUD.m in Sources */ = {isa = PBXBuildFile; fileRef = 989E6E21198799AE00FB8510 /* DatastoreCRUD.m */; };
 		989E6E23198799AE00FB8510 /* DatastoreCRUD.m in Sources */ = {isa = PBXBuildFile; fileRef = 989E6E21198799AE00FB8510 /* DatastoreCRUD.m */; };
-		8E3377D518ABF36E003E3D93 /* IndexManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E3377D418ABF36E003E3D93 /* IndexManagerTests.m */; };
-		8E3377D618ABF42A003E3D93 /* IndexManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E3377D418ABF36E003E3D93 /* IndexManagerTests.m */; };
 		9985C74919AE5D8300636AB6 /* CDTQueryBuilderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9985C74819AE5D8300636AB6 /* CDTQueryBuilderTests.m */; };
 		9F0D23E918888C6C00D3D04E /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F0D23E818888C6C00D3D04E /* Foundation.framework */; };
 		9F0D23F1188B4FA900D3D04E /* TDMultipartReaderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F0D23F0188B4FA900D3D04E /* TDMultipartReaderTests.m */; };
@@ -68,10 +64,12 @@
 		9F0D24181893161000D3D04E /* TDReachabilityTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F0D24161893161000D3D04E /* TDReachabilityTests.m */; };
 		9F0D241A18932DA700D3D04E /* TDSequenceMapTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F0D241918932DA700D3D04E /* TDSequenceMapTests.m */; };
 		9F0D241B18932DA700D3D04E /* TDSequenceMapTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F0D241918932DA700D3D04E /* TDSequenceMapTests.m */; };
+		9F4E646B19DC815B00FE37E1 /* CDTReplicationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F4E646919DC815B00FE37E1 /* CDTReplicationTests.m */; };
+		9F4E646C19DC815B00FE37E1 /* CDTReplicationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F4E646919DC815B00FE37E1 /* CDTReplicationTests.m */; };
+		9F4E646D19DC815B00FE37E1 /* SetUpDatastore.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F4E646A19DC815B00FE37E1 /* SetUpDatastore.m */; };
+		9F4E646E19DC815B00FE37E1 /* SetUpDatastore.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F4E646A19DC815B00FE37E1 /* SetUpDatastore.m */; };
 		9F95D61018CF6A580006D349 /* DBQueryUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F95D60F18CF6A580006D349 /* DBQueryUtils.m */; };
 		9F95D61118CF6A580006D349 /* DBQueryUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F95D60F18CF6A580006D349 /* DBQueryUtils.m */; };
-		9FA839CB18FC474F0054512E /* CDTReplicationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FA839CA18FC474F0054512E /* CDTReplicationTests.m */; };
-		9FA839CC18FC474F0054512E /* CDTReplicationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FA839CA18FC474F0054512E /* CDTReplicationTests.m */; };
 		9FC082981913378F0024EA1E /* DatastoreConflictResolvers.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FC082971913378F0024EA1E /* DatastoreConflictResolvers.m */; };
 		9FC082991913378F0024EA1E /* DatastoreConflictResolvers.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FC082971913378F0024EA1E /* DatastoreConflictResolvers.m */; };
 /* End PBXBuildFile section */
@@ -87,7 +85,6 @@
 		27389E2D18534E050027A404 /* CloudantSyncTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CloudantSyncTests.h; sourceTree = "<group>"; };
 		27389E2E18534E050027A404 /* CloudantSyncTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CloudantSyncTests.m; sourceTree = "<group>"; };
 		27389E3018534E050027A404 /* DatastoreActions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DatastoreActions.m; sourceTree = "<group>"; };
-		27389E3418534E050027A404 /* SetUpDatastore.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SetUpDatastore.m; sourceTree = "<group>"; };
 		27651C6319001B54006FEF7F /* bonsai-boston.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; name = "bonsai-boston.jpg"; path = "Assets/bonsai-boston.jpg"; sourceTree = "<group>"; };
 		27CCEDC6187AD64F006F3C66 /* Tests OSX.octest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Tests OSX.octest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		27CCEDCA187AD64F006F3C66 /* Tests OSX-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Tests OSX-Info.plist"; sourceTree = "<group>"; };
@@ -105,7 +102,6 @@
 		985FEFFD19CC597400EA5392 /* IndexManagerTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IndexManagerTests.h; sourceTree = "<group>"; };
 		985FEFFE19CC597400EA5392 /* IndexManagerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IndexManagerTests.m; sourceTree = "<group>"; };
 		989E6E21198799AE00FB8510 /* DatastoreCRUD.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DatastoreCRUD.m; sourceTree = "<group>"; };
-		8E3377D418ABF36E003E3D93 /* IndexManagerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IndexManagerTests.m; sourceTree = "<group>"; };
 		9985C74819AE5D8300636AB6 /* CDTQueryBuilderTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTQueryBuilderTests.m; sourceTree = "<group>"; };
 		9F0D23E818888C6C00D3D04E /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		9F0D23F0188B4FA900D3D04E /* TDMultipartReaderTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TDMultipartReaderTests.m; sourceTree = "<group>"; };
@@ -121,9 +117,10 @@
 		9F0D24131892E9B800D3D04E /* TDPusherTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TDPusherTests.m; sourceTree = "<group>"; };
 		9F0D24161893161000D3D04E /* TDReachabilityTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TDReachabilityTests.m; sourceTree = "<group>"; };
 		9F0D241918932DA700D3D04E /* TDSequenceMapTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TDSequenceMapTests.m; sourceTree = "<group>"; };
+		9F4E646919DC815B00FE37E1 /* CDTReplicationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTReplicationTests.m; sourceTree = "<group>"; };
+		9F4E646A19DC815B00FE37E1 /* SetUpDatastore.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SetUpDatastore.m; sourceTree = "<group>"; };
 		9F95D60E18CF6A580006D349 /* DBQueryUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DBQueryUtils.h; sourceTree = "<group>"; };
 		9F95D60F18CF6A580006D349 /* DBQueryUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DBQueryUtils.m; sourceTree = "<group>"; };
-		9FA839CA18FC474F0054512E /* CDTReplicationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTReplicationTests.m; sourceTree = "<group>"; };
 		9FC082961913378F0024EA1E /* DatastoreConflictResolvers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DatastoreConflictResolvers.h; sourceTree = "<group>"; };
 		9FC082971913378F0024EA1E /* DatastoreConflictResolvers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DatastoreConflictResolvers.m; sourceTree = "<group>"; };
 		B8C5CE07530A44358897106E /* Pods-ios.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ios.xcconfig"; path = "Pods/Pods-ios.xcconfig"; sourceTree = "<group>"; };
@@ -208,14 +205,10 @@
 				989E6E21198799AE00FB8510 /* DatastoreCRUD.m */,
 				9F95D60E18CF6A580006D349 /* DBQueryUtils.h */,
 				9F95D60F18CF6A580006D349 /* DBQueryUtils.m */,
+				9F4E646919DC815B00FE37E1 /* CDTReplicationTests.m */,
+				9F4E646A19DC815B00FE37E1 /* SetUpDatastore.m */,
 				27ACD1EC193DDDCC00658EC2 /* Events */,
-				27389E3418534E050027A404 /* SetUpDatastore.m */,
-				9FA839CA18FC474F0054512E /* CDTReplicationTests.m */,
-				27B34A5A18C0B204009F18E6 /* IndexManagerTests.h */,
-				8E3377D418ABF36E003E3D93 /* IndexManagerTests.m */,
 				27F43D4618E99C31003E8422 /* osx-aws-toolkit */,
-				27389E3418534E050027A404 /* SetUpDatastore.m */,
-				9FA839CA18FC474F0054512E /* CDTReplicationTests.m */,
 				27389E16185345FD0027A404 /* Supporting Files */,
 				9F0D23FE188DF96600D3D04E /* TD_DatabaseManagerTests.m */,
 				9F0D23F9188DF36800D3D04E /* TD_DatabaseTests.m */,
@@ -461,7 +454,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9FA839CB18FC474F0054512E /* CDTReplicationTests.m in Sources */,
 				9F0D2408188E378700D3D04E /* TDCanonicalJSONTests.m in Sources */,
 				9F0D23F1188B4FA900D3D04E /* TDMultipartReaderTests.m in Sources */,
 				9F0D23FF188DF96600D3D04E /* TD_DatabaseManagerTests.m in Sources */,
@@ -477,16 +469,16 @@
 				9FC082981913378F0024EA1E /* DatastoreConflictResolvers.m in Sources */,
 				9F0D23FA188DF36800D3D04E /* TD_DatabaseTests.m in Sources */,
 				985F84D4198BD3A4004D8713 /* AttachmentCRUD.m in Sources */,
+				9F4E646B19DC815B00FE37E1 /* CDTReplicationTests.m in Sources */,
 				9F0D2402188DFE8600D3D04E /* TD_RevisionTests.m in Sources */,
+				9F4E646D19DC815B00FE37E1 /* SetUpDatastore.m in Sources */,
 				985A188A19D2CCEB000283E9 /* DatastoreConflicts.m in Sources */,
 				985A188719D2CC54000283E9 /* CDTDatastoreEvents.m in Sources */,
 				9F0D240B188E3C3A00D3D04E /* TDCollateJSONTests.m in Sources */,
-				27389E3818534E050027A404 /* SetUpDatastore.m in Sources */,
 				9F0D24171893161000D3D04E /* TDReachabilityTests.m in Sources */,
 				985FEFFF19CC597400EA5392 /* IndexManagerTests.m in Sources */,
 				9F95D61018CF6A580006D349 /* DBQueryUtils.m in Sources */,
 				9F0D23F4188B4FFF00D3D04E /* TDMultipartWriterTests.m in Sources */,
-				27ACD1EE193DDDF000658EC2 /* CDTDatastoreEvents.m in Sources */,
 				9F0D24141892E9B800D3D04E /* TDPusherTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -497,7 +489,6 @@
 			files = (
 				270ED44E19D165BB007E08C4 /* CDTQueryBuilderTests.m in Sources */,
 				985F84D5198BDA6D004D8713 /* AttachmentCRUD.m in Sources */,
-				9FA839CC18FC474F0054512E /* CDTReplicationTests.m in Sources */,
 				9F0D2409188E378700D3D04E /* TDCanonicalJSONTests.m in Sources */,
 				9F0D23F2188B4FA900D3D04E /* TDMultipartReaderTests.m in Sources */,
 				9F0D2400188DF96600D3D04E /* TD_DatabaseManagerTests.m in Sources */,
@@ -511,16 +502,16 @@
 				9FC082991913378F0024EA1E /* DatastoreConflictResolvers.m in Sources */,
 				9F0D23FB188DF36800D3D04E /* TD_DatabaseTests.m in Sources */,
 				9F0D2403188DFE8600D3D04E /* TD_RevisionTests.m in Sources */,
+				9F4E646C19DC815B00FE37E1 /* CDTReplicationTests.m in Sources */,
 				985A188B19D2CCEB000283E9 /* DatastoreConflicts.m in Sources */,
+				9F4E646E19DC815B00FE37E1 /* SetUpDatastore.m in Sources */,
 				985A188819D2CC54000283E9 /* CDTDatastoreEvents.m in Sources */,
 				9F0D240C188E3C3A00D3D04E /* TDCollateJSONTests.m in Sources */,
-				27CCEDD9187AD719006F3C66 /* SetUpDatastore.m in Sources */,
 				9F0D24181893161000D3D04E /* TDReachabilityTests.m in Sources */,
 				985FF00019CC597400EA5392 /* IndexManagerTests.m in Sources */,
 				9F95D61118CF6A580006D349 /* DBQueryUtils.m in Sources */,
 				27CCEDD6187AD70C006F3C66 /* CloudantSyncTests.m in Sources */,
 				9F0D23F5188B4FFF00D3D04E /* TDMultipartWriterTests.m in Sources */,
-				27ACD1EF193DDDF000658EC2 /* CDTDatastoreEvents.m in Sources */,
 				9F0D24151892E9B800D3D04E /* TDPusherTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
Fixes reference to the SetUpDatastore.m, CDTReplicationTests.m and IndexManagerTests.m files in the Tests project. Previously there were two references to these files which, I believe, was causing Travis to fail. 
