### PR TITLE
Added .clang-format file

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,17 @@
+BasedOnStyle: Google
+ColumnLimit: 100
+IndentWidth: 4
+UseTab: Never
+BreakBeforeBraces: Linux
+BreakBeforeBinaryOperators: false
+KeepEmptyLinesAtTheStartOfBlocks: false
+ObjCSpaceAfterProperty: true
+ObjCSpaceBeforeProtocolList: true
+PointerBindsToType: false
+SpacesBeforeTrailingComments: 2
+SpaceBeforeParens: ControlStatements
+TabWidth: 4
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+AllowShortBlocksOnASingleLine: false
+MaxEmptyLinesToKeep: 1
+ObjCSpaceAfterProperty: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,8 @@ sudo gem install xcpretty
 
 ## Coding guidelines
 
-The house style is [documented](doc/style-guide.md).
+The house style is [documented](doc/style-guide.md). There's information there on using
+`clang-format` to automatically use the right format.
 
 ## Getting started with the project
 

--- a/doc/style-guide.md
+++ b/doc/style-guide.md
@@ -15,6 +15,37 @@ about style; Apple's guidelines cover the essentials of naming.
 - The [Google guidelines](http://google-styleguide.googlecode.com/svn/trunk/objcguide.xml).
 - [NYT Guidelines](https://github.com/NYTimes/objective-c-style-guide)
 
+## Automating
+
+Code style for CDTDatastore is defined with a clang format file (.clang-format) in the 
+root of the project. All code should be formatted using the clang-format tool. 
+
+### Installing clang-format into Xcode
+
+Clang-format should be installed into xcode using the 
+[ClangFormat-Xcode](https://github.com/travisjeffery/ClangFormat-Xcode) plug-in, 
+the easiest way to do this is via [Alcatraz](https://github.com/mneorr/Alcatraz). 
+You can also install the plugin from source using the instractions at 
+[ClangFormat-Xcode](https://github.com/travisjeffery/ClangFormat-Xcode).
+
+#### Setting up Xcode
+
+We suggest Xcode should be set up to use clang-format to format code on save, 
+and map the format command to `ctrl-i`
+
+- Setting clang-format to run on save 
+
+
+In the menu, open Edit > Clang Format > Click Format on save (a checkmark 
+appears in this menu item indicicating that the feature is active.)
+
+- Assign keyboard shortcut
+
+- Open the System Preferences > Keyboard > Shortcuts > App Shortcuts > Click `+`
+- Set the application to be Xcode
+- Set the menu title to "Format File in Focus"
+- Set your shortcut to `ctrl-i`
+
 ## Mechanics
 
 Your editor can be set up to enforce some of these.


### PR DESCRIPTION
Added .clang-format to specify the code format for the project.
It relies on the tool clang-format. clang-format is not shipped
in xcode command line tools. To use clang-format inside xcode
download and install clangformat-xcode
https://github.com/travisjeffery/ClangFormat-Xcode

Updated contirbuting to add insturctions on setting up
xcode to use clang-format
