### PR TITLE
Example app doesn't work anymore

### DIFF
--- a/Project/Podfile
+++ b/Project/Podfile
@@ -1,3 +1,4 @@
+source 'https://github.com/CocoaPods/Specs.git'
 xcodeproj 'Project'
 
 def import_pods


### PR DESCRIPTION
When first trying Cloudant Query, you are instructed to 

```
$ cd Project
$ pod install
$ open Project.xcworkspace
```

the "pod install" line fails with:

```
.
.
[!] The use of implicit sources has been deprecated. To continue using all of the sources currently on your machine, add the following to the top of your Podfile:

    source 'https://github.com/CocoaPods/Specs.git'
```

This commit fixes this.
