### PR TITLE
Fixes the example app to use the new CDTReplicatorFactory.

### DIFF
--- a/Project/Project/CDTAppDelegate.m
+++ b/Project/Project/CDTAppDelegate.m
@@ -83,7 +83,6 @@
 {
     // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
 
-    [self.replicatorFactory stop];
 }
 
 /**
@@ -133,11 +132,6 @@
 
     self.replicatorFactory = [[CDTReplicatorFactory alloc] initWithDatastoreManager:manager];
 
-    __weak CDTAppDelegate *weakSelf = self;
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        [weakSelf.replicatorFactory start];
-    });
-    
     CDTDatastore *datastore = [manager datastoreNamed:@"todo_items" error:&outError];
 
     if (nil != outError) {

--- a/Project/Project/CDTTodoReplicator.m
+++ b/Project/Project/CDTTodoReplicator.m
@@ -103,7 +103,13 @@
     [self log:@"%@ state: %@ (%d)", label, state, replicator.state];
 
     [replicator setDelegate:self];
-    [replicator start];
+    NSError *error;
+    if (![replicator startWithError:&error]) {
+        [self log:@"error starting %@ replicator: %@", label, error];
+        state = [CDTReplicator stringForReplicatorState:replicator.state];
+        [self log:@"%@ state: %@ (%d)", label, state, replicator.state];
+        return;
+    }
 
     state = [CDTReplicator stringForReplicatorState:replicator.state];
     [self log:@"%@ state: %@ (%d)", label, state, replicator.state];


### PR DESCRIPTION
The the CDTReplicatorFactory -start and -stop methods have been deprecated.

Also, the example app now uses the CDTReplictor -startWithError method.

This fixes the compile error in issue 92: https://github.com/cloudant/CDTDatastore/issues/92
