### PR TITLE
Mutablecopy on a mutablecopy

### DIFF
--- a/Classes/common/CDTMutableDocumentRevision.m
+++ b/Classes/common/CDTMutableDocumentRevision.m
@@ -59,4 +59,10 @@
     self.private_attachments = [attachments mutableCopy];
 }
 
+-(CDTMutableDocumentRevision*) mutableCopy{
+    CDTMutableDocumentRevision * copy = [super mutableCopy];
+    copy.sourceRevId = self.sourceRevId;
+    return copy;
+}
+
 @end


### PR DESCRIPTION
When calling mutableCopy on CDTMutableDocumentRevision a mutable copy
with a a source rev set to the same source rev as the instance of
CDTMutableDocumentRevision which is being copied.
