### PR TITLE
Prototype of CDTDatastoreFromQuery

### DIFF
--- a/CDTDatastore.xcworkspace/contents.xcworkspacedata
+++ b/CDTDatastore.xcworkspace/contents.xcworkspacedata
@@ -104,6 +104,12 @@
             location = "group:CDTDatastore.m">
          </FileRef>
          <FileRef
+            location = "group:CDTDatastoreFromQuery.h">
+         </FileRef>
+         <FileRef
+            location = "group:CDTDatastoreFromQuery.m">
+         </FileRef>
+         <FileRef
             location = "group:CDTDatastore+Conflicts.h">
          </FileRef>
          <FileRef

--- a/Classes/common/CDTDatastoreFromQuery.h
+++ b/Classes/common/CDTDatastoreFromQuery.h
@@ -1,0 +1,82 @@
+//
+//  CDTDatastoreFromQuery.h
+//  
+//
+//  Created by tomblench on 15/10/2014.
+//
+//
+
+#ifndef _CDTDatastoreFromQuery_h
+#define _CDTDatastoreFromQuery_h
+
+#import "CDTDatastore.h"
+#import "CDTDatastoreManager.h"
+#import "CDTReplicator.h"
+#import "CDTReplicatorFactory.h"
+
+@class CDTDatastoreFromQuery;
+
+@interface CDTCustomDelegateReplicator: CDTReplicator
+- (void) setDelegate:(NSObject<CDTReplicatorDelegate>*)delegate;
+
+@property (readonly,strong) NSObject<CDTReplicatorDelegate> *userDelegate;
+@property (readonly,strong) NSObject<CDTReplicatorDelegate> *privateDelegate;
+
+@end
+
+// TODO - this is just for prototyping, represent query as opaque object
+@interface CDTDatastoreQuery : NSObject
+
+@property (strong) NSDictionary *queryDictionary;
+
+@end
+
+@interface CDTDatastoreFromQueryPushDelegate : NSObject<CDTReplicatorDelegate>
+
+- (id)initWithDatastore:(CDTDatastoreFromQuery*)datastore;
+- (void)replicatorDidComplete:(CDTReplicator*)replicator;
+
+@property (readonly,strong) CDTDatastoreFromQuery *datastore;
+
+@end
+
+@interface CDTDatastoreFromQuery : NSObject
+
+@property (readonly,strong) CDTDatastoreQuery *query;
+
+// TODO - for now this is the current set of filtered doc IDs
+@property NSArray *docIds;
+
+
+@property (readonly,strong) CDTDatastoreManager *datastoreManager;
+
+// façade lots of operations into CDTDatastore
+@property (readonly,strong) CDTDatastore *datastore;
+
+// URL of remote database
+@property (readonly,strong) NSURL *remote;
+
+@property (readonly,strong) CDTDatastoreFromQueryPushDelegate *pushDelegate;
+
+@property (readonly,strong) CDTReplicatorFactory *factory;
+
+// TODO - private?
+-(NSString*)queryToDatastoreName:(CDTDatastoreQuery*)query;
+
+-(id)initWithQuery:(CDTDatastoreQuery*)query
+    localDirectory:(NSString*)local
+            remote:(NSURL*)remote;
+
+-(id)initWithQuery:(CDTDatastoreQuery*)query
+  datastoreManager:(CDTDatastoreManager*)manager
+            remote:(NSURL*)remote;
+
+// TODO these might take arguments eg error         
+-(CDTReplicator*)pull;
+-(CDTReplicator*)push;
+
+
+@end
+
+
+#endif

--- a/Classes/common/CDTDatastoreFromQuery.m
+++ b/Classes/common/CDTDatastoreFromQuery.m
@@ -1,0 +1,143 @@
+//
+//  CDTDatastoreFromQuery.m
+//  
+//
+//  Created by tomblench on 15/10/2014.
+//
+//
+
+#import <Foundation/Foundation.h>
+#import "CDTDatastoreFromQuery.h"
+#import "CDTPullReplication.h"
+#import "CDTReplicatorFactory.h"
+#import "CDTDatastoreManager.h"
+#import "CDTReplicatorDelegate.h"
+#import "CDTDocumentRevision.h"
+#import "TD_Database.h"
+#import "TD_Database+Insertion.h"
+#import "TDCanonicalJSON.h"
+
+@implementation CDTDatastoreQuery : NSObject
+
+
+@end
+
+@implementation CDTDatastoreFromQueryPushDelegate
+
+- (id)initWithDatastore:(CDTDatastoreFromQuery*)datastore
+{
+    if (self = [super init])
+    {
+        _datastore = datastore;
+    }
+    return self;
+}
+
+// TODO call all of the user delegates
+- (void)replicatorDidComplete:(CDTDatastoreFromQuery*)replicator
+{
+    NSLog(@"done, now purging");
+    NSMutableDictionary *revsToPurge = [NSMutableDictionary dictionary];
+    NSDictionary *result;
+    // purge every revision of every docid not in the filter list
+    // TODO whatever the optimisation is to only get the doc ids
+    for (CDTDocumentRevision *rev in [[_datastore datastore] getAllDocuments]) {
+        if (![[_datastore docIds] containsObject:[rev docId]]) {
+            NSMutableArray *revIds = [NSMutableArray array];
+            for (CDTDocumentRevision *revObj in [[_datastore datastore] getRevisionHistory:rev]) {
+                [revIds addObject:[revObj revId]];
+            }
+            [revsToPurge setObject:revIds forKey:[rev docId]];
+        }
+    }
+    [[[_datastore datastore] database] purgeRevisions:revsToPurge result:&result];
+}
+
+@end
+
+@implementation CDTDatastoreFromQuery
+
+-(id)initWithQuery:(CDTDatastoreQuery*)query
+  datastoreManager:(CDTDatastoreManager*)manager
+            remote:(NSURL*)remote
+{
+    if (self = [super init]) {
+        _datastoreManager = manager;
+        _query = query;
+        _docIds = [self queryToDocIds:_query];
+        _remote = remote;
+        // TODO datastore name to be derived from query
+        _datastore = [manager datastoreNamed:[self queryToDatastoreName:query] error:nil];
+        _factory = [[CDTReplicatorFactory alloc] initWithDatastoreManager:self.datastoreManager];
+        [_factory start];
+        _pushDelegate = [[CDTDatastoreFromQueryPushDelegate alloc] initWithDatastore:self];
+    }
+    return self;
+}
+
+-(id)initWithQuery:(CDTDatastoreQuery*)query
+    localDirectory:(NSString*)local
+            remote:(NSURL*)remote
+{
+    if (self = [super init]) {
+        NSError *err;
+        _datastoreManager = [[CDTDatastoreManager alloc] initWithDirectory:local error:&err];
+        // TODO why is _datastoreManager.manager.replicatorManager.replicatorsBySessionID nil?
+        _query = query;
+        _docIds = [self queryToDocIds:_query];
+        _remote = remote;
+        // TODO datastore name to be derived from query
+        _datastore = [_datastoreManager datastoreNamed:[self queryToDatastoreName:query] error:nil];
+        _pushDelegate = [[CDTDatastoreFromQueryPushDelegate alloc] initWithDatastore:self];
+        _factory = [[CDTReplicatorFactory alloc] initWithDatastoreManager:self.datastoreManager];
+        [_factory start];
+
+    }
+    return self;
+}
+
+-(NSArray*)queryToDocIds:(CDTDatastoreQuery*)query
+{
+    // dummy implementation
+    // TODO
+    return @[@"doc-1",@"doc-2",@"doc-3"];
+}
+
+-(NSString*)queryToDatastoreName:(CDTDatastoreQuery*)query
+{
+    NSLog(@"%@",[TDCanonicalJSON canonicalString: query.queryDictionary]);
+    return TDHexSHA1Digest([TDCanonicalJSON canonicalData: query.queryDictionary]);
+}
+
+-(CDTReplicator*)pull
+{
+    // standard pull by doc id
+    // could purge before / after?
+    
+    CDTPullReplication *pull = [CDTPullReplication replicationWithSource:self.remote
+                                                                  target:self.datastore];
+    pull.clientFilterDocIds = self.docIds;
+    
+    NSError *error;
+    CDTReplicator *replicator =  [_factory oneWay:pull error:&error];
+    return replicator;
+ }
+
+-(CDTReplicator*)push
+{
+    // has the id list changed?
+    // push everything
+    // then purge local docs not in id list
+    // TODO - how to manage lifecycle, need to add a block to run on completion of push using notifications
+
+    CDTPullReplication *push = [CDTPullReplication replicationWithSource:self.remote
+                                                                  target:self.datastore];
+    NSError *error;
+    CDTReplicator *replicator =  [_factory oneWay:push error:&error];
+    replicator.delegate = _pushDelegate;
+    
+    return replicator;
+}
+
+@end
+

--- a/Classes/common/CDTReplicator/CDTPullReplication.h
+++ b/Classes/common/CDTReplicator/CDTPullReplication.h
@@ -152,4 +152,24 @@
  */
 @property (nonatomic, copy) NSDictionary *filterParams;
 
+/** The list of document IDs to pull during a replication.
+
+ All other documents are filtered out and not included in the replication.
+
+ Modifying the example above, in order to replicate a subset of known document 
+ IDs, specify:
+ 
+    pull.clientFilterDocIds = @[@"doc-1", @"doc-2", @"doc-12"];
+ 
+ before calling:
+ 
+    CDTReplicator *rep = [replicatorFactory oneWay:pull error:&error];
+ 
+ Now only the documents already extant in the database will be updated, and 
+ any additional documents with the specified IDs (if present) will be pulled.
+ 
+ */
+@property (nonatomic, copy) NSArray *clientFilterDocIds;
+
+
 @end

--- a/Classes/common/CDTReplicator/CDTPullReplication.m
+++ b/Classes/common/CDTReplicator/CDTPullReplication.m
@@ -46,6 +46,7 @@
         copy.target = self.target;
         copy.filter = self.filter;
         copy.filterParams = self.filterParams;
+        copy.clientFilterDocIds = self.clientFilterDocIds;
     }
 
     return copy;
@@ -95,7 +96,11 @@
             [doc setObject:self.filterParams forKey:@"query_params"];
         }
     }
-
+    
+    if (self.clientFilterDocIds) {
+        [doc setObject:self.clientFilterDocIds forKey:@"client_filter_doc_ids"];
+    }
+    
     return doc;
 }
 

--- a/Classes/common/CDTReplicator/CDTPushReplication.h
+++ b/Classes/common/CDTReplicator/CDTPushReplication.h
@@ -60,6 +60,11 @@ typedef BOOL (^CDTFilterBlock)(CDTDocumentRevision *revision, NSDictionary *para
  */
 + (instancetype)replicationWithSource:(CDTDatastore *)source target:(NSURL *)target;
 
++(instancetype) replicationWithSource:(CDTDatastore *)source
+                               target:(NSURL *)target
+                    purgeOnCompletion:(BOOL)purge;
+
+
 /**
  @name Accessing the replication source and target
  */
@@ -143,5 +148,8 @@ typedef BOOL (^CDTFilterBlock)(CDTDocumentRevision *revision, NSDictionary *para
  @see -filter
  */
 @property (nonatomic, copy) NSDictionary *filterParams;
+
+@property BOOL purgeOnCompletion;
+
 
 @end

--- a/Classes/common/CDTReplicator/CDTPushReplication.m
+++ b/Classes/common/CDTReplicator/CDTPushReplication.m
@@ -27,14 +27,24 @@
 
 + (instancetype)replicationWithSource:(CDTDatastore *)source target:(NSURL *)target
 {
-    return [[self alloc] initWithSource:source target:target];
+    return [[self alloc] initWithSource:source target:target purgeOnCompletion:NO];
 }
 
-- (instancetype)initWithSource:(CDTDatastore *)source target:(NSURL *)target
++(instancetype) replicationWithSource:(CDTDatastore *)source
+                               target:(NSURL *)target
+                    purgeOnCompletion:(BOOL)purge
+{
+    return [[self alloc] initWithSource:source target:target purgeOnCompletion:purge];
+}
+
+-(instancetype) initWithSource:(CDTDatastore *)source
+                        target:(NSURL *)target
+             purgeOnCompletion:(BOOL)purge
 {
     if (self = [super init]) {
         _source = source;
         _target = target;
+        _purgeOnCompletion = purge;
     }
     return self;
 }

--- a/Classes/common/touchdb/TDPuller.h
+++ b/Classes/common/touchdb/TDPuller.h
@@ -16,15 +16,22 @@
 @interface TDPuller : TDReplicator {
    @private
     TDChangeTracker* _changeTracker;
-    BOOL _caughtUp;                      // Have I received all current _changes entries?
-    TDSequenceMap* _pendingSequences;    // Received but not yet copied into local DB
-    NSMutableArray* _revsToPull;         // Queue of TDPulledRevisions to download
-    NSMutableArray* _deletedRevsToPull;  // Separate lower-priority of deleted TDPulledRevisions
-    NSMutableArray* _bulkRevsToPull;     // TDPulledRevisions that can be fetched in bulk
-    NSUInteger _httpConnectionCount;     // Number of active NSURLConnections
-    TDBatcher* _downloadsToInsert;       // Queue of TDPulledRevisions, with bodies, to insert in DB
+    BOOL _caughtUp;                     // Have I received all current _changes entries?
+    TDSequenceMap* _pendingSequences;   // Received but not yet copied into local DB
+    NSMutableArray* _revsToPull;        // Queue of TDPulledRevisions to download
+    NSMutableArray* _deletedRevsToPull; // Separate lower-priority of deleted TDPulledRevisions
+    NSMutableArray* _bulkRevsToPull;    // TDPulledRevisions that can be fetched in bulk
+    NSUInteger _httpConnectionCount;    // Number of active NSURLConnections
+    TDBatcher* _downloadsToInsert;      // Queue of TDPulledRevisions, with bodies, to insert in DB
+    NSArray* _clientFilterDocIds;       // If set, only pull this subset of doc ids
+    NSMutableSet *_clientFilterNewDocIds; // The set difference: _clientFilterDocIds - all doc ids in DB
 }
 
+// overriden from TDReplicator
+- (NSString*) remoteCheckpointDocID;
+// overriden from TDReplicator
+- (void) addToInbox: (TD_Revision*)rev;
+- (void) setClientFilterDocIds:(NSArray *)clientFilterDocIds;
 @end
 
 /** A revision received from a remote server during a pull. Tracks the opaque remote sequence ID. */

--- a/Classes/common/touchdb/TDReplicator.h
+++ b/Classes/common/touchdb/TDReplicator.h
@@ -84,6 +84,9 @@ extern NSString* TDReplicatorStoppedNotification;
     TDReplicatorStoppedNotification will be posted when it finally stops. */
 - (void)stop;
 
+/** Internal method, declared for sub-classes to over-ride */
+- (NSString*) remoteCheckpointDocID;
+
 /** Is the replicator running? (Observable) */
 @property (readonly, nonatomic) BOOL running;
 

--- a/Classes/common/touchdb/TD_DatabaseManager.m
+++ b/Classes/common/touchdb/TD_DatabaseManager.m
@@ -20,6 +20,7 @@
 #import "TD_DatabaseManager.h"
 #import "TD_Database.h"
 #import "TDPusher.h"
+#import "TDPuller.h"
 #import "TDReplicatorManager.h"
 #import "TDInternal.h"
 #import "TDMisc.h"
@@ -280,7 +281,8 @@ static NSDictionary* parseSourceOrTarget(NSDictionary* properties, NSString* key
                                 authorizer:NULL];
 }
 
-- (TDReplicator*)replicatorWithProperties:(NSDictionary*)properties status:(TDStatus*)outStatus
+- (TDReplicator*) replicatorWithProperties: (NSDictionary*)properties
+                                    status: (TDStatus*)outStatus
 {
     // Extract the parameters from the JSON request body:
     // http://wiki.apache.org/couchdb/Replication
@@ -316,9 +318,14 @@ static NSDictionary* parseSourceOrTarget(NSDictionary* properties, NSString* key
     repl.options = properties;
     repl.requestHeaders = headers;
     repl.authorizer = authorizer;
-    if (push) ((TDPusher*)repl).createTarget = createTarget;
 
-    if (outStatus) *outStatus = kTDStatusOK;
+    if (push)
+        ((TDPusher*)repl).createTarget = createTarget;
+    if (!push)
+        [(TDPuller*)repl setClientFilterDocIds:$castIf(NSArray, properties[@"client_filter_doc_ids"])];
+    
+    if (outStatus)
+        *outStatus = kTDStatusOK;
     return repl;
 }
 

--- a/ReplicationAcceptance/ReplicationAcceptance.xcodeproj/project.pbxproj
+++ b/ReplicationAcceptance/ReplicationAcceptance.xcodeproj/project.pbxproj
@@ -1,1104 +1,2472 @@
-// !$*UTF8*$!
-{
-	archiveVersion = 1;
-	classes = {
-	};
-	objectVersion = 46;
-	objects = {
-
-/* Begin PBXBuildFile section */
-		277992B818A24F0900BAB6ED /* ReplicationAcceptance+CRUD.m in Sources */ = {isa = PBXBuildFile; fileRef = 277992B718A24F0900BAB6ED /* ReplicationAcceptance+CRUD.m */; };
-		277992B918A24F0900BAB6ED /* ReplicationAcceptance+CRUD.m in Sources */ = {isa = PBXBuildFile; fileRef = 277992B718A24F0900BAB6ED /* ReplicationAcceptance+CRUD.m */; };
-		277992BB18A2503C00BAB6ED /* ReplicationAcceptance.h in Resources */ = {isa = PBXBuildFile; fileRef = 277992BA18A2503C00BAB6ED /* ReplicationAcceptance.h */; };
-		277992BC18A2503C00BAB6ED /* ReplicationAcceptance.h in Resources */ = {isa = PBXBuildFile; fileRef = 277992BA18A2503C00BAB6ED /* ReplicationAcceptance.h */; };
-		27A7E68A18997412007FAF1C /* SenTestingKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 27A7E673189973EE007FAF1C /* SenTestingKit.framework */; };
-		27A7E68B18997412007FAF1C /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 27A7E675189973EE007FAF1C /* Foundation.framework */; };
-		27A7E68C18997412007FAF1C /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 27A7E677189973EE007FAF1C /* UIKit.framework */; };
-		27A7E69218997412007FAF1C /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 27A7E69018997412007FAF1C /* InfoPlist.strings */; };
-		27A7E69E1899741C007FAF1C /* SenTestingKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 27A7E673189973EE007FAF1C /* SenTestingKit.framework */; };
-		27A7E6A41899741C007FAF1C /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 27A7E6A21899741C007FAF1C /* InfoPlist.strings */; };
-		27A7E6AF189975B2007FAF1C /* CloudantReplicationBase.m in Sources */ = {isa = PBXBuildFile; fileRef = 27A7E6AE189975B2007FAF1C /* CloudantReplicationBase.m */; };
-		27A7E6B0189975B2007FAF1C /* CloudantReplicationBase.m in Sources */ = {isa = PBXBuildFile; fileRef = 27A7E6AE189975B2007FAF1C /* CloudantReplicationBase.m */; };
-		27A7E6B118997673007FAF1C /* ReplicationAcceptance.m in Sources */ = {isa = PBXBuildFile; fileRef = 27A7E67F189973EE007FAF1C /* ReplicationAcceptance.m */; };
-		27A7E6B218997677007FAF1C /* ReplicationAcceptance.m in Sources */ = {isa = PBXBuildFile; fileRef = 27A7E67F189973EE007FAF1C /* ReplicationAcceptance.m */; };
-		27BE3CEF189FBEA9000CD30D /* CloudantReplicationBase+CompareDb.m in Sources */ = {isa = PBXBuildFile; fileRef = 27BE3CEE189FBEA9000CD30D /* CloudantReplicationBase+CompareDb.m */; };
-		27DFEEB718DB4A0D0052D487 /* Attachments.m in Sources */ = {isa = PBXBuildFile; fileRef = 27DFEEB618DB4A0D0052D487 /* Attachments.m */; };
-		27DFEEB818DB4A0D0052D487 /* Attachments.m in Sources */ = {isa = PBXBuildFile; fileRef = 27DFEEB618DB4A0D0052D487 /* Attachments.m */; };
-		27E75E8D18B383CB004317D1 /* CloudantReplicationBase+CompareDb.m in Sources */ = {isa = PBXBuildFile; fileRef = 27BE3CEE189FBEA9000CD30D /* CloudantReplicationBase+CompareDb.m */; };
-		27ED1080192CF8DB00F75E95 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 27A7E675189973EE007FAF1C /* Foundation.framework */; };
-		27ED1082192CF8DB00F75E95 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 27ED1081192CF8DB00F75E95 /* CoreGraphics.framework */; };
-		27ED1083192CF8DB00F75E95 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 27A7E677189973EE007FAF1C /* UIKit.framework */; };
-		27ED1089192CF8DB00F75E95 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 27ED1087192CF8DB00F75E95 /* InfoPlist.strings */; };
-		27ED108B192CF8DB00F75E95 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 27ED108A192CF8DB00F75E95 /* main.m */; };
-		27ED108F192CF8DB00F75E95 /* CDTAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 27ED108E192CF8DB00F75E95 /* CDTAppDelegate.m */; };
-		27ED1091192CF8DB00F75E95 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 27ED1090192CF8DB00F75E95 /* Images.xcassets */; };
-		27ED1099192CF8DB00F75E95 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 27A7E675189973EE007FAF1C /* Foundation.framework */; };
-		27ED109A192CF8DB00F75E95 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 27A7E677189973EE007FAF1C /* UIKit.framework */; };
-		27ED10A2192CF8DB00F75E95 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 27ED10A0192CF8DB00F75E95 /* InfoPlist.strings */; };
-		27ED10AB192CF8FF00F75E95 /* ReplicationAcceptance.m in Sources */ = {isa = PBXBuildFile; fileRef = 27A7E67F189973EE007FAF1C /* ReplicationAcceptance.m */; };
-		27ED10AC192CF8FF00F75E95 /* Attachments.m in Sources */ = {isa = PBXBuildFile; fileRef = 27DFEEB618DB4A0D0052D487 /* Attachments.m */; };
-		27ED10AD192CF8FF00F75E95 /* CloudantReplicationBase.m in Sources */ = {isa = PBXBuildFile; fileRef = 27A7E6AE189975B2007FAF1C /* CloudantReplicationBase.m */; };
-		27ED10AE192CF8FF00F75E95 /* CloudantReplicationBase+CompareDb.m in Sources */ = {isa = PBXBuildFile; fileRef = 27BE3CEE189FBEA9000CD30D /* CloudantReplicationBase+CompareDb.m */; };
-		27ED10AF192CF8FF00F75E95 /* ReplicationAcceptance+CRUD.m in Sources */ = {isa = PBXBuildFile; fileRef = 277992B718A24F0900BAB6ED /* ReplicationAcceptance+CRUD.m */; };
-		27ED10B0192CFA3600F75E95 /* SenTestingKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 27A7E673189973EE007FAF1C /* SenTestingKit.framework */; };
-		4510BA04F5FB481E882AF5EE /* libPods-ios.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C61CF9A9D4564F53BC1F7321 /* libPods-ios.a */; };
-		86A30343408047EEBBF8EC4C /* libPods-ios.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C61CF9A9D4564F53BC1F7321 /* libPods-ios.a */; };
-		8E89B680A5F347559033D1B3 /* libPods-osx.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 97F72706FFD44D88B6E5E667 /* libPods-osx.a */; };
-		9F1F14ED19870B88003E9F0B /* ReplicatorDelegates.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F1F14EC19870B88003E9F0B /* ReplicatorDelegates.m */; };
-		9F1F14EE19870B88003E9F0B /* ReplicatorDelegates.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F1F14EC19870B88003E9F0B /* ReplicatorDelegates.m */; };
-		9FC2F12C19F070710032A074 /* ReplicatorURLProtocol.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FC2F12B19F070710032A074 /* ReplicatorURLProtocol.m */; };
-		9FC2F12D19F070710032A074 /* ReplicatorURLProtocol.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FC2F12B19F070710032A074 /* ReplicatorURLProtocol.m */; };
-		9FC2F13119F72B710032A074 /* ReplicatorURLProtocolTester.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FC2F13019F72B710032A074 /* ReplicatorURLProtocolTester.m */; };
-		9FC2F13219F72B710032A074 /* ReplicatorURLProtocolTester.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FC2F13019F72B710032A074 /* ReplicatorURLProtocolTester.m */; };
-/* End PBXBuildFile section */
-
-/* Begin PBXContainerItemProxy section */
-		27ED109B192CF8DB00F75E95 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 27A7E666189973D6007FAF1C /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 27ED107E192CF8DB00F75E95;
-			remoteInfo = ReplicationAcceptanceApp;
-		};
-/* End PBXContainerItemProxy section */
-
-/* Begin PBXFileReference section */
-		02F8FB2013C0F891ADB8CC62 /* Pods-osx.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-osx.debug.xcconfig"; path = "Pods/Target Support Files/Pods-osx/Pods-osx.debug.xcconfig"; sourceTree = "<group>"; };
-		277992B618A24F0900BAB6ED /* ReplicationAcceptance+CRUD.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ReplicationAcceptance+CRUD.h"; sourceTree = "<group>"; };
-		277992B718A24F0900BAB6ED /* ReplicationAcceptance+CRUD.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "ReplicationAcceptance+CRUD.m"; sourceTree = "<group>"; };
-		277992BA18A2503C00BAB6ED /* ReplicationAcceptance.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ReplicationAcceptance.h; sourceTree = "<group>"; };
-		27A7E673189973EE007FAF1C /* SenTestingKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SenTestingKit.framework; path = Library/Frameworks/SenTestingKit.framework; sourceTree = DEVELOPER_DIR; };
-		27A7E675189973EE007FAF1C /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		27A7E677189973EE007FAF1C /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
-		27A7E67B189973EE007FAF1C /* ReplicationAcceptance-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "ReplicationAcceptance-Info.plist"; sourceTree = "<group>"; };
-		27A7E67D189973EE007FAF1C /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		27A7E67F189973EE007FAF1C /* ReplicationAcceptance.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ReplicationAcceptance.m; sourceTree = "<group>"; };
-		27A7E681189973EE007FAF1C /* ReplicationAcceptance-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ReplicationAcceptance-Prefix.pch"; sourceTree = "<group>"; };
-		27A7E68918997412007FAF1C /* RA_Tests_iOS.octest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RA_Tests_iOS.octest; sourceTree = BUILT_PRODUCTS_DIR; };
-		27A7E68F18997412007FAF1C /* RA_Tests_iOS-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "RA_Tests_iOS-Info.plist"; sourceTree = "<group>"; };
-		27A7E69118997412007FAF1C /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		27A7E69518997412007FAF1C /* RA_Tests_iOS-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RA_Tests_iOS-Prefix.pch"; sourceTree = "<group>"; };
-		27A7E69D1899741C007FAF1C /* RA_Tests_OSX.octest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RA_Tests_OSX.octest; sourceTree = BUILT_PRODUCTS_DIR; };
-		27A7E6A11899741C007FAF1C /* RA_Tests_OSX-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "RA_Tests_OSX-Info.plist"; sourceTree = "<group>"; };
-		27A7E6A31899741C007FAF1C /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		27A7E6A71899741C007FAF1C /* RA_Tests_OSX-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RA_Tests_OSX-Prefix.pch"; sourceTree = "<group>"; };
-		27A7E6AD189975B2007FAF1C /* CloudantReplicationBase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CloudantReplicationBase.h; sourceTree = "<group>"; };
-		27A7E6AE189975B2007FAF1C /* CloudantReplicationBase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CloudantReplicationBase.m; sourceTree = "<group>"; };
-		27A7E6B31899785B007FAF1C /* README.md */ = {isa = PBXFileReference; lastKnownFileType = text; path = README.md; sourceTree = "<group>"; };
-		27BE3CED189FBEA9000CD30D /* CloudantReplicationBase+CompareDb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "CloudantReplicationBase+CompareDb.h"; sourceTree = "<group>"; };
-		27BE3CEE189FBEA9000CD30D /* CloudantReplicationBase+CompareDb.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "CloudantReplicationBase+CompareDb.m"; sourceTree = "<group>"; };
-		27DFEEB618DB4A0D0052D487 /* Attachments.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Attachments.m; sourceTree = "<group>"; };
-		27ED107F192CF8DB00F75E95 /* ReplicationAcceptanceApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ReplicationAcceptanceApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		27ED1081192CF8DB00F75E95 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
-		27ED1086192CF8DB00F75E95 /* ReplicationAcceptanceApp-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "ReplicationAcceptanceApp-Info.plist"; sourceTree = "<group>"; };
-		27ED1088192CF8DB00F75E95 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		27ED108A192CF8DB00F75E95 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
-		27ED108C192CF8DB00F75E95 /* ReplicationAcceptanceApp-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ReplicationAcceptanceApp-Prefix.pch"; sourceTree = "<group>"; };
-		27ED108D192CF8DB00F75E95 /* CDTAppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CDTAppDelegate.h; sourceTree = "<group>"; };
-		27ED108E192CF8DB00F75E95 /* CDTAppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CDTAppDelegate.m; sourceTree = "<group>"; };
-		27ED1090192CF8DB00F75E95 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
-		27ED1096192CF8DB00F75E95 /* ReplicationAcceptanceAppTests.octest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ReplicationAcceptanceAppTests.octest; sourceTree = BUILT_PRODUCTS_DIR; };
-		27ED1097192CF8DB00F75E95 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
-		27ED109F192CF8DB00F75E95 /* ReplicationAcceptanceAppTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "ReplicationAcceptanceAppTests-Info.plist"; sourceTree = "<group>"; };
-		27ED10A1192CF8DB00F75E95 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		5E90CA923A123284AF6B8CE0 /* Pods-osx.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-osx.release.xcconfig"; path = "Pods/Target Support Files/Pods-osx/Pods-osx.release.xcconfig"; sourceTree = "<group>"; };
-		6A9AF7E2659CCF39B5454D35 /* Pods-ios.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ios.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ios/Pods-ios.debug.xcconfig"; sourceTree = "<group>"; };
-		97F72706FFD44D88B6E5E667 /* libPods-osx.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-osx.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		9F1F14EB19870B88003E9F0B /* ReplicatorDelegates.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ReplicatorDelegates.h; sourceTree = "<group>"; };
-		9F1F14EC19870B88003E9F0B /* ReplicatorDelegates.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ReplicatorDelegates.m; sourceTree = "<group>"; };
-		9FC2F12B19F070710032A074 /* ReplicatorURLProtocol.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ReplicatorURLProtocol.m; sourceTree = "<group>"; };
-		9FC2F12E19F070950032A074 /* ReplicatorURLProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ReplicatorURLProtocol.h; sourceTree = "<group>"; };
-		9FC2F12F19F72B710032A074 /* ReplicatorURLProtocolTester.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ReplicatorURLProtocolTester.h; sourceTree = "<group>"; };
-		9FC2F13019F72B710032A074 /* ReplicatorURLProtocolTester.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ReplicatorURLProtocolTester.m; sourceTree = "<group>"; };
-		C61CF9A9D4564F53BC1F7321 /* libPods-ios.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ios.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		EDDE94B9BFCFBFA9EE766F1D /* Pods-ios.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ios.release.xcconfig"; path = "Pods/Target Support Files/Pods-ios/Pods-ios.release.xcconfig"; sourceTree = "<group>"; };
-/* End PBXFileReference section */
-
-/* Begin PBXFrameworksBuildPhase section */
-		27A7E68618997412007FAF1C /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				27A7E68A18997412007FAF1C /* SenTestingKit.framework in Frameworks */,
-				27A7E68C18997412007FAF1C /* UIKit.framework in Frameworks */,
-				27A7E68B18997412007FAF1C /* Foundation.framework in Frameworks */,
-				4510BA04F5FB481E882AF5EE /* libPods-ios.a in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		27A7E69A1899741C007FAF1C /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				27A7E69E1899741C007FAF1C /* SenTestingKit.framework in Frameworks */,
-				8E89B680A5F347559033D1B3 /* libPods-osx.a in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		27ED107C192CF8DB00F75E95 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				27ED1082192CF8DB00F75E95 /* CoreGraphics.framework in Frameworks */,
-				27ED1083192CF8DB00F75E95 /* UIKit.framework in Frameworks */,
-				27ED1080192CF8DB00F75E95 /* Foundation.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		27ED1093192CF8DB00F75E95 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				27ED10B0192CFA3600F75E95 /* SenTestingKit.framework in Frameworks */,
-				27ED109A192CF8DB00F75E95 /* UIKit.framework in Frameworks */,
-				27ED1099192CF8DB00F75E95 /* Foundation.framework in Frameworks */,
-				86A30343408047EEBBF8EC4C /* libPods-ios.a in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXFrameworksBuildPhase section */
-
-/* Begin PBXGroup section */
-		253FF1720E618E1A275A8395 /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				6A9AF7E2659CCF39B5454D35 /* Pods-ios.debug.xcconfig */,
-				EDDE94B9BFCFBFA9EE766F1D /* Pods-ios.release.xcconfig */,
-				02F8FB2013C0F891ADB8CC62 /* Pods-osx.debug.xcconfig */,
-				5E90CA923A123284AF6B8CE0 /* Pods-osx.release.xcconfig */,
-			);
-			name = Pods;
-			sourceTree = "<group>";
-		};
-		27A7E665189973D6007FAF1C = {
-			isa = PBXGroup;
-			children = (
-				27A7E6B31899785B007FAF1C /* README.md */,
-				27A7E679189973EE007FAF1C /* ReplicationAcceptance */,
-				27A7E68D18997412007FAF1C /* RA_Tests_iOS */,
-				27A7E69F1899741C007FAF1C /* RA_Tests_OSX */,
-				27ED1084192CF8DB00F75E95 /* ReplicationAcceptanceApp */,
-				27ED109D192CF8DB00F75E95 /* ReplicationAcceptanceAppTests */,
-				27A7E672189973EE007FAF1C /* Frameworks */,
-				27A7E671189973EE007FAF1C /* Products */,
-				253FF1720E618E1A275A8395 /* Pods */,
-			);
-			sourceTree = "<group>";
-		};
-		27A7E671189973EE007FAF1C /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				27A7E68918997412007FAF1C /* RA_Tests_iOS.octest */,
-				27A7E69D1899741C007FAF1C /* RA_Tests_OSX.octest */,
-				27ED107F192CF8DB00F75E95 /* ReplicationAcceptanceApp.app */,
-				27ED1096192CF8DB00F75E95 /* ReplicationAcceptanceAppTests.octest */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		27A7E672189973EE007FAF1C /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				27A7E673189973EE007FAF1C /* SenTestingKit.framework */,
-				27A7E675189973EE007FAF1C /* Foundation.framework */,
-				27A7E677189973EE007FAF1C /* UIKit.framework */,
-				C61CF9A9D4564F53BC1F7321 /* libPods-ios.a */,
-				97F72706FFD44D88B6E5E667 /* libPods-osx.a */,
-				27ED1081192CF8DB00F75E95 /* CoreGraphics.framework */,
-				27ED1097192CF8DB00F75E95 /* XCTest.framework */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		27A7E679189973EE007FAF1C /* ReplicationAcceptance */ = {
-			isa = PBXGroup;
-			children = (
-				277992BA18A2503C00BAB6ED /* ReplicationAcceptance.h */,
-				27A7E67F189973EE007FAF1C /* ReplicationAcceptance.m */,
-				27DFEEB618DB4A0D0052D487 /* Attachments.m */,
-				27A7E67A189973EE007FAF1C /* Supporting Files */,
-				27A7E6AD189975B2007FAF1C /* CloudantReplicationBase.h */,
-				27A7E6AE189975B2007FAF1C /* CloudantReplicationBase.m */,
-				27BE3CED189FBEA9000CD30D /* CloudantReplicationBase+CompareDb.h */,
-				27BE3CEE189FBEA9000CD30D /* CloudantReplicationBase+CompareDb.m */,
-				277992B618A24F0900BAB6ED /* ReplicationAcceptance+CRUD.h */,
-				277992B718A24F0900BAB6ED /* ReplicationAcceptance+CRUD.m */,
-				9F1F14EB19870B88003E9F0B /* ReplicatorDelegates.h */,
-				9F1F14EC19870B88003E9F0B /* ReplicatorDelegates.m */,
-				9FC2F12E19F070950032A074 /* ReplicatorURLProtocol.h */,
-				9FC2F12B19F070710032A074 /* ReplicatorURLProtocol.m */,
-				9FC2F12F19F72B710032A074 /* ReplicatorURLProtocolTester.h */,
-				9FC2F13019F72B710032A074 /* ReplicatorURLProtocolTester.m */,
-			);
-			path = ReplicationAcceptance;
-			sourceTree = "<group>";
-		};
-		27A7E67A189973EE007FAF1C /* Supporting Files */ = {
-			isa = PBXGroup;
-			children = (
-				27A7E67B189973EE007FAF1C /* ReplicationAcceptance-Info.plist */,
-				27A7E67C189973EE007FAF1C /* InfoPlist.strings */,
-				27A7E681189973EE007FAF1C /* ReplicationAcceptance-Prefix.pch */,
-			);
-			name = "Supporting Files";
-			sourceTree = "<group>";
-		};
-		27A7E68D18997412007FAF1C /* RA_Tests_iOS */ = {
-			isa = PBXGroup;
-			children = (
-				27A7E68E18997412007FAF1C /* Supporting Files */,
-			);
-			path = RA_Tests_iOS;
-			sourceTree = "<group>";
-		};
-		27A7E68E18997412007FAF1C /* Supporting Files */ = {
-			isa = PBXGroup;
-			children = (
-				27A7E68F18997412007FAF1C /* RA_Tests_iOS-Info.plist */,
-				27A7E69018997412007FAF1C /* InfoPlist.strings */,
-				27A7E69518997412007FAF1C /* RA_Tests_iOS-Prefix.pch */,
-			);
-			name = "Supporting Files";
-			sourceTree = "<group>";
-		};
-		27A7E69F1899741C007FAF1C /* RA_Tests_OSX */ = {
-			isa = PBXGroup;
-			children = (
-				27A7E6A01899741C007FAF1C /* Supporting Files */,
-			);
-			path = RA_Tests_OSX;
-			sourceTree = "<group>";
-		};
-		27A7E6A01899741C007FAF1C /* Supporting Files */ = {
-			isa = PBXGroup;
-			children = (
-				27A7E6A11899741C007FAF1C /* RA_Tests_OSX-Info.plist */,
-				27A7E6A21899741C007FAF1C /* InfoPlist.strings */,
-				27A7E6A71899741C007FAF1C /* RA_Tests_OSX-Prefix.pch */,
-			);
-			name = "Supporting Files";
-			sourceTree = "<group>";
-		};
-		27ED1084192CF8DB00F75E95 /* ReplicationAcceptanceApp */ = {
-			isa = PBXGroup;
-			children = (
-				27ED108D192CF8DB00F75E95 /* CDTAppDelegate.h */,
-				27ED108E192CF8DB00F75E95 /* CDTAppDelegate.m */,
-				27ED1090192CF8DB00F75E95 /* Images.xcassets */,
-				27ED1085192CF8DB00F75E95 /* Supporting Files */,
-			);
-			path = ReplicationAcceptanceApp;
-			sourceTree = "<group>";
-		};
-		27ED1085192CF8DB00F75E95 /* Supporting Files */ = {
-			isa = PBXGroup;
-			children = (
-				27ED1086192CF8DB00F75E95 /* ReplicationAcceptanceApp-Info.plist */,
-				27ED1087192CF8DB00F75E95 /* InfoPlist.strings */,
-				27ED108A192CF8DB00F75E95 /* main.m */,
-				27ED108C192CF8DB00F75E95 /* ReplicationAcceptanceApp-Prefix.pch */,
-			);
-			name = "Supporting Files";
-			sourceTree = "<group>";
-		};
-		27ED109D192CF8DB00F75E95 /* ReplicationAcceptanceAppTests */ = {
-			isa = PBXGroup;
-			children = (
-				27ED109E192CF8DB00F75E95 /* Supporting Files */,
-			);
-			path = ReplicationAcceptanceAppTests;
-			sourceTree = "<group>";
-		};
-		27ED109E192CF8DB00F75E95 /* Supporting Files */ = {
-			isa = PBXGroup;
-			children = (
-				27ED109F192CF8DB00F75E95 /* ReplicationAcceptanceAppTests-Info.plist */,
-				27ED10A0192CF8DB00F75E95 /* InfoPlist.strings */,
-			);
-			name = "Supporting Files";
-			sourceTree = "<group>";
-		};
-/* End PBXGroup section */
-
-/* Begin PBXNativeTarget section */
-		27A7E68818997412007FAF1C /* RA_Tests_iOS */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 27A7E69618997412007FAF1C /* Build configuration list for PBXNativeTarget "RA_Tests_iOS" */;
-			buildPhases = (
-				5517C6B16DE048EF85C5A4A1 /* Check Pods Manifest.lock */,
-				27A7E68518997412007FAF1C /* Sources */,
-				27A7E68618997412007FAF1C /* Frameworks */,
-				27A7E68718997412007FAF1C /* Resources */,
-				DA7978ED7F6244DC8D4D91B8 /* Copy Pods Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = RA_Tests_iOS;
-			productName = RA_Tests_iOS;
-			productReference = 27A7E68918997412007FAF1C /* RA_Tests_iOS.octest */;
-			productType = "com.apple.product-type.bundle.ocunit-test";
-		};
-		27A7E69C1899741C007FAF1C /* RA_Tests_OSX */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 27A7E6AA1899741C007FAF1C /* Build configuration list for PBXNativeTarget "RA_Tests_OSX" */;
-			buildPhases = (
-				86D70F8BECFE48389B7B243B /* Check Pods Manifest.lock */,
-				27A7E6991899741C007FAF1C /* Sources */,
-				27A7E69A1899741C007FAF1C /* Frameworks */,
-				27A7E69B1899741C007FAF1C /* Resources */,
-				BB7BC6BD2CC743AAAAC21269 /* Copy Pods Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = RA_Tests_OSX;
-			productName = RA_Tests_OSX;
-			productReference = 27A7E69D1899741C007FAF1C /* RA_Tests_OSX.octest */;
-			productType = "com.apple.product-type.bundle.ocunit-test";
-		};
-		27ED107E192CF8DB00F75E95 /* ReplicationAcceptanceApp */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 27ED10A9192CF8DB00F75E95 /* Build configuration list for PBXNativeTarget "ReplicationAcceptanceApp" */;
-			buildPhases = (
-				27ED107B192CF8DB00F75E95 /* Sources */,
-				27ED107C192CF8DB00F75E95 /* Frameworks */,
-				27ED107D192CF8DB00F75E95 /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = ReplicationAcceptanceApp;
-			productName = ReplicationAcceptanceApp;
-			productReference = 27ED107F192CF8DB00F75E95 /* ReplicationAcceptanceApp.app */;
-			productType = "com.apple.product-type.application";
-		};
-		27ED1095192CF8DB00F75E95 /* ReplicationAcceptanceAppTests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 27ED10AA192CF8DB00F75E95 /* Build configuration list for PBXNativeTarget "ReplicationAcceptanceAppTests" */;
-			buildPhases = (
-				07555E6183AC4B279FE28BD6 /* Check Pods Manifest.lock */,
-				27ED1092192CF8DB00F75E95 /* Sources */,
-				27ED1093192CF8DB00F75E95 /* Frameworks */,
-				27ED1094192CF8DB00F75E95 /* Resources */,
-				4204E69A031642919A587BB0 /* Copy Pods Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				27ED109C192CF8DB00F75E95 /* PBXTargetDependency */,
-			);
-			name = ReplicationAcceptanceAppTests;
-			productName = ReplicationAcceptanceAppTests;
-			productReference = 27ED1096192CF8DB00F75E95 /* ReplicationAcceptanceAppTests.octest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
-/* End PBXNativeTarget section */
-
-/* Begin PBXProject section */
-		27A7E666189973D6007FAF1C /* Project object */ = {
-			isa = PBXProject;
-			attributes = {
-				LastTestingUpgradeCheck = 0600;
-				LastUpgradeCheck = 0500;
-				TargetAttributes = {
-					27A7E69C1899741C007FAF1C = {
-						TestTargetID = 27A7E68818997412007FAF1C;
-					};
-					27ED1095192CF8DB00F75E95 = {
-						TestTargetID = 27ED107E192CF8DB00F75E95;
-					};
-				};
-			};
-			buildConfigurationList = 27A7E669189973D6007FAF1C /* Build configuration list for PBXProject "ReplicationAcceptance" */;
-			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
-			hasScannedForEncodings = 0;
-			knownRegions = (
-				en,
-			);
-			mainGroup = 27A7E665189973D6007FAF1C;
-			productRefGroup = 27A7E671189973EE007FAF1C /* Products */;
-			projectDirPath = "";
-			projectRoot = "";
-			targets = (
-				27A7E68818997412007FAF1C /* RA_Tests_iOS */,
-				27A7E69C1899741C007FAF1C /* RA_Tests_OSX */,
-				27ED107E192CF8DB00F75E95 /* ReplicationAcceptanceApp */,
-				27ED1095192CF8DB00F75E95 /* ReplicationAcceptanceAppTests */,
-			);
-		};
-/* End PBXProject section */
-
-/* Begin PBXResourcesBuildPhase section */
-		27A7E68718997412007FAF1C /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				277992BB18A2503C00BAB6ED /* ReplicationAcceptance.h in Resources */,
-				27A7E69218997412007FAF1C /* InfoPlist.strings in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		27A7E69B1899741C007FAF1C /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				277992BC18A2503C00BAB6ED /* ReplicationAcceptance.h in Resources */,
-				27A7E6A41899741C007FAF1C /* InfoPlist.strings in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		27ED107D192CF8DB00F75E95 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				27ED1089192CF8DB00F75E95 /* InfoPlist.strings in Resources */,
-				27ED1091192CF8DB00F75E95 /* Images.xcassets in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		27ED1094192CF8DB00F75E95 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				27ED10A2192CF8DB00F75E95 /* InfoPlist.strings in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		07555E6183AC4B279FE28BD6 /* Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Check Pods Manifest.lock";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		4204E69A031642919A587BB0 /* Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ios/Pods-ios-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		5517C6B16DE048EF85C5A4A1 /* Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Check Pods Manifest.lock";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		86D70F8BECFE48389B7B243B /* Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Check Pods Manifest.lock";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		BB7BC6BD2CC743AAAAC21269 /* Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-osx/Pods-osx-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		DA7978ED7F6244DC8D4D91B8 /* Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ios/Pods-ios-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-/* End PBXShellScriptBuildPhase section */
-
-/* Begin PBXSourcesBuildPhase section */
-		27A7E68518997412007FAF1C /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				27BE3CEF189FBEA9000CD30D /* CloudantReplicationBase+CompareDb.m in Sources */,
-				9FC2F13119F72B710032A074 /* ReplicatorURLProtocolTester.m in Sources */,
-				277992B818A24F0900BAB6ED /* ReplicationAcceptance+CRUD.m in Sources */,
-				27A7E6B118997673007FAF1C /* ReplicationAcceptance.m in Sources */,
-				9F1F14ED19870B88003E9F0B /* ReplicatorDelegates.m in Sources */,
-				9FC2F12C19F070710032A074 /* ReplicatorURLProtocol.m in Sources */,
-				27A7E6AF189975B2007FAF1C /* CloudantReplicationBase.m in Sources */,
-				27DFEEB718DB4A0D0052D487 /* Attachments.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		27A7E6991899741C007FAF1C /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				27E75E8D18B383CB004317D1 /* CloudantReplicationBase+CompareDb.m in Sources */,
-				9FC2F13219F72B710032A074 /* ReplicatorURLProtocolTester.m in Sources */,
-				277992B918A24F0900BAB6ED /* ReplicationAcceptance+CRUD.m in Sources */,
-				27A7E6B218997677007FAF1C /* ReplicationAcceptance.m in Sources */,
-				9F1F14EE19870B88003E9F0B /* ReplicatorDelegates.m in Sources */,
-				9FC2F12D19F070710032A074 /* ReplicatorURLProtocol.m in Sources */,
-				27A7E6B0189975B2007FAF1C /* CloudantReplicationBase.m in Sources */,
-				27DFEEB818DB4A0D0052D487 /* Attachments.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		27ED107B192CF8DB00F75E95 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				27ED108F192CF8DB00F75E95 /* CDTAppDelegate.m in Sources */,
-				27ED108B192CF8DB00F75E95 /* main.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		27ED1092192CF8DB00F75E95 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				27ED10AB192CF8FF00F75E95 /* ReplicationAcceptance.m in Sources */,
-				27ED10AC192CF8FF00F75E95 /* Attachments.m in Sources */,
-				27ED10AD192CF8FF00F75E95 /* CloudantReplicationBase.m in Sources */,
-				27ED10AE192CF8FF00F75E95 /* CloudantReplicationBase+CompareDb.m in Sources */,
-				27ED10AF192CF8FF00F75E95 /* ReplicationAcceptance+CRUD.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXSourcesBuildPhase section */
-
-/* Begin PBXTargetDependency section */
-		27ED109C192CF8DB00F75E95 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 27ED107E192CF8DB00F75E95 /* ReplicationAcceptanceApp */;
-			targetProxy = 27ED109B192CF8DB00F75E95 /* PBXContainerItemProxy */;
-		};
-/* End PBXTargetDependency section */
-
-/* Begin PBXVariantGroup section */
-		27A7E67C189973EE007FAF1C /* InfoPlist.strings */ = {
-			isa = PBXVariantGroup;
-			children = (
-				27A7E67D189973EE007FAF1C /* en */,
-			);
-			name = InfoPlist.strings;
-			sourceTree = "<group>";
-		};
-		27A7E69018997412007FAF1C /* InfoPlist.strings */ = {
-			isa = PBXVariantGroup;
-			children = (
-				27A7E69118997412007FAF1C /* en */,
-			);
-			name = InfoPlist.strings;
-			sourceTree = "<group>";
-		};
-		27A7E6A21899741C007FAF1C /* InfoPlist.strings */ = {
-			isa = PBXVariantGroup;
-			children = (
-				27A7E6A31899741C007FAF1C /* en */,
-			);
-			name = InfoPlist.strings;
-			sourceTree = "<group>";
-		};
-		27ED1087192CF8DB00F75E95 /* InfoPlist.strings */ = {
-			isa = PBXVariantGroup;
-			children = (
-				27ED1088192CF8DB00F75E95 /* en */,
-			);
-			name = InfoPlist.strings;
-			sourceTree = "<group>";
-		};
-		27ED10A0192CF8DB00F75E95 /* InfoPlist.strings */ = {
-			isa = PBXVariantGroup;
-			children = (
-				27ED10A1192CF8DB00F75E95 /* en */,
-			);
-			name = InfoPlist.strings;
-			sourceTree = "<group>";
-		};
-/* End PBXVariantGroup section */
-
-/* Begin XCBuildConfiguration section */
-		27A7E66A189973D6007FAF1C /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
-			};
-			name = Debug;
-		};
-		27A7E66B189973D6007FAF1C /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
-			};
-			name = Release;
-		};
-		27A7E69718997412007FAF1C /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6A9AF7E2659CCF39B5454D35 /* Pods-ios.debug.xcconfig */;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = NO;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-					"$(DEVELOPER_FRAMEWORKS_DIR)",
-				);
-				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "RA_Tests_iOS/RA_Tests_iOS-Prefix.pch";
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				INFOPLIST_FILE = "RA_Tests_iOS/RA_Tests_iOS-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
-				ONLY_ACTIVE_ARCH = YES;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				WRAPPER_EXTENSION = octest;
-			};
-			name = Debug;
-		};
-		27A7E69818997412007FAF1C /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = EDDE94B9BFCFBFA9EE766F1D /* Pods-ios.release.xcconfig */;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = YES;
-				ENABLE_NS_ASSERTIONS = NO;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-					"$(DEVELOPER_FRAMEWORKS_DIR)",
-				);
-				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "RA_Tests_iOS/RA_Tests_iOS-Prefix.pch";
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				INFOPLIST_FILE = "RA_Tests_iOS/RA_Tests_iOS-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				VALIDATE_PRODUCT = YES;
-				WRAPPER_EXTENSION = octest;
-			};
-			name = Release;
-		};
-		27A7E6AB1899741C007FAF1C /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 02F8FB2013C0F891ADB8CC62 /* Pods-osx.debug.xcconfig */;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = NO;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(DEVELOPER_FRAMEWORKS_DIR)",
-					"$(inherited)",
-				);
-				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "RA_Tests_OSX/RA_Tests_OSX-Prefix.pch";
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				INFOPLIST_FILE = "RA_Tests_OSX/RA_Tests_OSX-Info.plist";
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
-				ONLY_ACTIVE_ARCH = YES;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = macosx;
-				WRAPPER_EXTENSION = octest;
-			};
-			name = Debug;
-		};
-		27A7E6AC1899741C007FAF1C /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5E90CA923A123284AF6B8CE0 /* Pods-osx.release.xcconfig */;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = YES;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				ENABLE_NS_ASSERTIONS = NO;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(DEVELOPER_FRAMEWORKS_DIR)",
-					"$(inherited)",
-				);
-				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "RA_Tests_OSX/RA_Tests_OSX-Prefix.pch";
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				INFOPLIST_FILE = "RA_Tests_OSX/RA_Tests_OSX-Info.plist";
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = macosx;
-				WRAPPER_EXTENSION = octest;
-			};
-			name = Release;
-		};
-		27ED10A5192CF8DB00F75E95 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				COPY_PHASE_STRIP = NO;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(DEVELOPER_FRAMEWORKS_DIR)",
-				);
-				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "ReplicationAcceptanceApp/ReplicationAcceptanceApp-Prefix.pch";
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				INFOPLIST_FILE = "ReplicationAcceptanceApp/ReplicationAcceptanceApp-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
-				ONLY_ACTIVE_ARCH = YES;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				WRAPPER_EXTENSION = app;
-			};
-			name = Debug;
-		};
-		27ED10A6192CF8DB00F75E95 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				COPY_PHASE_STRIP = YES;
-				ENABLE_NS_ASSERTIONS = NO;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(DEVELOPER_FRAMEWORKS_DIR)",
-				);
-				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "ReplicationAcceptanceApp/ReplicationAcceptanceApp-Prefix.pch";
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				INFOPLIST_FILE = "ReplicationAcceptanceApp/ReplicationAcceptanceApp-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
-				WRAPPER_EXTENSION = app;
-			};
-			name = Release;
-		};
-		27ED10A7192CF8DB00F75E95 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/ReplicationAcceptanceApp.app/ReplicationAcceptanceApp";
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = NO;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-					"$(DEVELOPER_FRAMEWORKS_DIR)",
-				);
-				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "ReplicationAcceptanceApp/ReplicationAcceptanceApp-Prefix.pch";
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				INFOPLIST_FILE = "ReplicationAcceptanceAppTests/ReplicationAcceptanceAppTests-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
-				ONLY_ACTIVE_ARCH = YES;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				TEST_HOST = "$(BUNDLE_LOADER)";
-				WRAPPER_EXTENSION = octest;
-			};
-			name = Debug;
-		};
-		27ED10A8192CF8DB00F75E95 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/ReplicationAcceptanceApp.app/ReplicationAcceptanceApp";
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = YES;
-				ENABLE_NS_ASSERTIONS = NO;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-					"$(DEVELOPER_FRAMEWORKS_DIR)",
-				);
-				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "ReplicationAcceptanceApp/ReplicationAcceptanceApp-Prefix.pch";
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				INFOPLIST_FILE = "ReplicationAcceptanceAppTests/ReplicationAcceptanceAppTests-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				TEST_HOST = "$(BUNDLE_LOADER)";
-				VALIDATE_PRODUCT = YES;
-				WRAPPER_EXTENSION = octest;
-			};
-			name = Release;
-		};
-/* End XCBuildConfiguration section */
-
-/* Begin XCConfigurationList section */
-		27A7E669189973D6007FAF1C /* Build configuration list for PBXProject "ReplicationAcceptance" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				27A7E66A189973D6007FAF1C /* Debug */,
-				27A7E66B189973D6007FAF1C /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		27A7E69618997412007FAF1C /* Build configuration list for PBXNativeTarget "RA_Tests_iOS" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				27A7E69718997412007FAF1C /* Debug */,
-				27A7E69818997412007FAF1C /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		27A7E6AA1899741C007FAF1C /* Build configuration list for PBXNativeTarget "RA_Tests_OSX" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				27A7E6AB1899741C007FAF1C /* Debug */,
-				27A7E6AC1899741C007FAF1C /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		27ED10A9192CF8DB00F75E95 /* Build configuration list for PBXNativeTarget "ReplicationAcceptanceApp" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				27ED10A5192CF8DB00F75E95 /* Debug */,
-				27ED10A6192CF8DB00F75E95 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		27ED10AA192CF8DB00F75E95 /* Build configuration list for PBXNativeTarget "ReplicationAcceptanceAppTests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				27ED10A7192CF8DB00F75E95 /* Debug */,
-				27ED10A8192CF8DB00F75E95 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-/* End XCConfigurationList section */
-	};
-	rootObject = 27A7E666189973D6007FAF1C /* Project object */;
-}
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>archiveVersion</key>
+	<string>1</string>
+	<key>classes</key>
+	<dict/>
+	<key>objectVersion</key>
+	<string>46</string>
+	<key>objects</key>
+	<dict>
+		<key>07555E6183AC4B279FE28BD6</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array/>
+			<key>inputPaths</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXShellScriptBuildPhase</string>
+			<key>name</key>
+			<string>Check Pods Manifest.lock</string>
+			<key>outputPaths</key>
+			<array/>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+			<key>shellPath</key>
+			<string>/bin/sh</string>
+			<key>shellScript</key>
+			<string>diff "${PODS_ROOT}/../Podfile.lock" "${PODS_ROOT}/Manifest.lock" &gt; /dev/null
+if [[ $? != 0 ]] ; then
+    cat &lt;&lt; EOM
+error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.
+EOM
+    exit 1
+fi
+</string>
+			<key>showEnvVarsInLog</key>
+			<string>0</string>
+		</dict>
+		<key>12C21B4A5C5E501D34006B36</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>name</key>
+			<string>Pods-osx.release.xcconfig</string>
+			<key>path</key>
+			<string>Pods/Target Support Files/Pods-osx/Pods-osx.release.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>277992B618A24F0900BAB6ED</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>ReplicationAcceptance+CRUD.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>277992B718A24F0900BAB6ED</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>ReplicationAcceptance+CRUD.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>277992B818A24F0900BAB6ED</key>
+		<dict>
+			<key>fileRef</key>
+			<string>277992B718A24F0900BAB6ED</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>277992B918A24F0900BAB6ED</key>
+		<dict>
+			<key>fileRef</key>
+			<string>277992B718A24F0900BAB6ED</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>277992BA18A2503C00BAB6ED</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>ReplicationAcceptance.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>277992BB18A2503C00BAB6ED</key>
+		<dict>
+			<key>fileRef</key>
+			<string>277992BA18A2503C00BAB6ED</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>277992BC18A2503C00BAB6ED</key>
+		<dict>
+			<key>fileRef</key>
+			<string>277992BA18A2503C00BAB6ED</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>27A7E665189973D6007FAF1C</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>27A7E6B31899785B007FAF1C</string>
+				<string>27A7E679189973EE007FAF1C</string>
+				<string>27A7E69F1899741C007FAF1C</string>
+				<string>27ED1084192CF8DB00F75E95</string>
+				<string>27ED109D192CF8DB00F75E95</string>
+				<string>27A7E672189973EE007FAF1C</string>
+				<string>27A7E671189973EE007FAF1C</string>
+				<string>99F07C58C4C4546997797701</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27A7E666189973D6007FAF1C</key>
+		<dict>
+			<key>attributes</key>
+			<dict>
+				<key>LastUpgradeCheck</key>
+				<string>0500</string>
+				<key>TargetAttributes</key>
+				<dict>
+					<key>27A7E69C1899741C007FAF1C</key>
+					<dict>
+						<key>TestTargetID</key>
+						<string>27A7E68818997412007FAF1C</string>
+					</dict>
+					<key>27ED1095192CF8DB00F75E95</key>
+					<dict>
+						<key>TestTargetID</key>
+						<string>27ED107E192CF8DB00F75E95</string>
+					</dict>
+				</dict>
+			</dict>
+			<key>buildConfigurationList</key>
+			<string>27A7E669189973D6007FAF1C</string>
+			<key>compatibilityVersion</key>
+			<string>Xcode 3.2</string>
+			<key>developmentRegion</key>
+			<string>English</string>
+			<key>hasScannedForEncodings</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXProject</string>
+			<key>knownRegions</key>
+			<array>
+				<string>en</string>
+			</array>
+			<key>mainGroup</key>
+			<string>27A7E665189973D6007FAF1C</string>
+			<key>productRefGroup</key>
+			<string>27A7E671189973EE007FAF1C</string>
+			<key>projectDirPath</key>
+			<string></string>
+			<key>projectReferences</key>
+			<array/>
+			<key>projectRoot</key>
+			<string></string>
+			<key>targets</key>
+			<array>
+				<string>27A7E68818997412007FAF1C</string>
+				<string>27A7E69C1899741C007FAF1C</string>
+				<string>27ED107E192CF8DB00F75E95</string>
+				<string>27ED1095192CF8DB00F75E95</string>
+			</array>
+		</dict>
+		<key>27A7E669189973D6007FAF1C</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>27A7E66A189973D6007FAF1C</string>
+				<string>27A7E66B189973D6007FAF1C</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>27A7E66A189973D6007FAF1C</key>
+		<dict>
+			<key>buildSettings</key>
+			<dict/>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>27A7E66B189973D6007FAF1C</key>
+		<dict>
+			<key>buildSettings</key>
+			<dict/>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>27A7E671189973EE007FAF1C</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>27A7E68918997412007FAF1C</string>
+				<string>27A7E69D1899741C007FAF1C</string>
+				<string>27ED107F192CF8DB00F75E95</string>
+				<string>27ED1096192CF8DB00F75E95</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Products</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27A7E672189973EE007FAF1C</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>27A7E673189973EE007FAF1C</string>
+				<string>27A7E675189973EE007FAF1C</string>
+				<string>27A7E677189973EE007FAF1C</string>
+				<string>C61CF9A9D4564F53BC1F7321</string>
+				<string>97F72706FFD44D88B6E5E667</string>
+				<string>27ED1081192CF8DB00F75E95</string>
+				<string>27ED1097192CF8DB00F75E95</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Frameworks</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27A7E673189973EE007FAF1C</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>wrapper.framework</string>
+			<key>name</key>
+			<string>SenTestingKit.framework</string>
+			<key>path</key>
+			<string>Library/Frameworks/SenTestingKit.framework</string>
+			<key>sourceTree</key>
+			<string>DEVELOPER_DIR</string>
+		</dict>
+		<key>27A7E675189973EE007FAF1C</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>wrapper.framework</string>
+			<key>name</key>
+			<string>Foundation.framework</string>
+			<key>path</key>
+			<string>Library/Frameworks/Foundation.framework</string>
+			<key>sourceTree</key>
+			<string>DEVELOPER_DIR</string>
+		</dict>
+		<key>27A7E677189973EE007FAF1C</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>wrapper.framework</string>
+			<key>name</key>
+			<string>UIKit.framework</string>
+			<key>path</key>
+			<string>Library/Frameworks/UIKit.framework</string>
+			<key>sourceTree</key>
+			<string>DEVELOPER_DIR</string>
+		</dict>
+		<key>27A7E679189973EE007FAF1C</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>277992BA18A2503C00BAB6ED</string>
+				<string>27A7E67F189973EE007FAF1C</string>
+				<string>27DFEEB618DB4A0D0052D487</string>
+				<string>27A7E67A189973EE007FAF1C</string>
+				<string>27A7E6AD189975B2007FAF1C</string>
+				<string>27A7E68D18997412007FAF1C</string>
+				<string>27A7E6AE189975B2007FAF1C</string>
+				<string>27BE3CED189FBEA9000CD30D</string>
+				<string>27BE3CEE189FBEA9000CD30D</string>
+				<string>277992B618A24F0900BAB6ED</string>
+				<string>277992B718A24F0900BAB6ED</string>
+				<string>9F1F14EB19870B88003E9F0B</string>
+				<string>9F1F14EC19870B88003E9F0B</string>
+				<string>8EA6E3B619F00B70001528E1</string>
+				<string>8EA6E3B719F00B70001528E1</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>ReplicationAcceptance</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27A7E67A189973EE007FAF1C</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>27A7E67B189973EE007FAF1C</string>
+				<string>27A7E67C189973EE007FAF1C</string>
+				<string>27A7E681189973EE007FAF1C</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Supporting Files</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27A7E67B189973EE007FAF1C</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.xml</string>
+			<key>path</key>
+			<string>ReplicationAcceptance-Info.plist</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27A7E67C189973EE007FAF1C</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>27A7E67D189973EE007FAF1C</string>
+			</array>
+			<key>isa</key>
+			<string>PBXVariantGroup</string>
+			<key>name</key>
+			<string>InfoPlist.strings</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27A7E67D189973EE007FAF1C</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.strings</string>
+			<key>name</key>
+			<string>en</string>
+			<key>path</key>
+			<string>en.lproj/InfoPlist.strings</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27A7E67F189973EE007FAF1C</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>ReplicationAcceptance.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27A7E681189973EE007FAF1C</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>ReplicationAcceptance-Prefix.pch</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27A7E68518997412007FAF1C</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>27BE3CEF189FBEA9000CD30D</string>
+				<string>8EA6E3B819F00B70001528E1</string>
+				<string>277992B818A24F0900BAB6ED</string>
+				<string>27A7E6B118997673007FAF1C</string>
+				<string>9F1F14ED19870B88003E9F0B</string>
+				<string>27A7E6AF189975B2007FAF1C</string>
+				<string>27DFEEB718DB4A0D0052D487</string>
+			</array>
+			<key>isa</key>
+			<string>PBXSourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>27A7E68618997412007FAF1C</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>27A7E68A18997412007FAF1C</string>
+				<string>27A7E68C18997412007FAF1C</string>
+				<string>27A7E68B18997412007FAF1C</string>
+				<string>4510BA04F5FB481E882AF5EE</string>
+			</array>
+			<key>isa</key>
+			<string>PBXFrameworksBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>27A7E68718997412007FAF1C</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>277992BB18A2503C00BAB6ED</string>
+				<string>27A7E69218997412007FAF1C</string>
+			</array>
+			<key>isa</key>
+			<string>PBXResourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>27A7E68818997412007FAF1C</key>
+		<dict>
+			<key>buildConfigurationList</key>
+			<string>27A7E69618997412007FAF1C</string>
+			<key>buildPhases</key>
+			<array>
+				<string>5517C6B16DE048EF85C5A4A1</string>
+				<string>27A7E68518997412007FAF1C</string>
+				<string>27A7E68618997412007FAF1C</string>
+				<string>27A7E68718997412007FAF1C</string>
+				<string>DA7978ED7F6244DC8D4D91B8</string>
+			</array>
+			<key>buildRules</key>
+			<array/>
+			<key>dependencies</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXNativeTarget</string>
+			<key>name</key>
+			<string>RA_Tests_iOS</string>
+			<key>productName</key>
+			<string>RA_Tests_iOS</string>
+			<key>productReference</key>
+			<string>27A7E68918997412007FAF1C</string>
+			<key>productType</key>
+			<string>com.apple.product-type.bundle.ocunit-test</string>
+		</dict>
+		<key>27A7E68918997412007FAF1C</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>wrapper.cfbundle</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>RA_Tests_iOS.octest</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>27A7E68A18997412007FAF1C</key>
+		<dict>
+			<key>fileRef</key>
+			<string>27A7E673189973EE007FAF1C</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>27A7E68B18997412007FAF1C</key>
+		<dict>
+			<key>fileRef</key>
+			<string>27A7E675189973EE007FAF1C</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>27A7E68C18997412007FAF1C</key>
+		<dict>
+			<key>fileRef</key>
+			<string>27A7E677189973EE007FAF1C</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>27A7E68D18997412007FAF1C</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>27A7E68E18997412007FAF1C</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>RA_Tests_iOS</string>
+			<key>path</key>
+			<string>../RA_Tests_iOS</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27A7E68E18997412007FAF1C</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>27A7E68F18997412007FAF1C</string>
+				<string>27A7E69018997412007FAF1C</string>
+				<string>27A7E69518997412007FAF1C</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Supporting Files</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27A7E68F18997412007FAF1C</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.xml</string>
+			<key>path</key>
+			<string>RA_Tests_iOS-Info.plist</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27A7E69018997412007FAF1C</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>27A7E69118997412007FAF1C</string>
+			</array>
+			<key>isa</key>
+			<string>PBXVariantGroup</string>
+			<key>name</key>
+			<string>InfoPlist.strings</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27A7E69118997412007FAF1C</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.strings</string>
+			<key>name</key>
+			<string>en</string>
+			<key>path</key>
+			<string>en.lproj/InfoPlist.strings</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27A7E69218997412007FAF1C</key>
+		<dict>
+			<key>fileRef</key>
+			<string>27A7E69018997412007FAF1C</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>27A7E69518997412007FAF1C</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>RA_Tests_iOS-Prefix.pch</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27A7E69618997412007FAF1C</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>27A7E69718997412007FAF1C</string>
+				<string>27A7E69818997412007FAF1C</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>27A7E69718997412007FAF1C</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>3A667A31E143FB2C04570CA7</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>ALWAYS_SEARCH_USER_PATHS</key>
+				<string>NO</string>
+				<key>ARCHS</key>
+				<string>$(ARCHS_STANDARD_INCLUDING_64_BIT)</string>
+				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
+				<string>gnu++0x</string>
+				<key>CLANG_CXX_LIBRARY</key>
+				<string>libc++</string>
+				<key>CLANG_ENABLE_MODULES</key>
+				<string>YES</string>
+				<key>CLANG_ENABLE_OBJC_ARC</key>
+				<string>YES</string>
+				<key>CLANG_WARN_BOOL_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
+				<string>YES_ERROR</string>
+				<key>CLANG_WARN_EMPTY_BODY</key>
+				<string>YES</string>
+				<key>CLANG_WARN_ENUM_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_INT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
+				<string>YES_ERROR</string>
+				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
+				<string>YES</string>
+				<key>COPY_PHASE_STRIP</key>
+				<string>NO</string>
+				<key>FRAMEWORK_SEARCH_PATHS</key>
+				<array>
+					<string>$(SDKROOT)/Developer/Library/Frameworks</string>
+					<string>$(inherited)</string>
+					<string>$(DEVELOPER_FRAMEWORKS_DIR)</string>
+				</array>
+				<key>GCC_C_LANGUAGE_STANDARD</key>
+				<string>gnu99</string>
+				<key>GCC_DYNAMIC_NO_PIC</key>
+				<string>NO</string>
+				<key>GCC_OPTIMIZATION_LEVEL</key>
+				<string>0</string>
+				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
+				<string>YES</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>RA_Tests_iOS/RA_Tests_iOS-Prefix.pch</string>
+				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
+				<array>
+					<string>DEBUG=1</string>
+					<string>$(inherited)</string>
+				</array>
+				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
+				<string>NO</string>
+				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
+				<string>YES</string>
+				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
+				<string>YES_ERROR</string>
+				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNUSED_FUNCTION</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNUSED_VARIABLE</key>
+				<string>YES</string>
+				<key>INFOPLIST_FILE</key>
+				<string>RA_Tests_iOS/RA_Tests_iOS-Info.plist</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>7.0</string>
+				<key>ONLY_ACTIVE_ARCH</key>
+				<string>YES</string>
+				<key>PRODUCT_NAME</key>
+				<string>$(TARGET_NAME)</string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+				<key>WRAPPER_EXTENSION</key>
+				<string>octest</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>27A7E69818997412007FAF1C</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>EF12D0FFB8B3A747D51E465C</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>ALWAYS_SEARCH_USER_PATHS</key>
+				<string>NO</string>
+				<key>ARCHS</key>
+				<string>$(ARCHS_STANDARD_INCLUDING_64_BIT)</string>
+				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
+				<string>gnu++0x</string>
+				<key>CLANG_CXX_LIBRARY</key>
+				<string>libc++</string>
+				<key>CLANG_ENABLE_MODULES</key>
+				<string>YES</string>
+				<key>CLANG_ENABLE_OBJC_ARC</key>
+				<string>YES</string>
+				<key>CLANG_WARN_BOOL_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
+				<string>YES_ERROR</string>
+				<key>CLANG_WARN_EMPTY_BODY</key>
+				<string>YES</string>
+				<key>CLANG_WARN_ENUM_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_INT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
+				<string>YES_ERROR</string>
+				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
+				<string>YES</string>
+				<key>COPY_PHASE_STRIP</key>
+				<string>YES</string>
+				<key>ENABLE_NS_ASSERTIONS</key>
+				<string>NO</string>
+				<key>FRAMEWORK_SEARCH_PATHS</key>
+				<array>
+					<string>$(SDKROOT)/Developer/Library/Frameworks</string>
+					<string>$(inherited)</string>
+					<string>$(DEVELOPER_FRAMEWORKS_DIR)</string>
+				</array>
+				<key>GCC_C_LANGUAGE_STANDARD</key>
+				<string>gnu99</string>
+				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
+				<string>YES</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>RA_Tests_iOS/RA_Tests_iOS-Prefix.pch</string>
+				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
+				<string>YES</string>
+				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
+				<string>YES_ERROR</string>
+				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNUSED_FUNCTION</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNUSED_VARIABLE</key>
+				<string>YES</string>
+				<key>INFOPLIST_FILE</key>
+				<string>RA_Tests_iOS/RA_Tests_iOS-Info.plist</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>7.0</string>
+				<key>PRODUCT_NAME</key>
+				<string>$(TARGET_NAME)</string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+				<key>VALIDATE_PRODUCT</key>
+				<string>YES</string>
+				<key>WRAPPER_EXTENSION</key>
+				<string>octest</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>27A7E6991899741C007FAF1C</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>27E75E8D18B383CB004317D1</string>
+				<string>277992B918A24F0900BAB6ED</string>
+				<string>27A7E6B218997677007FAF1C</string>
+				<string>9F1F14EE19870B88003E9F0B</string>
+				<string>27A7E6B0189975B2007FAF1C</string>
+				<string>27DFEEB818DB4A0D0052D487</string>
+			</array>
+			<key>isa</key>
+			<string>PBXSourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>27A7E69A1899741C007FAF1C</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>27A7E69E1899741C007FAF1C</string>
+				<string>8E89B680A5F347559033D1B3</string>
+			</array>
+			<key>isa</key>
+			<string>PBXFrameworksBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>27A7E69B1899741C007FAF1C</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>277992BC18A2503C00BAB6ED</string>
+				<string>27A7E6A41899741C007FAF1C</string>
+			</array>
+			<key>isa</key>
+			<string>PBXResourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>27A7E69C1899741C007FAF1C</key>
+		<dict>
+			<key>buildConfigurationList</key>
+			<string>27A7E6AA1899741C007FAF1C</string>
+			<key>buildPhases</key>
+			<array>
+				<string>86D70F8BECFE48389B7B243B</string>
+				<string>27A7E6991899741C007FAF1C</string>
+				<string>27A7E69A1899741C007FAF1C</string>
+				<string>27A7E69B1899741C007FAF1C</string>
+				<string>BB7BC6BD2CC743AAAAC21269</string>
+			</array>
+			<key>buildRules</key>
+			<array/>
+			<key>dependencies</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXNativeTarget</string>
+			<key>name</key>
+			<string>RA_Tests_OSX</string>
+			<key>productName</key>
+			<string>RA_Tests_OSX</string>
+			<key>productReference</key>
+			<string>27A7E69D1899741C007FAF1C</string>
+			<key>productType</key>
+			<string>com.apple.product-type.bundle.ocunit-test</string>
+		</dict>
+		<key>27A7E69D1899741C007FAF1C</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>wrapper.cfbundle</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>RA_Tests_OSX.octest</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>27A7E69E1899741C007FAF1C</key>
+		<dict>
+			<key>fileRef</key>
+			<string>27A7E673189973EE007FAF1C</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>27A7E69F1899741C007FAF1C</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>27A7E6A01899741C007FAF1C</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>RA_Tests_OSX</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27A7E6A01899741C007FAF1C</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>27A7E6A11899741C007FAF1C</string>
+				<string>27A7E6A21899741C007FAF1C</string>
+				<string>27A7E6A71899741C007FAF1C</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Supporting Files</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27A7E6A11899741C007FAF1C</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.xml</string>
+			<key>path</key>
+			<string>RA_Tests_OSX-Info.plist</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27A7E6A21899741C007FAF1C</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>27A7E6A31899741C007FAF1C</string>
+			</array>
+			<key>isa</key>
+			<string>PBXVariantGroup</string>
+			<key>name</key>
+			<string>InfoPlist.strings</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27A7E6A31899741C007FAF1C</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.strings</string>
+			<key>name</key>
+			<string>en</string>
+			<key>path</key>
+			<string>en.lproj/InfoPlist.strings</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27A7E6A41899741C007FAF1C</key>
+		<dict>
+			<key>fileRef</key>
+			<string>27A7E6A21899741C007FAF1C</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>27A7E6A71899741C007FAF1C</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>RA_Tests_OSX-Prefix.pch</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27A7E6AA1899741C007FAF1C</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>27A7E6AB1899741C007FAF1C</string>
+				<string>27A7E6AC1899741C007FAF1C</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>27A7E6AB1899741C007FAF1C</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>49A0C744B12F77EFB17A92FC</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>ALWAYS_SEARCH_USER_PATHS</key>
+				<string>NO</string>
+				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
+				<string>gnu++0x</string>
+				<key>CLANG_CXX_LIBRARY</key>
+				<string>libc++</string>
+				<key>CLANG_ENABLE_OBJC_ARC</key>
+				<string>YES</string>
+				<key>CLANG_WARN_BOOL_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
+				<string>YES_ERROR</string>
+				<key>CLANG_WARN_EMPTY_BODY</key>
+				<string>YES</string>
+				<key>CLANG_WARN_ENUM_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_INT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
+				<string>YES_ERROR</string>
+				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
+				<string>YES</string>
+				<key>COPY_PHASE_STRIP</key>
+				<string>NO</string>
+				<key>FRAMEWORK_SEARCH_PATHS</key>
+				<array>
+					<string>$(DEVELOPER_FRAMEWORKS_DIR)</string>
+					<string>$(inherited)</string>
+				</array>
+				<key>GCC_C_LANGUAGE_STANDARD</key>
+				<string>gnu99</string>
+				<key>GCC_DYNAMIC_NO_PIC</key>
+				<string>NO</string>
+				<key>GCC_ENABLE_OBJC_EXCEPTIONS</key>
+				<string>YES</string>
+				<key>GCC_OPTIMIZATION_LEVEL</key>
+				<string>0</string>
+				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
+				<string>YES</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>RA_Tests_OSX/RA_Tests_OSX-Prefix.pch</string>
+				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
+				<array>
+					<string>DEBUG=1</string>
+					<string>$(inherited)</string>
+				</array>
+				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
+				<string>NO</string>
+				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
+				<string>YES</string>
+				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
+				<string>YES_ERROR</string>
+				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNUSED_FUNCTION</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNUSED_VARIABLE</key>
+				<string>YES</string>
+				<key>INFOPLIST_FILE</key>
+				<string>RA_Tests_OSX/RA_Tests_OSX-Info.plist</string>
+				<key>MACOSX_DEPLOYMENT_TARGET</key>
+				<string>10.9</string>
+				<key>ONLY_ACTIVE_ARCH</key>
+				<string>YES</string>
+				<key>PRODUCT_NAME</key>
+				<string>$(TARGET_NAME)</string>
+				<key>SDKROOT</key>
+				<string>macosx</string>
+				<key>WRAPPER_EXTENSION</key>
+				<string>octest</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>27A7E6AC1899741C007FAF1C</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>12C21B4A5C5E501D34006B36</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>ALWAYS_SEARCH_USER_PATHS</key>
+				<string>NO</string>
+				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
+				<string>gnu++0x</string>
+				<key>CLANG_CXX_LIBRARY</key>
+				<string>libc++</string>
+				<key>CLANG_ENABLE_OBJC_ARC</key>
+				<string>YES</string>
+				<key>CLANG_WARN_BOOL_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
+				<string>YES_ERROR</string>
+				<key>CLANG_WARN_EMPTY_BODY</key>
+				<string>YES</string>
+				<key>CLANG_WARN_ENUM_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_INT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
+				<string>YES_ERROR</string>
+				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
+				<string>YES</string>
+				<key>COPY_PHASE_STRIP</key>
+				<string>YES</string>
+				<key>DEBUG_INFORMATION_FORMAT</key>
+				<string>dwarf-with-dsym</string>
+				<key>ENABLE_NS_ASSERTIONS</key>
+				<string>NO</string>
+				<key>FRAMEWORK_SEARCH_PATHS</key>
+				<array>
+					<string>$(DEVELOPER_FRAMEWORKS_DIR)</string>
+					<string>$(inherited)</string>
+				</array>
+				<key>GCC_C_LANGUAGE_STANDARD</key>
+				<string>gnu99</string>
+				<key>GCC_ENABLE_OBJC_EXCEPTIONS</key>
+				<string>YES</string>
+				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
+				<string>YES</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>RA_Tests_OSX/RA_Tests_OSX-Prefix.pch</string>
+				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
+				<string>YES</string>
+				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
+				<string>YES_ERROR</string>
+				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNUSED_FUNCTION</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNUSED_VARIABLE</key>
+				<string>YES</string>
+				<key>INFOPLIST_FILE</key>
+				<string>RA_Tests_OSX/RA_Tests_OSX-Info.plist</string>
+				<key>MACOSX_DEPLOYMENT_TARGET</key>
+				<string>10.9</string>
+				<key>PRODUCT_NAME</key>
+				<string>$(TARGET_NAME)</string>
+				<key>SDKROOT</key>
+				<string>macosx</string>
+				<key>WRAPPER_EXTENSION</key>
+				<string>octest</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>27A7E6AD189975B2007FAF1C</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>CloudantReplicationBase.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27A7E6AE189975B2007FAF1C</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>CloudantReplicationBase.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27A7E6AF189975B2007FAF1C</key>
+		<dict>
+			<key>fileRef</key>
+			<string>27A7E6AE189975B2007FAF1C</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>27A7E6B0189975B2007FAF1C</key>
+		<dict>
+			<key>fileRef</key>
+			<string>27A7E6AE189975B2007FAF1C</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>27A7E6B118997673007FAF1C</key>
+		<dict>
+			<key>fileRef</key>
+			<string>27A7E67F189973EE007FAF1C</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>27A7E6B218997677007FAF1C</key>
+		<dict>
+			<key>fileRef</key>
+			<string>27A7E67F189973EE007FAF1C</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>27A7E6B31899785B007FAF1C</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text</string>
+			<key>path</key>
+			<string>README.md</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27BE3CED189FBEA9000CD30D</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>CloudantReplicationBase+CompareDb.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27BE3CEE189FBEA9000CD30D</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>CloudantReplicationBase+CompareDb.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27BE3CEF189FBEA9000CD30D</key>
+		<dict>
+			<key>fileRef</key>
+			<string>27BE3CEE189FBEA9000CD30D</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>27DFEEB618DB4A0D0052D487</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>Attachments.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27DFEEB718DB4A0D0052D487</key>
+		<dict>
+			<key>fileRef</key>
+			<string>27DFEEB618DB4A0D0052D487</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>27DFEEB818DB4A0D0052D487</key>
+		<dict>
+			<key>fileRef</key>
+			<string>27DFEEB618DB4A0D0052D487</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>27E75E8D18B383CB004317D1</key>
+		<dict>
+			<key>fileRef</key>
+			<string>27BE3CEE189FBEA9000CD30D</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>27ED107B192CF8DB00F75E95</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>27ED108F192CF8DB00F75E95</string>
+				<string>27ED108B192CF8DB00F75E95</string>
+			</array>
+			<key>isa</key>
+			<string>PBXSourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>27ED107C192CF8DB00F75E95</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>27ED1082192CF8DB00F75E95</string>
+				<string>27ED1083192CF8DB00F75E95</string>
+				<string>27ED1080192CF8DB00F75E95</string>
+			</array>
+			<key>isa</key>
+			<string>PBXFrameworksBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>27ED107D192CF8DB00F75E95</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>27ED1089192CF8DB00F75E95</string>
+				<string>27ED1091192CF8DB00F75E95</string>
+			</array>
+			<key>isa</key>
+			<string>PBXResourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>27ED107E192CF8DB00F75E95</key>
+		<dict>
+			<key>buildConfigurationList</key>
+			<string>27ED10A9192CF8DB00F75E95</string>
+			<key>buildPhases</key>
+			<array>
+				<string>27ED107B192CF8DB00F75E95</string>
+				<string>27ED107C192CF8DB00F75E95</string>
+				<string>27ED107D192CF8DB00F75E95</string>
+			</array>
+			<key>buildRules</key>
+			<array/>
+			<key>dependencies</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXNativeTarget</string>
+			<key>name</key>
+			<string>ReplicationAcceptanceApp</string>
+			<key>productName</key>
+			<string>ReplicationAcceptanceApp</string>
+			<key>productReference</key>
+			<string>27ED107F192CF8DB00F75E95</string>
+			<key>productType</key>
+			<string>com.apple.product-type.application</string>
+		</dict>
+		<key>27ED107F192CF8DB00F75E95</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>wrapper.application</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>ReplicationAcceptanceApp.app</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>27ED1080192CF8DB00F75E95</key>
+		<dict>
+			<key>fileRef</key>
+			<string>27A7E675189973EE007FAF1C</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>27ED1081192CF8DB00F75E95</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>wrapper.framework</string>
+			<key>name</key>
+			<string>CoreGraphics.framework</string>
+			<key>path</key>
+			<string>System/Library/Frameworks/CoreGraphics.framework</string>
+			<key>sourceTree</key>
+			<string>SDKROOT</string>
+		</dict>
+		<key>27ED1082192CF8DB00F75E95</key>
+		<dict>
+			<key>fileRef</key>
+			<string>27ED1081192CF8DB00F75E95</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>27ED1083192CF8DB00F75E95</key>
+		<dict>
+			<key>fileRef</key>
+			<string>27A7E677189973EE007FAF1C</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>27ED1084192CF8DB00F75E95</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>27ED108D192CF8DB00F75E95</string>
+				<string>27ED108E192CF8DB00F75E95</string>
+				<string>27ED1090192CF8DB00F75E95</string>
+				<string>27ED1085192CF8DB00F75E95</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>ReplicationAcceptanceApp</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27ED1085192CF8DB00F75E95</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>27ED1086192CF8DB00F75E95</string>
+				<string>27ED1087192CF8DB00F75E95</string>
+				<string>27ED108A192CF8DB00F75E95</string>
+				<string>27ED108C192CF8DB00F75E95</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Supporting Files</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27ED1086192CF8DB00F75E95</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.xml</string>
+			<key>path</key>
+			<string>ReplicationAcceptanceApp-Info.plist</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27ED1087192CF8DB00F75E95</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>27ED1088192CF8DB00F75E95</string>
+			</array>
+			<key>isa</key>
+			<string>PBXVariantGroup</string>
+			<key>name</key>
+			<string>InfoPlist.strings</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27ED1088192CF8DB00F75E95</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.strings</string>
+			<key>name</key>
+			<string>en</string>
+			<key>path</key>
+			<string>en.lproj/InfoPlist.strings</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27ED1089192CF8DB00F75E95</key>
+		<dict>
+			<key>fileRef</key>
+			<string>27ED1087192CF8DB00F75E95</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>27ED108A192CF8DB00F75E95</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>main.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27ED108B192CF8DB00F75E95</key>
+		<dict>
+			<key>fileRef</key>
+			<string>27ED108A192CF8DB00F75E95</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>27ED108C192CF8DB00F75E95</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>ReplicationAcceptanceApp-Prefix.pch</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27ED108D192CF8DB00F75E95</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>CDTAppDelegate.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27ED108E192CF8DB00F75E95</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>CDTAppDelegate.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27ED108F192CF8DB00F75E95</key>
+		<dict>
+			<key>fileRef</key>
+			<string>27ED108E192CF8DB00F75E95</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>27ED1090192CF8DB00F75E95</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>folder.assetcatalog</string>
+			<key>path</key>
+			<string>Images.xcassets</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27ED1091192CF8DB00F75E95</key>
+		<dict>
+			<key>fileRef</key>
+			<string>27ED1090192CF8DB00F75E95</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>27ED1092192CF8DB00F75E95</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>27ED10AB192CF8FF00F75E95</string>
+				<string>27ED10AC192CF8FF00F75E95</string>
+				<string>27ED10AD192CF8FF00F75E95</string>
+				<string>27ED10AE192CF8FF00F75E95</string>
+				<string>27ED10AF192CF8FF00F75E95</string>
+			</array>
+			<key>isa</key>
+			<string>PBXSourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>27ED1093192CF8DB00F75E95</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>27ED10B0192CFA3600F75E95</string>
+				<string>27ED109A192CF8DB00F75E95</string>
+				<string>27ED1099192CF8DB00F75E95</string>
+				<string>86A30343408047EEBBF8EC4C</string>
+			</array>
+			<key>isa</key>
+			<string>PBXFrameworksBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>27ED1094192CF8DB00F75E95</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>27ED10A2192CF8DB00F75E95</string>
+			</array>
+			<key>isa</key>
+			<string>PBXResourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>27ED1095192CF8DB00F75E95</key>
+		<dict>
+			<key>buildConfigurationList</key>
+			<string>27ED10AA192CF8DB00F75E95</string>
+			<key>buildPhases</key>
+			<array>
+				<string>07555E6183AC4B279FE28BD6</string>
+				<string>27ED1092192CF8DB00F75E95</string>
+				<string>27ED1093192CF8DB00F75E95</string>
+				<string>27ED1094192CF8DB00F75E95</string>
+				<string>4204E69A031642919A587BB0</string>
+			</array>
+			<key>buildRules</key>
+			<array/>
+			<key>dependencies</key>
+			<array>
+				<string>27ED109C192CF8DB00F75E95</string>
+			</array>
+			<key>isa</key>
+			<string>PBXNativeTarget</string>
+			<key>name</key>
+			<string>ReplicationAcceptanceAppTests</string>
+			<key>productName</key>
+			<string>ReplicationAcceptanceAppTests</string>
+			<key>productReference</key>
+			<string>27ED1096192CF8DB00F75E95</string>
+			<key>productType</key>
+			<string>com.apple.product-type.bundle.unit-test</string>
+		</dict>
+		<key>27ED1096192CF8DB00F75E95</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>wrapper.cfbundle</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>ReplicationAcceptanceAppTests.octest</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>27ED1097192CF8DB00F75E95</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>wrapper.framework</string>
+			<key>name</key>
+			<string>XCTest.framework</string>
+			<key>path</key>
+			<string>Library/Frameworks/XCTest.framework</string>
+			<key>sourceTree</key>
+			<string>DEVELOPER_DIR</string>
+		</dict>
+		<key>27ED1099192CF8DB00F75E95</key>
+		<dict>
+			<key>fileRef</key>
+			<string>27A7E675189973EE007FAF1C</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>27ED109A192CF8DB00F75E95</key>
+		<dict>
+			<key>fileRef</key>
+			<string>27A7E677189973EE007FAF1C</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>27ED109B192CF8DB00F75E95</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>27A7E666189973D6007FAF1C</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>1</string>
+			<key>remoteGlobalIDString</key>
+			<string>27ED107E192CF8DB00F75E95</string>
+			<key>remoteInfo</key>
+			<string>ReplicationAcceptanceApp</string>
+		</dict>
+		<key>27ED109C192CF8DB00F75E95</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXTargetDependency</string>
+			<key>target</key>
+			<string>27ED107E192CF8DB00F75E95</string>
+			<key>targetProxy</key>
+			<string>27ED109B192CF8DB00F75E95</string>
+		</dict>
+		<key>27ED109D192CF8DB00F75E95</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>27ED109E192CF8DB00F75E95</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>ReplicationAcceptanceAppTests</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27ED109E192CF8DB00F75E95</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>27ED109F192CF8DB00F75E95</string>
+				<string>27ED10A0192CF8DB00F75E95</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Supporting Files</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27ED109F192CF8DB00F75E95</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.xml</string>
+			<key>path</key>
+			<string>ReplicationAcceptanceAppTests-Info.plist</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27ED10A0192CF8DB00F75E95</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>27ED10A1192CF8DB00F75E95</string>
+			</array>
+			<key>isa</key>
+			<string>PBXVariantGroup</string>
+			<key>name</key>
+			<string>InfoPlist.strings</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27ED10A1192CF8DB00F75E95</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.strings</string>
+			<key>name</key>
+			<string>en</string>
+			<key>path</key>
+			<string>en.lproj/InfoPlist.strings</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>27ED10A2192CF8DB00F75E95</key>
+		<dict>
+			<key>fileRef</key>
+			<string>27ED10A0192CF8DB00F75E95</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>27ED10A5192CF8DB00F75E95</key>
+		<dict>
+			<key>buildSettings</key>
+			<dict>
+				<key>ALWAYS_SEARCH_USER_PATHS</key>
+				<string>NO</string>
+				<key>ASSETCATALOG_COMPILER_APPICON_NAME</key>
+				<string>AppIcon</string>
+				<key>ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME</key>
+				<string>LaunchImage</string>
+				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
+				<string>gnu++0x</string>
+				<key>CLANG_CXX_LIBRARY</key>
+				<string>libc++</string>
+				<key>CLANG_ENABLE_MODULES</key>
+				<string>YES</string>
+				<key>CLANG_ENABLE_OBJC_ARC</key>
+				<string>YES</string>
+				<key>CLANG_WARN_BOOL_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
+				<string>YES_ERROR</string>
+				<key>CLANG_WARN_EMPTY_BODY</key>
+				<string>YES</string>
+				<key>CLANG_WARN_ENUM_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_INT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
+				<string>YES_ERROR</string>
+				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
+				<string>YES</string>
+				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
+				<string>iPhone Developer</string>
+				<key>COPY_PHASE_STRIP</key>
+				<string>NO</string>
+				<key>FRAMEWORK_SEARCH_PATHS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>$(DEVELOPER_FRAMEWORKS_DIR)</string>
+				</array>
+				<key>GCC_C_LANGUAGE_STANDARD</key>
+				<string>gnu99</string>
+				<key>GCC_DYNAMIC_NO_PIC</key>
+				<string>NO</string>
+				<key>GCC_OPTIMIZATION_LEVEL</key>
+				<string>0</string>
+				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
+				<string>YES</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>ReplicationAcceptanceApp/ReplicationAcceptanceApp-Prefix.pch</string>
+				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
+				<array>
+					<string>DEBUG=1</string>
+					<string>$(inherited)</string>
+				</array>
+				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
+				<string>NO</string>
+				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
+				<string>YES</string>
+				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
+				<string>YES_ERROR</string>
+				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
+				<string>YES_AGGRESSIVE</string>
+				<key>GCC_WARN_UNUSED_FUNCTION</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNUSED_VARIABLE</key>
+				<string>YES</string>
+				<key>INFOPLIST_FILE</key>
+				<string>ReplicationAcceptanceApp/ReplicationAcceptanceApp-Info.plist</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>7.1</string>
+				<key>ONLY_ACTIVE_ARCH</key>
+				<string>YES</string>
+				<key>PRODUCT_NAME</key>
+				<string>$(TARGET_NAME)</string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+				<key>TARGETED_DEVICE_FAMILY</key>
+				<string>1,2</string>
+				<key>WRAPPER_EXTENSION</key>
+				<string>app</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>27ED10A6192CF8DB00F75E95</key>
+		<dict>
+			<key>buildSettings</key>
+			<dict>
+				<key>ALWAYS_SEARCH_USER_PATHS</key>
+				<string>NO</string>
+				<key>ASSETCATALOG_COMPILER_APPICON_NAME</key>
+				<string>AppIcon</string>
+				<key>ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME</key>
+				<string>LaunchImage</string>
+				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
+				<string>gnu++0x</string>
+				<key>CLANG_CXX_LIBRARY</key>
+				<string>libc++</string>
+				<key>CLANG_ENABLE_MODULES</key>
+				<string>YES</string>
+				<key>CLANG_ENABLE_OBJC_ARC</key>
+				<string>YES</string>
+				<key>CLANG_WARN_BOOL_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
+				<string>YES_ERROR</string>
+				<key>CLANG_WARN_EMPTY_BODY</key>
+				<string>YES</string>
+				<key>CLANG_WARN_ENUM_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_INT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
+				<string>YES_ERROR</string>
+				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
+				<string>YES</string>
+				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
+				<string>iPhone Developer</string>
+				<key>COPY_PHASE_STRIP</key>
+				<string>YES</string>
+				<key>ENABLE_NS_ASSERTIONS</key>
+				<string>NO</string>
+				<key>FRAMEWORK_SEARCH_PATHS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>$(DEVELOPER_FRAMEWORKS_DIR)</string>
+				</array>
+				<key>GCC_C_LANGUAGE_STANDARD</key>
+				<string>gnu99</string>
+				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
+				<string>YES</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>ReplicationAcceptanceApp/ReplicationAcceptanceApp-Prefix.pch</string>
+				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
+				<string>YES</string>
+				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
+				<string>YES_ERROR</string>
+				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
+				<string>YES_AGGRESSIVE</string>
+				<key>GCC_WARN_UNUSED_FUNCTION</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNUSED_VARIABLE</key>
+				<string>YES</string>
+				<key>INFOPLIST_FILE</key>
+				<string>ReplicationAcceptanceApp/ReplicationAcceptanceApp-Info.plist</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>7.1</string>
+				<key>PRODUCT_NAME</key>
+				<string>$(TARGET_NAME)</string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+				<key>TARGETED_DEVICE_FAMILY</key>
+				<string>1,2</string>
+				<key>VALIDATE_PRODUCT</key>
+				<string>YES</string>
+				<key>WRAPPER_EXTENSION</key>
+				<string>app</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>27ED10A7192CF8DB00F75E95</key>
+		<dict>
+			<key>buildSettings</key>
+			<dict>
+				<key>ALWAYS_SEARCH_USER_PATHS</key>
+				<string>NO</string>
+				<key>BUNDLE_LOADER</key>
+				<string>$(BUILT_PRODUCTS_DIR)/ReplicationAcceptanceApp.app/ReplicationAcceptanceApp</string>
+				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
+				<string>gnu++0x</string>
+				<key>CLANG_CXX_LIBRARY</key>
+				<string>libc++</string>
+				<key>CLANG_ENABLE_MODULES</key>
+				<string>YES</string>
+				<key>CLANG_ENABLE_OBJC_ARC</key>
+				<string>YES</string>
+				<key>CLANG_WARN_BOOL_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
+				<string>YES_ERROR</string>
+				<key>CLANG_WARN_EMPTY_BODY</key>
+				<string>YES</string>
+				<key>CLANG_WARN_ENUM_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_INT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
+				<string>YES_ERROR</string>
+				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
+				<string>YES</string>
+				<key>COPY_PHASE_STRIP</key>
+				<string>NO</string>
+				<key>FRAMEWORK_SEARCH_PATHS</key>
+				<array>
+					<string>$(SDKROOT)/Developer/Library/Frameworks</string>
+					<string>$(inherited)</string>
+					<string>$(DEVELOPER_FRAMEWORKS_DIR)</string>
+				</array>
+				<key>GCC_C_LANGUAGE_STANDARD</key>
+				<string>gnu99</string>
+				<key>GCC_DYNAMIC_NO_PIC</key>
+				<string>NO</string>
+				<key>GCC_OPTIMIZATION_LEVEL</key>
+				<string>0</string>
+				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
+				<string>YES</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>ReplicationAcceptanceApp/ReplicationAcceptanceApp-Prefix.pch</string>
+				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
+				<array>
+					<string>DEBUG=1</string>
+					<string>$(inherited)</string>
+				</array>
+				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
+				<string>NO</string>
+				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
+				<string>YES</string>
+				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
+				<string>YES_ERROR</string>
+				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
+				<string>YES_AGGRESSIVE</string>
+				<key>GCC_WARN_UNUSED_FUNCTION</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNUSED_VARIABLE</key>
+				<string>YES</string>
+				<key>INFOPLIST_FILE</key>
+				<string>ReplicationAcceptanceAppTests/ReplicationAcceptanceAppTests-Info.plist</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>7.1</string>
+				<key>ONLY_ACTIVE_ARCH</key>
+				<string>YES</string>
+				<key>PRODUCT_NAME</key>
+				<string>$(TARGET_NAME)</string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+				<key>TEST_HOST</key>
+				<string>$(BUNDLE_LOADER)</string>
+				<key>WRAPPER_EXTENSION</key>
+				<string>octest</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>27ED10A8192CF8DB00F75E95</key>
+		<dict>
+			<key>buildSettings</key>
+			<dict>
+				<key>ALWAYS_SEARCH_USER_PATHS</key>
+				<string>NO</string>
+				<key>BUNDLE_LOADER</key>
+				<string>$(BUILT_PRODUCTS_DIR)/ReplicationAcceptanceApp.app/ReplicationAcceptanceApp</string>
+				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
+				<string>gnu++0x</string>
+				<key>CLANG_CXX_LIBRARY</key>
+				<string>libc++</string>
+				<key>CLANG_ENABLE_MODULES</key>
+				<string>YES</string>
+				<key>CLANG_ENABLE_OBJC_ARC</key>
+				<string>YES</string>
+				<key>CLANG_WARN_BOOL_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
+				<string>YES_ERROR</string>
+				<key>CLANG_WARN_EMPTY_BODY</key>
+				<string>YES</string>
+				<key>CLANG_WARN_ENUM_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_INT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
+				<string>YES_ERROR</string>
+				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
+				<string>YES</string>
+				<key>COPY_PHASE_STRIP</key>
+				<string>YES</string>
+				<key>ENABLE_NS_ASSERTIONS</key>
+				<string>NO</string>
+				<key>FRAMEWORK_SEARCH_PATHS</key>
+				<array>
+					<string>$(SDKROOT)/Developer/Library/Frameworks</string>
+					<string>$(inherited)</string>
+					<string>$(DEVELOPER_FRAMEWORKS_DIR)</string>
+				</array>
+				<key>GCC_C_LANGUAGE_STANDARD</key>
+				<string>gnu99</string>
+				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
+				<string>YES</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>ReplicationAcceptanceApp/ReplicationAcceptanceApp-Prefix.pch</string>
+				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
+				<string>YES</string>
+				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
+				<string>YES_ERROR</string>
+				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
+				<string>YES_AGGRESSIVE</string>
+				<key>GCC_WARN_UNUSED_FUNCTION</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNUSED_VARIABLE</key>
+				<string>YES</string>
+				<key>INFOPLIST_FILE</key>
+				<string>ReplicationAcceptanceAppTests/ReplicationAcceptanceAppTests-Info.plist</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>7.1</string>
+				<key>PRODUCT_NAME</key>
+				<string>$(TARGET_NAME)</string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+				<key>TEST_HOST</key>
+				<string>$(BUNDLE_LOADER)</string>
+				<key>VALIDATE_PRODUCT</key>
+				<string>YES</string>
+				<key>WRAPPER_EXTENSION</key>
+				<string>octest</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>27ED10A9192CF8DB00F75E95</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>27ED10A5192CF8DB00F75E95</string>
+				<string>27ED10A6192CF8DB00F75E95</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>27ED10AA192CF8DB00F75E95</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>27ED10A7192CF8DB00F75E95</string>
+				<string>27ED10A8192CF8DB00F75E95</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>27ED10AB192CF8FF00F75E95</key>
+		<dict>
+			<key>fileRef</key>
+			<string>27A7E67F189973EE007FAF1C</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>27ED10AC192CF8FF00F75E95</key>
+		<dict>
+			<key>fileRef</key>
+			<string>27DFEEB618DB4A0D0052D487</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>27ED10AD192CF8FF00F75E95</key>
+		<dict>
+			<key>fileRef</key>
+			<string>27A7E6AE189975B2007FAF1C</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>27ED10AE192CF8FF00F75E95</key>
+		<dict>
+			<key>fileRef</key>
+			<string>27BE3CEE189FBEA9000CD30D</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>27ED10AF192CF8FF00F75E95</key>
+		<dict>
+			<key>fileRef</key>
+			<string>277992B718A24F0900BAB6ED</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>27ED10B0192CFA3600F75E95</key>
+		<dict>
+			<key>fileRef</key>
+			<string>27A7E673189973EE007FAF1C</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>3A667A31E143FB2C04570CA7</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>name</key>
+			<string>Pods-ios.debug.xcconfig</string>
+			<key>path</key>
+			<string>Pods/Target Support Files/Pods-ios/Pods-ios.debug.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>4204E69A031642919A587BB0</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array/>
+			<key>inputPaths</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXShellScriptBuildPhase</string>
+			<key>name</key>
+			<string>Copy Pods Resources</string>
+			<key>outputPaths</key>
+			<array/>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+			<key>shellPath</key>
+			<string>/bin/sh</string>
+			<key>shellScript</key>
+			<string>"${SRCROOT}/Pods/Target Support Files/Pods-ios/Pods-ios-resources.sh"
+</string>
+			<key>showEnvVarsInLog</key>
+			<string>0</string>
+		</dict>
+		<key>4510BA04F5FB481E882AF5EE</key>
+		<dict>
+			<key>fileRef</key>
+			<string>C61CF9A9D4564F53BC1F7321</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>49A0C744B12F77EFB17A92FC</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>name</key>
+			<string>Pods-osx.debug.xcconfig</string>
+			<key>path</key>
+			<string>Pods/Target Support Files/Pods-osx/Pods-osx.debug.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>5517C6B16DE048EF85C5A4A1</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array/>
+			<key>inputPaths</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXShellScriptBuildPhase</string>
+			<key>name</key>
+			<string>Check Pods Manifest.lock</string>
+			<key>outputPaths</key>
+			<array/>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+			<key>shellPath</key>
+			<string>/bin/sh</string>
+			<key>shellScript</key>
+			<string>diff "${PODS_ROOT}/../Podfile.lock" "${PODS_ROOT}/Manifest.lock" &gt; /dev/null
+if [[ $? != 0 ]] ; then
+    cat &lt;&lt; EOM
+error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.
+EOM
+    exit 1
+fi
+</string>
+			<key>showEnvVarsInLog</key>
+			<string>0</string>
+		</dict>
+		<key>86A30343408047EEBBF8EC4C</key>
+		<dict>
+			<key>fileRef</key>
+			<string>C61CF9A9D4564F53BC1F7321</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>86D70F8BECFE48389B7B243B</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array/>
+			<key>inputPaths</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXShellScriptBuildPhase</string>
+			<key>name</key>
+			<string>Check Pods Manifest.lock</string>
+			<key>outputPaths</key>
+			<array/>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+			<key>shellPath</key>
+			<string>/bin/sh</string>
+			<key>shellScript</key>
+			<string>diff "${PODS_ROOT}/../Podfile.lock" "${PODS_ROOT}/Manifest.lock" &gt; /dev/null
+if [[ $? != 0 ]] ; then
+    cat &lt;&lt; EOM
+error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.
+EOM
+    exit 1
+fi
+</string>
+			<key>showEnvVarsInLog</key>
+			<string>0</string>
+		</dict>
+		<key>8E89B680A5F347559033D1B3</key>
+		<dict>
+			<key>fileRef</key>
+			<string>97F72706FFD44D88B6E5E667</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>8EA6E3B619F00B70001528E1</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>CDTDatastoreFromQueryAcceptance.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>8EA6E3B719F00B70001528E1</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>CDTDatastoreFromQueryAcceptance.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>8EA6E3B819F00B70001528E1</key>
+		<dict>
+			<key>fileRef</key>
+			<string>8EA6E3B719F00B70001528E1</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>97F72706FFD44D88B6E5E667</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>archive.ar</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>libPods-osx.a</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>99F07C58C4C4546997797701</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>3A667A31E143FB2C04570CA7</string>
+				<string>EF12D0FFB8B3A747D51E465C</string>
+				<string>49A0C744B12F77EFB17A92FC</string>
+				<string>12C21B4A5C5E501D34006B36</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Pods</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>9F1F14EB19870B88003E9F0B</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>ReplicatorDelegates.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>9F1F14EC19870B88003E9F0B</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>ReplicatorDelegates.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>9F1F14ED19870B88003E9F0B</key>
+		<dict>
+			<key>fileRef</key>
+			<string>9F1F14EC19870B88003E9F0B</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>9F1F14EE19870B88003E9F0B</key>
+		<dict>
+			<key>fileRef</key>
+			<string>9F1F14EC19870B88003E9F0B</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BB7BC6BD2CC743AAAAC21269</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array/>
+			<key>inputPaths</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXShellScriptBuildPhase</string>
+			<key>name</key>
+			<string>Copy Pods Resources</string>
+			<key>outputPaths</key>
+			<array/>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+			<key>shellPath</key>
+			<string>/bin/sh</string>
+			<key>shellScript</key>
+			<string>"${SRCROOT}/Pods/Target Support Files/Pods-osx/Pods-osx-resources.sh"
+</string>
+			<key>showEnvVarsInLog</key>
+			<string>0</string>
+		</dict>
+		<key>C61CF9A9D4564F53BC1F7321</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>archive.ar</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>libPods-ios.a</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>DA7978ED7F6244DC8D4D91B8</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array/>
+			<key>inputPaths</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXShellScriptBuildPhase</string>
+			<key>name</key>
+			<string>Copy Pods Resources</string>
+			<key>outputPaths</key>
+			<array/>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+			<key>shellPath</key>
+			<string>/bin/sh</string>
+			<key>shellScript</key>
+			<string>"${SRCROOT}/Pods/Target Support Files/Pods-ios/Pods-ios-resources.sh"
+</string>
+			<key>showEnvVarsInLog</key>
+			<string>0</string>
+		</dict>
+		<key>EF12D0FFB8B3A747D51E465C</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>name</key>
+			<string>Pods-ios.release.xcconfig</string>
+			<key>path</key>
+			<string>Pods/Target Support Files/Pods-ios/Pods-ios.release.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+	</dict>
+	<key>rootObject</key>
+	<string>27A7E666189973D6007FAF1C</string>
+</dict>
+</plist>
+>>>>>>> Some initial changes to filter incoming docs by id

--- a/ReplicationAcceptance/ReplicationAcceptance/ReplicationAcceptance+CRUD.m
+++ b/ReplicationAcceptance/ReplicationAcceptance/ReplicationAcceptance+CRUD.m
@@ -120,15 +120,15 @@
 
 - (void)createRemoteDocs:(NSInteger)count
 {
-    [self createRemoteDocs:count suffixFrom:0];
+    [self createRemoteDocs:count suffixFrom:1];
 }
 
 -(void) createRemoteDocs:(NSInteger)count suffixFrom:(NSInteger)start
 {
     NSMutableArray *docs = [NSMutableArray array];
-    NSUInteger currentIndex = start;
-    for (long i = 1; i < count+1; i++) {
-        currentIndex++;
+    NSUInteger currentIndex;
+    for (long i = 0; i < count; i++) {
+        currentIndex = start+i;
         NSString *docId = [NSString stringWithFormat:@"doc-%li", currentIndex];
         NSDictionary *dict = @{@"_id": docId, 
                                @"hello": @"world", 

--- a/ReplicationAcceptance/ReplicationAcceptance/ReplicationAcceptance.h
+++ b/ReplicationAcceptance/ReplicationAcceptance/ReplicationAcceptance.h
@@ -13,7 +13,8 @@
 
 @class CDTDatastore;
 @class CDTReplicatorFactory;
-
+@class CDTReplicator;
+@class CDTDatastoreFromQuery;
 
 @interface ReplicationAcceptance : CloudantReplicationBase
 

--- a/ReplicationAcceptance/ReplicationAcceptance/ReplicationAcceptance.m
+++ b/ReplicationAcceptance/ReplicationAcceptance/ReplicationAcceptance.m
@@ -30,6 +30,7 @@
 #import "TDReplicatorManager.h"
 #import "TDReplicator.h"
 #import "CDTReplicator.h"
+#import "CDTDatastoreFromQuery.h"
 
 @interface ReplicationAcceptance ()
 
@@ -96,16 +97,25 @@ static NSUInteger largeRevTreeSize = 1500;
  Create a new replicator, and wait for replication from the remote database to complete.
  */
 -(CDTReplicator *) pullFromRemote {
-    return [self pullFromRemoteWithFilter:nil params:nil];
+    return [self pullFromRemoteWithFilter:nil params:nil clientFilterDocIds:nil];
 }
 
--(CDTReplicator *) pullFromRemoteWithFilter:(NSString*)filterName params:(NSDictionary*)params
+-(CDTReplicator *) pullFromRemoteWithFilter:(NSString*)filterName
+                                     params:(NSDictionary*)params
+{
+    return [self pullFromRemoteWithFilter:filterName params:params clientFilterDocIds:nil];
+}
+
+-(CDTReplicator *) pullFromRemoteWithFilter:(NSString*)filterName
+                                     params:(NSDictionary*)params
+                         clientFilterDocIds:(NSArray*)filterDocIds
 {
     CDTPullReplication *pull = [CDTPullReplication replicationWithSource:self.primaryRemoteDatabaseURL
                                                                   target:self.datastore];
     
     pull.filter = filterName;
     pull.filterParams = params;
+    pull.clientFilterDocIds = filterDocIds;
     
     NSError *error;
     CDTReplicator *replicator =  [self.replicatorFactory oneWay:pull error:&error];
@@ -124,6 +134,11 @@ static NSUInteger largeRevTreeSize = 1500;
     
     return replicator;
 }
+
+-(CDTReplicator *) pullFromRemoteWithClientFilterDocIds:(NSArray*)clientFilterDocIds {
+    return [self pullFromRemoteWithFilter:nil params:nil clientFilterDocIds:clientFilterDocIds];
+}
+
 
 
 /**
@@ -861,6 +876,213 @@ static NSUInteger largeRevTreeSize = 1500;
 }
 
 
+-(void) testPullClientFilteredLots {
+    // Create large number of documents locally and remotely
+    // ensure all updated documents on remote side are pulled
+    // ensure new documents on remote side matching id list are pulled
+    
+    // Create docs in remote database
+    NSLog(@"Creating documents...");
+    
+    int localdocs = 5000;
+    int remotedocs = 5000;
+    
+    // 0..5000 local
+    // 5001..10000 remote
+    // then upload 2-rev 0..5000 remote
+    
+    [self createLocalDocs:localdocs];
+    [self createRemoteDocs:remotedocs suffixFrom:localdocs+1];
+    // now do some updates
+    for (CDTDocumentRevision *rev in [self.datastore getAllDocuments]) {
+        // 2-rev, with the 1-rev as parent
+        NSMutableDictionary *dict = [rev.body mutableCopy];
+        NSString *localRevId = [rev revId];
+        [dict setValue:localRevId forKey:@"_rev"];
+        [dict setValue:@YES forKey:@"updated"];
+        [self createRemoteDocWithId:rev.docId body:dict];
+    }
+    
+    NSMutableArray *filterDocIds = [NSMutableArray array];
+    int i;
+    for (i=0; i<localdocs+remotedocs; i++) {
+        if (i % 2 == 1) {
+            [filterDocIds addObject:[NSString stringWithFormat:@"doc-%i", i+1]];
+        }
+    }
+  
+    [self pullFromRemoteWithClientFilterDocIds:filterDocIds];
+    
+    //5000 local + 5000/2 remote = 7500
+    STAssertEquals(self.datastore.documentCount, (unsigned long)(localdocs+remotedocs/2),
+                   @"Incorrect number of documents created");
+
+    //5000 local + 5000/2 remote + 5000 remote copies of local (rev-2)
+    STAssertEquals(self.datastore.database.lastSequence, (long long)(localdocs+remotedocs/2+localdocs),
+                   @"Incorrect sequence number");
+
+    // document checks:
+    // 0..5000 all have 2-rev
+    // 5000..10000 are all even numbers and have a 1-rev
+    for (CDTDocumentRevision *rev in [self.datastore getAllDocuments]) {
+        long docNo = [[rev.docId substringFromIndex:4] integerValue];
+        if (docNo <= localdocs+1) {
+            STAssertTrue([rev.revId hasPrefix:@"2-"], @"rev id %@ does not start 2- for doc id %@", rev.revId, rev.docId);
+        }
+        if (docNo > localdocs && docNo <= localdocs+remotedocs+1) {
+            STAssertTrue(docNo %2 == 0, @"document number must be even");
+            STAssertTrue([rev.revId hasPrefix:@"1-"], @"rev id does not start 1-");
+        }
+    }
+}
+
+-(void) testPullClientFiltered {
+    // Create n docs and pull a subset of them, filtered by ID
+    
+    // Create docs in remote database
+    NSLog(@"Creating documents...");
+    
+    int ndocs = 50; //don't need 100k docs
+    
+    [self createRemoteDocs:ndocs];
+    
+    NSArray *filterDocIds = @[[NSString stringWithFormat:@"doc-%i", 1],
+                        [NSString stringWithFormat:@"doc-%i", 3],
+                        [NSString stringWithFormat:@"doc-%i", 13],
+                        [NSString stringWithFormat:@"doc-%i", 23]];
+
+    [self pullFromRemoteWithClientFilterDocIds:filterDocIds];
+    STAssertTrue(filterDocIds.count == [self.datastore documentCount], @"unexpected number of docs: %@",[self.datastore documentCount]);
+    
+    NSArray *localDocs = [self.datastore getDocumentsWithIds:filterDocIds];
+    
+    STAssertNotNil(localDocs, @"nil");
+    STAssertTrue(localDocs.count == filterDocIds.count, @"unexpected number of docs: %@",localDocs.count);
+    STAssertTrue(self.datastore.documentCount == filterDocIds.count,
+                 @"Incorrect number of documents created %lu", self.datastore.documentCount);
+}
+
+-(void) testPullClientFilteredNewDocsAppear {
+    // Create n docs and pull a subset of them, filtered by ID
+    // then create another n docs, some of which are also included in the filter
+    
+    // Create docs in remote database
+    NSLog(@"Creating documents...");
+    
+    int ndocs = 50; //don't need 100k docs
+    
+    [self createRemoteDocs:ndocs];
+    
+    NSArray *filterDocIds = @[[NSString stringWithFormat:@"doc-%i", 1],
+                              [NSString stringWithFormat:@"doc-%i", 3],
+                              [NSString stringWithFormat:@"doc-%i", 13],
+                              [NSString stringWithFormat:@"doc-%i", 23],
+                              [NSString stringWithFormat:@"doc-%i", 70]];
+    
+    [self pullFromRemoteWithClientFilterDocIds:filterDocIds];
+
+    STAssertEquals([self.datastore.database lastSequence], 4ll, @"Incorrect sequence number");
+    STAssertEquals(self.datastore.documentCount, 4ul,
+                   @"Incorrect number of documents created");
+    
+    // 50 more
+    [self createRemoteDocs:ndocs suffixFrom:51];
+
+    [self pullFromRemoteWithClientFilterDocIds:filterDocIds];
+
+    STAssertEquals([self.datastore.database lastSequence], 5ll, @"Incorrect sequence number");
+    STAssertEquals(self.datastore.documentCount, 5ul,
+                 @"Incorrect number of documents created");
+
+    
+    NSArray *localDocs = [self.datastore getAllDocuments];
+    
+    STAssertEquals(localDocs.count, filterDocIds.count, @"unexpected number of docs");
+    STAssertEquals(self.datastore.documentCount, filterDocIds.count,
+                 @"Incorrect number of documents created");
+}
+
+-(void) testPullClientFilterLargeRevTree {
+    // create n docs with m revisions and pull a subset of them, filtered by ID
+    
+    int ndocs = 50;
+    
+    NSArray *filterDocIds = @[[NSString stringWithFormat:@"doc-%i", 1],
+                              [NSString stringWithFormat:@"doc-%i", 3],
+                              [NSString stringWithFormat:@"doc-%i", 13],
+                              [NSString stringWithFormat:@"doc-%i", 23],
+                              [NSString stringWithFormat:@"doc-%i", 70]];
+    
+    for(int i=0; i<ndocs; i++) {
+        // Create the initial rev in remote datastore
+        NSString *docId = [NSString stringWithFormat:@"doc-%i", i];
+        [self createRemoteDocWithId:docId revs:50];
+    }
+    
+    [self pullFromRemoteWithClientFilterDocIds:filterDocIds];
+
+    // 50 * 4 docs
+    STAssertEquals([self.datastore.database lastSequence], 200ll, @"Incorrect sequence number");
+    STAssertEquals(self.datastore.documentCount, 4ul,
+                 @"Incorrect number of documents created");
+
+    // 50 more
+    for(int i=50; i<ndocs+50; i++) {
+        // Create the initial rev in remote datastore
+        NSString *docId = [NSString stringWithFormat:@"doc-%i", i];
+        [self createRemoteDocWithId:docId revs:50];
+    }
+    
+    [self pullFromRemoteWithClientFilterDocIds:filterDocIds];
+    
+    STAssertEquals([self.datastore.database lastSequence], 250ll, @"Incorrect sequence number");
+    STAssertEquals(self.datastore.documentCount, 5ul,
+                 @"Incorrect number of documents created");
+
+}
+
+-(void) testPullClientFilterUpdates {
+    // create n docs and pull a subset of them, filtered by ID
+    // update them and pull the same subset, filtered by ID
+    
+    // Create docs in remote database
+    NSLog(@"Creating documents...");
+    
+    int ndocs = 50; //don't need 100k docs
+    
+    [self createRemoteDocs:ndocs];
+    
+    NSArray *filterDocIds = @[[NSString stringWithFormat:@"doc-%i", 1],
+                              [NSString stringWithFormat:@"doc-%i", 3],
+                              [NSString stringWithFormat:@"doc-%i", 13],
+                              [NSString stringWithFormat:@"doc-%i", 23],
+                              [NSString stringWithFormat:@"doc-%i", 70]];
+    
+    [self pullFromRemoteWithClientFilterDocIds:filterDocIds];
+
+    STAssertEquals([self.datastore.database lastSequence], 4ll, @"Incorrect sequence number");
+    STAssertEquals(self.datastore.documentCount, 4ul,
+                 @"Incorrect number of documents created");
+    
+    // now do some updates
+    for (CDTDocumentRevision *rev in [self.datastore getAllDocuments]) {
+        NSMutableDictionary *dict = [rev.body mutableCopy];
+        [dict setValue:rev.revId forKey:@"_rev"];
+        [dict setValue:@YES forKey:@"updated"];
+        [self createRemoteDocWithId:rev.docId body:dict];
+    }
+
+    [self pullFromRemoteWithClientFilterDocIds:filterDocIds];
+    
+    for (CDTDocumentRevision *rev in [self.datastore getAllDocuments]) {
+        STAssertTrue([rev.revId hasPrefix:@"2-"], @"rev id does not start 2-");
+    }
+
+    STAssertEquals([self.datastore.database lastSequence], 8ll, @"Incorrect sequence number");
+    STAssertEquals(self.datastore.documentCount, 4ul,
+                 @"Incorrect number of documents updated");
+}
+
 /**
  Reproduce reported issue:
  
@@ -989,4 +1211,61 @@ static NSUInteger largeRevTreeSize = 1500;
     }
 }
 
+- (void)testPullFromQuery {
+    // TODO this query is a dummy object for now rather than a real query
+    CDTDatastoreQuery *query;
+    
+    CDTDatastoreFromQuery *datastoreFromQuery = [[CDTDatastoreFromQuery alloc] initWithQuery:query
+                                                             localDirectory:self.factoryPath
+                                                                     remote:self.primaryRemoteDatabaseURL];
+    
+    CDTReplicator *filteredPull;
+    CDTReplicator *filteredPush;
+
+    NSError *error;
+    
+    // Create n docs and pull a subset of them, filtered by ID
+    
+    // Create docs in remote database
+    NSLog(@"Creating documents...");
+    
+    int ndocs = 50;
+    
+    [self createRemoteDocs:ndocs];
+    
+    NSArray *filterDocIds = @[[NSString stringWithFormat:@"doc-%i", 1],
+                              [NSString stringWithFormat:@"doc-%i", 3],
+                              [NSString stringWithFormat:@"doc-%i", 13],
+                              [NSString stringWithFormat:@"doc-%i", 23]];
+    
+    // TODO in the real implementation these IDs would be derived from the query
+    datastoreFromQuery.docIds = filterDocIds;
+    
+    filteredPull = [datastoreFromQuery pull];
+    if (![filteredPull startWithError:&error]) {
+        STFail(@"Failed to start pull %@", error);
+    }
+    
+    while([filteredPull isActive]) {
+        [NSThread sleepForTimeInterval:1.0f];
+    }
+    // create some more docs, outside the filter list
+    [self createLocalDocs:50 suffixFrom:51];
+    STAssertEquals(datastoreFromQuery.datastore.documentCount, 54ul,
+                   @"Incorrect number of documents in store");
+    
+    filteredPush = [datastoreFromQuery push];
+    if (![filteredPush startWithError:nil]) {
+        STFail(@"Failed to start push %@", error);
+    }
+    while([filteredPush isActive]) {
+        [NSThread sleepForTimeInterval:1.0f];
+    }
+
+    [NSThread sleepForTimeInterval:1.0f];
+    
+    // now our extra docs should have been purged
+    STAssertEquals(datastoreFromQuery.datastore.documentCount, 4ul,
+                   @"Incorrect number of documents in store");
+}
 @end

--- a/Tests/Tests.xcodeproj/xcshareddata/xcschemes/Tests.xcscheme
+++ b/Tests/Tests.xcodeproj/xcshareddata/xcschemes/Tests.xcscheme
@@ -73,6 +73,15 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "27389E0B185345FD0027A404"
+            BuildableName = "Tests.octest"
+            BlueprintName = "Tests"
+            ReferencedContainer = "container:Tests.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <EnvironmentVariables>
          <EnvironmentVariable
             key = "OBJC_DISABLE_GC"
@@ -85,7 +94,7 @@
    </LaunchAction>
    <ProfileAction
       shouldUseLaunchSchemeArgsEnv = "YES"
-      savedToolIdentifier = ""
+      savedToolIdentifier = "/Applications/Xcode.app/Contents/Applications/Instruments.app/Contents/Resources/templates/Leaks.tracetemplate"
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Release"
       debugDocumentVersioning = "YES">

--- a/Tests/Tests/CDTDatastoreFromQueryTests.h
+++ b/Tests/Tests/CDTDatastoreFromQueryTests.h
@@ -1,0 +1,13 @@
+//
+//  CDTDatastoreFromQueryTests.h
+//  Tests
+//
+//  Created by tomblench on 21/10/2014.
+//
+//
+
+#import <SenTestingKit/SenTestingKit.h>
+
+@interface CDTDatastoreFromQueryTests : SenTestCase
+
+@end

--- a/Tests/Tests/CDTDatastoreFromQueryTests.m
+++ b/Tests/Tests/CDTDatastoreFromQueryTests.m
@@ -1,0 +1,49 @@
+//
+//  CDTDatastoreFromQueryTests.m
+//  Tests
+//
+//  Created by tomblench on 21/10/2014.
+//
+//
+
+#import "CDTDatastoreFromQuery.h"
+#import "CDTDatastoreFromQueryTests.h"
+
+
+@implementation CDTDatastoreFromQueryTests
+
+- (void)testQuery
+{
+    NSDictionary *query1 = @{@"$or": @[@{@"name": @"mike"},
+                                          @{@"pet": @"cat"},
+                                          @{@"$or": @[@{@"name": @"mike"},
+                                                      @{@"pet": @"cat"}
+                                                      ]},
+                                          @{@"$and": @[@{@"name": @"tom"},
+                                                       @{@"pet": @"dog"}
+                                                       ]}
+                                          ]
+                                };
+    
+    NSDictionary *query2 = @{@"$or": @[@{@"name": @"mike"},
+                                       @{@"pet": @"cat"},
+                                       @{@"$or": @[@{@"name": @"mike"},
+                                                   @{@"pet": @"cat"}
+                                                   ]},
+                                       @{@"$and": @[@{@"name": @"tom"},
+                                                    @{@"pet": @"dog"}
+                                                    ]}
+                                       ]
+                             };
+    
+    // we don't actually depend on any state of this object so we don't need to fully initialise it
+    CDTDatastoreFromQuery *q = [[CDTDatastoreFromQuery alloc] init];
+    CDTDatastoreQuery *cdtQuery = [[CDTDatastoreQuery alloc] init];
+    cdtQuery.queryDictionary = query1;
+    NSString *str1 = [q queryToDatastoreName:cdtQuery];
+    cdtQuery.queryDictionary = query2;
+    NSString *str2 = [q queryToDatastoreName:cdtQuery];
+    STAssertEqualObjects(str1, str2, @"strings should be equal");
+}
+
+@end


### PR DESCRIPTION
Test case shows how to create a CDTDatastoreFromQuery object and push/pull on it.

Deriving the list of Doc IDs is currently mocked with a fixed list of IDs but this can be replaced with a real implementation once the query work is complete.

Similarly, automatic naming of the database based on the query is not yet present but this is anticipated to be some sort of stable hash based on the query (the same query gets the same name each time).
