### PR TITLE
Cleans credentials from log messages.

### DIFF
--- a/Classes/common/CDTReplicator/CDTAbstractReplication.m
+++ b/Classes/common/CDTReplicator/CDTAbstractReplication.m
@@ -127,12 +127,6 @@ NSString *const CDTReplicationErrorDomain = @"CDTReplicationErrorDomain";
     return [NSDictionary dictionaryWithDictionary:doc];
 }
 
-- (NSString *)description
-{
-    return [NSString
-        stringWithFormat:@"Replicator Doc: %@", [self dictionaryForReplicatorDocument:nil]];
-}
-
 - (BOOL)validateRemoteDatastoreURL:(NSURL *)url error:(NSError *__autoreleasing *)error
 {
     NSString *scheme = [url.scheme lowercaseString];

--- a/Classes/common/CDTReplicator/CDTPullReplication.m
+++ b/Classes/common/CDTReplicator/CDTPullReplication.m
@@ -16,6 +16,7 @@
 #import "CDTPullReplication.h"
 #import "CDTDatastore.h"
 #import "CDTLogging.h"
+#import "TDMisc.h"
 
 @interface CDTPullReplication ()
 @property (nonatomic, strong, readwrite) CDTDatastore *target;
@@ -49,6 +50,13 @@
     }
 
     return copy;
+}
+
+- (NSString *)description
+{
+    NSMutableDictionary *dictionary = [[self dictionaryForReplicatorDocument:nil] mutableCopy];
+    dictionary[@"source"] = TDCleanURLtoString(self.source);
+    return [NSString stringWithFormat:@"%@: %@", [self class], dictionary];
 }
 
 - (NSDictionary *)dictionaryForReplicatorDocument:(NSError *__autoreleasing *)error

--- a/Classes/common/CDTReplicator/CDTPushReplication.m
+++ b/Classes/common/CDTReplicator/CDTPushReplication.m
@@ -53,6 +53,13 @@
     return copy;
 }
 
+- (NSString *)description
+{
+    NSMutableDictionary *dictionary = [[self dictionaryForReplicatorDocument:nil] mutableCopy];
+    dictionary[@"target"] = TDCleanURLtoString(self.target);
+    return [NSString stringWithFormat:@"%@: %@", [self class], dictionary];
+}
+
 - (NSDictionary *)dictionaryForReplicatorDocument:(NSError *__autoreleasing *)error
 {
     NSError *localError;

--- a/Classes/common/CDTReplicator/CDTReplicator.m
+++ b/Classes/common/CDTReplicator/CDTReplicator.m
@@ -105,27 +105,9 @@ static NSString *const CDTReplicatorErrorDomain = @"CDTReplicatorErrorDomain";
         //report error
         NSError *deallocError;
         
-        NSString *replicationType;
-        NSString *source;
-        NSString *target;
-        
-        if ( [self.tdReplicator isPush] ) {
-            replicationType = @"push" ;
-            source = self.tdReplicator.db.name;
-            target = [self cleanRemote];
-        }
-        else {
-            replicationType = @"pull" ;
-            source = [self cleanRemote];
-            target = self.tdReplicator.db.name;
-        }
-        
         NSString *message = [NSString stringWithFormat: @"Object deallocated before completed "
                              @"replication. Keep a strong reference to the replicator object to "
-                             @"avoid this.\n CDTReplicator %@, source: %@, target: %@ "
-                             @"filter name: %@, filter parameters %@, unique replication session "
-                             @"ID: %@", replicationType, source, target, self.tdReplicator.filterName,
-                             self.tdReplicator.filterParameters, self.tdReplicator.sessionID];
+                             @"avoid this.\n %@", self];
         
         NSDictionary *userInfo = @{
                                    NSLocalizedDescriptionKey :
@@ -143,12 +125,32 @@ static NSString *const CDTReplicatorErrorDomain = @"CDTReplicatorErrorDomain";
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
-- (NSString*) cleanRemote
+- (NSString*) description
 {
-    NSURL *remote = self.tdReplicator.remote;
-    return [NSString stringWithFormat:@"%@://%@:****@%@%@", remote.scheme, remote.user,
-            remote.host, remote.path ];
+    NSString *replicationType;
+    NSString *source;
+    NSString *target;
+    
+    if ( self.tdReplicator.isPush ) {
+        replicationType = @"push" ;
+        source = self.tdReplicator.db.name;
+        target = TDCleanURLtoString(self.tdReplicator.remote);
+        
+    }
+    else {
+        replicationType = @"pull" ;
+        source = TDCleanURLtoString(self.tdReplicator.remote);
+        target = self.tdReplicator.db.name;
+    }
+    
+    NSString *fullinfo = [NSString stringWithFormat: @"CDTReplicator %@, source: %@, target: %@ "
+                          @"filter name: %@, filter parameters %@, unique replication session "
+                          @"ID: %@", replicationType, source, target, self.tdReplicator.filterName,
+                          self.tdReplicator.filterParameters, self.tdReplicator.sessionID];
+    
+    return fullinfo;
 }
+
 
 #pragma mark Lifecycle
 

--- a/Classes/common/touchdb/ChangeTracker/TDSocketChangeTracker.m
+++ b/Classes/common/touchdb/ChangeTracker/TDSocketChangeTracker.m
@@ -25,6 +25,7 @@
 #import "TDBase64.h"
 #import "MYBlockUtils.h"
 #import "MYURLUtils.h"
+#import "TDMisc.h"
 #import <string.h>
 #import "TDJSON.h"
 #import "CDTLogging.h"
@@ -95,7 +96,7 @@
     }
 
     // Now open the connection:
-    CDTLogVerbose(CDTREPLICATION_LOG_CONTEXT, @"%@: GET %@", self, url.resourceSpecifier);
+    CDTLogVerbose(CDTREPLICATION_LOG_CONTEXT, @"%@: GET %@", self, TDCleanURLtoString(url));
     CFReadStreamRef cfInputStream = CFReadStreamCreateForHTTPRequest(NULL, request);
     CFRelease(request);
     if (!cfInputStream) return NO;
@@ -135,7 +136,7 @@
     [_trackingInput scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
     [_trackingInput open];
     _startTime = CFAbsoluteTimeGetCurrent();
-    CDTLogInfo(CDTREPLICATION_LOG_CONTEXT, @"%@: Started... <%@>", self, self.changesFeedURL);
+    CDTLogInfo(CDTREPLICATION_LOG_CONTEXT, @"%@: Started... <%@>", self, TDCleanURLtoString(self.changesFeedURL));
     return YES;
 }
 

--- a/Classes/common/touchdb/TDAuthorizer.m
+++ b/Classes/common/touchdb/TDAuthorizer.m
@@ -35,7 +35,7 @@
 
 - (id)initWithURL:(NSURL*)url
 {
-    CDTLogDebug(CDTTD_REMOTE_REQUEST_CONTEXT, @"TDBasicAuthorizer initWith <%@>", url);  // TEMP
+    CDTLogDebug(CDTTD_REMOTE_REQUEST_CONTEXT, @"TDBasicAuthorizer initWith <%@>", TDCleanURLtoString(url));  // TEMP
     NSURLCredential* cred =
         [url my_credentialForRealm:nil authenticationMethod:NSURLAuthenticationMethodHTTPBasic];
     if (!cred) return nil;
@@ -66,7 +66,7 @@
     return nil;
 }
 
-- (NSString*)description { return $sprintf(@"%@[%@/****]", self.class, _credential.user); }
+- (NSString*)description { return $sprintf(@"%@", self.class); }
 
 #if 0
 // If enabled, these methods would make TouchDB use cookie-based login intstead of basic auth;

--- a/Classes/common/touchdb/TDMisc.h
+++ b/Classes/common/touchdb/TDMisc.h
@@ -63,5 +63,12 @@ NSURL* TDURLWithoutQuery(NSURL* url);
 /** Appends path components to a URL. These will NOT be URL-escaped, so you can include queries. */
 NSURL* TDAppendToURL(NSURL* baseURL, NSString* toAppend);
 
+/** Cleans username and password from a NSURL and returns a string. Use this function when needed
+ to send an NSURL address to a log or console but do not want to expose credentials.
+ 
+ If the NSURL does not have a password it returns NSURL -absoluteString. Otherwise, the string will 
+ be of the form 'https://*****\@host:port/path?query#fragment' */
+NSString* TDCleanURLtoString(NSURL* url);
+
 /** Filter block, used in replication. */
 typedef BOOL (^TD_FilterBlock)(TD_Revision* revision, NSDictionary* params);

--- a/Classes/common/touchdb/TDMisc.m
+++ b/Classes/common/touchdb/TDMisc.m
@@ -258,3 +258,33 @@ NSURL* TDAppendToURL(NSURL* baseURL, NSString* toAppend)
     [urlStr appendString:toAppend];
     return [NSURL URLWithString:urlStr];
 }
+
+NSString* TDCleanURLtoString(NSURL* url)
+{
+    if ([url.password length] != 0) {
+        NSString *cleanedURL = [NSString stringWithFormat:@"%@://%@:*****@%@",
+                                url.scheme, url.user, url.host];
+        
+        if (url.port) {
+            cleanedURL = [cleanedURL stringByAppendingFormat:@":%@", url.port];
+        }
+
+        if (url.path) {
+            cleanedURL = [cleanedURL stringByAppendingString:url.path];
+        }
+        
+        if (url.query) {
+            cleanedURL = [cleanedURL stringByAppendingFormat:@"?%@", url.query];
+        }
+
+        if (url.fragment) {
+            cleanedURL = [cleanedURL stringByAppendingFormat:@"#%@", url.fragment];
+        }
+        
+        return cleanedURL;
+    }
+    else {
+        return [url absoluteString];
+    }
+}
+

--- a/Classes/common/touchdb/TDRemoteRequest.m
+++ b/Classes/common/touchdb/TDRemoteRequest.m
@@ -125,7 +125,7 @@
 
 - (NSString *)description
 {
-    return $sprintf(@"%@[%@ %@]", [self class], _request.HTTPMethod, _request.URL);
+    return $sprintf(@"%@[%@ %@]", [self class], _request.HTTPMethod, TDCleanURLtoString(_request.URL));
 }
 
 - (NSMutableDictionary *)statusInfo
@@ -337,7 +337,7 @@
 {
     if (!(_dontLog404 && error.code == kTDStatusNotFound &&
           $equal(error.domain, TDHTTPErrorDomain)))
-        CDTLogVerbose(CDTTD_REMOTE_REQUEST_CONTEXT, @"%@: Got error %@", self, error);
+        CDTLogVerbose(CDTTD_REMOTE_REQUEST_CONTEXT, @"%@: Got error. domain %@, code %@", self, error.domain, error.code);
 
     // If the error is likely transient, retry:
     if (TDMayBeTransientError(error) && [self retry]) return;
@@ -395,7 +395,7 @@
         result = [TDJSON JSONObjectWithData:_jsonBuffer options:0 error:NULL];
         if (!result) {
             CDTLogWarn(CDTTD_REMOTE_REQUEST_CONTEXT, @"%@: %@ %@ returned unparseable data '%@'", self,
-                    _request.HTTPMethod, _request.URL, [_jsonBuffer my_UTF8ToString]);
+                    _request.HTTPMethod, TDCleanURLtoString(_request.URL), [_jsonBuffer my_UTF8ToString]);
             error = TDStatusToNSError(kTDStatusUpstreamError, _request.URL);
         }
     } else {

--- a/Classes/common/touchdb/TDReplicator.m
+++ b/Classes/common/touchdb/TDReplicator.m
@@ -122,8 +122,7 @@ NSString* TDReplicatorStartedNotification = @"TDReplicatorStarted";
 }
 
 - (NSString*) description {
-    return $sprintf(@"%@ [%@://%@:****@%@\%@]", [self class], _remote.scheme, _remote.user,
-                    _remote.host, _remote.path);
+    return $sprintf(@"%@ [%@]", [self class], TDCleanURLtoString(_remote));
 }
 
 

--- a/Tests/Tests/TDMiscTests.m
+++ b/Tests/Tests/TDMiscTests.m
@@ -75,5 +75,68 @@
     [self escapeIDTest:@"foo&bar" str2:@"foo%26bar"];
 }
 
+-(void)testCleanURL
+{
+    NSString *cleanString;
+    NSURL *testUrl;
+    
+    //these should create a cleaned URL.
+    testUrl = [NSURL URLWithString: @"https://adam:adamspassword@myhost.com:1234/db?all_docs=true"];
+    cleanString = TDCleanURLtoString(testUrl);
+    XCTAssertEqualObjects(cleanString, @"https://adam:*****@myhost.com:1234/db?all_docs=true",
+                          @"not cleaned: %@", cleanString);
+    
+    testUrl = [NSURL URLWithString:
+               @"https://adam:adamspassword@myhost.com:1234/db/with/long/path.html?q=true"];
+    cleanString = TDCleanURLtoString(testUrl);
+    XCTAssertEqualObjects(cleanString, @"https://adam:*****@myhost.com:1234/db/with/long/path.html?q=true",
+                          @"not cleaned: %@", cleanString);
+    
+    testUrl = [NSURL URLWithString:
+               @"https://adam:adamspassword@myhost.com:1234/db/with/long/path.html?q=true&foo=bar&bam=baz"];
+    cleanString = TDCleanURLtoString(testUrl);
+    XCTAssertEqualObjects(cleanString,
+                          @"https://adam:*****@myhost.com:1234/db/with/long/path.html?q=true&foo=bar&bam=baz",
+                          @"not cleaned: %@", cleanString);
+
+    testUrl = [NSURL URLWithString:@"https://adam:adamspassword@myhost.com/db?all_docs=true"];
+    cleanString = TDCleanURLtoString(testUrl);
+    XCTAssertEqualObjects(cleanString, @"https://adam:*****@myhost.com/db?all_docs=true",
+                          @"not cleaned: %@", cleanString);
+    
+    testUrl = [NSURL URLWithString:@"https://adam:adamspassword@myhost.com/db"];
+    cleanString = TDCleanURLtoString(testUrl);
+    XCTAssertEqualObjects(cleanString, @"https://adam:*****@myhost.com/db",
+                          @"not cleaned: %@", cleanString);
+    
+    testUrl = [NSURL URLWithString:
+               @"https://adam:adamspassword@myhost.com:1234/db?all_docs=true#some_fragment"];
+    cleanString = TDCleanURLtoString(testUrl);
+    XCTAssertEqualObjects(cleanString,
+                          @"https://adam:*****@myhost.com:1234/db?all_docs=true#some_fragment",
+                          @"not cleaned: %@", cleanString);
+    
+    testUrl = [NSURL URLWithString:@"https://adam@/db"];
+    cleanString = TDCleanURLtoString(testUrl);
+    XCTAssertEqualObjects(cleanString, @"https://adam@/db", @"should not have changed: %@",
+                          cleanString);
+    
+    testUrl = [NSURL URLWithString:@"https://adam@"];
+    cleanString = TDCleanURLtoString(testUrl);
+    XCTAssertEqualObjects(cleanString, @"https://adam@", @"should not have changed: %@",
+                          cleanString);
+    
+    testUrl = [NSURL URLWithString:@"https://adam@myhost.com/db"];
+    cleanString = TDCleanURLtoString(testUrl);
+    XCTAssertEqualObjects(cleanString, @"https://adam@myhost.com/db", @"should not have changed: %@",
+                          cleanString);
+    
+    testUrl = [NSURL URLWithString:@"https://nothing.to.clean/db"];
+    cleanString = TDCleanURLtoString(testUrl);
+    XCTAssertEqualObjects(cleanString, @"https://nothing.to.clean/db", @"should not have changed: %@",
+                          cleanString);
+
+    
+}
 
 @end


### PR DESCRIPTION
This commit adds the TDCleanURLtoString function, which will
return a string representation of the URL with the username and
password values masked to '*****'. This works with most, but not
all NSURL objects. It does work with all expected NSURL objects
created by/for the CDTDatastore. Also, it attempts to hide
credentials when a typographical error occurs in the URL.

When the TDCleanURLtoString detects an NSURL that is not
properly formatted (could not detect a scheme or host), it returns
a NSString containing an error message. This error message will
show up in the log output instead of a URL that may contain
sensitive credentials.

Tests were added for a number of URLs.