### PR TITLE
Implement listDatastores method

### DIFF
--- a/Classes/common/CDTDatastoreManager.h
+++ b/Classes/common/CDTDatastoreManager.h
@@ -64,4 +64,11 @@ extern NSString *const CDTDatastoreErrorDomain;
  */
 - (BOOL)deleteDatastoreNamed:(NSString *)name error:(NSError *__autoreleasing *)error;
 
+/**
+ 
+ Returns an array of datastore names (NSString) that are managed by this CDTDatastoreManager.
+ 
+ */
+- (NSArray* /* NSString */)allDatastores;
+
 @end

--- a/Classes/common/CDTDatastoreManager.m
+++ b/Classes/common/CDTDatastoreManager.m
@@ -96,4 +96,9 @@ NSString *const CDTExtensionsDirName = @"_extensions";
     }
 }
 
+- (NSArray* /* NSString */) allDatastores
+{
+    return [self.manager allDatabaseNames];
+}
+
 @end

--- a/Tests/Tests.xcodeproj/project.pbxproj
+++ b/Tests/Tests.xcodeproj/project.pbxproj
@@ -38,6 +38,8 @@
 		989E6E23198799AE00FB8510 /* DatastoreCRUD.m in Sources */ = {isa = PBXBuildFile; fileRef = 989E6E21198799AE00FB8510 /* DatastoreCRUD.m */; };
 		98BB740019E5927600C57866 /* CloudantTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98BB73FF19E5927600C57866 /* CloudantTests.m */; };
 		98BB740119E5927600C57866 /* CloudantTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98BB73FF19E5927600C57866 /* CloudantTests.m */; };
+		98DDEB9F1A41CD3400767178 /* DatastoreManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98DDEB9E1A41CD3400767178 /* DatastoreManagerTests.m */; };
+		98DDEBA01A41CD3400767178 /* DatastoreManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98DDEB9E1A41CD3400767178 /* DatastoreManagerTests.m */; };
 		9985C74919AE5D8300636AB6 /* CDTQueryBuilderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9985C74819AE5D8300636AB6 /* CDTQueryBuilderTests.m */; };
 		9F0D23E918888C6C00D3D04E /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F0D23E818888C6C00D3D04E /* Foundation.framework */; };
 		9F0D23F1188B4FA900D3D04E /* TDMultipartReaderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F0D23F0188B4FA900D3D04E /* TDMultipartReaderTests.m */; };
@@ -107,6 +109,7 @@
 		989E6E21198799AE00FB8510 /* DatastoreCRUD.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DatastoreCRUD.m; sourceTree = "<group>"; };
 		98BB73FE19E5927600C57866 /* CloudantTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CloudantTests.h; sourceTree = "<group>"; };
 		98BB73FF19E5927600C57866 /* CloudantTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CloudantTests.m; sourceTree = "<group>"; };
+		98DDEB9E1A41CD3400767178 /* DatastoreManagerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DatastoreManagerTests.m; sourceTree = "<group>"; };
 		9985C74819AE5D8300636AB6 /* CDTQueryBuilderTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTQueryBuilderTests.m; sourceTree = "<group>"; };
 		9A7D07FED5506284BDC1ACC8 /* Pods-osx.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-osx.debug.xcconfig"; path = "Pods/Target Support Files/Pods-osx/Pods-osx.debug.xcconfig"; sourceTree = "<group>"; };
 		9E965C9FF72A8429FFFF4E1F /* Pods-ios.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ios.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ios/Pods-ios.debug.xcconfig"; sourceTree = "<group>"; };
@@ -198,6 +201,7 @@
 			isa = PBXGroup;
 			children = (
 				98BB73FE19E5927600C57866 /* CloudantTests.h */,
+				98DDEB9E1A41CD3400767178 /* DatastoreManagerTests.m */,
 				98BB73FF19E5927600C57866 /* CloudantTests.m */,
 				27D96E3318E0996C00DEA006 /* Attachments */,
 				9985C74819AE5D8300636AB6 /* CDTQueryBuilderTests.m */,
@@ -487,6 +491,7 @@
 				9FC082981913378F0024EA1E /* DatastoreConflictResolvers.m in Sources */,
 				9F0D23FA188DF36800D3D04E /* TD_DatabaseTests.m in Sources */,
 				985F84D4198BD3A4004D8713 /* AttachmentCRUD.m in Sources */,
+				98DDEB9F1A41CD3400767178 /* DatastoreManagerTests.m in Sources */,
 				9F4E646B19DC815B00FE37E1 /* CDTReplicationTests.m in Sources */,
 				98BB740019E5927600C57866 /* CloudantTests.m in Sources */,
 				9F0D2402188DFE8600D3D04E /* TD_RevisionTests.m in Sources */,
@@ -521,6 +526,7 @@
 				9FC082991913378F0024EA1E /* DatastoreConflictResolvers.m in Sources */,
 				9F0D23FB188DF36800D3D04E /* TD_DatabaseTests.m in Sources */,
 				9F0D2403188DFE8600D3D04E /* TD_RevisionTests.m in Sources */,
+				98DDEBA01A41CD3400767178 /* DatastoreManagerTests.m in Sources */,
 				9F4E646C19DC815B00FE37E1 /* CDTReplicationTests.m in Sources */,
 				98BB740119E5927600C57866 /* CloudantTests.m in Sources */,
 				985A188B19D2CCEB000283E9 /* DatastoreConflicts.m in Sources */,

--- a/Tests/Tests/DatastoreManagerTests.m
+++ b/Tests/Tests/DatastoreManagerTests.m
@@ -1,0 +1,64 @@
+//
+//  DatastoreManagerTests.m
+//  Tests
+//
+//  Created by Rhys Short on 17/12/2014.
+//
+//
+
+#import <Foundation/Foundation.h>
+#import <CloudantSync.h>
+#import "CloudantSyncTests.h"
+
+@interface DatastoreManagerTests : CloudantSyncTests
+
+@end
+
+@implementation DatastoreManagerTests
+
+
+
+- (void)testList5Datastores {
+    
+    NSArray * array = @[@"datastore0",@"datastore1",@"datastore2",@"datastore3",@"datastore4"];
+    
+    for(NSString * dsName in array){
+        [self.factory datastoreNamed:dsName error:nil];
+    }
+    
+    NSArray * datastores = [self.factory allDatastores];
+    STAssertEquals((NSUInteger)5, [datastores count],
+                   @"Wrong number of datastores returned, expected 5 got %d",
+                   [datastores count]);
+    
+    for(NSString * dsname in array){
+        STAssertTrue([datastores containsObject:dsname], @"Object missing from datastores list");
+    }
+    
+}
+
+- (void) testListDatastoresWithSlash {
+    
+    [self.factory datastoreNamed:@"adatabase/withaslash" error:nil];
+    NSArray * datastores = [self.factory allDatastores];
+    STAssertEquals((NSUInteger)1,
+                   [datastores count],
+                   @"Wrong number of datastores returned, expected 1 got %d",
+                   [datastores count]);
+    STAssertEqualObjects(@"adatabase/withaslash",
+                         [datastores objectAtIndex:0],
+                         @"Datastore names do not match");
+    
+}
+
+-(void) testListEmptyDatastores {
+    NSArray * datastores = [self.factory allDatastores];
+    STAssertEquals((NSUInteger)0, [datastores count],
+                   @"Wrong number of datastores returned, expected 0 got %d",
+                   [datastores count]);
+
+}
+
+@end
+
+


### PR DESCRIPTION
Implement listDatastores method on CDTDatastoreManager. Returns an
array of strings contain the name of datastores managed by this db
