### PR TITLE
42444 Updates the example app to use CDTReplicators properly.

### DIFF
--- a/Project/Project/CDTAppDelegate.h
+++ b/Project/Project/CDTAppDelegate.h
@@ -18,12 +18,14 @@
 @class CDTDatastore;
 @class CDTIndexManager;
 @class CDTReplicatorFactory;
+@class CDTTodoReplicator;
 
 @interface CDTAppDelegate : UIResponder <UIApplicationDelegate>
 
 @property (nonatomic, strong) CDTDatastore *datastore;
 @property (nonatomic, strong) CDTIndexManager *indexManager;
 @property (nonatomic, strong) CDTReplicatorFactory *replicatorFactory;
+@property (nonatomic, strong) CDTTodoReplicator *todoReplicator;
 
 @property (strong, nonatomic) UIWindow *window;
 

--- a/Project/Project/CDTTodoReplicator.m
+++ b/Project/Project/CDTTodoReplicator.m
@@ -15,9 +15,7 @@
 //
 
 #import "CDTTodoReplicator.h"
-
 #import "CDTAppDelegate.h"
-
 
 @interface CDTTodoReplicator ()
 
@@ -25,10 +23,20 @@
 -(NSURL*)replicatorURL;
 -(void)startAndFollowReplicator:(CDTReplicator*)replicator label:(NSString*)label;
 
+@property (nonatomic, strong) NSMutableArray *replicators; //array of CDTReplicators
+
 @end
 
 @implementation CDTTodoReplicator
 
+-(id) init
+{
+    self = [super init];
+    if (self) {
+        _replicators = [[NSMutableArray alloc] init];
+    }
+    return self;
+}
 
 -(NSURL*)replicatorURL {
     // Shared database for demo purposes -- anyone can put stuff here...
@@ -71,9 +79,16 @@
 
     CDTAppDelegate *delegate = (CDTAppDelegate *)[[UIApplication sharedApplication] delegate];
     CDTReplicatorFactory *factory = delegate.replicatorFactory;
-    CDTReplicator *replicator = [factory onewaySourceURI:url targetDatastore:delegate.datastore];
-
-    [self startAndFollowReplicator:replicator label:@"pull"];
+    CDTPullReplication * replicationConfig = [CDTPullReplication replicationWithSource:url
+                                                                                target:delegate.datastore];
+    NSError *error;
+    CDTReplicator *aPullReplicator = [factory oneWay:replicationConfig error:&error];
+    if (!aPullReplicator) {
+        [self log:@"Error creating pull replicator: %@", error];
+    }
+    else {
+        [self startAndFollowReplicator:aPullReplicator label:@"pull"];
+    }
 }
 
 -(void)pushReplication
@@ -84,18 +99,22 @@
 
     CDTAppDelegate *delegate = (CDTAppDelegate *)[[UIApplication sharedApplication] delegate];
     CDTReplicatorFactory *factory = delegate.replicatorFactory;
-    CDTReplicator *replicator = [factory onewaySourceDatastore:delegate.datastore targetURI:url];
-
-    [self startAndFollowReplicator:replicator label:@"push"];
+    CDTPushReplication *replicationConfig = [CDTPushReplication replicationWithSource:delegate.datastore
+                                                                               target:url];
+    NSError *error;
+    CDTReplicator *aPushReplicator = [factory oneWay:replicationConfig error:&error];
+    if (!aPushReplicator) {
+        [self log:@"Error creating push replicator: %@", error];
+    }
+    else {
+        [self startAndFollowReplicator:aPushReplicator label:@"push"];
+    }
 }
-
 /**
- Starts a replication and waits for it to complete using polling.
+ Starts a replication and sets self as the delegate
  
- Also adds this class as a listener to demo that functionality. In real
- apps, you'd probably use the replicatorDidComplete: and replicatorDidError:
- callbacks to do something useful, updating the UI or showing an error for
- example.
+ In real apps, you'd probably use the replicatorDidComplete: and replicatorDidError:
+ callbacks to do something useful, updating the UI or showing an error for example.
  */
 -(void)startAndFollowReplicator:(CDTReplicator*)replicator label:(NSString*)label {
 
@@ -103,6 +122,7 @@
     [self log:@"%@ state: %@ (%d)", label, state, replicator.state];
 
     [replicator setDelegate:self];
+
     NSError *error;
     if (![replicator startWithError:&error]) {
         [self log:@"error starting %@ replicator: %@", label, error];
@@ -111,28 +131,9 @@
         return;
     }
 
-    state = [CDTReplicator stringForReplicatorState:replicator.state];
-    [self log:@"%@ state: %@ (%d)", label, state, replicator.state];
-
-    __weak CDTTodoReplicator *weakSelf = self;
-
-    dispatch_sync(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        while ([replicator isActive]) {
-            [NSThread sleepForTimeInterval:2.0f];
-
-            NSString *state = [CDTReplicator stringForReplicatorState:replicator.state];
-            [weakSelf log:@"%@ state: %@ (%d)", label, state, replicator.state];
-        }
-
-        NSString *state = [CDTReplicator stringForReplicatorState:replicator.state];
-        [weakSelf log:@"%@ state: %@ (%d)", label, state, replicator.state];
-
-        if (replicator.state == CDTReplicatorStateComplete || replicator.state == CDTReplicatorStateStopped) {
-            [weakSelf replicatorDidComplete:replicator];
-        } else if (replicator.state == CDTReplicatorStateError) {
-            [weakSelf replicatorDidError:replicator info:nil];
-        }
-    });
+    @synchronized(self){
+        [self.replicators addObject:replicator];
+    }
 }
 
 -(void)log:(NSString*)format, ... {
@@ -144,14 +145,40 @@
     NSLog(@"%@", message);
 }
 
-#pragma mark CDTReplicatorListener delegate
 
--(void)replicatorDidComplete:(CDTReplicator *)replicator {
-    [self log:@"complete"];
+#pragma mark CDTReplicatorDelegate
+
+-(void)replicatorDidComplete:(CDTReplicator *)replicator
+{
+    
+    [self log:@"%@ complete", replicator];
+    @synchronized(self){
+        [self.replicators removeObject:replicator];
+    }
 }
 
--(void)replicatorDidError:(CDTReplicator *)replicator info:(NSError *)info {
-    [self log:@"error: %@", info];
+-(void)replicatorDidError:(CDTReplicator *)replicator info:(NSError *)info
+{
+    
+    [self log:@"%@ error: %@", replicator, info];
+    @synchronized(self) {
+        [self.replicators removeObject:replicator];
+    }
+}
+
+-(void)replicatorDidChangeState:(CDTReplicator *)replicator
+{
+
+    NSString *state = [CDTReplicator stringForReplicatorState:replicator.state];
+    [self log:@"%@ new state: %@ (%d)", replicator, state, replicator.state];
+}
+
+-(void)replicatorDidChangeProgress:(CDTReplicator *)replicator
+{
+
+    NSString *state = [CDTReplicator stringForReplicatorState:replicator.state];
+    [self log:@"%@ changes total %ld. changes processed %ld. state: %@ (%d)", replicator,
+     replicator.changesTotal, replicator.changesProcessed, state, replicator.state];
 }
 
 @end

--- a/Project/Project/CDTViewController.m
+++ b/Project/Project/CDTViewController.m
@@ -24,6 +24,7 @@
 @interface CDTViewController ()
 
 @property (readonly) CDTDatastore *datastore;
+@property (readonly) CDTTodoReplicator *todoReplicator;
 @property (nonatomic,strong) NSArray *taskRevisions;
 @property (nonatomic,readonly) BOOL showOnlyCompleted;
 
@@ -153,6 +154,11 @@
     return delegate.datastore;
 }
 
+-(CDTTodoReplicator *)todoReplicator {
+    CDTAppDelegate *delegate = (CDTAppDelegate *)[[UIApplication sharedApplication] delegate];
+    return delegate.todoReplicator;
+}
+
 -(BOOL)showOnlyCompleted {
     return self.showCompletedSegmentedControl.selectedSegmentIndex != 0;
 }
@@ -180,7 +186,7 @@
     NSLog(@"Replicate");
 
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        [[[CDTTodoReplicator alloc] init] sync];
+        [self.todoReplicator sync];
         dispatch_async(dispatch_get_main_queue(), ^{
             [self reloadTasks];
             [self.tableView reloadData];


### PR DESCRIPTION
Updates the example app to show best-practices
around using CDTReplicators. CDTReplicators must be retained
in order for their replciation to complete. In this example,
they are held in an array. The CDTTodoReplicator class
becomes the delegate for each of the CDTReplicator objects it
creates. It reports on the status of the replication via
the callbacks and releases the CDTReplicator objects when they
either 'complete' or 'error' (in both cases, the CDTReplicator
has stopped operations).

The polling block has been removed. Previously, this polling
block was keeping the strong reference to the CDTReplicator,
but is no longer needed and also not encouraged.

The CDTTodoReplicator now uses the new CDTPush/PullReplication
configuration and the CDTReplicatorFactor -oneWay:error method
to build CDTReplicator objects, as the CDTReplicatorFactory
-onewaySourceDatastore:targetURI and
-onewaySourceURI:targetDatastore are deprecated.

Additionally, the CDTAppDelegate now keeps a persistent
CDTTodoReplicator object, which the CDTViewController uses to
fire off synchronization. A long-lived object that manages
and maintains individual CDTReplicator objects is necessary.