### PR TITLE
Remove variable define from header

### DIFF
--- a/CDTDatastore.xcworkspace/contents.xcworkspacedata
+++ b/CDTDatastore.xcworkspace/contents.xcworkspacedata
@@ -379,6 +379,9 @@
          <FileRef
             location = "group:CDTLogging.h">
          </FileRef>
+         <FileRef
+            location = "group:CDTLogging.m">
+         </FileRef>
       </Group>
       <Group
          location = "group:Classes/ios"

--- a/Classes/common/CDTLogging.h
+++ b/Classes/common/CDTLogging.h
@@ -29,26 +29,26 @@
 #define CDTTD_JSON_CONTEXT 15
 #define CDTTD_VIEW_CONTEXT 16
 
-#define START_CONTEXT CDTINDEX_LOG_CONTEXT
-#define END_CONTEXT CDTTD_VIEW_CONTEXT
+#define CDTSTART_CONTEXT CDTINDEX_LOG_CONTEXT
+#define CDTEND_CONTEXT CDTTD_VIEW_CONTEXT
 
-static DDLogLevel CDTLoggingLevels[] = {[0 ... END_CONTEXT - START_CONTEXT] = DDLogLevelOff};
+extern DDLogLevel CDTLoggingLevels[];
 
 #define CDTLogError(context, frmt, ...)                                                    \
-    LOG_MAYBE(NO, CDTLoggingLevels[context - START_CONTEXT], DDLogFlagError, context, nil, \
+    LOG_MAYBE(NO, CDTLoggingLevels[context - CDTSTART_CONTEXT], DDLogFlagError, context, nil, \
               __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
 #define CDTLogWarn(context, frmt, ...)                                                        \
-    LOG_MAYBE(YES, CDTLoggingLevels[context - START_CONTEXT], DDLogFlagWarning, context, nil, \
+    LOG_MAYBE(YES, CDTLoggingLevels[context - CDTSTART_CONTEXT], DDLogFlagWarning, context, nil, \
               __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
 #define CDTLogInfo(context, frmt, ...)                                                     \
-    LOG_MAYBE(YES, CDTLoggingLevels[context - START_CONTEXT], DDLogFlagInfo, context, nil, \
+    LOG_MAYBE(YES, CDTLoggingLevels[context - CDTSTART_CONTEXT], DDLogFlagInfo, context, nil, \
               __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
 #define CDTLogDebug(context, frmt, ...)                                                     \
-    LOG_MAYBE(YES, CDTLoggingLevels[context - START_CONTEXT], DDLogFlagDebug, context, nil, \
+    LOG_MAYBE(YES, CDTLoggingLevels[context - CDTSTART_CONTEXT], DDLogFlagDebug, context, nil, \
               __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
 #define CDTLogVerbose(context, frmt, ...)                                                     \
-    LOG_MAYBE(YES, CDTLoggingLevels[context - START_CONTEXT], DDLogFlagVerbose, context, nil, \
+    LOG_MAYBE(YES, CDTLoggingLevels[context - CDTSTART_CONTEXT], DDLogFlagVerbose, context, nil, \
               __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
-#define CDTChangeLogLevel(context, logLevel) CDTLoggingLevels[context - START_CONTEXT] = logLevel
+#define CDTChangeLogLevel(context, logLevel) CDTLoggingLevels[context - CDTSTART_CONTEXT] = logLevel
 
 #endif

--- a/Classes/common/CDTLogging.m
+++ b/Classes/common/CDTLogging.m
@@ -1,0 +1,21 @@
+//
+//  CDTLogging.m
+//  CloudantSync
+//  
+//
+//  Created by Rhys Short on 09/12/2014.
+//  Copyright (c) 2013 Cloudant. All rights reserved.
+//
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+
+#import "CDTLogging.h"
+
+DDLogLevel CDTLoggingLevels[] = {[0 ... CDTEND_CONTEXT - CDTSTART_CONTEXT] = DDLogLevelOff};

--- a/Tests/Tests/CloudantTests.m
+++ b/Tests/Tests/CloudantTests.m
@@ -14,10 +14,13 @@
 
 + (void)initialize
 {
-        [DDLog addLogger:[DDTTYLogger sharedInstance]];
-        for (int i = 0; i < sizeof(CDTLoggingLevels); i++) {
-            CDTLoggingLevels[i] = DDLogLevelAll;
-        }
+    [DDLog addLogger:[DDTTYLogger sharedInstance]];
+    CDTChangeLogLevel(CDTINDEX_LOG_CONTEXT, DDLogLevelWarning);
+    CDTChangeLogLevel(CDTREPLICATION_LOG_CONTEXT, DDLogLevelWarning);
+    CDTChangeLogLevel(CDTDATASTORE_LOG_CONTEXT, DDLogLevelWarning);
+    CDTChangeLogLevel(CDTDOCUMENT_REVISION_LOG_CONTEXT, DDLogLevelWarning);
+    CDTChangeLogLevel(CDTTD_REMOTE_REQUEST_CONTEXT, DDLogLevelWarning);
+    CDTChangeLogLevel(CDTTD_JSON_CONTEXT, DDLogLevelWarning);
 }
 
 @end


### PR DESCRIPTION
Remove variable define from header, into a seperate .m file
leaving only a declaration.

Modify tests to set up logging using macros.
