### PR TITLE
Restores CDTDocumentRevision init method to be successful with nil body.

### DIFF
--- a/Classes/common/CDTDocumentRevision.m
+++ b/Classes/common/CDTDocumentRevision.m
@@ -133,7 +133,7 @@
     
     if(self){
         
-        if(!docId || !revId || !body){
+        if(!docId || !revId){
             return nil;
         }
         _docId = docId;
@@ -141,7 +141,7 @@
         _deleted = deleted;
         _private_attachments = attachments;
         _sequence = sequence;
-        if(!deleted){
+        if(!deleted && body){  
             NSMutableDictionary *mutableCopy = [body mutableCopy];
             
             NSPredicate *_prefixPredicate = [NSPredicate predicateWithFormat:@" self BEGINSWITH '_'"];


### PR DESCRIPTION
Previously one could init a CDTDocumentRevision with a nil body parameter.
That was changed in a recent update. While this hasn't caused any
known bugs up to now, there is a potential for something to be
overlooked. This update restores the original functionality since
there does not seem to be any known side-effects.
