### PR TITLE
Allow setting certain HTTP headers for replication

### DIFF
--- a/Classes/common/CDTReplicator/CDTAbstractReplication.h
+++ b/Classes/common/CDTReplicator/CDTAbstractReplication.h
@@ -38,7 +38,15 @@ typedef NS_ENUM(NSInteger, CDTReplicationErrors) {
     /**
      Missing either a username or password.
      */
-    CDTReplicationErrorIncompleteCredentials
+    CDTReplicationErrorIncompleteCredentials,
+    /**
+     An optional HTTP Header key or value is not of type NSString.
+     */
+    CDTReplicationErrorBadOptionalHttpHeaderType,
+    /**
+     See below for a list of HTTP keys that one may not modify.
+     */
+    CDTReplicationErrorProhibitedOptionalHttpHeader
 };
 
 
@@ -54,7 +62,7 @@ typedef NS_ENUM(NSInteger, CDTReplicationErrors) {
  These are specified with the -target and -source properties found in the subclasses.
  
  */
-@interface CDTAbstractReplication : NSObject
+@interface CDTAbstractReplication : NSObject <NSCopying>
 
 
 /*
@@ -68,8 +76,63 @@ typedef NS_ENUM(NSInteger, CDTReplicationErrors) {
  http://docs.couchdb.org/en/latest/json-structure.html#replication-settings
  
  ---------------------------------------------------------------------------------------
- */
+*/
 
+/**
+ Set additional HTTP headers by providing an NSDictionary with the header
+ name-value string pairs. The headers will be added to all HTTP requests made on behalf
+ of a particular push or pull replication.
+ 
+ All keys and values are required to be NSString (or subclass) objects. If they are not NSString
+ or subclasses, then -dictionaryForReplicatorDocument will return an error and the CDTReplicator 
+ object will not be instantiated successfully.
+ 
+ Internally we use NSMutableURLRequest, which automatically sets some headers that should
+ not be modified. 
+ 
+ @see NSMutableURLRequest
+ 
+ NSURL will overwrite the following headers
+ 
+ * Authorization
+ * Connection
+ * Host
+ * WWW-Authenticate
+ 
+ CloudantSync will overwrite the following headers
+
+ * Content-Type
+ * Accept
+ * Content-Length
+ 
+ As such, these headers are prohibited. If one of these headers are set here, instantiation
+ of the CDTReplicator object will fail.
+ 
+ The header "User-Agent" may be changed or modified by using the optionalHeaders. In order
+ to modify the default header, obtain the default value from
+ (NSString*) +defaultUserAgentHTTPHeader and then set the header in optionalHeaders with your 
+ change.
+ 
+ For example:
+ 
+    CDTPullReplication* pull = [CDTPullReplication replicationWithSource:remote
+                                                                  target:datastore];
+ 
+    NSString *myUserAgent = [NSString stringWithFormat:@"%@/MyApplication",
+                                [CDTAbstractReplication defaultUserAgentHTTPHeader]];
+ 
+    NSDictionary *extraHeaders = @{@"SpecialHeader":@"foo", @"User-Agent":myUserAgent};
+ 
+ 
+
+ 
+*/
+@property (nonatomic, copy) NSDictionary* optionalHeaders;
+
+/**
+ Returns the default "User-Agent" header value used in HTTP requests made during replication.
+*/
++(NSString*) defaultUserAgentHTTPHeader;
 
 /*
  ---------------------------------------------------------------------------------------
@@ -82,15 +145,13 @@ typedef NS_ENUM(NSInteger, CDTReplicationErrors) {
  ---------------------------------------------------------------------------------------
  */
 
-/** The NSDictionary is used by CDTReplicatorFactory to generate the proper document for the 
- _replicator database.
- 
- @param error reports error information
- @return The NSDictionary that represents the JSON document to be written to the _replicator
- database.
- @warning This method is for internal use only. The CDTPushReplication and CDTPullReplication
-     classes implement this method.
+/** The NSDictionary is used by CDTReplicatorFactory to properly configure CDTReplicator objects.
 
+ @param error reports error information
+ @return The NSDictionary that configures a CDTReplicator instance.
+ @warning This method is for internal use only. The CDTPushReplication and CDTPullReplication
+     classes override this method.
+ 
  */
 -(NSDictionary*) dictionaryForReplicatorDocument:(NSError * __autoreleasing*)error;
 

--- a/Classes/common/CDTReplicator/CDTAbstractReplication.m
+++ b/Classes/common/CDTReplicator/CDTAbstractReplication.m
@@ -15,18 +15,115 @@
 #import "CDTAbstractReplication.h"
 #import "TD_DatabaseManager.h"
 #import "CDTLogging.h"
+#import "TDRemoteRequest.h"
 
 NSString* const CDTReplicationErrorDomain = @"CDTReplicationErrorDomain";
 
 @implementation CDTAbstractReplication
 
++(NSString*) defaultUserAgentHTTPHeader
+{
+    return [TDRemoteRequest userAgentHeader];
+}
+
+-(instancetype) copyWithZone:(NSZone *)zone
+{
+    CDTAbstractReplication *copy = [[[self class] allocWithZone:zone] init];
+    if (copy) {
+        copy.optionalHeaders = self.optionalHeaders;
+    }
+    
+    return copy;
+}
+
 /**
  This method sets all of the common replication parameters. The subclasses,
  CDTPushReplication and CDTPullReplication add source, target and filter. 
+ 
  */
 -(NSDictionary*) dictionaryForReplicatorDocument:(NSError * __autoreleasing*)error
 {
-    return nil;
+    NSMutableDictionary *doc = [[NSMutableDictionary alloc] init];
+    
+    if (self.optionalHeaders) {
+        
+        NSMutableArray *lowercaseOptionalHeaders = [[NSMutableArray alloc] init];
+        
+        //check for strings
+        for (id key in self.optionalHeaders) {
+            
+            if (![key isKindOfClass:[NSString class]]) {
+                LogWarn(REPLICATION_LOG_CONTEXT, @"CDTAbstractReplication "
+                        @"-dictionaryForReplicatorDocument Error: "
+                        @"Replication HTTP header key is invalid (%@).\n It must be NSString. "
+                        @"Found type %@", key, [key class]);
+
+                if (error) {
+                    NSString *msg = @"Cannot sync data. Bad optional HTTP header.";
+                    NSDictionary *userInfo = @{NSLocalizedDescriptionKey: NSLocalizedString(msg, nil)};
+                    *error = [NSError errorWithDomain:CDTReplicationErrorDomain
+                                                 code:CDTReplicationErrorBadOptionalHttpHeaderType
+                                             userInfo:userInfo];
+
+                }
+                return nil;
+            }
+            
+            if (![self.optionalHeaders[key] isKindOfClass:[NSString class]]) {
+                LogWarn(REPLICATION_LOG_CONTEXT, @"CDTAbstractReplication "
+                        @"-dictionaryForReplicatorDocument Error: "
+                        @"Value for replication HTTP header %@ is invalid (%@).\n"
+                        @"It must be NSString. Found type %@.",
+                        key, self.optionalHeaders[key], [self.optionalHeaders[key] class]);
+                
+                if (error) {
+                    NSString *msg = @"Cannot sync data. Bad optional HTTP header.";
+                    NSDictionary *userInfo = @{NSLocalizedDescriptionKey: NSLocalizedString(msg, nil)};
+                    *error = [NSError errorWithDomain:CDTReplicationErrorDomain
+                                                 code:CDTReplicationErrorBadOptionalHttpHeaderType
+                                             userInfo:userInfo];
+                    
+                }
+                return nil;
+            }
+            
+            [lowercaseOptionalHeaders addObject:[(NSString *)key lowercaseString]];
+        }
+        
+        NSArray *prohibitedHeaders = @[@"authorization", @"www-authenticate", @"host",
+                                      @"connection", @"content-type", @"accept",
+                                      @"content-length"];
+        
+        NSMutableArray *badHeaders = [[NSMutableArray alloc] init];
+        
+        for (NSString *header in prohibitedHeaders) {
+            if ([lowercaseOptionalHeaders indexOfObject:header] != NSNotFound) {
+                [badHeaders addObject:header];
+            }
+        }
+        
+        if ([badHeaders count] > 0) {
+            LogWarn(REPLICATION_LOG_CONTEXT, @"CDTAbstractionReplication "
+                    @"-dictionaryForReplicatorDocument Error: "
+                    @"You may not use these prohibited headers: %@", badHeaders);
+            
+            if (error) {
+                NSString *msg = @"Cannot sync data. Bad optional HTTP header.";
+                NSDictionary *userInfo = @{NSLocalizedDescriptionKey: NSLocalizedString(msg, nil)};
+                *error = [NSError errorWithDomain:CDTReplicationErrorDomain
+                                             code:CDTReplicationErrorProhibitedOptionalHttpHeader
+                                         userInfo:userInfo];
+            }
+
+            return nil;
+
+        }
+        
+        doc[@"headers"]= self.optionalHeaders;
+        
+    }
+    
+    return [NSDictionary dictionaryWithDictionary:doc];
 }
 
 - (NSString *)description
@@ -40,10 +137,10 @@ NSString* const CDTReplicationErrorDomain = @"CDTReplicationErrorDomain";
     NSString *scheme = [url.scheme lowercaseString];
     NSArray *validSchemes = @[@"http", @"https"];
     if (![validSchemes containsObject:scheme]) {
+        LogWarn(REPLICATION_LOG_CONTEXT,@"%@ -validateRemoteDatastoreURL Error. "
+                @"Invalid scheme: %@", [self class], url.scheme);
+
         if (error) {
-            LogWarn(REPLICATION_LOG_CONTEXT,@"%@ -validateRemoteDatastoreURL Error. "
-                  @"Invalid scheme: %@", [self class], url.scheme);
-            
             NSString *msg = @"Cannot sync data. Invalid Remote Database URL";
             
             NSDictionary *userInfo = @{NSLocalizedDescriptionKey: NSLocalizedString(msg, nil)};
@@ -61,10 +158,11 @@ NSString* const CDTReplicationErrorDomain = @"CDTReplicationErrorDomain";
     
     if ( (!usernameSupplied && passwordSupplied) ||
          (usernameSupplied && !passwordSupplied)) {
+        LogWarn(REPLICATION_LOG_CONTEXT,@"%@ -validateRemoteDatastoreURL Error. "
+                @"Must have both username and password, or neither. ", [self class]);
+        
+
         if (error) {
-            LogWarn(REPLICATION_LOG_CONTEXT,@"%@ -validateRemoteDatastoreURL Error. "
-                  @"Must have both username and password, or neither. ", [self class]);
-            
             NSString *msg = [NSString stringWithFormat:@"Cannot sync data. Missing %@",
                              usernameSupplied ? @"password" : @"username"];
             

--- a/Classes/common/touchdb/TD_DatabaseManager.m
+++ b/Classes/common/touchdb/TD_DatabaseManager.m
@@ -262,7 +262,7 @@ static NSDictionary* parseSourceOrTarget(NSDictionary* properties, NSString* key
     if (outRemote)
         *outRemote = remote;
     if (outHeaders)
-        *outHeaders = $castIf(NSDictionary, remoteDict[@"headers"]);
+        *outHeaders = $castIf(NSDictionary, properties[@"headers"]);
     
 //    if (outAuthorizer) {
 //        *outAuthorizer = nil;

--- a/ReplicationAcceptance/ReplicationAcceptance.xcodeproj/project.pbxproj
+++ b/ReplicationAcceptance/ReplicationAcceptance.xcodeproj/project.pbxproj
@@ -46,6 +46,10 @@
 		8E89B680A5F347559033D1B3 /* libPods-osx.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 97F72706FFD44D88B6E5E667 /* libPods-osx.a */; };
 		9F1F14ED19870B88003E9F0B /* ReplicatorDelegates.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F1F14EC19870B88003E9F0B /* ReplicatorDelegates.m */; };
 		9F1F14EE19870B88003E9F0B /* ReplicatorDelegates.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F1F14EC19870B88003E9F0B /* ReplicatorDelegates.m */; };
+		9FC2F12C19F070710032A074 /* ReplicatorURLProtocol.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FC2F12B19F070710032A074 /* ReplicatorURLProtocol.m */; };
+		9FC2F12D19F070710032A074 /* ReplicatorURLProtocol.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FC2F12B19F070710032A074 /* ReplicatorURLProtocol.m */; };
+		9FC2F13119F72B710032A074 /* ReplicatorURLProtocolTester.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FC2F13019F72B710032A074 /* ReplicatorURLProtocolTester.m */; };
+		9FC2F13219F72B710032A074 /* ReplicatorURLProtocolTester.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FC2F13019F72B710032A074 /* ReplicatorURLProtocolTester.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -99,6 +103,10 @@
 		97F72706FFD44D88B6E5E667 /* libPods-osx.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-osx.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		9F1F14EB19870B88003E9F0B /* ReplicatorDelegates.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ReplicatorDelegates.h; sourceTree = "<group>"; };
 		9F1F14EC19870B88003E9F0B /* ReplicatorDelegates.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ReplicatorDelegates.m; sourceTree = "<group>"; };
+		9FC2F12B19F070710032A074 /* ReplicatorURLProtocol.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ReplicatorURLProtocol.m; sourceTree = "<group>"; };
+		9FC2F12E19F070950032A074 /* ReplicatorURLProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ReplicatorURLProtocol.h; sourceTree = "<group>"; };
+		9FC2F12F19F72B710032A074 /* ReplicatorURLProtocolTester.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ReplicatorURLProtocolTester.h; sourceTree = "<group>"; };
+		9FC2F13019F72B710032A074 /* ReplicatorURLProtocolTester.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ReplicatorURLProtocolTester.m; sourceTree = "<group>"; };
 		C61CF9A9D4564F53BC1F7321 /* libPods-ios.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ios.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D3EA8C0BBBD34854B2975F77 /* Pods-ios.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ios.xcconfig"; path = "Pods/Pods-ios.xcconfig"; sourceTree = "<group>"; };
 		ED591AE84EE34971AD9AAB01 /* Pods-osx.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-osx.xcconfig"; path = "Pods/Pods-osx.xcconfig"; sourceTree = "<group>"; };
@@ -205,6 +213,10 @@
 				277992B718A24F0900BAB6ED /* ReplicationAcceptance+CRUD.m */,
 				9F1F14EB19870B88003E9F0B /* ReplicatorDelegates.h */,
 				9F1F14EC19870B88003E9F0B /* ReplicatorDelegates.m */,
+				9FC2F12E19F070950032A074 /* ReplicatorURLProtocol.h */,
+				9FC2F12B19F070710032A074 /* ReplicatorURLProtocol.m */,
+				9FC2F12F19F72B710032A074 /* ReplicatorURLProtocolTester.h */,
+				9FC2F13019F72B710032A074 /* ReplicatorURLProtocolTester.m */,
 			);
 			path = ReplicationAcceptance;
 			sourceTree = "<group>";
@@ -545,9 +557,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				27BE3CEF189FBEA9000CD30D /* CloudantReplicationBase+CompareDb.m in Sources */,
+				9FC2F13119F72B710032A074 /* ReplicatorURLProtocolTester.m in Sources */,
 				277992B818A24F0900BAB6ED /* ReplicationAcceptance+CRUD.m in Sources */,
 				27A7E6B118997673007FAF1C /* ReplicationAcceptance.m in Sources */,
 				9F1F14ED19870B88003E9F0B /* ReplicatorDelegates.m in Sources */,
+				9FC2F12C19F070710032A074 /* ReplicatorURLProtocol.m in Sources */,
 				27A7E6AF189975B2007FAF1C /* CloudantReplicationBase.m in Sources */,
 				27DFEEB718DB4A0D0052D487 /* Attachments.m in Sources */,
 			);
@@ -558,9 +572,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				27E75E8D18B383CB004317D1 /* CloudantReplicationBase+CompareDb.m in Sources */,
+				9FC2F13219F72B710032A074 /* ReplicatorURLProtocolTester.m in Sources */,
 				277992B918A24F0900BAB6ED /* ReplicationAcceptance+CRUD.m in Sources */,
 				27A7E6B218997677007FAF1C /* ReplicationAcceptance.m in Sources */,
 				9F1F14EE19870B88003E9F0B /* ReplicatorDelegates.m in Sources */,
+				9FC2F12D19F070710032A074 /* ReplicatorURLProtocol.m in Sources */,
 				27A7E6B0189975B2007FAF1C /* CloudantReplicationBase.m in Sources */,
 				27DFEEB818DB4A0D0052D487 /* Attachments.m in Sources */,
 			);

--- a/ReplicationAcceptance/ReplicationAcceptance/ReplicationAcceptance.h
+++ b/ReplicationAcceptance/ReplicationAcceptance/ReplicationAcceptance.h
@@ -9,6 +9,7 @@
 #import <SenTestingKit/SenTestingKit.h>
 
 #import "CloudantReplicationBase.h"
+#import "ReplicatorURLProtocol.h"
 
 @class CDTDatastore;
 @class CDTReplicatorFactory;

--- a/ReplicationAcceptance/ReplicationAcceptance/ReplicationAcceptance.m
+++ b/ReplicationAcceptance/ReplicationAcceptance/ReplicationAcceptance.m
@@ -18,6 +18,8 @@
 #import "CloudantReplicationBase+CompareDb.h"
 #import "ReplicationAcceptance+CRUD.h"
 #import "ReplicatorDelegates.h"
+#import "ReplicatorURLProtocol.h"
+#import "ReplicatorURLProtocolTester.h"
 
 #import "CDTDatastoreManager.h"
 #import "CDTDatastore.h"
@@ -46,7 +48,7 @@
  as all these documents are read from both local and remote databases
  during the check phase.
  */
-static NSUInteger n_docs = 1000;
+static NSUInteger n_docs = 10000;
 /**
  Rev tree size for "large rev tree" tests.
  */
@@ -932,5 +934,58 @@ static NSUInteger largeRevTreeSize = 1500;
     STAssertTrue(same, @"Remote and local databases differ");
 }
 
+/**
+ Test that we can successfully add extra headers to HTTP requests. 
+ */
+-(void)testCreateReplicationWithExtraHeaders
+{
+    
+    [self createRemoteDocs:100];
+    
+    CDTPullReplication *pull = [CDTPullReplication replicationWithSource:self.primaryRemoteDatabaseURL
+                                                                  target:self.datastore];
+
+    
+    NSString *userAgent = [NSString stringWithFormat:@"%@/testCreateReplicationWithExtraHeaders",
+                           [CDTAbstractReplication defaultUserAgentHTTPHeader]];
+    NSDictionary *extraHeaders = @{@"SpecialHeader": @"foo", @"user-agent":userAgent};
+    pull.optionalHeaders = extraHeaders;
+    
+    NSDictionary *pullDoc = [pull dictionaryForReplicatorDocument:nil];
+    STAssertEqualObjects(pullDoc[@"headers"][@"SpecialHeader"], @"foo", @"Bad headers: %@",
+                         pullDoc[@"headers"]);
+    
+    STAssertEqualObjects(pullDoc[@"headers"][@"user-agent"], userAgent, @"Bad headers: %@",
+                         pullDoc[@"headers"]);
+
+    
+    ReplicatorURLProtocolTester* tester = [[ReplicatorURLProtocolTester alloc] init];
+
+    tester.expectedHeaders = extraHeaders;
+    [ReplicatorURLProtocol setTestDelegate:tester];
+
+    [NSURLProtocol registerClass:[ReplicatorURLProtocol class]];
+
+    CDTReplicator *replicator =  [self.replicatorFactory oneWay:pull error:nil];
+    
+    [replicator startWithError:nil];
+    
+    while (replicator.isActive) {
+        [NSThread sleepForTimeInterval:0.5f];
+        NSLog(@" -> %@", [CDTReplicator stringForReplicatorState:replicator.state]);
+    }
+    
+    [NSURLProtocol unregisterClass:[ReplicatorURLProtocol class]];
+    [ReplicatorURLProtocol setTestDelegate:nil];
+    
+    STAssertNotNil(tester.headerFailures, @"Expect to contain failure with header: baz");
+    
+    for (NSString *headerName in tester.headerFailures) {
+        
+        STAssertTrue([tester.headerFailures[headerName] integerValue] != [@0 integerValue],
+                     @"Expected to find failures with the header \"%@\"", headerName);
+        
+    }
+}
 
 @end

--- a/ReplicationAcceptance/ReplicationAcceptance/ReplicatorURLProtocol.h
+++ b/ReplicationAcceptance/ReplicationAcceptance/ReplicatorURLProtocol.h
@@ -1,0 +1,16 @@
+//
+//  ReplicatorURLProtocol.h
+//  ReplicationAcceptance
+//
+//  Created by Adam Cox on 10/16/14.
+//
+//
+#import <Foundation/Foundation.h>
+#import <SenTestingKit/SenTestingKit.h>
+
+@class ReplicatorURLProtocolTester;
+
+@interface ReplicatorURLProtocol : NSURLProtocol
++(void)setTestDelegate:(ReplicatorURLProtocolTester*) delegate;
+@end
+

--- a/ReplicationAcceptance/ReplicationAcceptance/ReplicatorURLProtocol.m
+++ b/ReplicationAcceptance/ReplicationAcceptance/ReplicatorURLProtocol.m
@@ -1,0 +1,38 @@
+//
+//  ReplicatorURLProtocol.m
+//  ReplicationAcceptance
+//
+//  Created by Adam Cox on 10/16/14.
+//
+//
+
+#import "ReplicatorURLProtocol.h"
+#import "ReplicatorURLProtocolTester.h"
+
+static ReplicatorURLProtocolTester* gReplicatorTester = nil;
+
+@implementation ReplicatorURLProtocol
+
++ (BOOL)canInitWithRequest:(NSURLRequest *)request {
+    // Capture all of the GET, PUT and POST calls
+    // This protocol must be registered just before replication
+    // and then unregistered immediately after the test. We then assume all HTTP
+    // calls captured here are for execution of the replication.
+    
+    NSString *httpmethod = [request HTTPMethod];
+    
+    if ( ([httpmethod isEqualToString:@"GET"] || [httpmethod isEqualToString:@"PUT"] ||
+        [httpmethod isEqualToString:@"POST"]) &&  gReplicatorTester) {
+        
+        [gReplicatorTester runTestForRequest:request];
+
+    }
+    return NO;
+}
+
++(void)setTestDelegate:(ReplicatorURLProtocolTester*) delegate
+{
+    gReplicatorTester = delegate;
+}
+
+@end

--- a/ReplicationAcceptance/ReplicationAcceptance/ReplicatorURLProtocolTester.h
+++ b/ReplicationAcceptance/ReplicationAcceptance/ReplicatorURLProtocolTester.h
@@ -1,0 +1,15 @@
+//
+//  ReplicatorURLProtocolTester.h
+//  ReplicationAcceptance
+//
+//  Created by Adam Cox on 10/21/14.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+@interface ReplicatorURLProtocolTester : NSObject 
+@property (nonatomic, strong) NSDictionary *expectedHeaders;
+@property (nonatomic, readonly) NSMutableDictionary *headerFailures;
+-(void) runTestForRequest:(NSURLRequest*)request;
+@end

--- a/ReplicationAcceptance/ReplicationAcceptance/ReplicatorURLProtocolTester.m
+++ b/ReplicationAcceptance/ReplicationAcceptance/ReplicatorURLProtocolTester.m
@@ -1,0 +1,43 @@
+//
+//  ReplicatorURLProtocolTester.m
+//  ReplicationAcceptance
+//
+//  Created by Adam Cox on 10/21/14.
+//
+//
+
+#import "ReplicatorURLProtocolTester.h"
+
+@interface ReplicatorURLProtocolTester()
+@property (nonatomic, readwrite) NSMutableDictionary *headerFailures;
+@end
+
+
+@implementation ReplicatorURLProtocolTester
+
+-(void) runTestForRequest:(NSURLRequest*)request
+{
+    for (NSString* name in self.expectedHeaders) {
+        NSString *httpValue = [request valueForHTTPHeaderField:name];
+        
+        if (![httpValue isEqualToString:self.expectedHeaders[name]]) {
+            
+            if (!self.headerFailures) {
+                self.headerFailures = [[NSMutableDictionary alloc] init];
+            }
+
+            if (self.headerFailures[name]) {
+                NSInteger number = [[self.headerFailures objectForKey:name] integerValue];
+                number+=1;
+                self.headerFailures[name] = @(number);
+            }
+            else {
+                self.headerFailures[name] = @1;
+            }
+        }
+        
+    }
+}
+
+
+@end

--- a/Tests/Tests/CDTReplicationTests.m
+++ b/Tests/Tests/CDTReplicationTests.m
@@ -295,5 +295,70 @@
     
 }
 
+-(CDTPullReplication*)createPullReplicationWithHeaders:(NSDictionary *)optionalHeaders
+{
+    NSString *remoteUrl = @"https://adam:cox@myaccount.cloudant.com/mydb";
+    
+    CDTDatastore *tmp = [self.factory datastoreNamed:@"test_database" error:nil];
+    CDTPullReplication *pull = [CDTPullReplication replicationWithSource:[NSURL URLWithString:remoteUrl]
+                                                                  target:tmp];
+    
+    pull.optionalHeaders = optionalHeaders;
+
+    return pull;
+}
+
+-(void)testForProhibitedOptionalReplicationHeaders
+{
+    CDTPullReplication *pull;
+    NSError *error;
+    NSDictionary *pullDoc;
+    NSDictionary *optionalHeaders;
+    
+    optionalHeaders = @{@"User-Agent": @"My Agent"};
+    pull = [self createPullReplicationWithHeaders:optionalHeaders];
+    error = nil;
+    pullDoc = [pull dictionaryForReplicatorDocument:&error];
+    STAssertNotNil(pullDoc, @"CDTPullReplication -dictionaryForReplicatorDocument failed with "
+                   @"header: %@", optionalHeaders);
+    
+    STAssertTrue([pullDoc[@"headers"][@"User-Agent"] isEqualToString:@"My Agent"],
+                 @"Bad headers: %@", pullDoc[@"headers"]);
+    
+    
+    NSArray *prohibitedUpperArray = @[@"Authorization", @"WWW-Authenticate", @"Host",
+                                  @"Connection", @"Content-Type", @"Accept",
+                                  @"Content-Length"];
+    
+    NSMutableArray *prohibitedLowerArray = [[NSMutableArray alloc] init];
+    
+    for (NSString *header in prohibitedUpperArray) {
+        [prohibitedLowerArray addObject:[header lowercaseString]];
+    }
+    
+    for (NSString* prohibitedHeader in prohibitedUpperArray) {
+        optionalHeaders = @{prohibitedHeader: @"some value"};
+        pull = [self createPullReplicationWithHeaders:optionalHeaders];
+        error = nil;
+        pullDoc = [pull dictionaryForReplicatorDocument:&error];
+        STAssertNil(pullDoc, @"CDTPullReplication -dictionaryForReplicatorDocument passed with "
+                       @"header: %@, pullDoc: %@", optionalHeaders, pullDoc);
+        STAssertNotNil(error, @"Error was not set");
+        STAssertEquals(error.code, CDTReplicationErrorProhibitedOptionalHttpHeader,
+                       @"Wrote error code: %@", error.code);
+    }
+    //make sure the lower case versions fail too
+    for (NSString* prohibitedHeader in prohibitedLowerArray) {
+        optionalHeaders = @{prohibitedHeader: @"some value"};
+        pull = [self createPullReplicationWithHeaders:optionalHeaders];
+        error = nil;
+        pullDoc = [pull dictionaryForReplicatorDocument:&error];
+        STAssertNil(pullDoc, @"CDTPullReplication -dictionaryForReplicatorDocument passed with "
+                    @"header: %@, pullDoc: %@", optionalHeaders, pullDoc);
+        STAssertNotNil(error, @"Error was not set");
+        STAssertEquals(error.code, CDTReplicationErrorProhibitedOptionalHttpHeader,
+                       @"Wrote error code: %@", error.code);
+    }
+}
 
 @end


### PR DESCRIPTION
Allows one to set optional HTTP headers for replication during the configuration
of the CDTPull/PushReplication objects.

Fixes a bug in TD_DatabaseManager.m that prevented headers to be set via
the 'properties' NSDictionary object used to create TDReplicator objects.

Adds tests for HTTP headers during replication

ReplicatorURLProtocol inherits from NSURLProtocol and is
a registered URL request in order to gain access to all
NSURLRequests made during replication.
This class does not manipulate or handle the HTTP requests, but
it does pass the NSURLRequest to a delegate to object that
tests the headers.
