### PR TITLE
42938 upgrade to xctest

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,12 +6,12 @@ end
 desc "Run the CDTDatastore Tests for iOS"
 task :testios do
     # build using xcpretty as otherwise it's very verbose when running tests
-  $ios_success = system("xcodebuild -workspace CDTDatastore.xcworkspace -scheme 'Tests' -destination 'platform=iOS Simulator,OS=8.1,name=iPhone 4S' build | xcpretty; exit ${PIPESTATUS[0]}")
+  $ios_success = system("xcodebuild -workspace CDTDatastore.xcworkspace -scheme 'Tests iOS' -destination 'platform=iOS Simulator,OS=8.1,name=iPhone 4S' build | xcpretty; exit ${PIPESTATUS[0]}")
   unless $ios_success
     puts "** Build failed"
     exit(-1)
   end
-  $ios_success = system("xcodebuild -workspace CDTDatastore.xcworkspace -scheme 'Tests' -destination 'platform=iOS Simulator,OS=8.1,name=iPhone 4S' test")
+  $ios_success = system("xcodebuild -workspace CDTDatastore.xcworkspace -scheme 'Tests iOS' -destination 'platform=iOS Simulator,OS=8.1,name=iPhone 4S' test")
   puts "\033[0;31m! iOS unit tests failed with status code #{$?}" unless $ios_success
   if $ios_success
     puts "** All tests executed successfully"
@@ -23,12 +23,12 @@ end
 desc "Run the CDTDatastore Tests for OS X"
 task :testosx do
     # build using xcpretty as otherwise it's very verbose when running tests
-  $osx_success = system("xcodebuild -workspace CDTDatastore.xcworkspace -scheme 'Tests' -destination 'platform=OS X' build | xcpretty; exit ${PIPESTATUS[0]}")
+  $osx_success = system("xcodebuild -workspace CDTDatastore.xcworkspace -scheme 'Tests OSX' -destination 'platform=OS X' build | xcpretty; exit ${PIPESTATUS[0]}")
   unless $osx_success
     puts "** Build failed"
     exit(-1)
   end
-  $osx_success = system("xcodebuild -workspace CDTDatastore.xcworkspace -scheme 'Tests' -destination 'platform=OS X' test")
+  $osx_success = system("xcodebuild -workspace CDTDatastore.xcworkspace -scheme 'Tests OSX' -destination 'platform=OS X' test")
   puts "\033[0;31m! OS X unit tests failed with status code #{$?}" unless $osx_success
   if $osx_success
     puts "** All tests executed successfully"
@@ -46,7 +46,7 @@ end
 desc "Task for travis"
 task :travis do
   sh "rake testios"
-  # sh "rake testosx"
+  sh "rake testosx"
   sh "pod lib lint"
 end
 

--- a/ReplicationAcceptance/ReplicationAcceptance.xcodeproj/project.pbxproj
+++ b/ReplicationAcceptance/ReplicationAcceptance.xcodeproj/project.pbxproj
@@ -70,11 +70,11 @@
 		27A7E67D189973EE007FAF1C /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		27A7E67F189973EE007FAF1C /* ReplicationAcceptance.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ReplicationAcceptance.m; sourceTree = "<group>"; };
 		27A7E681189973EE007FAF1C /* ReplicationAcceptance-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ReplicationAcceptance-Prefix.pch"; sourceTree = "<group>"; };
-		27A7E68918997412007FAF1C /* RA_Tests_iOS.octest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RA_Tests_iOS.octest; sourceTree = BUILT_PRODUCTS_DIR; };
+		27A7E68918997412007FAF1C /* RA_Tests_iOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RA_Tests_iOS.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		27A7E68F18997412007FAF1C /* RA_Tests_iOS-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "RA_Tests_iOS-Info.plist"; sourceTree = "<group>"; };
 		27A7E69118997412007FAF1C /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		27A7E69518997412007FAF1C /* RA_Tests_iOS-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RA_Tests_iOS-Prefix.pch"; sourceTree = "<group>"; };
-		27A7E69D1899741C007FAF1C /* RA_Tests_OSX.octest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RA_Tests_OSX.octest; sourceTree = BUILT_PRODUCTS_DIR; };
+		27A7E69D1899741C007FAF1C /* RA_Tests_OSX.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RA_Tests_OSX.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		27A7E6A11899741C007FAF1C /* RA_Tests_OSX-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "RA_Tests_OSX-Info.plist"; sourceTree = "<group>"; };
 		27A7E6A31899741C007FAF1C /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		27A7E6A71899741C007FAF1C /* RA_Tests_OSX-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RA_Tests_OSX-Prefix.pch"; sourceTree = "<group>"; };
@@ -181,8 +181,8 @@
 		27A7E671189973EE007FAF1C /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				27A7E68918997412007FAF1C /* RA_Tests_iOS.octest */,
-				27A7E69D1899741C007FAF1C /* RA_Tests_OSX.octest */,
+				27A7E68918997412007FAF1C /* RA_Tests_iOS.xctest */,
+				27A7E69D1899741C007FAF1C /* RA_Tests_OSX.xctest */,
 				27ED107F192CF8DB00F75E95 /* ReplicationAcceptanceApp.app */,
 				27ED1096192CF8DB00F75E95 /* ReplicationAcceptanceAppTests.octest */,
 			);
@@ -329,7 +329,7 @@
 			);
 			name = RA_Tests_iOS;
 			productName = RA_Tests_iOS;
-			productReference = 27A7E68918997412007FAF1C /* RA_Tests_iOS.octest */;
+			productReference = 27A7E68918997412007FAF1C /* RA_Tests_iOS.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 		27A7E69C1899741C007FAF1C /* RA_Tests_OSX */ = {
@@ -348,7 +348,7 @@
 			);
 			name = RA_Tests_OSX;
 			productName = RA_Tests_OSX;
-			productReference = 27A7E69D1899741C007FAF1C /* RA_Tests_OSX.octest */;
+			productReference = 27A7E69D1899741C007FAF1C /* RA_Tests_OSX.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 		27ED107E192CF8DB00F75E95 /* ReplicationAcceptanceApp */ = {

--- a/ReplicationAcceptance/ReplicationAcceptance.xcodeproj/project.pbxproj
+++ b/ReplicationAcceptance/ReplicationAcceptance.xcodeproj/project.pbxproj
@@ -11,11 +11,9 @@
 		277992B918A24F0900BAB6ED /* ReplicationAcceptance+CRUD.m in Sources */ = {isa = PBXBuildFile; fileRef = 277992B718A24F0900BAB6ED /* ReplicationAcceptance+CRUD.m */; };
 		277992BB18A2503C00BAB6ED /* ReplicationAcceptance.h in Resources */ = {isa = PBXBuildFile; fileRef = 277992BA18A2503C00BAB6ED /* ReplicationAcceptance.h */; };
 		277992BC18A2503C00BAB6ED /* ReplicationAcceptance.h in Resources */ = {isa = PBXBuildFile; fileRef = 277992BA18A2503C00BAB6ED /* ReplicationAcceptance.h */; };
-		27A7E68A18997412007FAF1C /* SenTestingKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 27A7E673189973EE007FAF1C /* SenTestingKit.framework */; };
 		27A7E68B18997412007FAF1C /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 27A7E675189973EE007FAF1C /* Foundation.framework */; };
 		27A7E68C18997412007FAF1C /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 27A7E677189973EE007FAF1C /* UIKit.framework */; };
 		27A7E69218997412007FAF1C /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 27A7E69018997412007FAF1C /* InfoPlist.strings */; };
-		27A7E69E1899741C007FAF1C /* SenTestingKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 27A7E673189973EE007FAF1C /* SenTestingKit.framework */; };
 		27A7E6A41899741C007FAF1C /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 27A7E6A21899741C007FAF1C /* InfoPlist.strings */; };
 		27A7E6AF189975B2007FAF1C /* CloudantReplicationBase.m in Sources */ = {isa = PBXBuildFile; fileRef = 27A7E6AE189975B2007FAF1C /* CloudantReplicationBase.m */; };
 		27A7E6B0189975B2007FAF1C /* CloudantReplicationBase.m in Sources */ = {isa = PBXBuildFile; fileRef = 27A7E6AE189975B2007FAF1C /* CloudantReplicationBase.m */; };
@@ -40,7 +38,6 @@
 		27ED10AD192CF8FF00F75E95 /* CloudantReplicationBase.m in Sources */ = {isa = PBXBuildFile; fileRef = 27A7E6AE189975B2007FAF1C /* CloudantReplicationBase.m */; };
 		27ED10AE192CF8FF00F75E95 /* CloudantReplicationBase+CompareDb.m in Sources */ = {isa = PBXBuildFile; fileRef = 27BE3CEE189FBEA9000CD30D /* CloudantReplicationBase+CompareDb.m */; };
 		27ED10AF192CF8FF00F75E95 /* ReplicationAcceptance+CRUD.m in Sources */ = {isa = PBXBuildFile; fileRef = 277992B718A24F0900BAB6ED /* ReplicationAcceptance+CRUD.m */; };
-		27ED10B0192CFA3600F75E95 /* SenTestingKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 27A7E673189973EE007FAF1C /* SenTestingKit.framework */; };
 		4510BA04F5FB481E882AF5EE /* libPods-ios.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C61CF9A9D4564F53BC1F7321 /* libPods-ios.a */; };
 		86A30343408047EEBBF8EC4C /* libPods-ios.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C61CF9A9D4564F53BC1F7321 /* libPods-ios.a */; };
 		8E89B680A5F347559033D1B3 /* libPods-osx.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 97F72706FFD44D88B6E5E667 /* libPods-osx.a */; };
@@ -67,7 +64,6 @@
 		277992B618A24F0900BAB6ED /* ReplicationAcceptance+CRUD.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ReplicationAcceptance+CRUD.h"; sourceTree = "<group>"; };
 		277992B718A24F0900BAB6ED /* ReplicationAcceptance+CRUD.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "ReplicationAcceptance+CRUD.m"; sourceTree = "<group>"; };
 		277992BA18A2503C00BAB6ED /* ReplicationAcceptance.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ReplicationAcceptance.h; sourceTree = "<group>"; };
-		27A7E673189973EE007FAF1C /* SenTestingKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SenTestingKit.framework; path = Library/Frameworks/SenTestingKit.framework; sourceTree = DEVELOPER_DIR; };
 		27A7E675189973EE007FAF1C /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		27A7E677189973EE007FAF1C /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
 		27A7E67B189973EE007FAF1C /* ReplicationAcceptance-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "ReplicationAcceptance-Info.plist"; sourceTree = "<group>"; };
@@ -119,7 +115,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				27A7E68A18997412007FAF1C /* SenTestingKit.framework in Frameworks */,
 				27A7E68C18997412007FAF1C /* UIKit.framework in Frameworks */,
 				27A7E68B18997412007FAF1C /* Foundation.framework in Frameworks */,
 				4510BA04F5FB481E882AF5EE /* libPods-ios.a in Frameworks */,
@@ -130,7 +125,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				27A7E69E1899741C007FAF1C /* SenTestingKit.framework in Frameworks */,
 				8E89B680A5F347559033D1B3 /* libPods-osx.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -149,7 +143,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				27ED10B0192CFA3600F75E95 /* SenTestingKit.framework in Frameworks */,
 				27ED109A192CF8DB00F75E95 /* UIKit.framework in Frameworks */,
 				27ED1099192CF8DB00F75E95 /* Foundation.framework in Frameworks */,
 				86A30343408047EEBBF8EC4C /* libPods-ios.a in Frameworks */,
@@ -199,7 +192,6 @@
 		27A7E672189973EE007FAF1C /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				27A7E673189973EE007FAF1C /* SenTestingKit.framework */,
 				27A7E675189973EE007FAF1C /* Foundation.framework */,
 				27A7E677189973EE007FAF1C /* UIKit.framework */,
 				C61CF9A9D4564F53BC1F7321 /* libPods-ios.a */,
@@ -338,7 +330,7 @@
 			name = RA_Tests_iOS;
 			productName = RA_Tests_iOS;
 			productReference = 27A7E68918997412007FAF1C /* RA_Tests_iOS.octest */;
-			productType = "com.apple.product-type.bundle.ocunit-test";
+			productType = "com.apple.product-type.bundle.unit-test";
 		};
 		27A7E69C1899741C007FAF1C /* RA_Tests_OSX */ = {
 			isa = PBXNativeTarget;
@@ -357,7 +349,7 @@
 			name = RA_Tests_OSX;
 			productName = RA_Tests_OSX;
 			productReference = 27A7E69D1899741C007FAF1C /* RA_Tests_OSX.octest */;
-			productType = "com.apple.product-type.bundle.ocunit-test";
+			productType = "com.apple.product-type.bundle.unit-test";
 		};
 		27ED107E192CF8DB00F75E95 /* ReplicationAcceptanceApp */ = {
 			isa = PBXNativeTarget;
@@ -702,6 +694,7 @@
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
@@ -729,7 +722,6 @@
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
-				WRAPPER_EXTENSION = octest;
 			};
 			name = Debug;
 		};
@@ -751,6 +743,7 @@
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				COPY_PHASE_STRIP = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -772,7 +765,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;
-				WRAPPER_EXTENSION = octest;
 			};
 			name = Release;
 		};
@@ -819,7 +811,6 @@
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
-				WRAPPER_EXTENSION = octest;
 			};
 			name = Debug;
 		};
@@ -860,7 +851,6 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
-				WRAPPER_EXTENSION = octest;
 			};
 			name = Release;
 		};

--- a/ReplicationAcceptance/ReplicationAcceptance.xcodeproj/xcshareddata/xcschemes/RA_Tests.xcscheme
+++ b/ReplicationAcceptance/ReplicationAcceptance.xcodeproj/xcshareddata/xcschemes/RA_Tests.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "27A7E68818997412007FAF1C"
-               BuildableName = "RA_Tests_iOS.octest"
+               BuildableName = "RA_Tests_iOS.xctest"
                BlueprintName = "RA_Tests_iOS"
                ReferencedContainer = "container:ReplicationAcceptance.xcodeproj">
             </BuildableReference>
@@ -29,7 +29,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "27A7E69C1899741C007FAF1C"
-               BuildableName = "RA_Tests_OSX.octest"
+               BuildableName = "RA_Tests_OSX.xctest"
                BlueprintName = "RA_Tests_OSX"
                ReferencedContainer = "container:ReplicationAcceptance.xcodeproj">
             </BuildableReference>
@@ -47,7 +47,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "27A7E68818997412007FAF1C"
-               BuildableName = "RA_Tests_iOS.octest"
+               BuildableName = "RA_Tests_iOS.xctest"
                BlueprintName = "RA_Tests_iOS"
                ReferencedContainer = "container:ReplicationAcceptance.xcodeproj">
             </BuildableReference>
@@ -57,7 +57,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "27A7E69C1899741C007FAF1C"
-               BuildableName = "RA_Tests_OSX.octest"
+               BuildableName = "RA_Tests_OSX.xctest"
                BlueprintName = "RA_Tests_OSX"
                ReferencedContainer = "container:ReplicationAcceptance.xcodeproj">
             </BuildableReference>
@@ -77,7 +77,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "27A7E68818997412007FAF1C"
-            BuildableName = "RA_Tests_iOS.octest"
+            BuildableName = "RA_Tests_iOS.xctest"
             BlueprintName = "RA_Tests_iOS"
             ReferencedContainer = "container:ReplicationAcceptance.xcodeproj">
          </BuildableReference>

--- a/ReplicationAcceptance/ReplicationAcceptance.xcodeproj/xcshareddata/xcschemes/RA_Tests_OSX.xcscheme
+++ b/ReplicationAcceptance/ReplicationAcceptance.xcodeproj/xcshareddata/xcschemes/RA_Tests_OSX.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "27A7E69C1899741C007FAF1C"
-               BuildableName = "RA_Tests_OSX.octest"
+               BuildableName = "RA_Tests_OSX.xctest"
                BlueprintName = "RA_Tests_OSX"
                ReferencedContainer = "container:ReplicationAcceptance.xcodeproj">
             </BuildableReference>
@@ -33,7 +33,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "27A7E69C1899741C007FAF1C"
-               BuildableName = "RA_Tests_OSX.octest"
+               BuildableName = "RA_Tests_OSX.xctest"
                BlueprintName = "RA_Tests_OSX"
                ReferencedContainer = "container:ReplicationAcceptance.xcodeproj">
             </BuildableReference>
@@ -43,7 +43,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "27A7E69C1899741C007FAF1C"
-            BuildableName = "RA_Tests_OSX.octest"
+            BuildableName = "RA_Tests_OSX.xctest"
             BlueprintName = "RA_Tests_OSX"
             ReferencedContainer = "container:ReplicationAcceptance.xcodeproj">
          </BuildableReference>
@@ -62,7 +62,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "27A7E69C1899741C007FAF1C"
-            BuildableName = "RA_Tests_OSX.octest"
+            BuildableName = "RA_Tests_OSX.xctest"
             BlueprintName = "RA_Tests_OSX"
             ReferencedContainer = "container:ReplicationAcceptance.xcodeproj">
          </BuildableReference>
@@ -87,7 +87,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "27A7E69C1899741C007FAF1C"
-            BuildableName = "RA_Tests_OSX.octest"
+            BuildableName = "RA_Tests_OSX.xctest"
             BlueprintName = "RA_Tests_OSX"
             ReferencedContainer = "container:ReplicationAcceptance.xcodeproj">
          </BuildableReference>

--- a/ReplicationAcceptance/ReplicationAcceptance/Attachments.m
+++ b/ReplicationAcceptance/ReplicationAcceptance/Attachments.m
@@ -10,7 +10,7 @@
 #import "CloudantReplicationBase+CompareDb.h"
 
 #import <UNIRest.h>
-#import <SenTestingKit/SenTestingKit.h>
+#import <XCTest/XCTest.h>
 #import <CloudantSync.h>
 #import <FMDatabase.h>
 
@@ -32,7 +32,7 @@
 
     NSError *error;
     self.datastore = [self.factory datastoreNamed:@"test" error:&error];
-    STAssertNotNil(self.datastore, @"datastore is nil");
+    XCTAssertNotNil(self.datastore, @"datastore is nil");
 
     self.replicatorFactory = [[CDTReplicatorFactory alloc] initWithDatastoreManager:self.factory];
     
@@ -95,7 +95,7 @@
         [request setUrl:[attachmentURL absoluteString]];
         [request setHeaders:headers];
     }] asJson];
-    STAssertTrue([response.body.object objectForKey:@"ok"] != nil, @"Remote db delete failed");
+    XCTAssertTrue([response.body.object objectForKey:@"ok"] != nil, @"Remote db delete failed");
 }
 
 #pragma mark Tests
@@ -151,17 +151,17 @@
     
     rev = [self.datastore getDocumentWithId:@"attachments1"
                                       error:nil];
-    STAssertTrue([self isNumberOfAttachmentsForRevision:rev equalTo:(NSUInteger)1],
+    XCTAssertTrue([self isNumberOfAttachmentsForRevision:rev equalTo:(NSUInteger)1],
                  @"Incorrect number of attachments");
     
     rev = [self.datastore getDocumentWithId:@"attachments3"
                                       error:nil];
-    STAssertTrue([self isNumberOfAttachmentsForRevision:rev equalTo:(NSUInteger)3],
+    XCTAssertTrue([self isNumberOfAttachmentsForRevision:rev equalTo:(NSUInteger)3],
                  @"Incorrect number of attachments");
     
     rev = [self.datastore getDocumentWithId:@"attachments4"
                                       error:nil];
-    STAssertTrue([self isNumberOfAttachmentsForRevision:rev equalTo:(NSUInteger)4],
+    XCTAssertTrue([self isNumberOfAttachmentsForRevision:rev equalTo:(NSUInteger)4],
                  @"Incorrect number of attachments");
     
     //
@@ -219,8 +219,8 @@
     CDTDocumentRevision *rev = [self.datastore createDocumentFromRevision:mrev error:&error];
 
 
-    STAssertNotNil(rev, @"Unable to add attachments to document");
-    STAssertTrue([self isNumberOfAttachmentsForRevision:rev equalTo:nAttachments],
+    XCTAssertNotNil(rev, @"Unable to add attachments to document");
+    XCTAssertTrue([self isNumberOfAttachmentsForRevision:rev equalTo:nAttachments],
                  @"Incorrect number of attachments");
     
     // 
@@ -233,10 +233,10 @@
     // Checks
     //
     
-    STAssertTrue([self compareDatastore:self.datastore withDatabase:remoteDbURL],
+    XCTAssertTrue([self compareDatastore:self.datastore withDatabase:remoteDbURL],
                  @"Local and remote database comparison failed");
     
-    STAssertTrue([self compareAttachmentsForCurrentRevisions:self.datastore 
+    XCTAssertTrue([self compareAttachmentsForCurrentRevisions:self.datastore 
                                                 withDatabase:remoteDbURL],
                  @"Local and remote database attachment comparison failed");
                  
@@ -299,8 +299,8 @@
     mrev.attachments = attachments;
     CDTDocumentRevision *rev = [self.datastore createDocumentFromRevision:mrev error:&error];
 
-    STAssertNotNil(rev, @"Unable to add attachments to document");
-    STAssertTrue([self isNumberOfAttachmentsForRevision:rev equalTo:nAttachments],
+    XCTAssertNotNil(rev, @"Unable to add attachments to document");
+    XCTAssertTrue([self isNumberOfAttachmentsForRevision:rev equalTo:nAttachments],
                  @"Incorrect number of attachments");
     
     // 
@@ -323,8 +323,8 @@
     
     rev = [self.datastore updateDocumentFromRevision:mrev error:nil];
     
-    STAssertNotNil(rev, @"Attachments are not deleted.");
-    STAssertTrue([self isNumberOfAttachmentsForRevision:rev equalTo:nAttachments/2],
+    XCTAssertNotNil(rev, @"Attachments are not deleted.");
+    XCTAssertTrue([self isNumberOfAttachmentsForRevision:rev equalTo:nAttachments/2],
                  @"Incorrect number of attachments");
     
     [self pushTo:remoteDbURL from:self.datastore];
@@ -333,10 +333,10 @@
     // Checks
     //
     
-    STAssertTrue([self compareDatastore:self.datastore withDatabase:remoteDbURL],
+    XCTAssertTrue([self compareDatastore:self.datastore withDatabase:remoteDbURL],
                  @"Local and remote database comparison failed");
     
-    STAssertTrue([self compareAttachmentsForCurrentRevisions:self.datastore 
+    XCTAssertTrue([self compareAttachmentsForCurrentRevisions:self.datastore 
                                                 withDatabase:remoteDbURL],
                  @"Local and remote database attachment comparison failed");
     
@@ -399,8 +399,8 @@
     mrev.attachments = attachments;
     CDTDocumentRevision *rev = [self.datastore createDocumentFromRevision:mrev error:&error];
     
-    STAssertNotNil(rev, @"Unable to add attachments to document");
-    STAssertTrue([self isNumberOfAttachmentsForRevision:rev equalTo:nAttachments],
+    XCTAssertNotNil(rev, @"Unable to add attachments to document");
+    XCTAssertTrue([self isNumberOfAttachmentsForRevision:rev equalTo:nAttachments],
                  @"Incorrect number of attachments");
     
     // 
@@ -423,8 +423,8 @@
     
     rev = [self.datastore updateDocumentFromRevision:mrev error:nil];
     
-    STAssertNotNil(rev, @"Attachments are not deleted.");
-    STAssertTrue([self isNumberOfAttachmentsForRevision:rev equalTo:nAttachments/2],
+    XCTAssertNotNil(rev, @"Attachments are not deleted.");
+    XCTAssertTrue([self isNumberOfAttachmentsForRevision:rev equalTo:nAttachments/2],
                  @"Incorrect number of attachments");
     
     // To get the 412 response to happen, we have to change the revpos in the attachments
@@ -441,10 +441,10 @@
     // Checks
     //
     
-    STAssertTrue([self compareDatastore:self.datastore withDatabase:remoteDbURL],
+    XCTAssertTrue([self compareDatastore:self.datastore withDatabase:remoteDbURL],
                  @"Local and remote database comparison failed");
     
-    STAssertTrue([self compareAttachmentsForCurrentRevisions:self.datastore 
+    XCTAssertTrue([self compareAttachmentsForCurrentRevisions:self.datastore 
                                                 withDatabase:remoteDbURL],
                  @"Local and remote database attachment comparison failed");
     
@@ -514,19 +514,19 @@
     CDTDocumentRevision *rev;
     rev = [self.datastore getDocumentWithId:docId
                                       error:nil];
-    STAssertTrue([self isNumberOfAttachmentsForRevision:rev equalTo:nAttachments],
+    XCTAssertTrue([self isNumberOfAttachmentsForRevision:rev equalTo:nAttachments],
                  @"Incorrect number of attachments");
     
     for (NSString *attachmentName in [originalAttachments keyEnumerator]) {
 
         CDTAttachment *a = [[rev attachments] objectForKey:attachmentName];
         
-        STAssertNotNil(a, @"No attachment named %@", attachmentName);
+        XCTAssertNotNil(a, @"No attachment named %@", attachmentName);
         
         NSData *data = [a dataFromAttachmentContent];
         NSData *originalData = originalAttachments[attachmentName];
         
-        STAssertEqualObjects(data, originalData, @"attachment content didn't match");
+        XCTAssertEqualObjects(data, originalData, @"attachment content didn't match");
     }
     
     //
@@ -592,7 +592,7 @@
     [mrev.attachments setObject:attachment forKey:attachmentName];
     rev = [self.datastore updateDocumentFromRevision:mrev error:&error];
 
-    STAssertNotNil(rev, @"Unable to add attachments to document");
+    XCTAssertNotNil(rev, @"Unable to add attachments to document");
     
     [self pushTo:remoteDbURL from:self.datastore];
     
@@ -600,10 +600,10 @@
     // Checks
     //
     
-    STAssertTrue([self compareDatastore:self.datastore withDatabase:remoteDbURL],
+    XCTAssertTrue([self compareDatastore:self.datastore withDatabase:remoteDbURL],
                  @"Local and remote database comparison failed");
     
-    STAssertTrue([self compareAttachmentsForCurrentRevisions:self.datastore 
+    XCTAssertTrue([self compareAttachmentsForCurrentRevisions:self.datastore 
                                                 withDatabase:remoteDbURL],
                  @"Local and remote database attachment comparison failed");
     
@@ -663,8 +663,8 @@
     [mrev.attachments removeObjectForKey:attachmentName];
     rev = [self.datastore updateDocumentFromRevision:mrev error:nil];
 
-    STAssertNotNil(rev, @"Unable to add attachments to document");
-    STAssertTrue([self isNumberOfAttachmentsForRevision:rev equalTo:(NSUInteger)0],
+    XCTAssertNotNil(rev, @"Unable to add attachments to document");
+    XCTAssertTrue([self isNumberOfAttachmentsForRevision:rev equalTo:(NSUInteger)0],
                  @"Incorrect number of attachments");
     
     
@@ -674,9 +674,9 @@
     // Checks
     //
     
-    STAssertTrue([self compareDatastore:self.datastore withDatabase:remoteDbURL],
+    XCTAssertTrue([self compareDatastore:self.datastore withDatabase:remoteDbURL],
                  @"Local and remote database comparison failed");
-    STAssertTrue([self compareAttachmentsForCurrentRevisions:self.datastore 
+    XCTAssertTrue([self compareAttachmentsForCurrentRevisions:self.datastore 
                                                 withDatabase:remoteDbURL],
                  @"Local and remote database attachment comparison failed");
     
@@ -743,7 +743,7 @@
     
     CDTDocumentRevision *rev = [self.datastore getDocumentWithId:docId
                                                            error:nil];
-    STAssertTrue([self isNumberOfAttachmentsForRevision:rev equalTo:(NSUInteger)0],
+    XCTAssertTrue([self isNumberOfAttachmentsForRevision:rev equalTo:(NSUInteger)0],
                  @"Incorrect number of attachments");
     
     //
@@ -815,10 +815,10 @@
     
     // The regression this tests for is triggered by the attachment's revpos being
     // greater than the generation of the revision.
-    STAssertEqualObjects(json[@"_attachments"][@"txtDoc"][@"revpos"], 
+    XCTAssertEqualObjects(json[@"_attachments"][@"txtDoc"][@"revpos"], 
                          @(2), 
                          @"revpos not expected");
-    STAssertTrue([json[@"_rev"] hasPrefix:@"1"], @"revpos not expected");
+    XCTAssertTrue([json[@"_rev"] hasPrefix:@"1"], @"revpos not expected");
     
     //
     // Replicate to local database
@@ -834,12 +834,12 @@
     
     rev = [self.datastore getDocumentWithId:docId
                                       error:nil];
-    STAssertTrue([self isNumberOfAttachmentsForRevision:rev equalTo:(NSUInteger)1],
+    XCTAssertTrue([self isNumberOfAttachmentsForRevision:rev equalTo:(NSUInteger)1],
                  @"Incorrect number of attachments");
     
     rev = [self.datastore getDocumentWithId:copiedDocId
                                       error:nil];
-    STAssertTrue([self isNumberOfAttachmentsForRevision:rev equalTo:(NSUInteger)1],
+    XCTAssertTrue([self isNumberOfAttachmentsForRevision:rev equalTo:(NSUInteger)1],
                  @"Incorrect number of attachments");
     
     //

--- a/ReplicationAcceptance/ReplicationAcceptance/CloudantReplicationBase+CompareDb.m
+++ b/ReplicationAcceptance/ReplicationAcceptance/CloudantReplicationBase+CompareDb.m
@@ -10,7 +10,7 @@
 
 #import <CloudantSync.h>
 #import <CDTDatastore+Internal.h>
-#import <SenTestingKit/SenTestingKit.h>
+#import <XCTest/XCTest.h>
 #import <UNIRest.h>
 #import <CommonCrypto/CommonDigest.h>
 #import <NSData+Base64.h>
@@ -98,14 +98,14 @@
 
     // Check both databases have the same doc IDs
     if (![[localDocs allKeys] isEqualToArray:[remoteDocs allKeys]]) {
-        STFail(@"Local and remote docIds not equal");
+        XCTFail(@"Local and remote docIds not equal");
         return NO;
     }
 
     // Check each docId has the same rev
     for (NSString *docId in [localDocs allKeys]) {
         if (![localDocs[docId] isEqualToString:remoteDocs[docId]]) {
-            STFail(@"Local and remote revs don't match");
+            XCTFail(@"Local and remote revs don't match");
             return NO;
         }
     }
@@ -169,7 +169,7 @@
             localRevIds = [localRevIds subarrayWithRange:range];
 
             if (![localRevIds isEqualToArray:remoteRevIds]) {
-                STFail(@"Local and remote rev histories don't match");
+                XCTFail(@"Local and remote rev histories don't match");
                 return;
             }
         }
@@ -202,12 +202,12 @@
          
          NSDictionary *remoteAttachments = json[@"_attachments"];
          
-         STAssertEquals(localAttachments.count, 
+         XCTAssertEqual(localAttachments.count, 
                         remoteAttachments.count, 
                         @"Wrong attachment number");
          NSArray *remoteAttachmentNames = [remoteAttachments allKeys];
          for (NSString *name in [localAttachments allKeys]) {
-             STAssertTrue([remoteAttachmentNames containsObject:name], 
+             XCTAssertTrue([remoteAttachmentNames containsObject:name], 
                           @"local had attachment remote didn't");
          }
          
@@ -224,7 +224,7 @@
              NSData *remoteData = [NSData dataFromBase64String:rAttachment[@"data"]];
              NSString *remoteValue = [[NSString alloc] initWithData:remoteData
                                                            encoding:NSUTF8StringEncoding];
-             STAssertEqualObjects(localValue, remoteValue, @"Attachment data didn't match");
+             XCTAssertEqualObjects(localValue, remoteValue, @"Attachment data didn't match");
              
              // This doesn't work right now, the MD5s don't match
              // even though the data does.

--- a/ReplicationAcceptance/ReplicationAcceptance/CloudantReplicationBase.h
+++ b/ReplicationAcceptance/ReplicationAcceptance/CloudantReplicationBase.h
@@ -6,11 +6,11 @@
 //
 //
 
-#import <SenTestingKit/SenTestingKit.h>
+#import <XCTest/XCTest.h>
 
 @class CDTDatastoreManager;
 
-@interface CloudantReplicationBase : SenTestCase
+@interface CloudantReplicationBase : XCTestCase
 
 +(NSString*)generateRandomString:(int)num;
 

--- a/ReplicationAcceptance/ReplicationAcceptance/CloudantReplicationBase.m
+++ b/ReplicationAcceptance/ReplicationAcceptance/CloudantReplicationBase.m
@@ -25,8 +25,8 @@
     NSError *error;
     self.factory = [[CDTDatastoreManager alloc] initWithDirectory:self.factoryPath error:&error];
 
-    STAssertNil(error, @"CDTDatastoreManager had error");
-    STAssertNotNil(self.factory, @"Factory is nil");
+    XCTAssertNil(error, @"CDTDatastoreManager had error");
+    XCTAssertNotNil(self.factory, @"Factory is nil");
 
     self.remoteRootURL = [NSURL URLWithString:@"http://localhost:5984"];
     self.remoteDbPrefix = @"replication-acceptance";
@@ -38,7 +38,7 @@
 
     NSError *error;
     [[NSFileManager defaultManager] removeItemAtPath:self.factoryPath error:&error];
-    STAssertNil(error, @"Error deleting temporary directory.");
+    XCTAssertNil(error, @"Error deleting temporary directory.");
 
     // Put teardown code here; it will be run once, after the last test case.
     [super tearDown];
@@ -65,7 +65,7 @@
     char *result = mkdtemp(tempDirectoryNameCString);
     if (!result)
     {
-        STFail(@"Couldn't create temporary directory");
+        XCTFail(@"Couldn't create temporary directory");
     }
     
     NSString *path = [[NSFileManager defaultManager]
@@ -94,7 +94,7 @@
         [request setHeaders:headers];
         [request setBody:[NSData data]];
     }] asJson];
-    STAssertTrue([response.body.object objectForKey:@"ok"] != nil, @"Remote db create failed");
+    XCTAssertTrue([response.body.object objectForKey:@"ok"] != nil, @"Remote db create failed");
 }
 
 /**
@@ -110,7 +110,7 @@
         [request setUrl:[remoteDatabaseURL absoluteString]];
         [request setHeaders:headers];
     }] asJson];
-    STAssertTrue([response.body.object objectForKey:@"ok"] != nil, @"Remote db delete failed");
+    XCTAssertTrue([response.body.object objectForKey:@"ok"] != nil, @"Remote db delete failed");
 }
 
 
@@ -131,7 +131,7 @@
                                                          options:0
                                                            error:nil]];
     }] asJson];
-    STAssertTrue([response.body.object objectForKey:@"ok"] != nil, @"Create document failed");
+    XCTAssertTrue([response.body.object objectForKey:@"ok"] != nil, @"Create document failed");
     NSString *revId = [response.body.object objectForKey:@"rev"];
     return revId;
 }
@@ -158,7 +158,7 @@
         [request setHeaders:headers];
         [request setBody:data];
     }] asJson];
-    STAssertTrue([response.body.object objectForKey:@"rev"] != nil, @"Adding attachment failed");
+    XCTAssertTrue([response.body.object objectForKey:@"rev"] != nil, @"Adding attachment failed");
     NSString *newRevId = [response.body.object objectForKey:@"rev"];
     return newRevId;
 }
@@ -180,7 +180,7 @@
                                                               headers:headers
                                                              username:nil 
                                                              password:nil] asJson];
-    STAssertTrue([response.body.object objectForKey:@"ok"] != nil, @"Copy document failed");
+    XCTAssertTrue([response.body.object objectForKey:@"ok"] != nil, @"Copy document failed");
     NSString *revId = [response.body.object objectForKey:@"rev"];
     return revId;
 }

--- a/ReplicationAcceptance/ReplicationAcceptance/ReplicationAcceptance+CRUD.m
+++ b/ReplicationAcceptance/ReplicationAcceptance/ReplicationAcceptance+CRUD.m
@@ -57,8 +57,8 @@
         if (updates) {
             rev = [self.datastore getDocumentWithId:docId error:&error];
             if (error.code != 404) {  // new doc, so not error
-                STAssertNil(error, @"Error creating docs: %@", error);
-                STAssertNotNil(rev, @"Error creating docs: rev was nil");
+                XCTAssertNil(error, @"Error creating docs: %@", error);
+                XCTAssertNotNil(rev, @"Error creating docs: rev was nil");
             }
         }
 
@@ -71,15 +71,15 @@
             rev = [self.datastore createDocumentFromRevision:mdrev
                                                        error:&error];
             //            NSLog(@"Created %@", docId);
-            STAssertNil(error, @"Error creating doc: %@", error);
-            STAssertNotNil(rev, @"Error creating doc: rev was nil");
+            XCTAssertNil(error, @"Error creating doc: %@", error);
+            XCTAssertNotNil(rev, @"Error creating doc: rev was nil");
         } else {
             mdrev.sourceRevId = rev.revId;
             rev = [self.datastore updateDocumentFromRevision:mdrev error:&error];
 
             //            NSLog(@"Updated %@", docId);
-            STAssertNil(error, @"Error updating doc: %@", error);
-            STAssertNotNil(rev, @"Error updating doc: rev was nil");
+            XCTAssertNil(error, @"Error updating doc: %@", error);
+            XCTAssertNotNil(rev, @"Error updating doc: rev was nil");
         }
 
 
@@ -99,14 +99,14 @@
     
     CDTDocumentRevision *rev = [self.datastore createDocumentFromRevision:mdrev error:&error];
 
-    STAssertNil(error, @"Error creating docs: %@", error);
-    STAssertNotNil(rev, @"Error creating docs: rev was nil, but so was error");
+    XCTAssertNil(error, @"Error creating docs: %@", error);
+    XCTAssertNotNil(rev, @"Error creating docs: rev was nil, but so was error");
 
     // Create revisions of document in local store
     rev = [self addRevsToDocumentRevision:rev count:n_revs];
 
     NSString *revPrefix = [NSString stringWithFormat:@"%li", (long)n_revs];
-    STAssertTrue([rev.revId hasPrefix:revPrefix], @"Unexpected current rev in local document, %@", rev.revId);
+    XCTAssertTrue([rev.revId hasPrefix:revPrefix], @"Unexpected current rev in local document, %@", rev.revId);
 }
 
 -(CDTDocumentRevision*) addRevsToDocumentRevision:(CDTDocumentRevision*)rev count:(NSInteger)n_revs
@@ -150,7 +150,7 @@
                                                            error:nil]];
     }] asJson];
     //    NSLog(@"%@", response.body.array);
-    STAssertTrue([response.body.array count] == count, @"Remote db has wrong number of docs");
+    XCTAssertTrue([response.body.array count] == count, @"Remote db has wrong number of docs");
 }
 
 -(void) createRemoteDocWithId:(NSString*)docId revs:(NSInteger)n_revs
@@ -179,7 +179,7 @@
     }
 
     NSString *revPrefix = [NSString stringWithFormat:@"%li", (long)n_revs];
-    STAssertTrue([revId hasPrefix:revPrefix], @"Unexpected current rev in local document, %@", revId);
+    XCTAssertTrue([revId hasPrefix:revPrefix], @"Unexpected current rev in local document, %@", revId);
 }
 
 -(NSString*) createRemoteDocWithId:(NSString *)docId body:(NSDictionary*)body
@@ -195,7 +195,7 @@
                                                          options:0
                                                            error:nil]];
     }] asJson];
-    STAssertTrue([response.body.object objectForKey:@"ok"] != nil, @"Create document failed");
+    XCTAssertTrue([response.body.object objectForKey:@"ok"] != nil, @"Create document failed");
     return [response.body.object objectForKey:@"rev"];
 }
 
@@ -217,7 +217,7 @@
         NSDictionary* headers = @{@"accept": @"application/json", @"If-Match": revId};
         [request setHeaders:headers];
     }] asJson];
-    STAssertTrue([response.body.object objectForKey:@"ok"] != nil, @"Delete document failed");
+    XCTAssertTrue([response.body.object objectForKey:@"ok"] != nil, @"Delete document failed");
     return [response.body.object objectForKey:@"rev"];
 }
 
@@ -235,10 +235,10 @@
 -(void) assertRemoteDatabaseHasDocCount:(NSInteger)count deletedDocs:(NSInteger)deleted
 {
     NSDictionary *dbMeta = [self remoteDbMetadata];
-    STAssertEquals(count,
+    XCTAssertEqual(count,
                    [dbMeta[@"doc_count"] integerValue],
                    @"Wrong number of remote docs");
-    STAssertEquals(deleted,
+    XCTAssertEqual(deleted,
                    [dbMeta[@"doc_del_count"] integerValue],
                    @"Wrong number of remote deleted docs");
 }

--- a/ReplicationAcceptance/ReplicationAcceptance/ReplicationAcceptance.h
+++ b/ReplicationAcceptance/ReplicationAcceptance/ReplicationAcceptance.h
@@ -6,7 +6,7 @@
 //
 //
 
-#import <SenTestingKit/SenTestingKit.h>
+#import <XCTest/XCTest.h>
 
 #import "CloudantReplicationBase.h"
 #import "ReplicatorURLProtocol.h"

--- a/ReplicationAcceptance/ReplicationAcceptance/ReplicationAcceptance.m
+++ b/ReplicationAcceptance/ReplicationAcceptance/ReplicationAcceptance.m
@@ -8,7 +8,7 @@
 
 #import "ReplicationAcceptance.h"
 
-#import <SenTestingKit/SenTestingKit.h>
+#import <XCTest/XCTest.h>
 
 #import <CloudantSync.h>
 #import <UNIRest.h>
@@ -64,7 +64,7 @@ static NSUInteger largeRevTreeSize = 1500;
 
     NSError *error;
     self.datastore = [self.factory datastoreNamed:@"test" error:&error];
-    STAssertNotNil(self.datastore, @"datastore is nil");
+    XCTAssertNotNil(self.datastore, @"datastore is nil");
 
     self.primaryRemoteDatabaseName = [NSString stringWithFormat:@"%@-test-database-%@",
                                     self.remoteDbPrefix,
@@ -107,12 +107,12 @@ static NSUInteger largeRevTreeSize = 1500;
     
     NSError *error;
     CDTReplicator *replicator =  [self.replicatorFactory oneWay:pull error:&error];
-    STAssertNil(error, @"%@",error);
-    STAssertNotNil(replicator, @"CDTReplicator is nil");
+    XCTAssertNil(error, @"%@",error);
+    XCTAssertNotNil(replicator, @"CDTReplicator is nil");
     
     NSLog(@"Replicating from %@", [pull.source absoluteString]);
     if (![replicator startWithError:&error]) {
-        STFail(@"CDTReplicator -startWithError: %@", error);
+        XCTFail(@"CDTReplicator -startWithError: %@", error);
     }
     
     while (replicator.isActive) {
@@ -143,12 +143,12 @@ static NSUInteger largeRevTreeSize = 1500;
     
     NSError *error;
     CDTReplicator *replicator =  [self.replicatorFactory oneWay:push error:&error];
-    STAssertNil(error, @"%@",error);
-    STAssertNotNil(replicator, @"CDTReplicator is nil");
+    XCTAssertNil(error, @"%@",error);
+    XCTAssertNotNil(replicator, @"CDTReplicator is nil");
     
     NSLog(@"Replicating to %@", [self.primaryRemoteDatabaseURL absoluteString]);
     if (![replicator startWithError:&error]) {
-        STFail(@"CDTReplicator -startWithError: %@", error);
+        XCTFail(@"CDTReplicator -startWithError: %@", error);
     }
    
     while (replicator.isActive) {
@@ -171,7 +171,7 @@ static NSUInteger largeRevTreeSize = 1500;
     // Create docs in local store
     NSLog(@"Creating documents...");
     [self createLocalDocs:n_docs];
-    STAssertEquals(self.datastore.documentCount, n_docs, @"Incorrect number of documents created");
+    XCTAssertEqual(self.datastore.documentCount, n_docs, @"Incorrect number of documents created");
 
     CDTReplicator *replicator = [self pushToRemote];
 
@@ -180,10 +180,10 @@ static NSUInteger largeRevTreeSize = 1500;
 
     BOOL same = [self compareDatastore:self.datastore
                           withDatabase:self.primaryRemoteDatabaseURL];
-    STAssertTrue(same, @"Remote and local databases differ");
+    XCTAssertTrue(same, @"Remote and local databases differ");
 
-    STAssertEquals(n_docs, (NSUInteger)replicator.changesTotal, @"total number of changes mismatch");
-    STAssertEquals(n_docs, (NSUInteger)replicator.changesProcessed, @"processed number of changes mismatch");
+    XCTAssertEqual(n_docs, (NSUInteger)replicator.changesTotal, @"total number of changes mismatch");
+    XCTAssertEqual(n_docs, (NSUInteger)replicator.changesProcessed, @"processed number of changes mismatch");
 }
 
 /**
@@ -201,15 +201,15 @@ static NSUInteger largeRevTreeSize = 1500;
 
     CDTReplicator *replicator = [self pullFromRemote];
 
-    STAssertEquals(self.datastore.documentCount, n_docs, @"Incorrect number of documents created");
+    XCTAssertEqual(self.datastore.documentCount, n_docs, @"Incorrect number of documents created");
 
     BOOL same = [self compareDatastore:self.datastore
                           withDatabase:self.primaryRemoteDatabaseURL];
-    STAssertTrue(same, @"Remote and local databases differ");
+    XCTAssertTrue(same, @"Remote and local databases differ");
     
-    STAssertEquals(n_docs, (NSUInteger)replicator.changesTotal, @"total number of changes mismatch");
+    XCTAssertEqual(n_docs, (NSUInteger)replicator.changesTotal, @"total number of changes mismatch");
     
-    STAssertEquals(n_docs, (NSUInteger)replicator.changesProcessed, @"processed number of changes mismatch");
+    XCTAssertEqual(n_docs, (NSUInteger)replicator.changesProcessed, @"processed number of changes mismatch");
 }
 
 -(void) testPullErrorsWhenLocalDatabaseIsDeleted
@@ -230,7 +230,7 @@ static NSUInteger largeRevTreeSize = 1500;
     replicator.delegate = mydel;
     
     error = nil;
-    STAssertTrue([replicator startWithError:&error], @"CDTReplicator -startWithError: %@", error);
+    XCTAssertTrue([replicator startWithError:&error], @"CDTReplicator -startWithError: %@", error);
     
     while (replicator.isActive) {
         [NSThread sleepForTimeInterval:1.0f];
@@ -238,17 +238,17 @@ static NSUInteger largeRevTreeSize = 1500;
     }
 
     
-    STAssertTrue(n_docs != (NSUInteger)replicator.changesTotal, @"changesTotal: %ld, n_docs %ld",
+    XCTAssertTrue(n_docs != (NSUInteger)replicator.changesTotal, @"changesTotal: %ld, n_docs %ld",
                  replicator.changesTotal, n_docs);
     
-    STAssertTrue(n_docs != (NSUInteger)replicator.changesProcessed, @"changesProcessed: %ld, n_docs %ld",
+    XCTAssertTrue(n_docs != (NSUInteger)replicator.changesProcessed, @"changesProcessed: %ld, n_docs %ld",
                    replicator.changesProcessed, n_docs);
     
-    STAssertEquals(replicator.state, CDTReplicatorStateError, @"Found: %@, expected: (%@)",
+    XCTAssertEqual(replicator.state, CDTReplicatorStateError, @"Found: %@, expected: (%@)",
                    [CDTReplicator stringForReplicatorState:replicator.state],
                    [CDTReplicator stringForReplicatorState:CDTReplicatorStateError]);
 
-    STAssertEquals(mydel.error.code, CDTReplicatorErrorLocalDatabaseDeleted,
+    XCTAssertEqual(mydel.error.code, CDTReplicatorErrorLocalDatabaseDeleted,
                    @"Wrong error code: %ld", mydel.error.code);
     
     //have to wait for the threadsto completely stop executing
@@ -256,9 +256,9 @@ static NSUInteger largeRevTreeSize = 1500;
         [NSThread sleepForTimeInterval:1.0f];
     }
 
-    STAssertFalse(replicator.threadExecuting, @"First replicator thread executing");
-    STAssertTrue(replicator.threadFinished, @"First replicator thread NOT finished");
-    STAssertTrue(replicator.threadCanceled, @"First replicator thread NOT canceled");
+    XCTAssertFalse(replicator.threadExecuting, @"First replicator thread executing");
+    XCTAssertTrue(replicator.threadFinished, @"First replicator thread NOT finished");
+    XCTAssertTrue(replicator.threadCanceled, @"First replicator thread NOT canceled");
     
 }
 
@@ -281,7 +281,7 @@ static NSUInteger largeRevTreeSize = 1500;
     
     error = nil;
     if (![replicator startWithError:&error]) {
-        STFail(@"CDTReplicator -startWithError: %@", error);
+        XCTFail(@"CDTReplicator -startWithError: %@", error);
     }
     
     while (replicator.isActive) {
@@ -290,17 +290,17 @@ static NSUInteger largeRevTreeSize = 1500;
     }
     
     
-    STAssertTrue(n_docs != (NSUInteger)replicator.changesTotal, @"changesTotal: %ld, n_docs %ld",
+    XCTAssertTrue(n_docs != (NSUInteger)replicator.changesTotal, @"changesTotal: %ld, n_docs %ld",
                  replicator.changesTotal, n_docs);
     
-    STAssertTrue(n_docs != (NSUInteger)replicator.changesProcessed, @"changesProcessed: %ld, n_docs %ld",
+    XCTAssertTrue(n_docs != (NSUInteger)replicator.changesProcessed, @"changesProcessed: %ld, n_docs %ld",
                  replicator.changesProcessed, n_docs);
     
-    STAssertEquals(replicator.state, CDTReplicatorStateError, @"Found: %@, expected: (%@)",
+    XCTAssertEqual(replicator.state, CDTReplicatorStateError, @"Found: %@, expected: (%@)",
                    [CDTReplicator stringForReplicatorState:replicator.state],
                    [CDTReplicator stringForReplicatorState:CDTReplicatorStateError]);
 
-    STAssertEquals(mydel.error.code, CDTReplicatorErrorLocalDatabaseDeleted,
+    XCTAssertEqual(mydel.error.code, CDTReplicatorErrorLocalDatabaseDeleted,
                    @"Wrong error code: %ld", mydel.error.code);
     
     //have to wait for the threadsto completely stop executing
@@ -308,9 +308,9 @@ static NSUInteger largeRevTreeSize = 1500;
         [NSThread sleepForTimeInterval:1.0f];
     }
     
-    STAssertFalse(replicator.threadExecuting, @"First replicator thread executing");
-    STAssertTrue(replicator.threadFinished, @"First replicator thread NOT finished");
-    STAssertTrue(replicator.threadCanceled, @"First replicator thread NOT canceled");
+    XCTAssertFalse(replicator.threadExecuting, @"First replicator thread executing");
+    XCTAssertTrue(replicator.threadFinished, @"First replicator thread NOT finished");
+    XCTAssertTrue(replicator.threadCanceled, @"First replicator thread NOT canceled");
 }
 
 /**
@@ -332,14 +332,14 @@ static NSUInteger largeRevTreeSize = 1500;
     
     [self pullFromRemote];
     
-    STAssertEquals(self.datastore.documentCount, n_docs, @"Incorrect number of documents created");
+    XCTAssertEqual(self.datastore.documentCount, n_docs, @"Incorrect number of documents created");
     
     BOOL same = [self compareDatastore:self.datastore
                           withDatabase:self.primaryRemoteDatabaseURL];
-    STAssertTrue(same, @"Remote and local databases differ");
+    XCTAssertTrue(same, @"Remote and local databases differ");
     
     CDTQueryResult *res = [im queryWithDictionary:@{@"hello":@"world"} error:&error];
-    STAssertEquals([[res documentIds] count], n_docs, @"Index does not return correct count");
+    XCTAssertEqual([[res documentIds] count], n_docs, @"Index does not return correct count");
 }
 
 -(void) testPullFilteredReplication {
@@ -383,9 +383,9 @@ static NSUInteger largeRevTreeSize = 1500;
                         [NSString stringWithFormat:@"doc-%i", 23]];
     
     NSArray *localDocs = [self.datastore getDocumentsWithIds:docids];
-    STAssertNotNil(localDocs, @"nil");
-    STAssertTrue(localDocs.count == totalReplicated, @"unexpected number of docs: %@",localDocs.count);
-    STAssertTrue(self.datastore.documentCount == totalReplicated,
+    XCTAssertNotNil(localDocs, @"nil");
+    XCTAssertTrue(localDocs.count == totalReplicated, @"unexpected number of docs: %@",localDocs.count);
+    XCTAssertTrue(self.datastore.documentCount == totalReplicated,
                  @"Incorrect number of documents created %lu", self.datastore.documentCount);
     
 }
@@ -413,8 +413,8 @@ static NSUInteger largeRevTreeSize = 1500;
         [request setHeaders:headers];
     }] asJson];
     NSDictionary *jsonResponse = response.body.object;
-    STAssertTrue([jsonResponse[@"_id"] isEqual:@"doc-3"], @"%@", jsonResponse);
-    STAssertTrue([jsonResponse[@"docnum"] isEqual:@3], @"%@", jsonResponse);
+    XCTAssertTrue([jsonResponse[@"_id"] isEqual:@"doc-3"], @"%@", jsonResponse);
+    XCTAssertTrue([jsonResponse[@"docnum"] isEqual:@3], @"%@", jsonResponse);
     
 }
 
@@ -452,29 +452,29 @@ static NSUInteger largeRevTreeSize = 1500;
     
     NSError *error;
     if (![replicator startWithError:&error]) {
-        STFail(@"CDTReplicator -startWithError: %@", error);
+        XCTFail(@"CDTReplicator -startWithError: %@", error);
     }
     
     while (replicator.isActive) {
         [NSThread sleepForTimeInterval:1.0f];
     }
 
-    STAssertEquals(replicator.state, CDTReplicatorStateStopped, @"expected a different state: %d (%@)",
+    XCTAssertEqual(replicator.state, CDTReplicatorStateStopped, @"expected a different state: %d (%@)",
                    replicator.state, [CDTReplicator stringForReplicatorState:replicator.state]);
     
     BOOL docComparison = [self compareDocCount:self.datastore
       expectFewerDocsInRemoteDatabase:self.primaryRemoteDatabaseURL];
     
-    STAssertTrue(docComparison, @"Remote database doesn't have fewer docs than local.");
+    XCTAssertTrue(docComparison, @"Remote database doesn't have fewer docs than local.");
     
     //have to wait for the threadsto completely stop executing
     while(replicator.threadExecuting) {
         [NSThread sleepForTimeInterval:1.0f];
     }
     
-    STAssertFalse(replicator.threadExecuting, @"First replicator thread executing");
-    STAssertTrue(replicator.threadFinished, @"First replicator thread NOT finished");
-    STAssertTrue(replicator.threadCanceled, @"First replicator thread NOT canceled");
+    XCTAssertFalse(replicator.threadExecuting, @"First replicator thread executing");
+    XCTAssertTrue(replicator.threadFinished, @"First replicator thread NOT finished");
+    XCTAssertTrue(replicator.threadCanceled, @"First replicator thread NOT canceled");
     
 }
 
@@ -486,7 +486,7 @@ static NSUInteger largeRevTreeSize = 1500;
     // Create the initial rev
     NSString *docId = @"doc-0";
     [self createLocalDocWithId:docId revs:largeRevTreeSize];
-    STAssertEquals(self.datastore.documentCount, (NSUInteger)1, @"Incorrect number of documents created");
+    XCTAssertEqual(self.datastore.documentCount, (NSUInteger)1, @"Incorrect number of documents created");
 
     [self pushToRemote];
 
@@ -506,12 +506,12 @@ static NSUInteger largeRevTreeSize = 1500;
     NSDictionary *jsonResponse = response.body.object;
 
     // default couchdb revs_limit is 1000
-    STAssertEquals([jsonResponse[@"_revisions"][@"ids"] count], (NSUInteger)1000, @"Wrong number of revs");
-    STAssertTrue([jsonResponse[@"_rev"] hasPrefix:@"1500"], @"Not all revs seem to be replicated");
+    XCTAssertEqual([jsonResponse[@"_revisions"][@"ids"] count], (NSUInteger)1000, @"Wrong number of revs");
+    XCTAssertTrue([jsonResponse[@"_rev"] hasPrefix:@"1500"], @"Not all revs seem to be replicated");
 
     BOOL same = [self compareDatastore:self.datastore
                           withDatabase:self.primaryRemoteDatabaseURL];
-    STAssertTrue(same, @"Remote and local databases differ");
+    XCTAssertTrue(same, @"Remote and local databases differ");
 }
 
 /**
@@ -529,14 +529,14 @@ static NSUInteger largeRevTreeSize = 1500;
 
     CDTDocumentRevision *rev = [self.datastore getDocumentWithId:docId
                                                            error:&error];
-    STAssertNil(error, @"Error getting replicated doc: %@", error);
-    STAssertNotNil(rev, @"Error creating doc: rev was nil, but so was error");
+    XCTAssertNil(error, @"Error getting replicated doc: %@", error);
+    XCTAssertNotNil(rev, @"Error creating doc: rev was nil, but so was error");
 
-    STAssertTrue([rev.revId hasPrefix:@"1500"], @"Unexpected current rev in local document");
+    XCTAssertTrue([rev.revId hasPrefix:@"1500"], @"Unexpected current rev in local document");
 
     BOOL same = [self compareDatastore:self.datastore
                           withDatabase:self.primaryRemoteDatabaseURL];
-    STAssertTrue(same, @"Remote and local databases differ");
+    XCTAssertTrue(same, @"Remote and local databases differ");
 }
 
 /**
@@ -553,13 +553,13 @@ static NSUInteger largeRevTreeSize = 1500;
     NSLog(@"Creating documents...");
     [self createRemoteDocs:n_docs];
     [self pullFromRemote];
-    STAssertEquals(self.datastore.documentCount, n_docs, @"Incorrect number of documents created");
+    XCTAssertEqual(self.datastore.documentCount, n_docs, @"Incorrect number of documents created");
 
     // Modify all the docs -- we know they're going to be doc-1 to doc-<n_docs+1>
     for (int i = 1; i < n_docs+1; i++) {
         NSString *docId = [NSString stringWithFormat:@"doc-%i", i];
         CDTDocumentRevision *rev = [self.datastore getDocumentWithId:docId error:&error];
-        STAssertNil(error, @"Couldn't get document");
+        XCTAssertNil(error, @"Couldn't get document");
         [self addRevsToDocumentRevision:rev count:n_mods];
     }
 
@@ -582,14 +582,14 @@ static NSUInteger largeRevTreeSize = 1500;
         }] asJson];
         NSDictionary *jsonResponse = response.body.object;
 
-        STAssertEquals([jsonResponse[@"_revisions"][@"ids"] count], (NSUInteger)n_mods, @"Wrong number of revs");
-        STAssertTrue([jsonResponse[@"_rev"] hasPrefix:@"10"], @"Not all revs seem to be replicated");
+        XCTAssertEqual([jsonResponse[@"_revisions"][@"ids"] count], (NSUInteger)n_mods, @"Wrong number of revs");
+        XCTAssertTrue([jsonResponse[@"_rev"] hasPrefix:@"10"], @"Not all revs seem to be replicated");
     }
 
 
     BOOL same = [self compareDatastore:self.datastore
                           withDatabase:self.primaryRemoteDatabaseURL];
-    STAssertTrue(same, @"Remote and local databases differ");
+    XCTAssertTrue(same, @"Remote and local databases differ");
 }
 
 
@@ -606,7 +606,7 @@ static NSUInteger largeRevTreeSize = 1500;
     NSLog(@"Creating documents...");
     [self createRemoteDocs:n_docs];
     [self pullFromRemote];
-    STAssertEquals(self.datastore.documentCount, n_docs, @"Incorrect number of documents created");
+    XCTAssertEqual(self.datastore.documentCount, n_docs, @"Incorrect number of documents created");
 
     // Modify all the docs -- we know they're going to be doc-1 to doc-<n_docs+1>
     for (int i = 1; i < n_docs+1; i++) {
@@ -614,7 +614,7 @@ static NSUInteger largeRevTreeSize = 1500;
         CDTDocumentRevision *rev = [self.datastore getDocumentWithId:docId error:&error];
 
         [self.datastore deleteDocumentFromRevision:rev error:&error];
-        STAssertNil(error, @"Couldn't delete document");
+        XCTAssertNil(error, @"Couldn't delete document");
     }
 
     // Replicate the changes
@@ -626,7 +626,7 @@ static NSUInteger largeRevTreeSize = 1500;
 
     BOOL same = [self compareDatastore:self.datastore
                           withDatabase:self.primaryRemoteDatabaseURL];
-    STAssertTrue(same, @"Remote and local databases differ");
+    XCTAssertTrue(same, @"Remote and local databases differ");
 }
 
 /**
@@ -651,7 +651,7 @@ static NSUInteger largeRevTreeSize = 1500;
 
     BOOL same = [self compareDatastore:self.datastore
                           withDatabase:self.primaryRemoteDatabaseURL];
-    STAssertTrue(same, @"Remote and local databases differ");
+    XCTAssertTrue(same, @"Remote and local databases differ");
 }
 
 -(void) pushDocsAsWritingThem_pullReplicateThenSignal:(TRVSMonitor*)monitor
@@ -670,7 +670,7 @@ static NSUInteger largeRevTreeSize = 1500;
 -(void) pushDocsAsWritingThem_populateLocalDatabaseThenSignal:(TRVSMonitor*)monitor
 {
     [self createLocalDocs:n_docs];
-    STAssertEquals(self.datastore.documentCount, n_docs, @"Incorrect number of documents created");
+    XCTAssertEqual(self.datastore.documentCount, n_docs, @"Incorrect number of documents created");
     [monitor signal];
 }
 
@@ -701,13 +701,13 @@ static NSUInteger largeRevTreeSize = 1500;
 
     [monitor wait];
 
-    STAssertEquals(self.datastore.documentCount, (NSUInteger)n_docs*2, @"Wrong number of local docs");
+    XCTAssertEqual(self.datastore.documentCount, (NSUInteger)n_docs*2, @"Wrong number of local docs");
 
     [self pushToRemote];
 
     BOOL same = [self compareDatastore:self.datastore
                           withDatabase:self.primaryRemoteDatabaseURL];
-    STAssertTrue(same, @"Remote and local databases differ");
+    XCTAssertTrue(same, @"Remote and local databases differ");
 }
 
 -(void) pullDocsWhileWritingOthers_pullReplicateThenSignal:(TRVSMonitor*)monitor
@@ -762,7 +762,7 @@ static NSUInteger largeRevTreeSize = 1500;
     NSLog(@"Replicating to %@", [thirdDatabase absoluteString]);
     NSError *error;
     if (![replicator startWithError:&error]) {
-        STFail(@"CDTReplicator -startWithError: %@", error);
+        XCTFail(@"CDTReplicator -startWithError: %@", error);
     }
     
     while (replicator.isActive) {
@@ -772,7 +772,7 @@ static NSUInteger largeRevTreeSize = 1500;
 
     BOOL same = [self compareDatastore:self.datastore
                           withDatabase:thirdDatabase];
-    STAssertTrue(same, @"Remote and local databases differ");
+    XCTAssertTrue(same, @"Remote and local databases differ");
 
     [self deleteRemoteDatabase:thirdDatabaseName instanceURL:self.remoteRootURL];
 }
@@ -809,11 +809,11 @@ static NSUInteger largeRevTreeSize = 1500;
 
     [self pushToRemote];
 
-    STAssertEquals(self.datastore.documentCount, (NSUInteger)n_docs, @"Wrong number of local docs");
+    XCTAssertEqual(self.datastore.documentCount, (NSUInteger)n_docs, @"Wrong number of local docs");
 
     BOOL same = [self compareDatastore:self.datastore
                           withDatabase:self.primaryRemoteDatabaseURL];
-    STAssertTrue(same, @"Remote and local databases differ");
+    XCTAssertTrue(same, @"Remote and local databases differ");
 }
 
 -(void) pullDocsWhileWritingSame_pullReplicateThenSignal:(TRVSMonitor*)monitor
@@ -871,7 +871,7 @@ static NSUInteger largeRevTreeSize = 1500;
     NSLog(@"Replicating to %@", [thirdDatabase absoluteString]);
     NSError *error;
     if (![replicator startWithError:&error]) {
-        STFail(@"CDTReplicator -startWithError: %@", error);
+        XCTFail(@"CDTReplicator -startWithError: %@", error);
     }
     
     while (replicator.isActive) {
@@ -881,7 +881,7 @@ static NSUInteger largeRevTreeSize = 1500;
 
     BOOL same = [self compareDatastore:self.datastore
                           withDatabase:thirdDatabase];
-    STAssertTrue(same, @"Remote and local databases differ");
+    XCTAssertTrue(same, @"Remote and local databases differ");
 
     [self deleteRemoteDatabase:thirdDatabaseName instanceURL:self.remoteRootURL];
 }
@@ -934,7 +934,7 @@ static NSUInteger largeRevTreeSize = 1500;
     
     BOOL same = [self compareDatastore:self.datastore
                           withDatabase:self.primaryRemoteDatabaseURL];
-    STAssertTrue(same, @"Remote and local databases differ");
+    XCTAssertTrue(same, @"Remote and local databases differ");
 }
 
 
@@ -957,7 +957,7 @@ static NSUInteger largeRevTreeSize = 1500;
     
     BOOL same = [self compareDatastore:self.datastore
                           withDatabase:self.primaryRemoteDatabaseURL];
-    STAssertTrue(same, @"Remote and local databases differ");
+    XCTAssertTrue(same, @"Remote and local databases differ");
 }
 
 /**
@@ -978,10 +978,10 @@ static NSUInteger largeRevTreeSize = 1500;
     pull.optionalHeaders = extraHeaders;
     
     NSDictionary *pullDoc = [pull dictionaryForReplicatorDocument:nil];
-    STAssertEqualObjects(pullDoc[@"headers"][@"SpecialHeader"], @"foo", @"Bad headers: %@",
+    XCTAssertEqualObjects(pullDoc[@"headers"][@"SpecialHeader"], @"foo", @"Bad headers: %@",
                          pullDoc[@"headers"]);
     
-    STAssertEqualObjects(pullDoc[@"headers"][@"user-agent"], userAgent, @"Bad headers: %@",
+    XCTAssertEqualObjects(pullDoc[@"headers"][@"user-agent"], userAgent, @"Bad headers: %@",
                          pullDoc[@"headers"]);
 
     
@@ -1004,11 +1004,11 @@ static NSUInteger largeRevTreeSize = 1500;
     [NSURLProtocol unregisterClass:[ReplicatorURLProtocol class]];
     [ReplicatorURLProtocol setTestDelegate:nil];
     
-    STAssertNil(tester.headerFailures, @"Errors found in headers.");
+    XCTAssertNil(tester.headerFailures, @"Errors found in headers.");
     
     for (NSString *headerName in tester.headerFailures) {
         
-        STAssertTrue([tester.headerFailures[headerName] integerValue] == [@0 integerValue],
+        XCTAssertTrue([tester.headerFailures[headerName] integerValue] == [@0 integerValue],
                      @"Found %ld failures with the header \"%@\"", 
                      [tester.headerFailures[headerName] integerValue], headerName);
         
@@ -1034,29 +1034,29 @@ static NSUInteger largeRevTreeSize = 1500;
     replicator.delegate = tester;
     secondReplicator.delegate = tester;
     
-    STAssertFalse(replicator.threadExecuting, @"First replicator thread executing");
-    STAssertFalse(replicator.threadFinished, @"First replicator thread finished");
-    STAssertFalse(replicator.threadCanceled, @"First replicator thread canceled");
+    XCTAssertFalse(replicator.threadExecuting, @"First replicator thread executing");
+    XCTAssertFalse(replicator.threadFinished, @"First replicator thread finished");
+    XCTAssertFalse(replicator.threadCanceled, @"First replicator thread canceled");
 
-    STAssertFalse(secondReplicator.threadExecuting, @"Second replicator thread executing");
-    STAssertFalse(secondReplicator.threadFinished, @"Second replicator thread finished");
-    STAssertFalse(secondReplicator.threadCanceled, @"Second replicator thread canceled");
+    XCTAssertFalse(secondReplicator.threadExecuting, @"Second replicator thread executing");
+    XCTAssertFalse(secondReplicator.threadFinished, @"Second replicator thread finished");
+    XCTAssertFalse(secondReplicator.threadCanceled, @"Second replicator thread canceled");
     
     NSError *error;
-    STAssertTrue([replicator startWithError:&error],
+    XCTAssertTrue([replicator startWithError:&error],
                 @"First replicator started with error: %@", error);
     error = nil;
-    STAssertTrue([secondReplicator startWithError:&error],
+    XCTAssertTrue([secondReplicator startWithError:&error],
                 @"Second replicator started with error: %@", error);
 
     
-    STAssertTrue(replicator.threadExecuting, @"First replicator thread NOT executing");
-    STAssertFalse(replicator.threadFinished, @"First replicator thread finished");
-    STAssertFalse(replicator.threadCanceled, @"First replicator thread canceled");
+    XCTAssertTrue(replicator.threadExecuting, @"First replicator thread NOT executing");
+    XCTAssertFalse(replicator.threadFinished, @"First replicator thread finished");
+    XCTAssertFalse(replicator.threadCanceled, @"First replicator thread canceled");
     
-    STAssertTrue(secondReplicator.threadExecuting, @"Second replicator thread NOT executing");
-    STAssertFalse(secondReplicator.threadFinished, @"Second replicator thread finished");
-    STAssertFalse(secondReplicator.threadCanceled, @"Second replicator thread canceled");
+    XCTAssertTrue(secondReplicator.threadExecuting, @"Second replicator thread NOT executing");
+    XCTAssertFalse(secondReplicator.threadFinished, @"Second replicator thread finished");
+    XCTAssertFalse(secondReplicator.threadCanceled, @"Second replicator thread canceled");
     
     while (replicator.isActive || secondReplicator.isActive) {
         [NSThread sleepForTimeInterval:1.0f];
@@ -1067,20 +1067,20 @@ static NSUInteger largeRevTreeSize = 1500;
         
     }
     
-    STAssertTrue(tester.multiThreaded, @"Delegate didn't find multithreading evidence.");
+    XCTAssertTrue(tester.multiThreaded, @"Delegate didn't find multithreading evidence.");
 
     //wait for the threads to completely stop executing
     while(replicator.threadExecuting || secondReplicator.threadExecuting) {
         [NSThread sleepForTimeInterval:1.0f];
     }
 
-    STAssertFalse(replicator.threadExecuting, @"First replicator thread executing");
-    STAssertTrue(replicator.threadFinished, @"First replicator thread NOT finished");
-    STAssertFalse(replicator.threadCanceled, @"First replicator thread canceled");
+    XCTAssertFalse(replicator.threadExecuting, @"First replicator thread executing");
+    XCTAssertTrue(replicator.threadFinished, @"First replicator thread NOT finished");
+    XCTAssertFalse(replicator.threadCanceled, @"First replicator thread canceled");
     
-    STAssertFalse(secondReplicator.threadExecuting, @"Second replicator thread executing");
-    STAssertTrue(secondReplicator.threadFinished, @"Second replicator thread NOT finished");
-    STAssertFalse(secondReplicator.threadCanceled, @"Second replicator thread canceled");
+    XCTAssertFalse(secondReplicator.threadExecuting, @"Second replicator thread executing");
+    XCTAssertTrue(secondReplicator.threadFinished, @"Second replicator thread NOT finished");
+    XCTAssertFalse(secondReplicator.threadCanceled, @"Second replicator thread canceled");
     
 }
 

--- a/ReplicationAcceptance/ReplicationAcceptance/ReplicatorURLProtocol.h
+++ b/ReplicationAcceptance/ReplicationAcceptance/ReplicatorURLProtocol.h
@@ -6,7 +6,7 @@
 //
 //
 #import <Foundation/Foundation.h>
-#import <SenTestingKit/SenTestingKit.h>
+#import <XCTest/XCTest.h>
 
 @class ReplicatorURLProtocolTester;
 

--- a/Tests/Tests.xcodeproj/project.pbxproj
+++ b/Tests/Tests.xcodeproj/project.pbxproj
@@ -78,7 +78,7 @@
 
 /* Begin PBXFileReference section */
 		03034DD60492427AC73C43CD /* Pods-osx.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-osx.release.xcconfig"; path = "Pods/Target Support Files/Pods-osx/Pods-osx.release.xcconfig"; sourceTree = "<group>"; };
-		27389E0C185345FD0027A404 /* Tests.octest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Tests.octest; sourceTree = BUILT_PRODUCTS_DIR; };
+		27389E0C185345FD0027A404 /* Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		27389E11185345FD0027A404 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		27389E13185345FD0027A404 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
 		27389E17185345FD0027A404 /* Tests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Tests-Info.plist"; sourceTree = "<group>"; };
@@ -88,7 +88,7 @@
 		27389E2E18534E050027A404 /* CloudantSyncTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CloudantSyncTests.m; sourceTree = "<group>"; };
 		27389E3018534E050027A404 /* DatastoreActions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DatastoreActions.m; sourceTree = "<group>"; };
 		27651C6319001B54006FEF7F /* bonsai-boston.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; name = "bonsai-boston.jpg"; path = "Assets/bonsai-boston.jpg"; sourceTree = "<group>"; };
-		27CCEDC6187AD64F006F3C66 /* Tests OSX.octest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Tests OSX.octest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		27CCEDC6187AD64F006F3C66 /* Tests OSX.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Tests OSX.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		27CCEDCA187AD64F006F3C66 /* Tests OSX-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Tests OSX-Info.plist"; sourceTree = "<group>"; };
 		27CCEDCC187AD64F006F3C66 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		27CCEDCE187AD64F006F3C66 /* Tests_OSX.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Tests_OSX.m; sourceTree = "<group>"; };
@@ -172,8 +172,8 @@
 		27389E0D185345FD0027A404 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				27389E0C185345FD0027A404 /* Tests.octest */,
-				27CCEDC6187AD64F006F3C66 /* Tests OSX.octest */,
+				27389E0C185345FD0027A404 /* Tests.xctest */,
+				27CCEDC6187AD64F006F3C66 /* Tests OSX.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -325,7 +325,7 @@
 			);
 			name = Tests;
 			productName = Tests;
-			productReference = 27389E0C185345FD0027A404 /* Tests.octest */;
+			productReference = 27389E0C185345FD0027A404 /* Tests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 		27CCEDC5187AD64F006F3C66 /* Tests OSX */ = {
@@ -344,7 +344,7 @@
 			);
 			name = "Tests OSX";
 			productName = "Tests OSX";
-			productReference = 27CCEDC6187AD64F006F3C66 /* Tests OSX.octest */;
+			productReference = 27CCEDC6187AD64F006F3C66 /* Tests OSX.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */

--- a/Tests/Tests.xcodeproj/project.pbxproj
+++ b/Tests/Tests.xcodeproj/project.pbxproj
@@ -9,7 +9,6 @@
 /* Begin PBXBuildFile section */
 		009D4E71AED34A54853B7F51 /* libPods-osx.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BBD8D50209E84CD981F3FA7A /* libPods-osx.a */; };
 		270ED44E19D165BB007E08C4 /* CDTQueryBuilderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9985C74819AE5D8300636AB6 /* CDTQueryBuilderTests.m */; };
-		27389E10185345FD0027A404 /* SenTestingKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 27389E0F185345FD0027A404 /* SenTestingKit.framework */; };
 		27389E12185345FD0027A404 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 27389E11185345FD0027A404 /* Foundation.framework */; };
 		27389E14185345FD0027A404 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 27389E13185345FD0027A404 /* UIKit.framework */; };
 		27389E1A185345FD0027A404 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 27389E18185345FD0027A404 /* InfoPlist.strings */; };
@@ -17,7 +16,6 @@
 		27389E3618534E050027A404 /* DatastoreActions.m in Sources */ = {isa = PBXBuildFile; fileRef = 27389E3018534E050027A404 /* DatastoreActions.m */; };
 		27651C6419001B54006FEF7F /* bonsai-boston.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 27651C6319001B54006FEF7F /* bonsai-boston.jpg */; };
 		27651C6519001B54006FEF7F /* bonsai-boston.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 27651C6319001B54006FEF7F /* bonsai-boston.jpg */; };
-		27CCEDC7187AD64F006F3C66 /* SenTestingKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 27389E0F185345FD0027A404 /* SenTestingKit.framework */; };
 		27CCEDCD187AD64F006F3C66 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 27CCEDCB187AD64F006F3C66 /* InfoPlist.strings */; };
 		27CCEDD6187AD70C006F3C66 /* CloudantSyncTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 27389E2E18534E050027A404 /* CloudantSyncTests.m */; };
 		27CCEDD7187AD719006F3C66 /* DatastoreActions.m in Sources */ = {isa = PBXBuildFile; fileRef = 27389E3018534E050027A404 /* DatastoreActions.m */; };
@@ -81,7 +79,6 @@
 /* Begin PBXFileReference section */
 		03034DD60492427AC73C43CD /* Pods-osx.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-osx.release.xcconfig"; path = "Pods/Target Support Files/Pods-osx/Pods-osx.release.xcconfig"; sourceTree = "<group>"; };
 		27389E0C185345FD0027A404 /* Tests.octest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Tests.octest; sourceTree = BUILT_PRODUCTS_DIR; };
-		27389E0F185345FD0027A404 /* SenTestingKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SenTestingKit.framework; path = Library/Frameworks/SenTestingKit.framework; sourceTree = DEVELOPER_DIR; };
 		27389E11185345FD0027A404 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		27389E13185345FD0027A404 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
 		27389E17185345FD0027A404 /* Tests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Tests-Info.plist"; sourceTree = "<group>"; };
@@ -142,7 +139,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				27389E10185345FD0027A404 /* SenTestingKit.framework in Frameworks */,
 				27389E14185345FD0027A404 /* UIKit.framework in Frameworks */,
 				27389E12185345FD0027A404 /* Foundation.framework in Frameworks */,
 				640AB8661E6344B98E64E18E /* libPods-ios.a in Frameworks */,
@@ -154,7 +150,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				9F0D23E918888C6C00D3D04E /* Foundation.framework in Frameworks */,
-				27CCEDC7187AD64F006F3C66 /* SenTestingKit.framework in Frameworks */,
 				009D4E71AED34A54853B7F51 /* libPods-osx.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -187,7 +182,6 @@
 			isa = PBXGroup;
 			children = (
 				9F0D23E818888C6C00D3D04E /* Foundation.framework */,
-				27389E0F185345FD0027A404 /* SenTestingKit.framework */,
 				27389E11185345FD0027A404 /* Foundation.framework */,
 				27389E13185345FD0027A404 /* UIKit.framework */,
 				635BE7F70A3A4DFFA9455CDC /* libPods.a */,
@@ -332,7 +326,7 @@
 			name = Tests;
 			productName = Tests;
 			productReference = 27389E0C185345FD0027A404 /* Tests.octest */;
-			productType = "com.apple.product-type.bundle.ocunit-test";
+			productType = "com.apple.product-type.bundle.unit-test";
 		};
 		27CCEDC5187AD64F006F3C66 /* Tests OSX */ = {
 			isa = PBXNativeTarget;
@@ -351,7 +345,7 @@
 			name = "Tests OSX";
 			productName = "Tests OSX";
 			productReference = 27CCEDC6187AD64F006F3C66 /* Tests OSX.octest */;
-			productType = "com.apple.product-type.bundle.ocunit-test";
+			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */
 
@@ -624,7 +618,6 @@
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
-				WRAPPER_EXTENSION = octest;
 			};
 			name = Debug;
 		};
@@ -668,7 +661,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;
-				WRAPPER_EXTENSION = octest;
 			};
 			name = Release;
 		};
@@ -715,7 +707,6 @@
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
-				WRAPPER_EXTENSION = octest;
 			};
 			name = Debug;
 		};
@@ -756,7 +747,6 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
-				WRAPPER_EXTENSION = octest;
 			};
 			name = Release;
 		};

--- a/Tests/Tests.xcodeproj/xcshareddata/xcschemes/Tests OSX.xcscheme
+++ b/Tests/Tests.xcodeproj/xcshareddata/xcschemes/Tests OSX.xcscheme
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0610"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "27CCEDC5187AD64F006F3C66"
+               BuildableName = "Tests OSX.xctest"
+               BlueprintName = "Tests OSX"
+               ReferencedContainer = "container:Tests.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "27CCEDC5187AD64F006F3C66"
+               BuildableName = "Tests OSX.xctest"
+               BlueprintName = "Tests OSX"
+               ReferencedContainer = "container:Tests.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "27CCEDC5187AD64F006F3C66"
+            BuildableName = "Tests OSX.xctest"
+            BlueprintName = "Tests OSX"
+            ReferencedContainer = "container:Tests.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "27CCEDC5187AD64F006F3C66"
+            BuildableName = "Tests OSX.xctest"
+            BlueprintName = "Tests OSX"
+            ReferencedContainer = "container:Tests.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "27CCEDC5187AD64F006F3C66"
+            BuildableName = "Tests OSX.xctest"
+            BlueprintName = "Tests OSX"
+            ReferencedContainer = "container:Tests.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Tests/Tests.xcodeproj/xcshareddata/xcschemes/Tests iOS.xcscheme
+++ b/Tests/Tests.xcodeproj/xcshareddata/xcschemes/Tests iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0500"
+   LastUpgradeVersion = "0610"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -9,28 +9,14 @@
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"
-            buildForProfiling = "YES"
+            buildForProfiling = "NO"
             buildForArchiving = "NO"
-            buildForAnalyzing = "NO">
+            buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "27389E0B185345FD0027A404"
                BuildableName = "Tests.xctest"
                BlueprintName = "Tests"
-               ReferencedContainer = "container:Tests.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "NO"
-            buildForAnalyzing = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "27CCEDC5187AD64F006F3C66"
-               BuildableName = "Tests OSX.xctest"
-               BlueprintName = "Tests OSX"
                ReferencedContainer = "container:Tests.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -52,17 +38,16 @@
                ReferencedContainer = "container:Tests.xcodeproj">
             </BuildableReference>
          </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "27CCEDC5187AD64F006F3C66"
-               BuildableName = "Tests OSX.xctest"
-               BlueprintName = "Tests OSX"
-               ReferencedContainer = "container:Tests.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "27389E0B185345FD0027A404"
+            BuildableName = "Tests.xctest"
+            BlueprintName = "Tests"
+            ReferencedContainer = "container:Tests.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </TestAction>
    <LaunchAction
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
@@ -82,13 +67,6 @@
             ReferencedContainer = "container:Tests.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <EnvironmentVariables>
-         <EnvironmentVariable
-            key = "OBJC_DISABLE_GC"
-            value = "YES"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-      </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>
@@ -98,6 +76,15 @@
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "27389E0B185345FD0027A404"
+            BuildableName = "Tests.xctest"
+            BlueprintName = "Tests"
+            ReferencedContainer = "container:Tests.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Tests/Tests.xcodeproj/xcshareddata/xcschemes/Tests.xcscheme
+++ b/Tests/Tests.xcodeproj/xcshareddata/xcschemes/Tests.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "27389E0B185345FD0027A404"
-               BuildableName = "Tests.octest"
+               BuildableName = "Tests.xctest"
                BlueprintName = "Tests"
                ReferencedContainer = "container:Tests.xcodeproj">
             </BuildableReference>
@@ -29,7 +29,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "27CCEDC5187AD64F006F3C66"
-               BuildableName = "Tests OSX.octest"
+               BuildableName = "Tests OSX.xctest"
                BlueprintName = "Tests OSX"
                ReferencedContainer = "container:Tests.xcodeproj">
             </BuildableReference>
@@ -47,7 +47,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "27389E0B185345FD0027A404"
-               BuildableName = "Tests.octest"
+               BuildableName = "Tests.xctest"
                BlueprintName = "Tests"
                ReferencedContainer = "container:Tests.xcodeproj">
             </BuildableReference>
@@ -57,7 +57,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "27CCEDC5187AD64F006F3C66"
-               BuildableName = "Tests OSX.octest"
+               BuildableName = "Tests OSX.xctest"
                BlueprintName = "Tests OSX"
                ReferencedContainer = "container:Tests.xcodeproj">
             </BuildableReference>
@@ -73,6 +73,15 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "27389E0B185345FD0027A404"
+            BuildableName = "Tests.xctest"
+            BlueprintName = "Tests"
+            ReferencedContainer = "container:Tests.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <EnvironmentVariables>
          <EnvironmentVariable
             key = "OBJC_DISABLE_GC"

--- a/Tests/Tests/Attachments/AttachmentCRUD.m
+++ b/Tests/Tests/Attachments/AttachmentCRUD.m
@@ -260,7 +260,8 @@
                                  table:@"attachments"
                                hasRows:expectedRows
                                  error:&validationError],
-                     [dc formattedErrors:validationError]);
+                                @"%@",
+                      [dc formattedErrors:validationError]);
     }];
 }
 
@@ -322,7 +323,8 @@
                                  table:@"attachments"
                                hasRows:expectedRows
                                  error:&validationError],
-                     [dc formattedErrors:validationError]);
+                      @"%@",
+                      [dc formattedErrors:validationError]);
     }];
 }
 
@@ -373,7 +375,8 @@
                                  table:@"attachments"
                                hasRows:expectedRows
                                  error:&validationError],
-                     [dc formattedErrors:validationError]);
+                      @"%@",
+                      [dc formattedErrors:validationError]);
     }];
 }
 
@@ -475,7 +478,8 @@
                                hasRows:expectedRows
                                orderBy:orderBy
                                  error:&validationError],
-                     [dc formattedErrors:validationError]);
+                      @"%@",
+                      [dc formattedErrors:validationError]);
     }];
 }
 
@@ -551,8 +555,9 @@
         XCTAssertTrue([dc checkDatabase:db
                                  table:@"attachments"
                                hasRows:expectedRows
-                                 error:&validationError],
-                     [dc formattedErrors:validationError]);
+                                  error:&validationError],
+                      @"%@",
+                      [dc formattedErrors:validationError]);
     }];
 }
 
@@ -671,7 +676,8 @@
                                  table:@"attachments"
                                hasRows:expectedRows
                                  error:&validationError],
-                     [dc formattedErrors:validationError]);
+                      @"%@",
+                      [dc formattedErrors:validationError]);
     }];
 }
 
@@ -742,7 +748,8 @@
                                  table:@"attachments"
                                hasRows:expectedRows
                                  error:&validationError],
-                     [dc formattedErrors:validationError]);
+                      @"%@",
+                      [dc formattedErrors:validationError]);
     }];
 }
 
@@ -856,7 +863,8 @@
                                  table:@"attachments"
                                hasRows:expectedRows
                                  error:&validationError],
-                     [dc formattedErrors:validationError]);
+                      @"%@",
+                      [dc formattedErrors:validationError]);
     }];
 }
 
@@ -903,7 +911,8 @@
                                  table:@"attachments"
                                hasRows:expectedRows
                                  error:&validationError],
-                     [dc formattedErrors:validationError]);
+                      @"%@",
+                      [dc formattedErrors:validationError]);
     }];
 
 }
@@ -958,7 +967,8 @@
                                  table:@"revs"
                                hasRows:expectedRows
                                  error:&validationError],
-                     [dc formattedErrors:validationError]);
+                      @"%@",
+                      [dc formattedErrors:validationError]);
         
         // Check the attachments table is empty
         expectedRows = @[
@@ -968,7 +978,8 @@
                                  table:@"attachments"
                                hasRows:expectedRows
                                  error:&validationError],
-                     [dc formattedErrors:validationError]);
+                       @"%@",
+                       [dc formattedErrors:validationError]);
     }];
 }
 

--- a/Tests/Tests/Attachments/AttachmentCRUD.m
+++ b/Tests/Tests/Attachments/AttachmentCRUD.m
@@ -13,7 +13,7 @@
 //  either express or implied. See the License for the specific language governing permissions
 //  and limitations under the License.
 
-#import <SenTestingKit/SenTestingKit.h>
+#import <XCTest/XCTest.h>
 #import <CommonCrypto/CommonDigest.h>
 
 #import <CloudantSync.h>
@@ -55,7 +55,7 @@
     self.dbutil =[[DBQueryUtils alloc]
                   initWithDbPath:[self pathForDBName:self.datastore.name]];
 
-    STAssertNotNil(self.datastore, @"datastore is nil");
+    XCTAssertNotNil(self.datastore, @"datastore is nil");
 }
 
 - (void)tearDown
@@ -125,27 +125,27 @@
     NSDictionary * body = @{@"aKey":@"aValue",@"hello":@"world"};
     
     
-    STAssertNil(error, @"Error should have been nil");
+    XCTAssertNil(error, @"Error should have been nil");
     
     CDTDocumentRevision * rev = [CDTDocumentRevision createRevisionFromJson:dict
                                                                 forDocument:[NSURL
                                                                              URLWithString:@"http://localhost:5984/temp/doc"]
                                                                       error:&error];
     
-    STAssertNil(error, @"Error occured creating document with valid data");
-    STAssertNotNil(rev, @"Revision was nil");
-    STAssertEqualObjects(@"someIdHere",
+    XCTAssertNil(error, @"Error occured creating document with valid data");
+    XCTAssertNotNil(rev, @"Revision was nil");
+    XCTAssertEqualObjects(@"someIdHere",
                          rev.docId,
                          @"docId was different, expected someIdHere actual %@",
                          rev.docId);
-    STAssertEqualObjects(@"3-750dac460a6cc41e6999f8943b8e603e",
+    XCTAssertEqualObjects(@"3-750dac460a6cc41e6999f8943b8e603e",
                          rev.revId,
                          @"Revision was different expected 3-750dac460a6cc41e6999f8943b8e603e actual %@",
                          rev.revId);
     
-    STAssertEqualObjects(body, rev.body, @"Body was different");
-    STAssertFalse(rev.deleted, @"Document is not marked as deleted");
-    STAssertEquals([rev.attachments count], (NSUInteger) 1, @"Attachment count is wrong, expected 1 actual %d", [rev.attachments count]);
+    XCTAssertEqualObjects(body, rev.body, @"Body was different");
+    XCTAssertFalse(rev.deleted, @"Document is not marked as deleted");
+    XCTAssertEqual([rev.attachments count], (NSUInteger) 1, @"Attachment count is wrong, expected 1 actual %d", [rev.attachments count]);
     
 }
 
@@ -179,27 +179,27 @@
     NSDictionary * body = @{@"aKey":@"aValue",@"hello":@"world"};
     
     
-    STAssertNil(error, @"Error should have been nil");
+    XCTAssertNil(error, @"Error should have been nil");
     
     CDTDocumentRevision * rev = [CDTDocumentRevision createRevisionFromJson:dict
                                                                 forDocument:attachmentDir
                                                                       error:&error];
     
-    STAssertNil(error, @"Error occured creating document with valid data");
-    STAssertNotNil(rev, @"Revision was nil");
-    STAssertEqualObjects(@"someIdHere",
+    XCTAssertNil(error, @"Error occured creating document with valid data");
+    XCTAssertNotNil(rev, @"Revision was nil");
+    XCTAssertEqualObjects(@"someIdHere",
                          rev.docId,
                          @"docId was different, expected someIdHere actual %@",
                          rev.docId);
-    STAssertEqualObjects(@"3-750dac460a6cc41e6999f8943b8e603e",
+    XCTAssertEqualObjects(@"3-750dac460a6cc41e6999f8943b8e603e",
                          rev.revId,
                          @"Revision was different expected 3-750dac460a6cc41e6999f8943b8e603e actual %@",
                          rev.revId);
     
-    STAssertEqualObjects(body, rev.body, @"Body was different");
-    STAssertFalse(rev.deleted, @"Document is not marked as deleted");
-    STAssertEquals([rev.attachments count], (NSUInteger) 1, @"Attachment count is wrong, expected 1 actual %d", [rev.attachments count]);
-    STAssertEqualObjects(data, [[rev.attachments objectForKey:@"bonsai-boston.jpg"]dataFromAttachmentContent],@"data was not the same");
+    XCTAssertEqualObjects(body, rev.body, @"Body was different");
+    XCTAssertFalse(rev.deleted, @"Document is not marked as deleted");
+    XCTAssertEqual([rev.attachments count], (NSUInteger) 1, @"Attachment count is wrong, expected 1 actual %d", [rev.attachments count]);
+    XCTAssertEqualObjects(data, [[rev.attachments objectForKey:@"bonsai-boston.jpg"]dataFromAttachmentContent],@"data was not the same");
     
 }
 
@@ -221,7 +221,7 @@
     CDTDocumentRevision *rev2 = [self.datastore updateDocumentFromRevision: document
                                                                      error:&error];
 
-    STAssertNotNil(rev2, @"Updating with an empty attachments array gave nil response");
+    XCTAssertNotNil(rev2, @"Updating with an empty attachments array gave nil response");
 
     NSBundle *bundle = [NSBundle bundleForClass:[self class]];
     NSString *imagePath = [bundle pathForResource:@"bonsai-boston" ofType:@"jpg"];
@@ -237,15 +237,15 @@
     CDTDocumentRevision *rev3 = [self.datastore updateDocumentFromRevision:document
                                                                      error:&error];
 
-    STAssertNotNil(rev3, @"Updating with a non-empty attachments array gave nil response");
+    XCTAssertNotNil(rev3, @"Updating with a non-empty attachments array gave nil response");
 
     NSDictionary *attachments = rev3.attachments;
-    STAssertEquals((NSUInteger)1, [attachments count], @"Wrong number of attachments");
+    XCTAssertEqual((NSUInteger)1, [attachments count], @"Wrong number of attachments");
     CDTSavedAttachment *savedAttachment = [attachments objectForKey:attachmentName];
-    STAssertEqualObjects(savedAttachment.name, attachmentName, @"Attachment wasn't in document");
+    XCTAssertEqualObjects(savedAttachment.name, attachmentName, @"Attachment wasn't in document");
 
     // Check db and fs
-    STAssertTrue([self attachmentExists:@"D55F9AC778BAF2256FA4DE87AAC61F590EBE66E0.blob"],
+    XCTAssertTrue([self attachmentExists:@"D55F9AC778BAF2256FA4DE87AAC61F590EBE66E0.blob"],
                  @"Attachment file doesn't exist");
 
     [self.dbutil.queue inDatabase:^(FMDatabase *db ) {
@@ -256,7 +256,7 @@
 
         MRDatabaseContentChecker *dc = [[MRDatabaseContentChecker alloc] init];
         NSError *validationError;
-        STAssertTrue([dc checkDatabase:db
+        XCTAssertTrue([dc checkDatabase:db
                                  table:@"attachments"
                                hasRows:expectedRows
                                  error:&validationError],
@@ -282,7 +282,7 @@
     CDTDocumentRevision *rev2 = [self.datastore updateDocumentFromRevision: document
                                                                      error:&error];
     
-    STAssertNotNil(rev2, @"Updating with an empty attachments array gave nil response");
+    XCTAssertNotNil(rev2, @"Updating with an empty attachments array gave nil response");
     
     NSBundle *bundle = [NSBundle bundleForClass:[self class]];
     NSString *imagePath = [bundle pathForResource:@"bonsai-boston" ofType:@"jpg"];
@@ -298,16 +298,16 @@
     CDTDocumentRevision *rev3 = [self.datastore updateDocumentFromRevision:document
                                                                      error:&error];
     
-    STAssertNotNil(rev3, @"Updating with a non-empty attachments array gave nil response");
+    XCTAssertNotNil(rev3, @"Updating with a non-empty attachments array gave nil response");
     
     NSDictionary *attachments = rev3.attachments;
     CDTSavedAttachment *savedAttachment = [attachments objectForKey:attachmentName];
-    STAssertEquals((NSUInteger)1, [attachments count], @"Wrong number of attachments");
-    STAssertEqualObjects(savedAttachment.name, attachmentName,
+    XCTAssertEqual((NSUInteger)1, [attachments count], @"Wrong number of attachments");
+    XCTAssertEqualObjects(savedAttachment.name, attachmentName,
                          @"Attachment wasn't in document");
     
     // Check db and fs
-    STAssertTrue([self attachmentExists:@"D55F9AC778BAF2256FA4DE87AAC61F590EBE66E0.blob"],
+    XCTAssertTrue([self attachmentExists:@"D55F9AC778BAF2256FA4DE87AAC61F590EBE66E0.blob"],
                  @"Attachment file doesn't exist");
     
     [self.dbutil.queue inDatabase:^(FMDatabase *db ) {
@@ -318,7 +318,7 @@
         
         MRDatabaseContentChecker *dc = [[MRDatabaseContentChecker alloc] init];
         NSError *validationError;
-        STAssertTrue([dc checkDatabase:db
+        XCTAssertTrue([dc checkDatabase:db
                                  table:@"attachments"
                                hasRows:expectedRows
                                  error:&validationError],
@@ -352,13 +352,13 @@
 
     NSDictionary *attachments = rev.attachments;
     CDTSavedAttachment *savedAttachment = [attachments objectForKey:@"bonsai-boston"];
-    STAssertEquals((NSUInteger)1, [attachments count], @"Wrong number of attachments");
-    STAssertEqualObjects(savedAttachment.name, @"bonsai-boston",
+    XCTAssertEqual((NSUInteger)1, [attachments count], @"Wrong number of attachments");
+    XCTAssertEqualObjects(savedAttachment.name, @"bonsai-boston",
                          @"Attachment wasn't in document");
 
     // Check db and fs
 
-    STAssertTrue([self attachmentExists:@"D55F9AC778BAF2256FA4DE87AAC61F590EBE66E0.blob"],
+    XCTAssertTrue([self attachmentExists:@"D55F9AC778BAF2256FA4DE87AAC61F590EBE66E0.blob"],
                  @"Attachment file doesn't exist");
 
     [self.dbutil.queue inDatabase:^(FMDatabase *db ) {
@@ -369,7 +369,7 @@
 
         MRDatabaseContentChecker *dc = [[MRDatabaseContentChecker alloc] init];
         NSError *validationError;
-        STAssertTrue([dc checkDatabase:db
+        XCTAssertTrue([dc checkDatabase:db
                                  table:@"attachments"
                                hasRows:expectedRows
                                  error:&validationError],
@@ -411,7 +411,7 @@
     rev = [self.datastore updateDocumentFromRevision:document error:&error];
     
 
-    STAssertEquals((NSUInteger)2,
+    XCTAssertEqual((NSUInteger)2,
                    [[rev attachments ] count],
                    @"Wrong number of attachments");
 
@@ -427,7 +427,7 @@
     rev = [self.datastore updateDocumentFromRevision:document error:&error];
 
     NSDictionary *attachments = rev.attachments;
-    STAssertEquals((NSUInteger)3, [attachments count], @"Wrong number of attachments");
+    XCTAssertEqual((NSUInteger)3, [attachments count], @"Wrong number of attachments");
 
     // Confirm each attachment has the correct data
 
@@ -445,14 +445,14 @@
         NSData *attachmentData = [retrievedAttachment dataFromAttachmentContent];
         NSData *retrievedMD5 = [self MD5:attachmentData];
 
-        STAssertEqualObjects(retrievedMD5, inputMD5, @"Received MD5s");
+        XCTAssertEqualObjects(retrievedMD5, inputMD5, @"Received MD5s");
     }
 
     // Check db and fs
 
-    STAssertTrue([self attachmentExists:@"D55F9AC778BAF2256FA4DE87AAC61F590EBE66E0.blob"],
+    XCTAssertTrue([self attachmentExists:@"D55F9AC778BAF2256FA4DE87AAC61F590EBE66E0.blob"],
                  @"Attachment file doesn't exist");  // image
-    STAssertTrue([self attachmentExists:@"3FF2989BCCF52150BBA806BAE1DB2E0B06AD6F88.blob"],
+    XCTAssertTrue([self attachmentExists:@"3FF2989BCCF52150BBA806BAE1DB2E0B06AD6F88.blob"],
                  @"Attachment file doesn't exist");  // text
 
     [self.dbutil.queue inDatabase:^(FMDatabase *db ) {
@@ -470,7 +470,7 @@
         MRDatabaseContentChecker *dc = [[MRDatabaseContentChecker alloc] init];
         NSError *validationError;
         NSArray * orderBy = @[@"sequence", @"filename"];
-        STAssertTrue([dc checkDatabase:db
+        XCTAssertTrue([dc checkDatabase:db
                                  table:@"attachments"
                                hasRows:expectedRows
                                orderBy:orderBy
@@ -514,7 +514,7 @@
     
     CDTDocumentRevision *revision = [self.datastore getDocumentWithId:rev.docId
                                                                 error:&error];
-    STAssertEquals((NSUInteger)2, [revision.attachments count],
+    XCTAssertEqual((NSUInteger)2, [revision.attachments count],
                    @"Wrong number of attachments");
 
     for (NSArray *item in @[ @[@"bonsai-boston", imageData], @[@"lorem", txtData] ]) {
@@ -528,14 +528,14 @@
         NSData *attachmentData = [retrievedAttachment dataFromAttachmentContent];
         NSData *retrievedMD5 = [self MD5:attachmentData];
 
-        STAssertEqualObjects(retrievedMD5, inputMD5, @"Received MD5s");
+        XCTAssertEqualObjects(retrievedMD5, inputMD5, @"Received MD5s");
     }
 
     // Check db and fs
 
-    STAssertTrue([self attachmentExists:@"D55F9AC778BAF2256FA4DE87AAC61F590EBE66E0.blob"],
+    XCTAssertTrue([self attachmentExists:@"D55F9AC778BAF2256FA4DE87AAC61F590EBE66E0.blob"],
                  @"Attachment file doesn't exist");  // image
-    STAssertTrue([self attachmentExists:@"3FF2989BCCF52150BBA806BAE1DB2E0B06AD6F88.blob"],
+    XCTAssertTrue([self attachmentExists:@"3FF2989BCCF52150BBA806BAE1DB2E0B06AD6F88.blob"],
                  @"Attachment file doesn't exist");  // text
 
     [self.dbutil.queue inDatabase:^(FMDatabase *db ) {
@@ -548,7 +548,7 @@
 
         MRDatabaseContentChecker *dc = [[MRDatabaseContentChecker alloc] init];
         NSError *validationError;
-        STAssertTrue([dc checkDatabase:db
+        XCTAssertTrue([dc checkDatabase:db
                                  table:@"attachments"
                                hasRows:expectedRows
                                  error:&validationError],
@@ -586,16 +586,16 @@
 
     NSDictionary *attachments = rev2.attachments;
     CDTSavedAttachment * savedAttachment = [attachments objectForKey:attachmentName];
-    STAssertEquals((NSUInteger)1, [attachments count], @"Wrong number of attachments");
-    STAssertEqualObjects([savedAttachment name], attachmentName, @"Attachment wasn't in document");
+    XCTAssertEqual((NSUInteger)1, [attachments count], @"Wrong number of attachments");
+    XCTAssertEqualObjects([savedAttachment name], attachmentName, @"Attachment wasn't in document");
 
     CDTAttachment *retrievedAttachment = [attachments objectForKey:attachmentName];
-    STAssertNotNil(retrievedAttachment, @"retrievedAttachment was nil");
+    XCTAssertNotNil(retrievedAttachment, @"retrievedAttachment was nil");
 
     NSData *attachmentData = [retrievedAttachment dataFromAttachmentContent];
     NSData *retrievedMD5 = [self MD5:attachmentData];
 
-    STAssertEqualObjects(retrievedMD5, inputMD5, @"Received MD5s");
+    XCTAssertEqualObjects(retrievedMD5, inputMD5, @"Received MD5s");
 }
 
 - (void)testUpdate
@@ -647,15 +647,15 @@
     NSData *attachmentData = [retrievedAttachment dataFromAttachmentContent];
     NSData *retrievedMD5 = [self MD5:attachmentData];
 
-    STAssertEqualObjects(retrievedMD5, inputMD5, @"Received MD5s");
+    XCTAssertEqualObjects(retrievedMD5, inputMD5, @"Received MD5s");
 
     // Check db and fs
 
     // Both files will remain until a -compact, even though the
     // image was "overwritten"
-    STAssertTrue([self attachmentExists:@"D55F9AC778BAF2256FA4DE87AAC61F590EBE66E0.blob"],
+    XCTAssertTrue([self attachmentExists:@"D55F9AC778BAF2256FA4DE87AAC61F590EBE66E0.blob"],
                  @"Attachment file doesn't exist");  // image
-    STAssertTrue([self attachmentExists:@"3FF2989BCCF52150BBA806BAE1DB2E0B06AD6F88.blob"],
+    XCTAssertTrue([self attachmentExists:@"3FF2989BCCF52150BBA806BAE1DB2E0B06AD6F88.blob"],
                  @"Attachment file doesn't exist");  // text
 
     [self.dbutil.queue inDatabase:^(FMDatabase *db ) {
@@ -667,7 +667,7 @@
 
         MRDatabaseContentChecker *dc = [[MRDatabaseContentChecker alloc] init];
         NSError *validationError;
-        STAssertTrue([dc checkDatabase:db
+        XCTAssertTrue([dc checkDatabase:db
                                  table:@"attachments"
                                hasRows:expectedRows
                                  error:&validationError],
@@ -703,8 +703,8 @@
 
     attachments = rev2.attachments;
     CDTSavedAttachment *savedAttachment = [attachments objectForKey:attachmentName];
-    STAssertEquals((NSUInteger)1, [attachments count], @"Wrong number of attachments");
-    STAssertEqualObjects(savedAttachment.name, attachmentName, @"Attachment wasn't in document");
+    XCTAssertEqual((NSUInteger)1, [attachments count], @"Wrong number of attachments");
+    XCTAssertEqualObjects(savedAttachment.name, attachmentName, @"Attachment wasn't in document");
 
     //
     // Delete the attachment we added
@@ -717,17 +717,17 @@
     // rev2 should still have an attachment
     attachments = [self.datastore getDocumentWithId:rev2.docId rev:rev2.revId error:&error]
                     .attachments;
-    STAssertEquals((NSUInteger)1, [attachments count], @"Wrong number of attachments");
+    XCTAssertEqual((NSUInteger)1, [attachments count], @"Wrong number of attachments");
 
     // whereas rev3 should not
     attachments = rev3.attachments;
-    STAssertEquals((NSUInteger)0, [attachments count], @"Wrong number of attachments");
+    XCTAssertEqual((NSUInteger)0, [attachments count], @"Wrong number of attachments");
 
     // Check db and fs
 
     // The file will remain until a -compact, even though the
     // attachment was deleted
-    STAssertTrue([self attachmentExists:@"D55F9AC778BAF2256FA4DE87AAC61F590EBE66E0.blob"],
+    XCTAssertTrue([self attachmentExists:@"D55F9AC778BAF2256FA4DE87AAC61F590EBE66E0.blob"],
                  @"Attachment file doesn't exist");  // image
 
     [self.dbutil.queue inDatabase:^(FMDatabase *db ) {
@@ -738,7 +738,7 @@
 
         MRDatabaseContentChecker *dc = [[MRDatabaseContentChecker alloc] init];
         NSError *validationError;
-        STAssertTrue([dc checkDatabase:db
+        XCTAssertTrue([dc checkDatabase:db
                                  table:@"attachments"
                                hasRows:expectedRows
                                  error:&validationError],
@@ -779,20 +779,20 @@
 
     NSDictionary *attachments = rev2.attachments;
     CDTSavedAttachment * savedAttachment = [attachments objectForKey:attachmentName];
-    STAssertEquals((NSUInteger)1, [attachments count], @"Wrong number of attachments");
-    STAssertEqualObjects(savedAttachment.name, attachmentName, @"Attachment wasn't in document");
+    XCTAssertEqual((NSUInteger)1, [attachments count], @"Wrong number of attachments");
+    XCTAssertEqualObjects(savedAttachment.name, attachmentName, @"Attachment wasn't in document");
 
     CDTAttachment *retrievedAttachment = [attachments objectForKey:attachmentName];
 
-    STAssertNotNil(retrievedAttachment, @"retrievedAttachment was nil");
+    XCTAssertNotNil(retrievedAttachment, @"retrievedAttachment was nil");
 
     NSData *attachmentData = [retrievedAttachment dataFromAttachmentContent];
     NSData *retrievedMD5 = [self MD5:attachmentData];
 
-    STAssertEqualObjects(retrievedMD5, inputMD5, @"Received MD5s");
+    XCTAssertEqualObjects(retrievedMD5, inputMD5, @"Received MD5s");
 
     // Check file exists, but we've checked DB several times so assume okay
-    STAssertTrue([self attachmentExists:@"D55F9AC778BAF2256FA4DE87AAC61F590EBE66E0.blob"],
+    XCTAssertTrue([self attachmentExists:@"D55F9AC778BAF2256FA4DE87AAC61F590EBE66E0.blob"],
                  @"Attachment file doesn't exist");  // image
 }
 
@@ -804,7 +804,7 @@
                                  initWithData:nil
                                          name:@"test_attachment"
                                          type:@"image/jpg"];
-    STAssertNil(attachment, @"Shouldn't be able to create attachment with nil data");
+    XCTAssertNil(attachment, @"Shouldn't be able to create attachment with nil data");
 }
 
 - (void) testBadFilePathPreventsInitAttachment
@@ -813,7 +813,7 @@
                                  initWithPath:@"/non_existant"
                                          name:@"test_attachment"
                                          type:@"text/plain"];
-    STAssertNil(attachment, @"Shouldn't be able to create attachment with bad file path");
+    XCTAssertNil(attachment, @"Shouldn't be able to create attachment with bad file path");
 }
 
 - (void) testFileDeletedAfterAttachmentCreatedGivesNilStream
@@ -822,7 +822,7 @@
     NSBundle *bundle = [NSBundle bundleForClass:[self class]];
     NSString *tempPath = [self tempFileName];
 
-    STAssertTrue([fm copyItemAtPath:[bundle pathForResource:@"bonsai-boston" ofType:@"jpg"]
+    XCTAssertTrue([fm copyItemAtPath:[bundle pathForResource:@"bonsai-boston" ofType:@"jpg"]
                              toPath:tempPath
                               error:nil],
                  @"File couldn't be copied");
@@ -832,18 +832,18 @@
                                          name:@"test_attachment"
                                          type:@"text/plain"];
     
-    STAssertNotNil(attachment, @"File path should exist");
+    XCTAssertNotNil(attachment, @"File path should exist");
 
-    STAssertTrue([fm removeItemAtPath:tempPath
+    XCTAssertTrue([fm removeItemAtPath:tempPath
                                 error:nil],
                  @"File couldn't be deleted");
 
     NSData *attachmentData = [attachment dataFromAttachmentContent];
-    STAssertNil(attachmentData, @"File deleted, input stream should be nil");
+    XCTAssertNil(attachmentData, @"File deleted, input stream should be nil");
 
     // Check fs and db -- file shouldn't exist, database should be empty
 
-    STAssertTrue([self attachmentsPathIsEmpty], @"Attachments directory wasn't empty");
+    XCTAssertTrue([self attachmentsPathIsEmpty], @"Attachments directory wasn't empty");
 
     [self.dbutil.queue inDatabase:^(FMDatabase *db ) {
         NSArray *expectedRows = @[
@@ -852,7 +852,7 @@
 
         MRDatabaseContentChecker *dc = [[MRDatabaseContentChecker alloc] init];
         NSError *validationError;
-        STAssertTrue([dc checkDatabase:db
+        XCTAssertTrue([dc checkDatabase:db
                                  table:@"attachments"
                                hasRows:expectedRows
                                  error:&validationError],
@@ -882,15 +882,15 @@
     CDTDocumentRevision *rev2 = [self.datastore updateDocumentFromRevision:mutableRev error:&error];
 
     // Should fail, we shouldn't get a revision and should get a decent error
-    STAssertNil(rev2, @"rev2 should be nil");
-    STAssertNotNil(error, @"error shouldn't have been nil");
-    STAssertEquals((NSInteger)kTDStatusAttachmentStreamError,
+    XCTAssertNil(rev2, @"rev2 should be nil");
+    XCTAssertNotNil(error, @"error shouldn't have been nil");
+    XCTAssertEqual((NSInteger)kTDStatusAttachmentStreamError,
                    error.code,
                    @"Error should be kTDStatusAttachmentStreamError");
 
     // Database should be empty
 
-    STAssertTrue([self attachmentsPathIsEmpty], @"Attachments directory wasn't empty");
+    XCTAssertTrue([self attachmentsPathIsEmpty], @"Attachments directory wasn't empty");
 
     [self.dbutil.queue inDatabase:^(FMDatabase *db ) {
         NSArray *expectedRows = @[
@@ -899,7 +899,7 @@
 
         MRDatabaseContentChecker *dc = [[MRDatabaseContentChecker alloc] init];
         NSError *validationError;
-        STAssertTrue([dc checkDatabase:db
+        XCTAssertTrue([dc checkDatabase:db
                                  table:@"attachments"
                                hasRows:expectedRows
                                  error:&validationError],
@@ -938,9 +938,9 @@
     
 
     
-    STAssertNil(rev2, @"Updating with broken attachment didn't give null response");
-    STAssertNotNil(error, @"error shouldn't have been nil");
-    STAssertEquals((NSInteger)kTDStatusAttachmentStreamError,
+    XCTAssertNil(rev2, @"Updating with broken attachment didn't give null response");
+    XCTAssertNotNil(error, @"error shouldn't have been nil");
+    XCTAssertEqual((NSInteger)kTDStatusAttachmentStreamError,
                    error.code,
                    @"Error should be kTDStatusAttachmentStreamError");
 
@@ -954,7 +954,7 @@
                                   ];
         
         NSError *validationError;
-        STAssertTrue([dc checkDatabase:db
+        XCTAssertTrue([dc checkDatabase:db
                                  table:@"revs"
                                hasRows:expectedRows
                                  error:&validationError],
@@ -964,7 +964,7 @@
         expectedRows = @[
                          @[@"sequence"],
                          ];
-        STAssertTrue([dc checkDatabase:db
+        XCTAssertTrue([dc checkDatabase:db
                                  table:@"attachments"
                                hasRows:expectedRows
                                  error:&validationError],
@@ -994,8 +994,8 @@
     CDTDocumentRevision *rev = [self.datastore createDocumentFromRevision:mutableRev  error:&error];
     
     
-    STAssertNil(error,@"An error occured saving the document");
-    STAssertNotNil(rev, @"First document was not created");
+    XCTAssertNil(error,@"An error occured saving the document");
+    XCTAssertNotNil(rev, @"First document was not created");
     
     mutableRev = [CDTMutableDocumentRevision revision];
     mutableRev.body = dict;
@@ -1003,8 +1003,8 @@
     
     CDTDocumentRevision *doc2 = [self.datastore createDocumentFromRevision:mutableRev error:&error];
     
-    STAssertNil(error, @"An error occured saving the document");
-    STAssertNotNil(doc2, @"New document was nil");
+    XCTAssertNil(error, @"An error occured saving the document");
+    XCTAssertNotNil(doc2, @"New document was nil");
     
 
 }
@@ -1027,7 +1027,7 @@
     CDTDocumentRevision *rev2 = [self.datastore updateDocumentFromRevision: document
                                                                      error:&error];
     
-    STAssertNotNil(rev2, @"Updating with an empty attachments array gave nil response");
+    XCTAssertNotNil(rev2, @"Updating with an empty attachments array gave nil response");
     
     NSBundle *bundle = [NSBundle bundleForClass:[self class]];
     NSString *imagePath = [bundle pathForResource:@"bonsai-boston" ofType:@"jpg"];
@@ -1048,7 +1048,7 @@
     NSArray * allDocuuments = [self.datastore getAllDocuments];
     
     for(CDTDocumentRevision * revision in allDocuuments){
-        STAssertTrue([revision.attachments count] == 1, @"Attachment count is %d not 1", [revision.attachments count]);
+        XCTAssertTrue([revision.attachments count] == 1, @"Attachment count is %d not 1", [revision.attachments count]);
     }
 }
 
@@ -1070,7 +1070,7 @@
     CDTDocumentRevision *rev2 = [self.datastore updateDocumentFromRevision: document
                                                                      error:&error];
     
-    STAssertNotNil(rev2, @"Updating with an empty attachments array gave nil response");
+    XCTAssertNotNil(rev2, @"Updating with an empty attachments array gave nil response");
     
     NSBundle *bundle = [NSBundle bundleForClass:[self class]];
     NSString *imagePath = [bundle pathForResource:@"bonsai-boston" ofType:@"jpg"];
@@ -1090,12 +1090,12 @@
     
     NSArray * allDocuuments = [self.datastore getDocumentsWithIds:@[rev.docId]];
     
-    STAssertTrue([allDocuuments count] == 1,
+    XCTAssertTrue([allDocuuments count] == 1,
                  @"Unexpected number of documents 1 expected got %d",
                  [allDocuuments count]);
     
     for(CDTDocumentRevision * revision in allDocuuments){
-        STAssertTrue([revision.attachments count] == 1, @"Attachment count is %d not 1", [revision.attachments count]);
+        XCTAssertTrue([revision.attachments count] == 1, @"Attachment count is %d not 1", [revision.attachments count]);
     }
 }
 

--- a/Tests/Tests/CDTQueryBuilderTests.m
+++ b/Tests/Tests/CDTQueryBuilderTests.m
@@ -39,7 +39,7 @@
     [self.factory deleteDatastoreNamed:@"test" error:&error];
     self.datastore = [self.factory datastoreNamed:@"test" error:&error];
     
-    STAssertNotNil(self.datastore, @"datastore is nil");
+    XCTAssertNotNil(self.datastore, @"datastore is nil");
 }
 
 
@@ -254,11 +254,11 @@
                                                                options: options
                                                                  error: &error];
     
-    STAssertEqualObjects(query.sql, sqlToVerify, nil);
-    STAssertEquals([query.values count], [valuesToVerify count], nil);
-    STAssertEqualObjects(query.values, valuesToVerify, nil);
-    STAssertEquals([query.usedIndexes count], [indexReferencesToVerify count], nil);
-    STAssertEqualObjects(query.usedIndexes, indexReferencesToVerify, nil);
+    XCTAssertEqualObjects(query.sql, sqlToVerify);
+    XCTAssertEqual([query.values count], [valuesToVerify count]);
+    XCTAssertEqualObjects(query.values, valuesToVerify);
+    XCTAssertEqual([query.usedIndexes count], [indexReferencesToVerify count]);
+    XCTAssertEqualObjects(query.usedIndexes, indexReferencesToVerify);
     
 }
 
@@ -272,8 +272,8 @@
                                     options: options
                                     error: &error];
     
-    STAssertTrue(query.sql == nil, nil);
-    STAssertTrue([error code] == codeToVerify, nil);
+    XCTAssertTrue(query.sql == nil);
+    XCTAssertTrue([error code] == codeToVerify);
     
 }
 
@@ -306,30 +306,30 @@
     }
     
     BOOL ok = [im ensureIndexedWithIndexName:@"name" fieldName:@"name" error:&error];
-    STAssertTrue(ok, @"ensureIndexedWithIndexName did not return true");
+    XCTAssertTrue(ok, @"ensureIndexedWithIndexName did not return true");
     
     ok = [im ensureIndexedWithIndexName: @"field"
                               fieldName: @"field"
                                    type: CDTIndexTypeInteger error:&error];
-    STAssertTrue(ok, @"ensureIndexedWithIndexName did not return true");
+    XCTAssertTrue(ok, @"ensureIndexedWithIndexName did not return true");
   
     CDTQueryResult* result = [im
                               queryWithPredicate: [NSPredicate predicateWithFormat:@"name = 'tom'"]
                                          options: nil error:&error];
-    STAssertTrue(result != nil, @"Result shouldn't be nil");
-    STAssertTrue([[result documentIds] count] == 1000,
+    XCTAssertTrue(result != nil, @"Result shouldn't be nil");
+    XCTAssertTrue([[result documentIds] count] == 1000,
                  @"Should have 1000 records with name = 'tom'");
   
     result = [im queryWithPredicate: [NSPredicate predicateWithFormat:@"field = 5" ]
                             options: nil
                               error: &error];
-    STAssertTrue([[result documentIds] count]==2, @"Should have two records with field value 5");
+    XCTAssertTrue([[result documentIds] count]==2, @"Should have two records with field value 5");
     
     result = [im
               queryWithPredicate:
                 [NSPredicate predicateWithFormat:@"(field = 5) and (name = 'tom')" ]
                            error: &error];
-    STAssertTrue([[result documentIds] count]==1,
+    XCTAssertTrue([[result documentIds] count]==1,
                  @"Should have one record with field value 5 and name = 'tom'");
     
     // use the convenience method without providing an options
@@ -337,7 +337,7 @@
               queryWithPredicate: [NSPredicate predicateWithFormat:@"(field = 5) or (name = 'tom')"]
                          options: nil
                            error: &error];
-    STAssertTrue([[result documentIds] count]==1001,
+    XCTAssertTrue([[result documentIds] count]==1001,
                  @"Should have 1001 records with field value 5 or name = 'tom' "
                   "(all tom plus one mary)");
     
@@ -347,7 +347,7 @@
               [NSPredicate predicateWithFormat:@"(field < 50) and (name = 'tom')" ]
                             options: options
                               error: &error];
-    STAssertTrue([[result documentIds] count]==50,
+    XCTAssertTrue([[result documentIds] count]==50,
                  @"Should have 50 (0 to 49) records with field value <50 and name = 'tom'");
     
     // I set offset without a limit first since the SQL Lite syntax requires a limit setting
@@ -358,7 +358,7 @@
               [NSPredicate predicateWithFormat:@"(field < 50) and (name = 'tom')" ]
                             options: options
                               error: &error];
-    STAssertTrue([[result documentIds] count]==40,
+    XCTAssertTrue([[result documentIds] count]==40,
                  @"Should have 40 (skip 1st 10) records with field value <50 and name = 'tom'");
     
     // Now put the limit in as well
@@ -368,7 +368,7 @@
                 [NSPredicate predicateWithFormat:@"(field < 50) and (name = 'tom')" ]
                                          options: options
                                            error: &error];
-    STAssertTrue([[result documentIds] count]==10,
+    XCTAssertTrue([[result documentIds] count]==10,
                  @"Should have 10 (limit to 10) records with field value <50 and name = 'tom'");
     
     // check sort results
@@ -377,10 +377,10 @@
         NSDictionary *object = [revision body];
         [queryResults addObject:object];
     }
-    STAssertTrue(([[[queryResults firstObject] objectForKey:@"field"] integerValue] == 10),
+    XCTAssertTrue(([[[queryResults firstObject] objectForKey:@"field"] integerValue] == 10),
                  @"1st obj should be 10");
     
-    STAssertTrue(([[[queryResults lastObject] objectForKey:@"field"] integerValue] == 19),
+    XCTAssertTrue(([[[queryResults lastObject] objectForKey:@"field"] integerValue] == 19),
                  @"last obj should be 19");
     
 }
@@ -396,9 +396,9 @@
                               queryWithPredicate: [NSPredicate predicateWithFormat:@"foo = 'tom'"]
                                          options: nil
                                            error: &error];
-    STAssertNil(result, @"Result should be nil since the index does not exist");
-    STAssertNotNil(error, @"Error should be populated with the right message");
-    STAssertTrue([error code] == CDTIndexErrorIndexDoesNotExist, @"Error should be Index does not "
+    XCTAssertNil(result, @"Result should be nil since the index does not exist");
+    XCTAssertNotNil(error, @"Error should be populated with the right message");
+    XCTAssertTrue([error code] == CDTIndexErrorIndexDoesNotExist, @"Error should be Index does not "
                  "exist");
     
     // try it with an index name that isn't valid
@@ -406,9 +406,9 @@
                 queryWithPredicate: [NSPredicate predicateWithFormat:@"_foo = 'tom'"]
                            options: nil
                              error: &error];
-    STAssertNil(result, @"Result should be nil since the index does not exist");
-    STAssertNotNil(error, @"Error should be populated with the right message");
-    STAssertTrue([error code] == CDTIndexErrorInvalidIndexName, @"Error should be Index name is "
+    XCTAssertNil(result, @"Result should be nil since the index does not exist");
+    XCTAssertNotNil(error, @"Error should be populated with the right message");
+    XCTAssertTrue([error code] == CDTIndexErrorInvalidIndexName, @"Error should be Index name is "
                  "invalid");
     
 }

--- a/Tests/Tests/CDTReplicationTests.m
+++ b/Tests/Tests/CDTReplicationTests.m
@@ -12,7 +12,7 @@
 //  either express or implied. See the License for the specific language governing permissions
 //  and limitations under the License.
 
-#import <SenTestingKit/SenTestingKit.h>
+#import <XCTest/XCTest.h>
 #import "CDTPullReplication.h"
 #import "CDTPushReplication.h"
 #import "CloudantSyncTests.h"
@@ -53,8 +53,8 @@
     
     error = nil;
     NSDictionary *pullDict = [pull dictionaryForReplicatorDocument:&error];
-    STAssertNil(error, @"Error creating dictionary. %@. Replicator: %@", error, pull);
-    STAssertEqualObjects(pullDict, expectedDictionary, @"pull dictionary: %@", pullDict);
+    XCTAssertNil(error, @"Error creating dictionary. %@. Replicator: %@", error, pull);
+    XCTAssertEqualObjects(pullDict, expectedDictionary, @"pull dictionary: %@", pullDict);
     
     //ensure that TDReplicatorManager makes the appropriate TDPuller object
     //The code to do this, seems, a bit precarious and this guards against any future
@@ -64,7 +64,7 @@
                                               initWithDatabaseManager:self.factory.manager];
     TDReplicator *tdreplicator = [replicatorManager createReplicatorWithProperties:pullDict
                                                                              error:&error];
-    STAssertEqualObjects([tdreplicator class], [TDPuller class], @"Wrong Type of TDReplicator. %@", error);
+    XCTAssertEqualObjects([tdreplicator class], [TDPuller class], @"Wrong Type of TDReplicator. %@", error);
 }
 
 -(void)testDictionaryForPushReplicationDocument
@@ -82,8 +82,8 @@
     
     error = nil;
     NSDictionary *pushDict = [push dictionaryForReplicatorDocument:&error];
-    STAssertNil(error, @"Error creating dictionary. %@. Replicator: %@", error, push);
-    STAssertEqualObjects(pushDict, expectedDictionary, @"push dictionary: %@", pushDict);
+    XCTAssertNil(error, @"Error creating dictionary. %@. Replicator: %@", error, push);
+    XCTAssertEqualObjects(pushDict, expectedDictionary, @"push dictionary: %@", pushDict);
     
     //ensure that TDReplicatorManager makes the appropriate TDPuller object
     //The code to do this, seems, a bit precarious and this guards against any future
@@ -93,7 +93,7 @@
                                               initWithDatabaseManager:self.factory.manager];
     TDReplicator *tdreplicator = [replicatorManager createReplicatorWithProperties:pushDict
                                                                              error:&error];
-    STAssertEqualObjects([tdreplicator class], [TDPusher class], @"Wrong Type of TDReplicator. %@", error);
+    XCTAssertEqualObjects([tdreplicator class], [TDPusher class], @"Wrong Type of TDReplicator. %@", error);
 }
 
 
@@ -117,13 +117,13 @@
     
     error = nil;
     CDTReplicator *replicator =  [replicatorFactory oneWay:push error:&error];
-    STAssertNotNil(replicator, @"%@", push);
-    STAssertNil(error, @"%@", error);
+    XCTAssertNotNil(replicator, @"%@", push);
+    XCTAssertNil(error, @"%@", error);
 
     NSDictionary *pushDoc = [push dictionaryForReplicatorDocument:nil];
     
-    STAssertTrue(push.filter != nil, @"No filter set in CDTPushReplication");
-    STAssertEqualObjects(@{@"param1":@"foo"}, pushDoc[@"query_params"], @"\n%@", pushDoc);
+    XCTAssertTrue(push.filter != nil, @"No filter set in CDTPushReplication");
+    XCTAssertEqualObjects(@{@"param1":@"foo"}, pushDoc[@"query_params"], @"\n%@", pushDoc);
     
     //ensure that TDReplicatorManager makes the appropriate TDPuller object
     //The code to do this, seems, a bit precarious and this guards against any future
@@ -133,7 +133,7 @@
                                               initWithDatabaseManager:self.factory.manager];
     TDReplicator *tdreplicator = [replicatorManager createReplicatorWithProperties:pushDoc
                                                                              error:&error];
-    STAssertEqualObjects([tdreplicator class], [TDPusher class], @"Wrong Type of TDReplicator. %@", error);
+    XCTAssertEqualObjects([tdreplicator class], [TDPusher class], @"Wrong Type of TDReplicator. %@", error);
 }
 
 -(CDTAbstractReplication *)buildReplicationObject:(Class)aClass remoteUrl:(NSURL *)url
@@ -160,7 +160,7 @@
 {
     CDTAbstractReplication *pr = [self buildReplicationObject:prClass remoteUrl:url];
     NSError *error = nil;
-    STAssertTrue([pr validateRemoteDatastoreURL:url error:&error], @"\nerror: %@ \nurl: %@", error, url);
+    XCTAssertTrue([pr validateRemoteDatastoreURL:url error:&error], @"\nerror: %@ \nurl: %@", error, url);
 }
 
 -(void)urlTestExpectFalse:(Class)prClass
@@ -170,8 +170,8 @@
     NSError *error = nil;
     CDTAbstractReplication *pr = [self buildReplicationObject:prClass remoteUrl:url];
     
-    STAssertFalse([pr validateRemoteDatastoreURL:url error:&error], @"\nerror: %@ \nurl: %@", error, url);
-    STAssertTrue(error.code == code, @"\nerror: %@  \nurl: %@", error, url);
+    XCTAssertFalse([pr validateRemoteDatastoreURL:url error:&error], @"\nerror: %@ \nurl: %@", error, url);
+    XCTAssertTrue(error.code == code, @"\nerror: %@  \nurl: %@", error, url);
 }
 
 -(void)runUrlTestFor:(Class)prClass
@@ -278,15 +278,15 @@
     
     error = nil;
     CDTReplicator *replicator =  [replicatorFactory oneWay:push error:&error];
-    STAssertNotNil(replicator, @"%@", push);
-    STAssertNil(error, @"%@", error);
+    XCTAssertNotNil(replicator, @"%@", push);
+    XCTAssertNil(error, @"%@", error);
     
-    STAssertEquals(replicator.state, CDTReplicatorStatePending, @"Unexpected state: %@",
+    XCTAssertEqual(replicator.state, CDTReplicatorStatePending, @"Unexpected state: %@",
                    [CDTReplicator stringForReplicatorState:replicator.state ]);
     
     [replicator stop];
     
-    STAssertEquals(replicator.state, CDTReplicatorStateStopped, @"Unexpected state: %@",
+    XCTAssertEqual(replicator.state, CDTReplicatorStateStopped, @"Unexpected state: %@",
                    [CDTReplicator stringForReplicatorState:replicator.state ]);
     
 }
@@ -315,10 +315,10 @@
     pull = [self createPullReplicationWithHeaders:optionalHeaders];
     error = nil;
     pullDoc = [pull dictionaryForReplicatorDocument:&error];
-    STAssertNotNil(pullDoc, @"CDTPullReplication -dictionaryForReplicatorDocument failed with "
+    XCTAssertNotNil(pullDoc, @"CDTPullReplication -dictionaryForReplicatorDocument failed with "
                    @"header: %@", optionalHeaders);
     
-    STAssertTrue([pullDoc[@"headers"][@"User-Agent"] isEqualToString:@"My Agent"],
+    XCTAssertTrue([pullDoc[@"headers"][@"User-Agent"] isEqualToString:@"My Agent"],
                  @"Bad headers: %@", pullDoc[@"headers"]);
     
     
@@ -337,10 +337,10 @@
         pull = [self createPullReplicationWithHeaders:optionalHeaders];
         error = nil;
         pullDoc = [pull dictionaryForReplicatorDocument:&error];
-        STAssertNil(pullDoc, @"CDTPullReplication -dictionaryForReplicatorDocument passed with "
+        XCTAssertNil(pullDoc, @"CDTPullReplication -dictionaryForReplicatorDocument passed with "
                        @"header: %@, pullDoc: %@", optionalHeaders, pullDoc);
-        STAssertNotNil(error, @"Error was not set");
-        STAssertEquals(error.code, CDTReplicationErrorProhibitedOptionalHttpHeader,
+        XCTAssertNotNil(error, @"Error was not set");
+        XCTAssertEqual(error.code, CDTReplicationErrorProhibitedOptionalHttpHeader,
                        @"Wrote error code: %@", error.code);
     }
     //make sure the lower case versions fail too
@@ -349,10 +349,10 @@
         pull = [self createPullReplicationWithHeaders:optionalHeaders];
         error = nil;
         pullDoc = [pull dictionaryForReplicatorDocument:&error];
-        STAssertNil(pullDoc, @"CDTPullReplication -dictionaryForReplicatorDocument passed with "
+        XCTAssertNil(pullDoc, @"CDTPullReplication -dictionaryForReplicatorDocument passed with "
                     @"header: %@, pullDoc: %@", optionalHeaders, pullDoc);
-        STAssertNotNil(error, @"Error was not set");
-        STAssertEquals(error.code, CDTReplicationErrorProhibitedOptionalHttpHeader,
+        XCTAssertNotNil(error, @"Error was not set");
+        XCTAssertEqual(error.code, CDTReplicationErrorProhibitedOptionalHttpHeader,
                        @"Wrote error code: %@", error.code);
     }
 }

--- a/Tests/Tests/CloudantSyncTests.m
+++ b/Tests/Tests/CloudantSyncTests.m
@@ -37,7 +37,7 @@
     char *result = mkdtemp(tempDirectoryNameCString);
     if (!result)
     {
-        STFail(@"Couldn't create temporary directory");
+        XCTFail(@"Couldn't create temporary directory");
     }
     
     NSString *path = [[NSFileManager defaultManager]
@@ -65,8 +65,8 @@
     NSError *error;
     self.factory = [[CDTDatastoreManager alloc] initWithDirectory:self.factoryPath error:&error];
     
-    STAssertNil(error, @"CDTDatastoreManager had error");
-    STAssertNotNil(self.factory, @"Factory is nil");
+    XCTAssertNil(error, @"CDTDatastoreManager had error");
+    XCTAssertNotNil(self.factory, @"Factory is nil");
     
 }
 
@@ -76,7 +76,7 @@
     
     NSError *error;
     [[NSFileManager defaultManager] removeItemAtPath:self.factoryPath error:&error];
-    STAssertNil(error, @"Error deleting temporary directory.");
+    XCTAssertNil(error, @"Error deleting temporary directory.");
 
     // Put teardown code here; it will be run once, after the last test case.
     [super tearDown];

--- a/Tests/Tests/CloudantTests.h
+++ b/Tests/Tests/CloudantTests.h
@@ -6,8 +6,8 @@
 //
 //
 
-#import <SenTestingKit/SenTestingKit.h>
+#import <XCTest/XCTest.h>
 
-@interface CloudantTests : SenTestCase
+@interface CloudantTests : XCTestCase
 
 @end

--- a/Tests/Tests/DBQueryUtils.m
+++ b/Tests/Tests/DBQueryUtils.m
@@ -178,7 +178,7 @@ NSString* const DBQueryUtilsErrorDomain = @"DBQueryUtilsErrorDomain";
             expectCount += [modifiedRowCount[table] integerValue];  //we expect there to be one new row in the modifiedTables
         
         NSInteger foundCount = [self rowCountForTable:table];
-        STAssertTrue( foundCount == expectCount,
+        XCTAssertTrue( foundCount == expectCount,
                      @"For table %@: row count mismatch. initial number of rows %d expected %d found %d.",
                      table, initCount, expectCount, foundCount);
         

--- a/Tests/Tests/DatastoreActions.m
+++ b/Tests/Tests/DatastoreActions.m
@@ -13,7 +13,7 @@
 //  either express or implied. See the License for the specific language governing permissions
 //  and limitations under the License.
 
-#import <SenTestingKit/SenTestingKit.h>
+#import <XCTest/XCTest.h>
 
 #import "CloudantSyncTests.h"
 #import "CDTDatastore.h"
@@ -34,8 +34,8 @@
 {
     NSError *error;
     CDTDatastore *tmp = [self.factory datastoreNamed:@"test_database" error:&error];
-    STAssertNotNil(tmp, @"Could not create test database");
-    STAssertTrue([tmp isKindOfClass:[CDTDatastore class]], @"Returned database not CDTDatastore");
+    XCTAssertNotNil(tmp, @"Could not create test database");
+    XCTAssertTrue([tmp isKindOfClass:[CDTDatastore class]], @"Returned database not CDTDatastore");
 }
 
 - (NSString*)createTemporaryFileAndReturnPath
@@ -48,7 +48,7 @@
     char *result = mktemp(tempFileNameCString);
     if (!result)
     {
-        STFail(@"Couldn't create temporary file");
+        XCTFail(@"Couldn't create temporary file");
     }
     
     NSString *path = [[NSFileManager defaultManager]
@@ -57,7 +57,7 @@
     
     BOOL fileCreated = [[NSFileManager defaultManager] createFileAtPath:path contents:nil attributes:nil];
     
-    STAssertTrue(fileCreated, @"File %@ not created in %s", path, __PRETTY_FUNCTION__);
+    XCTAssertTrue(fileCreated, @"File %@ not created in %s", path, __PRETTY_FUNCTION__);
     
     free(tempFileNameCString);
     
@@ -70,11 +70,11 @@
     NSString *localFilePath = [self createTemporaryFileAndReturnPath];
     
     CDTDatastoreManager *localFactory = [[CDTDatastoreManager alloc] initWithDirectory:localFilePath error:&error];
-    STAssertNil(localFactory, @"CDTDatastoreManager should fail with a pre-existing file at path in %s", __PRETTY_FUNCTION__);
+    XCTAssertNil(localFactory, @"CDTDatastoreManager should fail with a pre-existing file at path in %s", __PRETTY_FUNCTION__);
 
     error = nil;
     [[NSFileManager defaultManager] removeItemAtPath:localFilePath error:&error];
-    STAssertNil(error, @"Error deleting temporary directory.");
+    XCTAssertNil(error, @"Error deleting temporary directory.");
     
 }
 
@@ -84,11 +84,11 @@
     NSString *localDirPath = [self createTemporaryDirectoryAndReturnPath];
     
     CDTDatastoreManager *localFactory = [[CDTDatastoreManager alloc] initWithDirectory:localDirPath error:&error];
-    STAssertNotNil(localFactory, @"CDTDatastoreManager should not fail with a pre-existing directory at path in %s", __PRETTY_FUNCTION__);
+    XCTAssertNotNil(localFactory, @"CDTDatastoreManager should not fail with a pre-existing directory at path in %s", __PRETTY_FUNCTION__);
     
     error = nil;
     [[NSFileManager defaultManager] removeItemAtPath:localDirPath error:&error];
-    STAssertNil(error, @"Error deleting temporary directory.");
+    XCTAssertNil(error, @"Error deleting temporary directory.");
     
 }
 
@@ -107,8 +107,8 @@
     rev.body = @{ @"hello" : @"world", @"test" : @"testy" };
     revision = [datastore updateDocumentFromRevision:rev error:&error];
     
-    STAssertTrue([datastore compactWithError:&error],@"Compaction failed");
-    STAssertNil(error, @"Error compacting datastore, %@", error);
+    XCTAssertTrue([datastore compactWithError:&error],@"Compaction failed");
+    XCTAssertNil(error, @"Error compacting datastore, %@", error);
     
     NSArray *previsousRevs = [datastore getRevisionHistory:revision];
 
@@ -122,10 +122,10 @@
         if([prevRev.body count] == 0){
             compacted++;
         } else {
-            STAssertEqualObjects(rev.body, prevRev.body, @"Unexpected body, wrong revision compacted?");
+            XCTAssertEqualObjects(rev.body, prevRev.body, @"Unexpected body, wrong revision compacted?");
         }
     }
-    STAssertEquals(1, compacted, @"Wrong number of docs compacted");
+    XCTAssertEqual(1, compacted, @"Wrong number of docs compacted");
 }
 
 @end

--- a/Tests/Tests/DatastoreCRUD.m
+++ b/Tests/Tests/DatastoreCRUD.m
@@ -263,7 +263,8 @@
                                  table:@"docs"
                                hasRows:expectedRows
                                  error:&validationError],
-                     [dc formattedErrors:validationError]);
+                      @"%@",
+                      [dc formattedErrors:validationError]);
     }];
     
     
@@ -281,7 +282,8 @@
                                  table:@"revs"
                                hasRows:expectedRows
                                  error:&validationError],
-                     [dc formattedErrors:validationError]);
+                      @"%@",
+                      [dc formattedErrors:validationError]);
     }];
 }
 
@@ -942,7 +944,8 @@
                                  table:@"docs"
                                hasRows:expectedRows
                                  error:&validationError],
-                     [dc formattedErrors:validationError]);
+                      @"%@",
+                      [dc formattedErrors:validationError]);
     }];
     
     [self.dbutil.queue inDatabase:^(FMDatabase *db) {
@@ -966,7 +969,8 @@
                                  table:@"revs"
                                hasRows:expectedRows
                                  error:&validationError],
-                     [dc formattedErrors:validationError]);
+                      @"%@",
+                      [dc formattedErrors:validationError]);
     }];
 
 }
@@ -1051,7 +1055,8 @@
                                  table:@"docs"
                                hasRows:expectedRows
                                  error:&validationError],
-                     [dc formattedErrors:validationError]);
+                      @"%@",
+                      [dc formattedErrors:validationError]);
     }];
     
     [queue inDatabase:^(FMDatabase *db) {
@@ -1105,7 +1110,8 @@
                                  table:@"revs"
                                hasRows:expectedRows
                                  error:&validationError],
-                     [dc formattedErrors:validationError]);
+                      @"%@",
+                      [dc formattedErrors:validationError]);
 
     }];
 
@@ -1174,7 +1180,8 @@
                                  table:@"docs"
                                hasRows:expectedRows
                                  error:&validationError],
-                     [dc formattedErrors:validationError]);
+                      @"%@",
+                      [dc formattedErrors:validationError]);
     }];
     
     [self.dbutil.queue inDatabase:^(FMDatabase *db) {
@@ -1192,7 +1199,8 @@
                                  table:@"revs"
                                hasRows:expectedRows
                                  error:&validationError],
-                     [dc formattedErrors:validationError]);
+                      @"%@",
+                      [dc formattedErrors:validationError]);
     }];
     
 

--- a/Tests/Tests/DatastoreCRUD.m
+++ b/Tests/Tests/DatastoreCRUD.m
@@ -13,7 +13,7 @@
 //  either express or implied. See the License for the specific language governing permissions
 //  and limitations under the License.
 
-#import <SenTestingKit/SenTestingKit.h>
+#import <XCTest/XCTest.h>
 #import <Foundation/Foundation.h>
 #import <MRDatabaseContentChecker.h>
 
@@ -54,7 +54,7 @@
     self.datastore = [self.factory datastoreNamed:@"test" error:&error];
     self.dbutil =[[DBQueryUtils alloc] initWithDbPath:[self pathForDBName:self.datastore.name]];
     
-    STAssertNotNil(self.datastore, @"datastore is nil");
+    XCTAssertNotNil(self.datastore, @"datastore is nil");
 }
 
 - (void)tearDown
@@ -94,20 +94,20 @@
     NSDictionary * body = @{@"aKey":@"aValue",@"hello":@"world"};
     
     
-    STAssertNil(error, @"Error should have been nil");
+    XCTAssertNil(error, @"Error should have been nil");
     
     CDTDocumentRevision * rev = [CDTDocumentRevision createRevisionFromJson:dict
                                                                 forDocument:[NSURL
                                                                              URLWithString:@"http://localhost:5984/temp/doc"]
                                                                       error:&error];
     
-    STAssertNil(error, @"Error occured creating document with valid data");
-    STAssertNotNil(rev, @"Revision was nil");
-    STAssertEqualObjects(@"someIdHere", rev.docId, @"docId was different, expected someIdHere actual %@",rev.docId);
-    STAssertEqualObjects(@"3-750dac460a6cc41e6999f8943b8e603e", rev.revId, @"Revision was different expected 3-750dac460a6cc41e6999f8943b8e603e actual %@",rev.revId);
+    XCTAssertNil(error, @"Error occured creating document with valid data");
+    XCTAssertNotNil(rev, @"Revision was nil");
+    XCTAssertEqualObjects(@"someIdHere", rev.docId, @"docId was different, expected someIdHere actual %@",rev.docId);
+    XCTAssertEqualObjects(@"3-750dac460a6cc41e6999f8943b8e603e", rev.revId, @"Revision was different expected 3-750dac460a6cc41e6999f8943b8e603e actual %@",rev.revId);
 
-    STAssertEqualObjects(body, rev.body, @"Body was different");
-    STAssertFalse(rev.deleted, @"Document is not marked as deleted");
+    XCTAssertEqualObjects(body, rev.body, @"Body was different");
+    XCTAssertFalse(rev.deleted, @"Document is not marked as deleted");
     
 }
 
@@ -126,20 +126,20 @@
                             };
 
     
-    STAssertNil(error, @"Error should have been nil");
+    XCTAssertNil(error, @"Error should have been nil");
     
     CDTDocumentRevision * rev = [CDTDocumentRevision createRevisionFromJson:dict
                                                                 forDocument:[NSURL
                                                                              URLWithString:@"http://localhost:5984/temp/doc"]
                                                                       error:&error];
     
-    STAssertNil(error, @"Error occured creating document with valid data");
-    STAssertNotNil(rev, @"Revision was nil");
-    STAssertEqualObjects(@"someIdHere", rev.docId, @"docId was different, expected someIdHere actual %@",rev.docId);
-    STAssertEqualObjects(@"3-750dac460a6cc41e6999f8943b8e603e", rev.revId, @"Revision was different expected 3-750dac460a6cc41e6999f8943b8e603e actual %@",rev.revId);
+    XCTAssertNil(error, @"Error occured creating document with valid data");
+    XCTAssertNotNil(rev, @"Revision was nil");
+    XCTAssertEqualObjects(@"someIdHere", rev.docId, @"docId was different, expected someIdHere actual %@",rev.docId);
+    XCTAssertEqualObjects(@"3-750dac460a6cc41e6999f8943b8e603e", rev.revId, @"Revision was different expected 3-750dac460a6cc41e6999f8943b8e603e actual %@",rev.revId);
     
-    STAssertEqualObjects(@{}, rev.body, @"Body should be empty");
-    STAssertTrue(rev.deleted, @"Document is not marked as deleted");
+    XCTAssertEqualObjects(@{}, rev.body, @"Body should be empty");
+    XCTAssertTrue(rev.deleted, @"Document is not marked as deleted");
 }
 
 -(void)testDocumentRevisionValidDataDeletedDocWithoutBody{
@@ -150,20 +150,20 @@
                             };
     
     
-    STAssertNil(error, @"Error should have been nil");
+    XCTAssertNil(error, @"Error should have been nil");
     
     CDTDocumentRevision * rev = [CDTDocumentRevision createRevisionFromJson:dict
                                                                 forDocument:[NSURL
                                                                              URLWithString:@"http://localhost:5984/temp/doc"]
                                                                       error:&error];
     
-    STAssertNil(error, @"Error occured creating document with valid data");
-    STAssertNotNil(rev, @"Revision was nil");
-    STAssertEqualObjects(@"someIdHere", rev.docId, @"docId was different, expected someIdHere actual %@",rev.docId);
-    STAssertEqualObjects(@"3-750dac460a6cc41e6999f8943b8e603e", rev.revId, @"Revision was different expected 3-750dac460a6cc41e6999f8943b8e603e actual %@",rev.revId);
+    XCTAssertNil(error, @"Error occured creating document with valid data");
+    XCTAssertNotNil(rev, @"Revision was nil");
+    XCTAssertEqualObjects(@"someIdHere", rev.docId, @"docId was different, expected someIdHere actual %@",rev.docId);
+    XCTAssertEqualObjects(@"3-750dac460a6cc41e6999f8943b8e603e", rev.revId, @"Revision was different expected 3-750dac460a6cc41e6999f8943b8e603e actual %@",rev.revId);
     
-    STAssertEqualObjects([NSDictionary dictionary], rev.body, @"Body should be empty");
-    STAssertTrue(rev.deleted, @"Document is not marked as deleted");
+    XCTAssertEqualObjects([NSDictionary dictionary], rev.body, @"Body should be empty");
+    XCTAssertTrue(rev.deleted, @"Document is not marked as deleted");
 }
 
 -(void) testDocumentRevisionInvalidData{
@@ -175,15 +175,15 @@
                             @"_invalidKey":@"someValue"
                             };
     
-    STAssertNil(error, @"Error should have been nil");
+    XCTAssertNil(error, @"Error should have been nil");
     
     CDTDocumentRevision * rev = [CDTDocumentRevision createRevisionFromJson:dict
                                                                 forDocument:[NSURL
                                                                              URLWithString:@"http://localhost:5984/temp/doc"]
                                                                       error:&error];
     
-    STAssertNotNil(error, @"Error did not occur whencreating document with invalid data");
-    STAssertNil(rev, @"Revision was not nil");
+    XCTAssertNotNil(error, @"Error did not occur whencreating document with invalid data");
+    XCTAssertNil(rev, @"Revision was not nil");
 
 }
 
@@ -203,26 +203,26 @@
                             };
     NSDictionary * body = @{@"aKey":@"aValue",@"hello":@"world"};
     
-    STAssertNil(error, @"Error should have been nil");
+    XCTAssertNil(error, @"Error should have been nil");
     
     CDTDocumentRevision * rev = [CDTDocumentRevision createRevisionFromJson:dict
                                                                 forDocument:[NSURL
                                                                              URLWithString:@"http://localhost:5984/temp/doc"]
                                                                       error:&error];
     
-    STAssertNil(error, @"Error occured creating document with valid data");
-    STAssertNotNil(rev, @"Revision was nil");
-    STAssertEqualObjects(@"someIdHere",
+    XCTAssertNil(error, @"Error occured creating document with valid data");
+    XCTAssertNotNil(rev, @"Revision was nil");
+    XCTAssertEqualObjects(@"someIdHere",
                          rev.docId,
                          @"docId was different, expected someIdHere actual %@",
                          rev.docId);
-    STAssertEqualObjects(@"3-750dac460a6cc41e6999f8943b8e603e",
+    XCTAssertEqualObjects(@"3-750dac460a6cc41e6999f8943b8e603e",
                          rev.revId,
                          @"Revision was different expected 3-750dac460a6cc41e6999f8943b8e603e actual %@",
                          rev.revId);
     
-    STAssertEqualObjects(body, rev.body, @"Body was different");
-    STAssertFalse(rev.deleted, @"Document is not marked as deleted");
+    XCTAssertEqualObjects(body, rev.body, @"Body was different");
+    XCTAssertFalse(rev.deleted, @"Document is not marked as deleted");
     
 }
 
@@ -242,8 +242,8 @@
     doc.docId = testDocId;
     doc.body = [@{key:value} mutableCopy];
     CDTDocumentRevision *ob = [self.datastore createDocumentFromRevision:doc error:&error];
-    STAssertNil(error, @"Error creating document");
-    STAssertNotNil(ob, @"CDTDocumentRevision object was nil");
+    XCTAssertNil(error, @"Error creating document");
+    XCTAssertNotNil(ob, @"CDTDocumentRevision object was nil");
     
     NSDictionary *modifiedCount = @{@"docs": @1, @"revs": @1};
     
@@ -259,7 +259,7 @@
                                   @[testDocId]
                                   ];
         NSError *validationError;
-        STAssertTrue([dc checkDatabase:db
+        XCTAssertTrue([dc checkDatabase:db
                                  table:@"docs"
                                hasRows:expectedRows
                                  error:&validationError],
@@ -277,7 +277,7 @@
             @[@(1),      @1,          revId,    @YES,       @NO,        json]
         ];
         NSError *validationError;
-        STAssertTrue([dc checkDatabase:db
+        XCTAssertTrue([dc checkDatabase:db
                                  table:@"revs"
                                hasRows:expectedRows
                                  error:&validationError],
@@ -299,9 +299,9 @@
     NSMutableDictionary *initialRowCount = [self.dbutil getAllTablesRowCount];
     
     CDTDocumentRevision *ob = [self.datastore createDocumentFromRevision:rev error:&error];
-    STAssertNotNil(error, @"No Error creating document!");
-    STAssertTrue(error.code == 400, @"Error was not a 400. Found %ld", error.code);
-    STAssertNil(ob, @"CDTDocumentRevision object was not nil");
+    XCTAssertNotNil(error, @"No Error creating document!");
+    XCTAssertTrue(error.code == 400, @"Error was not a 400. Found %ld", error.code);
+    XCTAssertNil(ob, @"CDTDocumentRevision object was not nil");
     
     [self.dbutil checkTableRowCount:initialRowCount modifiedBy:nil];
 
@@ -318,8 +318,8 @@
     rev.body = [@{key:value,@"_id":testDocId} mutableCopy];
 
     CDTDocumentRevision *ob = [self.datastore createDocumentFromRevision:rev error:&error];
-    STAssertNotNil(error, @"Error creating document");
-    STAssertNil(ob, @"CDTDocumentRevision object was nil");
+    XCTAssertNotNil(error, @"Error creating document");
+    XCTAssertNil(ob, @"CDTDocumentRevision object was nil");
 }
 
 -(void)testCannotCreateNewDocWithoutUniqueID
@@ -333,17 +333,17 @@
     doc.docId = testDocId;
     doc.body = [@{key:value} mutableCopy];
     CDTDocumentRevision *ob = [self.datastore createDocumentFromRevision:doc error:&error];
-    STAssertNil(error, @"Error creating document");
-    STAssertNotNil(ob, @"CDTDocumentRevision object was nil");
+    XCTAssertNil(error, @"Error creating document");
+    XCTAssertNotNil(ob, @"CDTDocumentRevision object was nil");
     
     error = nil;
     doc = [CDTMutableDocumentRevision revision];
     doc.docId = testDocId;
     doc.body = [@{key:value} mutableCopy];
     ob = [self.datastore createDocumentFromRevision:doc error:&error];
-    STAssertNotNil(error, @"Error was nil when creating second doc with same doc_id");
-    STAssertTrue(error.code == 409, @"Error was not a 409. Found %ld", error.code);
-    STAssertNil(ob, @"CDTDocumentRevision object was not nil when creating second doc with same doc_id");
+    XCTAssertNotNil(error, @"Error was nil when creating second doc with same doc_id");
+    XCTAssertTrue(error.code == 409, @"Error was not a 409. Found %ld", error.code);
+    XCTAssertNil(ob, @"CDTDocumentRevision object was not nil when creating second doc with same doc_id");
 }
 
 -(void)testAddDocument
@@ -353,8 +353,8 @@
     doc.body = [@{@"hello": @"world"} mutableCopy];
     CDTDocumentRevision *ob = [self.datastore createDocumentFromRevision:doc error:&error];
     
-    STAssertNil(error, @"Error creating document");
-    STAssertNotNil(ob, @"CDTDocumentRevision object was nil");
+    XCTAssertNil(error, @"Error creating document");
+    XCTAssertNotNil(ob, @"CDTDocumentRevision object was nil");
 }
 
 -(void)testCreateDocumentWithId
@@ -366,21 +366,21 @@
     
     CDTDocumentRevision *ob = [self.datastore createDocumentFromRevision:doc error:&error];
     
-    STAssertNil(error, @"Error creating document");
-    STAssertNotNil(ob, @"CDTDocumentRevision object was nil");
-    STAssertEqualObjects(@"document_id_for_test", ob.docId, @"Document ID was not as set in test");
+    XCTAssertNil(error, @"Error creating document");
+    XCTAssertNotNil(ob, @"CDTDocumentRevision object was nil");
+    XCTAssertEqualObjects(@"document_id_for_test", ob.docId, @"Document ID was not as set in test");
     
     error = nil;
     NSString *docId = ob.docId;
     CDTDocumentRevision *retrieved = [self.datastore getDocumentWithId:docId error:&error];
     
-    STAssertNil(error, @"Error retrieving document");
-    STAssertNotNil(retrieved, @"retrieved object was nil");
-    STAssertEqualObjects(ob.docId, retrieved.docId, @"Object retrieved from database has wrong docid");
-    STAssertEqualObjects(ob.revId, retrieved.revId, @"Object retrieved from database has wrong revid");
+    XCTAssertNil(error, @"Error retrieving document");
+    XCTAssertNotNil(retrieved, @"retrieved object was nil");
+    XCTAssertEqualObjects(ob.docId, retrieved.docId, @"Object retrieved from database has wrong docid");
+    XCTAssertEqualObjects(ob.revId, retrieved.revId, @"Object retrieved from database has wrong revid");
     const NSUInteger expected_count = 1;
-    STAssertEquals(ob.body.count, expected_count, @"Object from database has != 1 key");
-    STAssertEqualObjects(ob.body[@"hello"], @"world", @"Object from database has wrong data");
+    XCTAssertEqual(ob.body.count, expected_count, @"Object from database has != 1 key");
+    XCTAssertEqualObjects(ob.body[@"hello"], @"world", @"Object from database has wrong data");
 }
 
 -(void)testCannotCreateConflict
@@ -391,8 +391,8 @@
     CDTMutableDocumentRevision *doc = [CDTMutableDocumentRevision revision];
     doc.body = [@{key1:value1} mutableCopy];
     CDTDocumentRevision *ob = [self.datastore createDocumentFromRevision:doc error:&error];
-    STAssertNil(error, @"Error creating document");
-    STAssertNotNil(ob, @"CDTDocumentRevision object was nil");
+    XCTAssertNil(error, @"Error creating document");
+    XCTAssertNotNil(ob, @"CDTDocumentRevision object was nil");
     
     error = nil;
     NSString *key2 = @"hi";
@@ -402,8 +402,8 @@
     doc.body = [@{key2:value2} mutableCopy];
     
     CDTDocumentRevision *ob2 = [self.datastore updateDocumentFromRevision:doc error:&error];
-    STAssertNil(error, @"Error updating document");
-    STAssertNotNil(ob2, @"CDTDocumentRevision object was nil");
+    XCTAssertNil(error, @"Error updating document");
+    XCTAssertNotNil(ob2, @"CDTDocumentRevision object was nil");
     
     //now create a conflict
     error = nil;
@@ -414,8 +414,8 @@
     doc.body = [@{key3:value3} mutableCopy];
     
     CDTDocumentRevision *ob3 = [self.datastore updateDocumentFromRevision:doc error:&error];
-    STAssertTrue(error.code == 409, @"Incorrect error code: %@", error);
-    STAssertNil(ob3, @"CDTDocumentRevision object was not nil");
+    XCTAssertTrue(error.code == 409, @"Incorrect error code: %@", error);
+    XCTAssertNil(ob3, @"CDTDocumentRevision object was not nil");
     
 }
 
@@ -426,7 +426,7 @@
     doc.body = [@{@"title":@"Testing New creation API",@"FirstTest":@YES} mutableCopy];
     doc.docId = @"MyFirstTestDoc";
     CDTDocumentRevision *saved = [self.datastore createDocumentFromRevision:doc error:&error];
-    STAssertTrue(saved, @"Failed to save new document");
+    XCTAssertTrue(saved, @"Failed to save new document");
     
 }
 
@@ -435,7 +435,7 @@
     NSError *error;
     CDTMutableDocumentRevision *doc = [CDTMutableDocumentRevision revision];
     CDTDocumentRevision *saved = [self.datastore createDocumentFromRevision:doc error:&error];
-    STAssertNil(saved, @"Document was created without a body");
+    XCTAssertNil(saved, @"Document was created without a body");
 }
 
 -(void)testCreateWithaDocumentIdNoBodyCDTMutableDocumentRevision{
@@ -443,7 +443,7 @@
     CDTMutableDocumentRevision *doc = [CDTMutableDocumentRevision revision];
     doc.docId = @"doc1";
     CDTDocumentRevision *saved = [self.datastore createDocumentFromRevision:doc error:&error];
-    STAssertNil(saved, @"Document with Id but no body created");
+    XCTAssertNil(saved, @"Document with Id but no body created");
 }
 
 -(void)testCreateWithOnlyBodyCDTMutableDocumentRevision{
@@ -451,7 +451,7 @@
     CDTMutableDocumentRevision *doc = [CDTMutableDocumentRevision revision];
     doc.body = [@{@"DocumentBodyItem1":@"Hi",@"Hello":@"World"} mutableCopy];
     CDTDocumentRevision *saved = [self.datastore createDocumentFromRevision: doc error:&error];
-    STAssertTrue(saved, @"Document was not created");
+    XCTAssertTrue(saved, @"Document was not created");
 }
 
 #pragma mark - READ tests
@@ -465,20 +465,20 @@
     
     CDTDocumentRevision *ob = [self.datastore createDocumentFromRevision:doc error:&error];
     
-    STAssertNil(error, @"Error creating document");
-    STAssertNotNil(ob, @"CDTDocumentRevision object was nil");
+    XCTAssertNil(error, @"Error creating document");
+    XCTAssertNotNil(ob, @"CDTDocumentRevision object was nil");
     
     error = nil;
     NSString *docId = ob.docId;
     CDTDocumentRevision *retrieved = [self.datastore getDocumentWithId:docId error:&error];
     
-    STAssertNil(error, @"Error retrieving document");
-    STAssertNotNil(retrieved, @"retrieved object was nil");
-    STAssertEqualObjects(ob.docId, retrieved.docId, @"Object retrieved from database has wrong docid");
-    STAssertEqualObjects(ob.revId, retrieved.revId, @"Object retrieved from database has wrong revid");
+    XCTAssertNil(error, @"Error retrieving document");
+    XCTAssertNotNil(retrieved, @"retrieved object was nil");
+    XCTAssertEqualObjects(ob.docId, retrieved.docId, @"Object retrieved from database has wrong docid");
+    XCTAssertEqualObjects(ob.revId, retrieved.revId, @"Object retrieved from database has wrong revid");
     const NSUInteger expected_count = 1;
-    STAssertEquals(ob.body.count, expected_count, @"Object from database has != 1 key");
-    STAssertEqualObjects(ob.body[@"hello"], @"world", @"Object from database has wrong data");
+    XCTAssertEqual(ob.body.count, expected_count, @"Object from database has != 1 key");
+    XCTAssertEqualObjects(ob.body[@"hello"], @"world", @"Object from database has wrong data");
 }
 
 -(void)testGetDocumentWithIdAndRev
@@ -489,20 +489,20 @@
     rev.body = [@{@"hello":@"world"} mutableCopy];
     
     CDTDocumentRevision *ob = [self.datastore createDocumentFromRevision:rev error:&error];
-    STAssertNil(error, @"Error creating document");
+    XCTAssertNil(error, @"Error creating document");
     
     error = nil;
     NSString *docId = ob.docId;
     NSString *revId = ob.revId;
     CDTDocumentRevision *retrieved = [self.datastore getDocumentWithId:docId rev:revId error:&error];
-    STAssertNil(error, @"Error retrieving document");
+    XCTAssertNil(error, @"Error retrieving document");
     
-    STAssertNotNil(retrieved, @"retrieved object was nil");
-    STAssertEqualObjects(ob.docId, retrieved.docId, @"Object retrieved from database has wrong docid");
-    STAssertEqualObjects(ob.revId, retrieved.revId, @"Object retrieved from database has wrong revid");
+    XCTAssertNotNil(retrieved, @"retrieved object was nil");
+    XCTAssertEqualObjects(ob.docId, retrieved.docId, @"Object retrieved from database has wrong docid");
+    XCTAssertEqualObjects(ob.revId, retrieved.revId, @"Object retrieved from database has wrong revid");
     const NSUInteger expected_count = 1;
-    STAssertEquals(ob.body.count, expected_count, @"Object from database has != 1 key");
-    STAssertEqualObjects(ob.body[@"hello"], @"world", @"Object from database has wrong data");
+    XCTAssertEqual(ob.body.count, expected_count, @"Object from database has != 1 key");
+    XCTAssertEqualObjects(ob.body[@"hello"], @"world", @"Object from database has wrong data");
 }
 
 -(void)testGetDocumentsWithIds
@@ -515,7 +515,7 @@
         CDTMutableDocumentRevision *rev = [CDTMutableDocumentRevision revision];
         rev.body = [@{@"hello":@"world",@"index":[NSNumber numberWithInt:i]} mutableCopy];
         CDTDocumentRevision *ob = [self.datastore createDocumentFromRevision:rev error:&error];
-        STAssertNil(error, @"Error creating document");
+        XCTAssertNil(error, @"Error creating document");
         
         NSString *docId = ob.docId;
         [docIds addObject:docId];
@@ -523,19 +523,19 @@
     
     NSArray *retrivedDocIds = @[docIds[5], docIds[7], docIds[12], docIds[170]];
     NSArray *obs = [self.datastore getDocumentsWithIds:retrivedDocIds];
-    STAssertNotNil(obs, @"Error getting documents");
+    XCTAssertNotNil(obs, @"Error getting documents");
     
     int ob_index = 0;
     for (NSNumber *index in @[@5, @7, @12, @170]) {
         NSString *docId = [docIds objectAtIndex:[index intValue]];
         CDTDocumentRevision *retrieved = [obs objectAtIndex:ob_index];
         
-        STAssertNotNil(retrieved, @"retrieved object was nil");
-        STAssertEqualObjects(retrieved.docId, docId, @"Object retrieved from database has wrong docid");
+        XCTAssertNotNil(retrieved, @"retrieved object was nil");
+        XCTAssertEqualObjects(retrieved.docId, docId, @"Object retrieved from database has wrong docid");
         const NSUInteger expected_count = 2;
-        STAssertEquals(retrieved.body.count, expected_count, @"Object from database has != 2 keys");
-        STAssertEqualObjects(retrieved.body[@"hello"], @"world", @"Object from database has wrong data");
-        STAssertEqualObjects(retrieved.body[@"index"], index, @"Object from database has wrong data");
+        XCTAssertEqual(retrieved.body.count, expected_count, @"Object from database has != 2 keys");
+        XCTAssertEqualObjects(retrieved.body[@"hello"], @"world", @"Object from database has wrong data");
+        XCTAssertEqualObjects(retrieved.body[@"index"], index, @"Object from database has wrong data");
         
         ob_index++;
     }
@@ -548,15 +548,15 @@
     CDTMutableDocumentRevision *rev = [CDTMutableDocumentRevision revision];
     rev.body = [@{@"hello":@"world"}mutableCopy];
     CDTDocumentRevision *ob = [self.datastore createDocumentFromRevision:rev error:&error];
-    STAssertNil(error, @"Error creating document");
+    XCTAssertNil(error, @"Error creating document");
     
     error = nil;
     NSString *docId = @"i_do_not_exist";
     NSString *revId = ob.revId;
     CDTDocumentRevision *retrieved = [self.datastore getDocumentWithId:docId rev:revId error:&error];
-    STAssertNotNil(error, @"Error should not be nil.");
-    STAssertTrue(error.code == 404, @"Error was not a 404. Found %ld", error.code);
-    STAssertNil(retrieved, @"retrieved object was nil");
+    XCTAssertNotNil(error, @"Error should not be nil.");
+    XCTAssertTrue(error.code == 404, @"Error was not a 404. Found %ld", error.code);
+    XCTAssertNil(retrieved, @"retrieved object was nil");
     
 }
 
@@ -591,20 +591,20 @@
         error = nil;
         if([lastDocForId[randomId][@"numUpdates"] intValue] == 0) {
             cdt_rev = [self.datastore createDocumentFromRevision:rev error:&error];
-            STAssertNil(error, @"Error creating document. %@", error);
-            STAssertNotNil(cdt_rev, @"CDTDocumentRevision was nil");
+            XCTAssertNil(error, @"Error creating document. %@", error);
+            XCTAssertNotNil(cdt_rev, @"CDTDocumentRevision was nil");
         }
         else{
             cdt_rev = [self.datastore getDocumentWithId:randomId
                                                   error:&error];
             CDTMutableDocumentRevision *update = [cdt_rev mutableCopy];
             update.body = rev.body;
-            STAssertNil(error, @"Error getting document");
-            STAssertNotNil(cdt_rev, @"retrieved CDTDocumentRevision was nil");
+            XCTAssertNil(error, @"Error getting document");
+            XCTAssertNotNil(cdt_rev, @"retrieved CDTDocumentRevision was nil");
             error = nil;
             cdt_rev = [self.datastore updateDocumentFromRevision:update error:&error];
-            STAssertNil(error, @"Error updating document");
-            STAssertNotNil(cdt_rev, @"updated CDTDocumentRevision was nil");
+            XCTAssertNil(error, @"Error updating document");
+            XCTAssertNotNil(cdt_rev, @"updated CDTDocumentRevision was nil");
         }
         
         //update our dictionary that is recording the last "event" for each doc id
@@ -613,7 +613,7 @@
         lastDocForId[randomId][@"lastrev"] =  cdt_rev.revId;
         lastDocForId[randomId][@"json"] = dict;
         
-        STAssertTrue([lastDocForId[randomId][@"numUpdates"] unsignedIntegerValue] == [TD_Revision generationFromRevID:cdt_rev.revId],
+        XCTAssertTrue([lastDocForId[randomId][@"numUpdates"] unsignedIntegerValue] == [TD_Revision generationFromRevID:cdt_rev.revId],
                        @"rev prefix value does not equal expected number of updates");
     }
     
@@ -623,7 +623,7 @@
     //now compact and check that all old revs obtained via CDTDatastore contain empty JSON.
     //note: I have to #import "TD_Database+Insertion.h" in order to compact.
     TDStatus statusResults = [self.datastore.database compact];
-    STAssertTrue([TDStatusToNSError( statusResults, nil) code] == 200,
+    XCTAssertTrue([TDStatusToNSError( statusResults, nil) code] == 200,
                  @"TDStatusAsNSError: %@", TDStatusToNSError( statusResults, nil));
     
     //number of table rows shouldn't have changed by compaction as all tombstones should be present
@@ -637,11 +637,11 @@
         NSUInteger numUpdates = [lastDocForId[aDocId][@"numUpdates"] unsignedIntegerValue];
         if(numUpdates > 0){
             cdt_rev = [self.datastore getDocumentWithId:aDocId error:&error];
-            STAssertNil(error, @"Error getting document");
-            STAssertNotNil(cdt_rev, @"retrieved object was nil");
-            STAssertEqualObjects(lastRev, cdt_rev.revId, @"Object retrieved from database has wrong revid");
-            STAssertEqualObjects(cdt_rev.body, lastRecordedJsonDoc, @"Object from database has wrong data");
-            STAssertTrue(numUpdates == [TD_Revision generationFromRevID:cdt_rev.revId], @"rev prefix value does not equal expected number of updates");
+            XCTAssertNil(error, @"Error getting document");
+            XCTAssertNotNil(cdt_rev, @"retrieved object was nil");
+            XCTAssertEqualObjects(lastRev, cdt_rev.revId, @"Object retrieved from database has wrong revid");
+            XCTAssertEqualObjects(cdt_rev.body, lastRecordedJsonDoc, @"Object from database has wrong data");
+            XCTAssertTrue(numUpdates == [TD_Revision generationFromRevID:cdt_rev.revId], @"rev prefix value does not equal expected number of updates");
         }
     }
     
@@ -656,23 +656,23 @@
             bool foundJSON = NO;
             
             while([result next]){
-                STAssertEqualObjects([result stringForColumn:@"docid"], aDocId,
+                XCTAssertEqualObjects([result stringForColumn:@"docid"], aDocId,
                                      @"Document ID mismatch: %@", [result stringForColumn:@"docid"]);
                 
                 NSString *revid = [result stringForColumn:@"revid"];
-                STAssertTrue([TD_Revision generationFromRevID:revid] - 1 == revPrefix, @"revision out of order: Found Rev: %@ and previous prefix %@", revid, revPrefix);
+                XCTAssertTrue([TD_Revision generationFromRevID:revid] - 1 == revPrefix, @"revision out of order: Found Rev: %@ and previous prefix %@", revid, revPrefix);
                 revPrefix = [TD_Revision generationFromRevID:revid];
                 
-                STAssertFalse([result boolForColumn:@"deleted"], @"deleted? %@", [result stringForColumn:@"deleted"]);
+                XCTAssertFalse([result boolForColumn:@"deleted"], @"deleted? %@", [result stringForColumn:@"deleted"]);
                 
                 //this should be the first row in the result
                 if(docNum == -1){
                     docNum = [result intForColumn:@"docnum"]; //make sure docNum is always the same
-                    STAssertEqualObjects([result objectForColumnName:@"parent"], [NSNull null], @"parent: %@", [result objectForColumnName:@"parent"]);
+                    XCTAssertEqualObjects([result objectForColumnName:@"parent"], [NSNull null], @"parent: %@", [result objectForColumnName:@"parent"]);
                 }
                 else{
-                    STAssertTrue([result intForColumn:@"docnum"] == docNum, @"%@", [result stringForColumn:@"docnum"]);
-                    STAssertTrue([result intForColumn:@"docnum"] <= ids.count, @"%@", [result stringForColumn:@"docnum"]);
+                    XCTAssertTrue([result intForColumn:@"docnum"] == docNum, @"%@", [result stringForColumn:@"docnum"]);
+                    XCTAssertTrue([result intForColumn:@"docnum"] <= ids.count, @"%@", [result stringForColumn:@"docnum"]);
                 }
                 
                 //only the last rev should have valid JSON data
@@ -682,20 +682,20 @@
                     NSDictionary* jsonDoc = [TDJSON JSONObjectWithData: [result dataForColumn:@"json"]
                                                                options: TDJSONReadingMutableContainers
                                                                  error: &error];
-                    STAssertTrue([jsonDoc isEqualToDictionary:lastDocForId[aDocId][@"json"]], @"Found: %@", jsonDoc);
+                    XCTAssertTrue([jsonDoc isEqualToDictionary:lastDocForId[aDocId][@"json"]], @"Found: %@", jsonDoc);
                     if(jsonDoc)
                         foundJSON = YES;
                 }
                 else{
                     //This was slightly unexpected. When TD_Database deletes, the JSON becomes an empty NSData
                     //object. But when compacting, it sets it to null. See TD_Database+Insertion compact.
-                    STAssertEqualObjects([result objectForColumnName:@"json"], [NSNull null],
+                    XCTAssertEqualObjects([result objectForColumnName:@"json"], [NSNull null],
                                          @"Expected revs.json to be empty NSData. Found %@", [result objectForColumnName:@"json"]);
                 }
                 
             }
             
-            STAssertTrue(foundJSON, @"didn't find json");
+            XCTAssertTrue(foundJSON, @"didn't find json");
             [result close];
         }];
     }
@@ -718,7 +718,7 @@
         rev.docId = docId;
         rev.body = bodies[i];
         CDTDocumentRevision *ob = [self.datastore createDocumentFromRevision:rev error:&error];
-        STAssertNil(error, @"Error creating document");
+        XCTAssertNil(error, @"Error creating document");
         [dbObjects addObject:ob];
     }
     //    NSArray* reversedObjects = [[dbObjects reverseObjectEnumerator] allObjects];
@@ -730,15 +730,15 @@
 
 -(void)assertIdAndRevisionAndShallowContentExpected:(CDTDocumentRevision *)expected actual:(CDTDocumentRevision *)actual
 {
-    STAssertEqualObjects([actual docId], [expected docId], @"docIDs don't match");
-    STAssertEqualObjects([actual revId], [expected revId], @"revIDs don't match");
+    XCTAssertEqualObjects([actual docId], [expected docId], @"docIDs don't match");
+    XCTAssertEqualObjects([actual revId], [expected revId], @"revIDs don't match");
     
     NSDictionary *expectedDict = expected.body;
     NSDictionary *actualDict = actual.body;
     
     for (NSString *key in [expectedDict keyEnumerator]) {
-        STAssertNotNil([actualDict objectForKey:key], @"Actual didn't contain key %s", key);
-        STAssertEqualObjects([actualDict objectForKey:key], [expectedDict objectForKey:key], @"Actual value didn't match expected value");
+        XCTAssertNotNil([actualDict objectForKey:key], @"Actual didn't contain key %s", key);
+        XCTAssertEqualObjects([actualDict objectForKey:key], [expectedDict objectForKey:key], @"Actual value didn't match expected value");
     }
 }
 
@@ -828,7 +828,7 @@
 -(void)getAllDocuments_compareResultExpected:(NSArray*)expectedDbObjects actual:(NSArray*)result count:(int)count offset:(int)offset
 {
     NSUInteger expected = (NSUInteger)count;
-    STAssertEquals(result.count, expected, @"expectedDbObject count didn't match result count");
+    XCTAssertEqual(result.count, expected, @"expectedDbObject count didn't match result count");
     for (int i = 0; i < result.count; i++) {
         CDTDocumentRevision *actual = result[i];
         CDTDocumentRevision *expected = expectedDbObjects[i + offset];
@@ -848,8 +848,8 @@
     CDTMutableDocumentRevision *rev = [CDTMutableDocumentRevision revision];
     rev.body = [@{key1:value1} mutableCopy];
     CDTDocumentRevision *ob = [self.datastore createDocumentFromRevision:rev error:&error];
-    STAssertNil(error, @"Error creating document");
-    STAssertNotNil(ob, @"CDTDocumentRevision object was nil");
+    XCTAssertNil(error, @"Error creating document");
+    XCTAssertNotNil(ob, @"CDTDocumentRevision object was nil");
     
     NSMutableDictionary *initialRowCount = [self.dbutil getAllTablesRowCount];
 
@@ -862,9 +862,9 @@
 
     CDTDocumentRevision *ob2 = [self.datastore updateDocumentFromRevision:rev error:&error];
     
-    STAssertNotNil(error, @"No error when updating document with bad id");
-    STAssertTrue(error.code == 404, @"Error was not a 404. Found %ld", error.code);
-    STAssertNil(ob2, @"CDTDocumentRevision object was not nil after update with bad rev");
+    XCTAssertNotNil(error, @"No error when updating document with bad id");
+    XCTAssertTrue(error.code == 404, @"Error was not a 404. Found %ld", error.code);
+    XCTAssertNil(ob2, @"CDTDocumentRevision object was not nil after update with bad rev");
     
     //expect the database to be unmodified
     [self.dbutil checkTableRowCount:initialRowCount modifiedBy:nil];
@@ -885,8 +885,8 @@
     rev.body = [@{key1:value1} mutableCopy];
     
     CDTDocumentRevision *ob = [self.datastore createDocumentFromRevision:rev error:&error];
-    STAssertNil(error, @"Error creating document");
-    STAssertNotNil(ob, @"CDTDocumentRevision object was nil");
+    XCTAssertNil(error, @"Error creating document");
+    XCTAssertNotNil(ob, @"CDTDocumentRevision object was nil");
     
     
     NSString *docId = ob.docId;
@@ -897,29 +897,29 @@
     rev.body = [@{key2:value2} mutableCopy];
 
     CDTDocumentRevision *ob2 = [self.datastore updateDocumentFromRevision:rev error:&error];
-    STAssertNotNil(ob2, @"CDTDocumentRevision object was nil");
+    XCTAssertNotNil(ob2, @"CDTDocumentRevision object was nil");
     
     // Check new revision
     const NSUInteger expected_count = 1;
     CDTDocumentRevision *retrieved;
     error = nil;
     retrieved = [self.datastore getDocumentWithId:docId error:&error];
-    STAssertNil(error, @"Error getting document");
-    STAssertNotNil(retrieved, @"retrieved object was nil");
-    STAssertEqualObjects(ob.docId, retrieved.docId, @"Object retrieved from database has wrong docid");
-    STAssertEqualObjects(ob2.revId, retrieved.revId, @"Object retrieved from database has wrong revid");
-    STAssertEquals(retrieved.body.count, expected_count, @"Object from database has != 1 key");
-    STAssertEqualObjects(retrieved.body[key2], value2, @"Object from database has wrong data");
+    XCTAssertNil(error, @"Error getting document");
+    XCTAssertNotNil(retrieved, @"retrieved object was nil");
+    XCTAssertEqualObjects(ob.docId, retrieved.docId, @"Object retrieved from database has wrong docid");
+    XCTAssertEqualObjects(ob2.revId, retrieved.revId, @"Object retrieved from database has wrong revid");
+    XCTAssertEqual(retrieved.body.count, expected_count, @"Object from database has != 1 key");
+    XCTAssertEqualObjects(retrieved.body[key2], value2, @"Object from database has wrong data");
     
     // Check we can get old revision
     error = nil;
     retrieved = [self.datastore getDocumentWithId:docId rev:ob.revId error:&error];
-    STAssertNil(error, @"Error getting document using old rev");
-    STAssertNotNil(retrieved, @"retrieved object was nil");
-    STAssertEqualObjects(ob.docId, retrieved.docId, @"Object retrieved from database has wrong docid");
-    STAssertEqualObjects(ob.revId, retrieved.revId, @"Object retrieved from database has wrong revid");
-    STAssertEquals(retrieved.body.count, expected_count, @"Object from database has != 1 key");
-    STAssertEqualObjects(retrieved.body[key1], value1, @"Object from database has wrong data");
+    XCTAssertNil(error, @"Error getting document using old rev");
+    XCTAssertNotNil(retrieved, @"retrieved object was nil");
+    XCTAssertEqualObjects(ob.docId, retrieved.docId, @"Object retrieved from database has wrong docid");
+    XCTAssertEqualObjects(ob.revId, retrieved.revId, @"Object retrieved from database has wrong revid");
+    XCTAssertEqual(retrieved.body.count, expected_count, @"Object from database has != 1 key");
+    XCTAssertEqualObjects(retrieved.body[key1], value1, @"Object from database has wrong data");
     
     
     //now test the content of docs/revs tables explicitely.
@@ -938,7 +938,7 @@
             @[@"doc_id",      @"docid"],
             @[expectedDoc_id, docId]
             ];
-        STAssertTrue([dc checkDatabase:db
+        XCTAssertTrue([dc checkDatabase:db
                                  table:@"docs"
                                hasRows:expectedRows
                                  error:&validationError],
@@ -962,7 +962,7 @@
             @[expectedDoc_id, @2,          revId2,   @YES,       @NO,        json2],
             ];
         NSError *validationError;
-        STAssertTrue([dc checkDatabase:db
+        XCTAssertTrue([dc checkDatabase:db
                                  table:@"revs"
                                hasRows:expectedRows
                                  error:&validationError],
@@ -981,8 +981,8 @@
     CDTMutableDocumentRevision *rev = [CDTMutableDocumentRevision revision];
     rev.body = [@{@"hello":@"world"} mutableCopy];
     CDTDocumentRevision *ob = [self.datastore createDocumentFromRevision:rev error:&error];
-    STAssertNil(error, @"Error creating document");
-    STAssertNotNil(ob, @"CDTDocumentRevision object was nil");
+    XCTAssertNil(error, @"Error creating document");
+    XCTAssertNotNil(ob, @"CDTDocumentRevision object was nil");
 
     NSMutableDictionary *initialRowCount = [self.dbutil getAllTablesRowCount];
     
@@ -991,9 +991,9 @@
     rev = [ob mutableCopy];
     rev.body = nil;
     CDTDocumentRevision *ob2 = [self.datastore updateDocumentFromRevision:rev error:&error];
-    STAssertNotNil(error, @"No Error updating document with nil CDTDocumentBody");
-    STAssertTrue(error.code == 400, @"Error was not a 400. Found %ld", error.code);
-    STAssertNil(ob2, @"CDTDocumentRevision object was not nil when updating with nil CDTDocumentBody");
+    XCTAssertNotNil(error, @"No Error updating document with nil CDTDocumentBody");
+    XCTAssertTrue(error.code == 400, @"Error was not a 400. Found %ld", error.code);
+    XCTAssertNil(ob2, @"CDTDocumentRevision object was not nil when updating with nil CDTDocumentBody");
     
     NSDictionary *modifiedCount = nil;
     [self.dbutil checkTableRowCount:initialRowCount modifiedBy:modifiedCount];
@@ -1007,7 +1007,7 @@
     NSString *dbPath = [self pathForDBName:self.datastore.name];
     
     FMDatabaseQueue *queue = [FMDatabaseQueue databaseQueueWithPath:dbPath];
-    STAssertNotNil(queue, @"FMDatabaseQueue was nil: %@", queue);
+    XCTAssertNotNil(queue, @"FMDatabaseQueue was nil: %@", queue);
     
     NSMutableDictionary *initialRowCount = [self.dbutil getAllTablesRowCount];
 
@@ -1019,21 +1019,21 @@
     CDTMutableDocumentRevision *rev = [CDTMutableDocumentRevision revision];
     rev.body = bodies[0];
     CDTDocumentRevision *ob = [self.datastore createDocumentFromRevision:rev error:&error];
-    STAssertNil(error, @"Error creating document");
-    STAssertNotNil(ob, @"CDTDocumentRevision object was nil");
-    STAssertNotNil(ob.docId, @"doc id is nil");
-    STAssertNotNil(ob.revId, @"rev id is nil");
+    XCTAssertNil(error, @"Error creating document");
+    XCTAssertNotNil(ob, @"CDTDocumentRevision object was nil");
+    XCTAssertNotNil(ob.docId, @"doc id is nil");
+    XCTAssertNotNil(ob.revId, @"rev id is nil");
     
     for(int i = 0; i < numOfUpdates; i++){
         error = nil;
         rev = [ob mutableCopy];
         rev.body = bodies[i+1];
         ob = [self.datastore updateDocumentFromRevision:rev error:&error];
-        STAssertNil(error, @"Error creating document. Update Number %d", i);
-        STAssertNotNil(ob, @"CDTDocumentRevision object was nil. Update Number %d", i);
+        XCTAssertNil(error, @"Error creating document. Update Number %d", i);
+        XCTAssertNotNil(ob, @"CDTDocumentRevision object was nil. Update Number %d", i);
         
-        STAssertNotNil(ob.docId, @"doc id is nil");
-        STAssertNotNil(ob.revId, @"rev id is nil");
+        XCTAssertNotNil(ob.docId, @"doc id is nil");
+        XCTAssertNotNil(ob.revId, @"rev id is nil");
     }
     
     NSDictionary *modifiedCount = @{@"docs": @1, @"revs": [[NSNumber alloc] initWithInt:numOfUpdates + 1]};
@@ -1047,7 +1047,7 @@
                                   @[@"docId"],
                                   @[ob.docId]
                                   ];
-        STAssertTrue([dc checkDatabase:db
+        XCTAssertTrue([dc checkDatabase:db
                                  table:@"docs"
                                hasRows:expectedRows
                                  error:&validationError],
@@ -1101,7 +1101,7 @@
         }
         
         NSError *validationError;
-        STAssertTrue([dc checkDatabase:db
+        XCTAssertTrue([dc checkDatabase:db
                                  table:@"revs"
                                hasRows:expectedRows
                                  error:&validationError],
@@ -1137,7 +1137,7 @@
     rev.body = [@{key1:value1} mutableCopy];
 
     CDTDocumentRevision *ob = [self.datastore createDocumentFromRevision:rev error:nil];
-    STAssertNotNil(ob, @"CDTDocumentRevision object was nil");
+    XCTAssertNotNil(ob, @"CDTDocumentRevision object was nil");
     
     // Attempt to update with a _deleted key in the body
     NSString *docId = ob.docId;
@@ -1150,10 +1150,10 @@
     rev = [ob mutableCopy];
     rev.body = [body2dict mutableCopy];
     CDTDocumentRevision *ob2 = [self.datastore updateDocumentFromRevision:rev error:&error];
-    STAssertNil(ob2, @"CDTDocumentRevision object was not nil");
-    STAssertNotNil(error, @"Error wasn't set");
-    STAssertEquals(error.code, (NSInteger)400, @"Wrong error code");
-    STAssertEquals([error.userInfo objectForKey:NSLocalizedFailureReasonErrorKey], 
+    XCTAssertNil(ob2, @"CDTDocumentRevision object was not nil");
+    XCTAssertNotNil(error, @"Error wasn't set");
+    XCTAssertEqual(error.code, (NSInteger)400, @"Wrong error code");
+    XCTAssertEqual([error.userInfo objectForKey:NSLocalizedFailureReasonErrorKey], 
                    @"Bodies may not contain _ prefixed fields. Use CDTDocumentRevision properties.", 
                    @"Incorrect error message");
     
@@ -1170,7 +1170,7 @@
                                   @[@"doc_id", @"docid"],
                                   @[@1,        docId]
                                   ];
-        STAssertTrue([dc checkDatabase:db
+        XCTAssertTrue([dc checkDatabase:db
                                  table:@"docs"
                                hasRows:expectedRows
                                  error:&validationError],
@@ -1188,7 +1188,7 @@
                                   @[@(1),      @1,          revId,    @YES,        @NO,        json],
                                   ];
         NSError *validationError;
-        STAssertTrue([dc checkDatabase:db
+        XCTAssertTrue([dc checkDatabase:db
                                  table:@"revs"
                                hasRows:expectedRows
                                  error:&validationError],
@@ -1205,12 +1205,12 @@
     doc.body = [@{@"title":@"Testing New creation API",@"FirstTest":@YES} mutableCopy];
     doc.docId = @"MyFirstTestDoc";
     CDTDocumentRevision *saved = [self.datastore createDocumentFromRevision:doc error:&error];
-    STAssertTrue(saved, @"Failed to save new document");
+    XCTAssertTrue(saved, @"Failed to save new document");
     
     CDTMutableDocumentRevision *update = [saved mutableCopy];
     [update.body setObject:@"UpdatedDocValue" forKey:@"UpdatedDoc"];
     CDTDocumentRevision *updated = [self.datastore updateDocumentFromRevision:update error:&error];
-    STAssertTrue(updated, @"Object did not update");
+    XCTAssertTrue(updated, @"Object did not update");
 }
 
 #pragma mark - DELETE tests
@@ -1229,8 +1229,8 @@
     CDTDocumentRevision *tmp = [self.datastore getDocumentWithId:rev.docId
                                                            error:&error];
 
-    STAssertNil(tmp, @"deleted doc returned");
-    STAssertEquals((NSInteger)404, [error code], @"Wrong error code for deleted item.");
+    XCTAssertNil(tmp, @"deleted doc returned");
+    XCTAssertEqual((NSInteger)404, [error code], @"Wrong error code for deleted item.");
 }
 
 - (void)testDeletedFlagOnDocumentRevision
@@ -1248,8 +1248,8 @@
                                         rev:rev.revId
                                       error:&error];
 
-    STAssertNotNil(tmp, @"Deleted doc not returned when queried with rev ID");
-    STAssertTrue(tmp.deleted, @"Deleted document was not flagged deleted");
+    XCTAssertNotNil(tmp, @"Deleted doc not returned when queried with rev ID");
+    XCTAssertTrue(tmp.deleted, @"Deleted document was not flagged deleted");
 }
 
 -(void)testDeleteDocument
@@ -1264,28 +1264,28 @@
     rev.body = [@{@"hello": @"world"} mutableCopy];
 
     CDTDocumentRevision *ob = [self.datastore createDocumentFromRevision:rev error:&error];
-    STAssertNil(error, @"Error creating document");
-    STAssertNotNil(ob, @"CDTDocumentRevision object was nil");
+    XCTAssertNil(error, @"Error creating document");
+    XCTAssertNotNil(ob, @"CDTDocumentRevision object was nil");
     
     error = nil;
     NSString *docId = ob.docId;
     CDTDocumentRevision *deleted = [self.datastore deleteDocumentFromRevision:ob error:&error];
-    STAssertNil(error, @"Error deleting document: %@", error);
-    STAssertNotNil(deleted, @"Error deleting document: %@", error);
+    XCTAssertNil(error, @"Error deleting document: %@", error);
+    XCTAssertNotNil(deleted, @"Error deleting document: %@", error);
     
     // Check new revision isn't found
     error = nil;
     CDTDocumentRevision *retrieved;
     retrieved = [self.datastore getDocumentWithId:docId error:&error];
-    STAssertNotNil(error, @"No Error getting deleted document");
-    STAssertTrue(error.code == 404, @"Error was not a 404. Found %ld", error.code);
-    STAssertNil(retrieved, @"retrieved object was not nil");
+    XCTAssertNotNil(error, @"No Error getting deleted document");
+    XCTAssertTrue(error.code == 404, @"Error was not a 404. Found %ld", error.code);
+    XCTAssertNil(retrieved, @"retrieved object was not nil");
     
     //Now try deleting it again.
     error = nil;
     deleted = [self.datastore deleteDocumentFromRevision:ob error:&error];
-    STAssertNil(deleted, @"CDTRevsision was not nil on Error deleting document: %@", error);
-    STAssertNotNil(error, @"No Error trying to delete already deleted document");
+    XCTAssertNil(deleted, @"CDTRevsision was not nil on Error deleting document: %@", error);
+    XCTAssertNotNil(error, @"No Error trying to delete already deleted document");
     //CouchDB/Cloudant returns 409, But CloudantSync returns a 404.
     //STAssertTrue(error.code == 409, @"Found %@", error);
     
@@ -1293,12 +1293,12 @@
     error = nil;
     const NSUInteger expected_count = 1;
     retrieved = [self.datastore getDocumentWithId:docId rev:ob.revId error:&error];
-    STAssertNil(error, @"Error getting document");
-    STAssertNotNil(retrieved, @"retrieved object was nil");
-    STAssertEqualObjects(ob.docId, retrieved.docId, @"Object retrieved from database has wrong docid");
-    STAssertEqualObjects(ob.revId, retrieved.revId, @"Object retrieved from database has wrong revid");
-    STAssertEquals(retrieved.body.count, expected_count, @"Object from database has != 1 key");
-    STAssertEqualObjects(retrieved.body[@"hello"], @"world", @"Object from database has wrong data");
+    XCTAssertNil(error, @"Error getting document");
+    XCTAssertNotNil(retrieved, @"retrieved object was nil");
+    XCTAssertEqualObjects(ob.docId, retrieved.docId, @"Object retrieved from database has wrong docid");
+    XCTAssertEqualObjects(ob.revId, retrieved.revId, @"Object retrieved from database has wrong revid");
+    XCTAssertEqual(retrieved.body.count, expected_count, @"Object from database has != 1 key");
+    XCTAssertEqualObjects(retrieved.body[@"hello"], @"world", @"Object from database has wrong data");
     
     
     NSDictionary *modifiedCount = @{@"docs": @1, @"revs": @2};
@@ -1309,9 +1309,9 @@
     [self.dbutil.queue inDatabase:^(FMDatabase *db) {
         FMResultSet *result = [db executeQuery:@"select * from docs"];
         [result next];
-        STAssertEqualObjects(docId, [result stringForColumn:@"docid"],@"%@ != %@", docId,[result stringForColumn:@"docid"]);
+        XCTAssertEqualObjects(docId, [result stringForColumn:@"docid"],@"%@ != %@", docId,[result stringForColumn:@"docid"]);
         doc_id_inDocsTable = [result intForColumn:@"doc_id"];
-        STAssertFalse([result next], @"There are too many rows in docs");
+        XCTAssertFalse([result next], @"There are too many rows in docs");
         [result close];
     }];
     
@@ -1322,38 +1322,38 @@
         
         NSError *error;
         
-        STAssertEquals(doc_id_inDocsTable, [result intForColumn:@"doc_id"], @"%d != %d", doc_id_inDocsTable, [result intForColumn:@"doc_id"]);
-        STAssertTrue([result intForColumn:@"sequence"] == 1, @"%d", [result intForColumn:@"sequence"]);
-        STAssertTrue([TD_Revision generationFromRevID:[result stringForColumn:@"revid"]] == 1, @"rev: %@", [result stringForColumn:@"revid"] );
-        STAssertFalse([result boolForColumn:@"current"], @"%@", [result stringForColumn:@"current"]);
-        STAssertFalse([result boolForColumn:@"deleted"], @"%@", [result stringForColumn:@"current"]);
-        STAssertEqualObjects([result objectForColumnName:@"parent"], [NSNull null], @"Found %@", [result objectForColumnName:@"parent"]);
+        XCTAssertEqual(doc_id_inDocsTable, [result intForColumn:@"doc_id"], @"%d != %d", doc_id_inDocsTable, [result intForColumn:@"doc_id"]);
+        XCTAssertTrue([result intForColumn:@"sequence"] == 1, @"%d", [result intForColumn:@"sequence"]);
+        XCTAssertTrue([TD_Revision generationFromRevID:[result stringForColumn:@"revid"]] == 1, @"rev: %@", [result stringForColumn:@"revid"] );
+        XCTAssertFalse([result boolForColumn:@"current"], @"%@", [result stringForColumn:@"current"]);
+        XCTAssertFalse([result boolForColumn:@"deleted"], @"%@", [result stringForColumn:@"current"]);
+        XCTAssertEqualObjects([result objectForColumnName:@"parent"], [NSNull null], @"Found %@", [result objectForColumnName:@"parent"]);
         NSDictionary* jsonDoc = [TDJSON JSONObjectWithData: [result dataForColumn:@"json"]
                                                    options: TDJSONReadingMutableContainers
                                                      error: &error];
-        STAssertTrue([jsonDoc isEqualToDictionary:@{@"hello": @"world"}],@"JSON %@. NSError %@", jsonDoc, error);
+        XCTAssertTrue([jsonDoc isEqualToDictionary:@{@"hello": @"world"}],@"JSON %@. NSError %@", jsonDoc, error);
         
         //next row
-        STAssertTrue([result next], @"Didn't find the second row in the revs table");
-        STAssertEquals(doc_id_inDocsTable, [result intForColumn:@"doc_id"], @"%d != %d", doc_id_inDocsTable, [result intForColumn:@"doc_id"]);
-        STAssertTrue([result intForColumn:@"sequence"] == 2, @"%d", [result intForColumn:@"sequence"]);
-        STAssertTrue([TD_Revision generationFromRevID:[result stringForColumn:@"revid"]] == 2, @"rev: %@", [result stringForColumn:@"revid"] );
-        STAssertTrue([result boolForColumn:@"current"], @"%@", [result stringForColumn:@"current"]);
-        STAssertTrue([result boolForColumn:@"deleted"], @"%@", [result stringForColumn:@"current"]);
-        STAssertTrue([result intForColumn:@"parent"] == 1, @"Found %@", [result intForColumn:@"parent"]);
+        XCTAssertTrue([result next], @"Didn't find the second row in the revs table");
+        XCTAssertEqual(doc_id_inDocsTable, [result intForColumn:@"doc_id"], @"%d != %d", doc_id_inDocsTable, [result intForColumn:@"doc_id"]);
+        XCTAssertTrue([result intForColumn:@"sequence"] == 2, @"%d", [result intForColumn:@"sequence"]);
+        XCTAssertTrue([TD_Revision generationFromRevID:[result stringForColumn:@"revid"]] == 2, @"rev: %@", [result stringForColumn:@"revid"] );
+        XCTAssertTrue([result boolForColumn:@"current"], @"%@", [result stringForColumn:@"current"]);
+        XCTAssertTrue([result boolForColumn:@"deleted"], @"%@", [result stringForColumn:@"current"]);
+        XCTAssertTrue([result intForColumn:@"parent"] == 1, @"Found %@", [result intForColumn:@"parent"]);
         
         //TD_Database+Insertion inserts an empty NSData object instead of NSNull on delete
-        STAssertEqualObjects([result objectForColumnName:@"json"], [NSData data], @"Found %@", [result objectForColumnName:@"json"]);
+        XCTAssertEqualObjects([result objectForColumnName:@"json"], [NSData data], @"Found %@", [result objectForColumnName:@"json"]);
         error = nil;
         jsonDoc = [TDJSON JSONObjectWithData: [result dataForColumn:@"json"]
                                      options: TDJSONReadingMutableContainers
                                        error: NULL];
-        STAssertNil(jsonDoc, @"Expected revs.json to be nil: %@",jsonDoc);
+        XCTAssertNil(jsonDoc, @"Expected revs.json to be nil: %@",jsonDoc);
         
         //shouldn't be any more rows.
-        STAssertFalse([result next], @"There are too many rows in revs");
-        STAssertNil([result stringForColumn:@"doc_id"], @"after [result next], doc_id is %@", [result stringForColumn:@"doc_id"]);
-        STAssertNil([result stringForColumn:@"revid"], @"after [result next],  revid is %@", [result stringForColumn:@"revid"]);
+        XCTAssertFalse([result next], @"There are too many rows in revs");
+        XCTAssertNil([result stringForColumn:@"doc_id"], @"after [result next], doc_id is %@", [result stringForColumn:@"doc_id"]);
+        XCTAssertNil([result stringForColumn:@"revid"], @"after [result next],  revid is %@", [result stringForColumn:@"revid"]);
         
         [result close];
     }];
@@ -1372,8 +1372,8 @@
     CDTMutableDocumentRevision *rev = [CDTMutableDocumentRevision revision];
     rev.body = [@{@"hello":@"world"} mutableCopy];
     CDTDocumentRevision *ob = [self.datastore createDocumentFromRevision:rev error:&error];
-    STAssertNil(error, @"Error creating document");
-    STAssertNotNil(ob, @"CDTDocumentRevision object was nil");
+    XCTAssertNil(error, @"Error creating document");
+    XCTAssertNotNil(ob, @"CDTDocumentRevision object was nil");
     
     //update document
     error = nil;
@@ -1383,33 +1383,33 @@
     rev = [ob mutableCopy];
     rev.body = [@{key2:value2} mutableCopy];
     CDTDocumentRevision *ob2 = [self.datastore updateDocumentFromRevision:rev error:&error];
-    STAssertNil(error, @"Error updating document");
-    STAssertNotNil(ob2, @"CDTDocumentRevision object was nil");
+    XCTAssertNil(error, @"Error updating document");
+    XCTAssertNotNil(ob2, @"CDTDocumentRevision object was nil");
     
     //delete doc.
     error = nil;
     CDTDocumentRevision *deleted = [self.datastore deleteDocumentFromRevision:ob2 error:&error];
-    STAssertNil(error, @"Error deleting document: %@", error);
-    STAssertNotNil(deleted, @"Error deleting document: %@", error);
+    XCTAssertNil(error, @"Error deleting document: %@", error);
+    XCTAssertNotNil(deleted, @"Error deleting document: %@", error);
     
     // Check new revision isn't found
     error = nil;
     CDTDocumentRevision *retrieved;
     retrieved = [self.datastore getDocumentWithId:docId error:&error];
-    STAssertNotNil(error, @"No Error getting deleted document");
-    STAssertTrue(error.code == 404, @"Error was not a 404. Found %ld", error.code);
-    STAssertNil(retrieved, @"retrieved object was not nil");
+    XCTAssertNotNil(error, @"No Error getting deleted document");
+    XCTAssertTrue(error.code == 404, @"Error was not a 404. Found %ld", error.code);
+    XCTAssertNil(retrieved, @"retrieved object was not nil");
     
     // Check we can get the updated revision before it was deleted (ob2)
     error = nil;
     const NSUInteger expected_count = 1;
     retrieved = [self.datastore getDocumentWithId:docId rev:ob2.revId error:&error];
-    STAssertNil(error, @"Error getting document");
-    STAssertNotNil(retrieved, @"retrieved object was nil");
-    STAssertEqualObjects(ob.docId, retrieved.docId, @"Object retrieved from database has wrong docid");
-    STAssertEqualObjects(ob2.revId, retrieved.revId, @"Object retrieved from database has wrong revid");
-    STAssertEquals(retrieved.body.count, expected_count, @"Object from database has != 1 key");
-    STAssertEqualObjects(retrieved.body[key2], value2, @"Object from database has wrong data");
+    XCTAssertNil(error, @"Error getting document");
+    XCTAssertNotNil(retrieved, @"retrieved object was nil");
+    XCTAssertEqualObjects(ob.docId, retrieved.docId, @"Object retrieved from database has wrong docid");
+    XCTAssertEqualObjects(ob2.revId, retrieved.revId, @"Object retrieved from database has wrong revid");
+    XCTAssertEqual(retrieved.body.count, expected_count, @"Object from database has != 1 key");
+    XCTAssertEqualObjects(retrieved.body[key2], value2, @"Object from database has wrong data");
     
     
     NSDictionary *modifiedCount = @{@"docs": @1, @"revs": @3};
@@ -1420,9 +1420,9 @@
     [self.dbutil.queue inDatabase:^(FMDatabase *db) {
         FMResultSet *result = [db executeQuery:@"select * from docs"];
         [result next];
-        STAssertEqualObjects(docId, [result stringForColumn:@"docid"],@"%@ != %@", docId,[result stringForColumn:@"docid"]);
+        XCTAssertEqualObjects(docId, [result stringForColumn:@"docid"],@"%@ != %@", docId,[result stringForColumn:@"docid"]);
         doc_id_inDocsTable = [result intForColumn:@"doc_id"];
-        STAssertFalse([result next], @"There are too many rows in docs");
+        XCTAssertFalse([result next], @"There are too many rows in docs");
         [result close];
     }];
     
@@ -1432,57 +1432,57 @@
         [result next];
             
         //initial doc
-        STAssertEquals(doc_id_inDocsTable, [result intForColumn:@"doc_id"], @"%d != %d", doc_id_inDocsTable, [result intForColumn:@"doc_id"]);
-        STAssertTrue([result intForColumn:@"sequence"] == 1, @"%d", [result intForColumn:@"sequence"]);
-        STAssertTrue([TD_Revision generationFromRevID:[result stringForColumn:@"revid"]] == 1, @"rev: %@", [result stringForColumn:@"revid"] );
-        STAssertFalse([result boolForColumn:@"current"], @"%@", [result stringForColumn:@"current"]);
-        STAssertFalse([result boolForColumn:@"deleted"], @"%@", [result stringForColumn:@"deleted"]);
-        STAssertEqualObjects([result objectForColumnName:@"parent"], [NSNull null], @"Found %@", [result objectForColumnName:@"parent"]);
+        XCTAssertEqual(doc_id_inDocsTable, [result intForColumn:@"doc_id"], @"%d != %d", doc_id_inDocsTable, [result intForColumn:@"doc_id"]);
+        XCTAssertTrue([result intForColumn:@"sequence"] == 1, @"%d", [result intForColumn:@"sequence"]);
+        XCTAssertTrue([TD_Revision generationFromRevID:[result stringForColumn:@"revid"]] == 1, @"rev: %@", [result stringForColumn:@"revid"] );
+        XCTAssertFalse([result boolForColumn:@"current"], @"%@", [result stringForColumn:@"current"]);
+        XCTAssertFalse([result boolForColumn:@"deleted"], @"%@", [result stringForColumn:@"deleted"]);
+        XCTAssertEqualObjects([result objectForColumnName:@"parent"], [NSNull null], @"Found %@", [result objectForColumnName:@"parent"]);
 
         NSError *error;
         NSDictionary* jsonDoc = [TDJSON JSONObjectWithData: [result dataForColumn:@"json"]
                                                    options: TDJSONReadingMutableContainers
                                                      error: &error];
-        STAssertTrue([jsonDoc isEqualToDictionary:@{@"hello": @"world"}],@"JSON %@. NSError %@", jsonDoc, error);
+        XCTAssertTrue([jsonDoc isEqualToDictionary:@{@"hello": @"world"}],@"JSON %@. NSError %@", jsonDoc, error);
         
         //updated doc
-        STAssertTrue([result next], @"Didn't find the second row in the revs table");
-        STAssertEquals(doc_id_inDocsTable, [result intForColumn:@"doc_id"], @"%d != %d", doc_id_inDocsTable, [result intForColumn:@"doc_id"]);
-        STAssertTrue([result intForColumn:@"sequence"] == 2, @"%d", [result intForColumn:@"sequence"]);
-        STAssertTrue([TD_Revision generationFromRevID:[result stringForColumn:@"revid"]] == 2, @"rev: %@", [result stringForColumn:@"revid"] );
-        STAssertFalse([result boolForColumn:@"current"], @"%@", [result stringForColumn:@"current"]);
-        STAssertFalse([result boolForColumn:@"deleted"], @"%@", [result stringForColumn:@"deleted"]);
-        STAssertTrue([result intForColumn:@"parent"] == 1, @"Found %d", [result intForColumn:@"parent"]);
+        XCTAssertTrue([result next], @"Didn't find the second row in the revs table");
+        XCTAssertEqual(doc_id_inDocsTable, [result intForColumn:@"doc_id"], @"%d != %d", doc_id_inDocsTable, [result intForColumn:@"doc_id"]);
+        XCTAssertTrue([result intForColumn:@"sequence"] == 2, @"%d", [result intForColumn:@"sequence"]);
+        XCTAssertTrue([TD_Revision generationFromRevID:[result stringForColumn:@"revid"]] == 2, @"rev: %@", [result stringForColumn:@"revid"] );
+        XCTAssertFalse([result boolForColumn:@"current"], @"%@", [result stringForColumn:@"current"]);
+        XCTAssertFalse([result boolForColumn:@"deleted"], @"%@", [result stringForColumn:@"deleted"]);
+        XCTAssertTrue([result intForColumn:@"parent"] == 1, @"Found %d", [result intForColumn:@"parent"]);
         
         error = nil;
         jsonDoc = [TDJSON JSONObjectWithData: [result dataForColumn:@"json"]
                                      options: TDJSONReadingMutableContainers
                                        error: &error];
-        STAssertTrue([jsonDoc isEqualToDictionary:@{key2: value2}],@"JSON %@. NSError %@", jsonDoc, error);
+        XCTAssertTrue([jsonDoc isEqualToDictionary:@{key2: value2}],@"JSON %@. NSError %@", jsonDoc, error);
    
         
         //deleted doc
-        STAssertTrue([result next], @"Didn't find the third row in the revs table");
-        STAssertEquals(doc_id_inDocsTable, [result intForColumn:@"doc_id"], @"%d != %d", doc_id_inDocsTable, [result intForColumn:@"doc_id"]);
-        STAssertTrue([result intForColumn:@"sequence"] == 3, @"%d", [result intForColumn:@"sequence"]);
-        STAssertTrue([TD_Revision generationFromRevID:[result stringForColumn:@"revid"]] == 3, @"rev: %@", [result stringForColumn:@"revid"] );
-        STAssertTrue([result boolForColumn:@"current"], @"%@", [result stringForColumn:@"current"]);
-        STAssertTrue([result boolForColumn:@"deleted"], @"%@", [result stringForColumn:@"current"]);
-        STAssertTrue([result intForColumn:@"parent"] == 2, @"Found %d", [result intForColumn:@"parent"]);
+        XCTAssertTrue([result next], @"Didn't find the third row in the revs table");
+        XCTAssertEqual(doc_id_inDocsTable, [result intForColumn:@"doc_id"], @"%d != %d", doc_id_inDocsTable, [result intForColumn:@"doc_id"]);
+        XCTAssertTrue([result intForColumn:@"sequence"] == 3, @"%d", [result intForColumn:@"sequence"]);
+        XCTAssertTrue([TD_Revision generationFromRevID:[result stringForColumn:@"revid"]] == 3, @"rev: %@", [result stringForColumn:@"revid"] );
+        XCTAssertTrue([result boolForColumn:@"current"], @"%@", [result stringForColumn:@"current"]);
+        XCTAssertTrue([result boolForColumn:@"deleted"], @"%@", [result stringForColumn:@"current"]);
+        XCTAssertTrue([result intForColumn:@"parent"] == 2, @"Found %d", [result intForColumn:@"parent"]);
         
         //TD_Database+Insertion inserts an empty NSData object instead of NSNull
-        STAssertEqualObjects([result objectForColumnName:@"json"], [NSData data], @"Found %@", [result objectForColumnName:@"json"]);
+        XCTAssertEqualObjects([result objectForColumnName:@"json"], [NSData data], @"Found %@", [result objectForColumnName:@"json"]);
         
         error = nil;
         jsonDoc = [TDJSON JSONObjectWithData: [result dataForColumn:@"json"]
                                      options: TDJSONReadingMutableContainers
                                        error: &error];
-        STAssertNil(jsonDoc, @"Expected json dictionary to be nil: %@. Error %@",jsonDoc, error);
+        XCTAssertNil(jsonDoc, @"Expected json dictionary to be nil: %@. Error %@",jsonDoc, error);
         
         //should be done
-        STAssertFalse([result next], @"There are too many rows in revs");
-        STAssertNil([result stringForColumn:@"doc_id"], @"after [result next], doc_id is %@", [result stringForColumn:@"doc_id"]);
-        STAssertNil([result stringForColumn:@"revid"], @"after [result next],  revid is %@", [result stringForColumn:@"revid"]);
+        XCTAssertFalse([result next], @"There are too many rows in revs");
+        XCTAssertNil([result stringForColumn:@"doc_id"], @"after [result next], doc_id is %@", [result stringForColumn:@"doc_id"]);
+        XCTAssertNil([result stringForColumn:@"revid"], @"after [result next],  revid is %@", [result stringForColumn:@"revid"]);
         
         [result close];
     }];
@@ -1498,8 +1498,8 @@
     rev.body = [@{@"hello": @"world"}mutableCopy];
 
     CDTDocumentRevision *ob = [self.datastore createDocumentFromRevision:rev error:&error];
-    STAssertNil(error, @"Error creating document");
-    STAssertNotNil(ob, @"CDTDocumentRevision object was nil");
+    XCTAssertNil(error, @"Error creating document");
+    XCTAssertNotNil(ob, @"CDTDocumentRevision object was nil");
     
     //update document rev 2-
     error = nil;
@@ -1509,33 +1509,33 @@
     rev = [ob mutableCopy];
     rev.body = [@{key2:value2} mutableCopy];
     CDTDocumentRevision *ob2 = [self.datastore updateDocumentFromRevision:rev error:&error];
-    STAssertNil(error, @"Error updating document");
-    STAssertNotNil(ob2, @"CDTDocumentRevision object was nil");
+    XCTAssertNil(error, @"Error updating document");
+    XCTAssertNotNil(ob2, @"CDTDocumentRevision object was nil");
     
     //delete doc. rev 3-
     error = nil;
     CDTDocumentRevision *deleted = [self.datastore deleteDocumentFromRevision:ob2 error:&error];
-    STAssertNil(error, @"Error deleting document: %@", error);
-    STAssertNotNil(deleted, @"Error deleting document: %@", error);
+    XCTAssertNil(error, @"Error deleting document: %@", error);
+    XCTAssertNotNil(deleted, @"Error deleting document: %@", error);
     
     // Check new revision isn't found
     error = nil;
     CDTDocumentRevision *retrieved;
     retrieved = [self.datastore getDocumentWithId:docId error:&error];
-    STAssertNotNil(error, @"No Error getting deleted document");
-    STAssertTrue(error.code == 404, @"Error was not a 404. Found %ld", error.code);
-    STAssertNil(retrieved, @"retrieved object was not nil");
+    XCTAssertNotNil(error, @"No Error getting deleted document");
+    XCTAssertTrue(error.code == 404, @"Error was not a 404. Found %ld", error.code);
+    XCTAssertNil(retrieved, @"retrieved object was not nil");
     
     //now try updating rev 2-
     
     //get update rev 2-
     error = nil;
     retrieved = [self.datastore getDocumentWithId:docId rev:ob2.revId error:&error];
-    STAssertNil(error, @"Error getting document");
-    STAssertNotNil(retrieved, @"retrieved object was nil");
-    STAssertEqualObjects(ob.docId, retrieved.docId, @"Object retrieved from database has wrong docid");
-    STAssertEqualObjects(ob2.revId, retrieved.revId, @"Object retrieved from database has wrong revid");
-    STAssertEqualObjects(retrieved.body[key2], value2, @"Object from database has wrong data");
+    XCTAssertNil(error, @"Error getting document");
+    XCTAssertNotNil(retrieved, @"retrieved object was nil");
+    XCTAssertEqualObjects(ob.docId, retrieved.docId, @"Object retrieved from database has wrong docid");
+    XCTAssertEqualObjects(ob2.revId, retrieved.revId, @"Object retrieved from database has wrong revid");
+    XCTAssertEqualObjects(retrieved.body[key2], value2, @"Object from database has wrong data");
     
     //try updating rev 2-
     error = nil;
@@ -1544,10 +1544,10 @@
     rev = [ob2 mutableCopy];
     rev.body = [@{key3:value3} mutableCopy];
     CDTDocumentRevision *ob3 = [self.datastore updateDocumentFromRevision:rev error:&error];
-    STAssertNotNil(error, @"No Error updating deleted document");
+    XCTAssertNotNil(error, @"No Error updating deleted document");
     //inconsitent with error reported by cloudant/couchdb. cloudant/couch returns 409, TD* retunrs 404
 //    STAssertTrue(error.code == 409, @"Error was not a 409. Found %ld", error.code);
-    STAssertNil(ob3, @"retrieved object was not nil");
+    XCTAssertNil(ob3, @"retrieved object was not nil");
 }
 
 -(void)testGetAllDocsDoesntFindDeletedDocs
@@ -1565,7 +1565,7 @@
         rev.docId = docId;
         rev.body = bodies[i];
         CDTDocumentRevision *ob = [self.datastore createDocumentFromRevision:rev error:&error];
-        STAssertNil(error, @"Error creating document");
+        XCTAssertNil(error, @"Error creating document");
         [dbObjects addObject:ob];
     }
     
@@ -1580,7 +1580,7 @@
             CDTDocumentRevision *deleted = [self.datastore deleteDocumentFromRevision:ob
                                                                                 error:&error];
 
-            STAssertNotNil(deleted, @"Error deleting document: %@", error);
+            XCTAssertNotNil(deleted, @"Error deleting document: %@", error);
             [deletedDbObjects addObject:ob];
             [deletedDbDicts addObject:ob.body];
         }
@@ -1601,31 +1601,31 @@
     //make sure none of the deleted documents are found in the results.
     for(CDTDocumentRevision* aRev in result){
         for(NSDictionary *aDeletedDict in deletedDbDicts){
-            STAssertFalse(aDeletedDict == aRev.body, @"Found equal pointers. %d == %d", aRev.body, aDeletedDict );
-            STAssertFalse([aDeletedDict isEqualToDictionary:aRev.body], @"Found deleted dictionary in results");
+            XCTAssertFalse(aDeletedDict == aRev.body, @"Found equal pointers. %d == %d", aRev.body, aDeletedDict );
+            XCTAssertFalse([aDeletedDict isEqualToDictionary:aRev.body], @"Found deleted dictionary in results");
         }
         //is this the same as above?
-        STAssertNil([deletedDbDicts member:aRev.body], @"Found result in deleted set: %@", aRev.body);
+        XCTAssertNil([deletedDbDicts member:aRev.body], @"Found result in deleted set: %@", aRev.body);
     }
 
     //get all of the previous revisions of the deleted docs and make sure they are deleted.
     [self.datastore documentCount];
     NSString *dbPath = [self pathForDBName:self.datastore.name];
     FMDatabaseQueue *queue = [FMDatabaseQueue databaseQueueWithPath:dbPath];
-    STAssertNotNil(queue, @"FMDatabaseQueue was nil: %@", queue);
+    XCTAssertNotNil(queue, @"FMDatabaseQueue was nil: %@", queue);
     
     for(CDTDocumentRevision *aRev in deletedDbObjects){
         NSError *error;
         CDTDocumentRevision *retrieved = [self.datastore getDocumentWithId:aRev.docId rev:aRev.revId error:&error];
-        STAssertNil(error, @"Error getting retreived doc. %@, %@", aRev.docId, aRev.revId);
-        STAssertNotNil(retrieved, @"CDTDocumentRevision was nil");
+        XCTAssertNil(error, @"Error getting retreived doc. %@, %@", aRev.docId, aRev.revId);
+        XCTAssertNotNil(retrieved, @"CDTDocumentRevision was nil");
         
         BOOL found = NO;
         for(NSDictionary *aDeletedDict in deletedDbDicts){
             if([aDeletedDict isEqualToDictionary:retrieved.body])
                 found = YES;
         }
-        STAssertTrue(found, @"didn't find %@", aRev.body);
+        XCTAssertTrue(found, @"didn't find %@", aRev.body);
         
         //query the database to ensure it has the proper structure
         [queue inDatabase:^(FMDatabase *db){
@@ -1636,20 +1636,20 @@
             while([result next]){
                 count++;
                 if(count == 2){
-                    STAssertTrue([result boolForColumn:@"deleted"], @"not deleted");
-                    STAssertTrue([result boolForColumn:@"current"], @"this rev is not current");
+                    XCTAssertTrue([result boolForColumn:@"deleted"], @"not deleted");
+                    XCTAssertTrue([result boolForColumn:@"current"], @"this rev is not current");
                 }
                 else{
-                    STAssertFalse([result boolForColumn:@"deleted"], @"wrong rev is deleted");
-                    STAssertFalse([result boolForColumn:@"current"], @"wrong rev is current");
+                    XCTAssertFalse([result boolForColumn:@"deleted"], @"wrong rev is deleted");
+                    XCTAssertFalse([result boolForColumn:@"current"], @"wrong rev is current");
                     NSError *error;
                     NSDictionary *jsonDoc = [TDJSON JSONObjectWithData: [result dataForColumn:@"json"]
                                                  options: TDJSONReadingMutableContainers
                                                    error: &error];
-                    STAssertTrue([jsonDoc isEqualToDictionary:aRev.body],@"JSON %@. NSError %@", jsonDoc, error);
+                    XCTAssertTrue([jsonDoc isEqualToDictionary:aRev.body],@"JSON %@. NSError %@", jsonDoc, error);
                 }
             }
-            STAssertTrue(count == 2, @"found more than %d rows", count);
+            XCTAssertTrue(count == 2, @"found more than %d rows", count);
             [result close];
         }];
     }
@@ -1673,7 +1673,7 @@
         rev.docId = docId;
         rev.body = bodies[i];
         CDTDocumentRevision *aRev = [self.datastore createDocumentFromRevision:rev error:&error];
-        STAssertNil(error, @"Error creating document");
+        XCTAssertNil(error, @"Error creating document");
         [dbObjects addObject:aRev];
     }
     
@@ -1684,15 +1684,15 @@
     error = nil;
     NSString *docId = @"idonotexist";
     CDTDocumentRevision *aRev = [self.datastore getDocumentWithId:docId error:&error ];
-    STAssertNotNil(error, @"No Error getting document that doesn't exist");
-    STAssertTrue(error.code == 404, @"Error was not a 404. Found %ld", error.code);
-    STAssertNil(aRev, @"CDTDocumentRevision should be nil after getting document that doesn't exist");
+    XCTAssertNotNil(error, @"No Error getting document that doesn't exist");
+    XCTAssertTrue(error.code == 404, @"Error was not a 404. Found %ld", error.code);
+    XCTAssertNil(aRev, @"CDTDocumentRevision should be nil after getting document that doesn't exist");
     
     error = nil;
     CDTDocumentRevision *deleted = [self.datastore deleteDocumentFromRevision:aRev error:&error];
-    STAssertNotNil(error, @"No Error deleting document that doesn't exist");
-    STAssertTrue(error.code == 400, @"Error was not a 400. Found %ld", error.code);
-    STAssertNil(deleted, @"CDTDocumentRevision* was not nil. Deletion successful?: %@", error);
+    XCTAssertNotNil(error, @"No Error deleting document that doesn't exist");
+    XCTAssertTrue(error.code == 400, @"Error was not a 400. Found %ld", error.code);
+    XCTAssertNil(deleted, @"CDTDocumentRevision* was not nil. Deletion successful?: %@", error);
     
     
     [self.dbutil checkTableRowCount:initialRowCount modifiedBy:nil];
@@ -1706,10 +1706,10 @@
     doc.body = [@{@"title":@"Testing New creation API",@"FirstTest":@YES} mutableCopy];
     doc.docId = @"MyFirstTestDoc";
     CDTDocumentRevision *saved = [self.datastore createDocumentFromRevision:doc error:&error];
-    STAssertTrue(saved, @"Failed to save new document");
+    XCTAssertTrue(saved, @"Failed to save new document");
     
     CDTDocumentRevision *deleted = [self.datastore deleteDocumentFromRevision:saved error:&error];
-    STAssertTrue(deleted && deleted.deleted, @"Document was not deleted");
+    XCTAssertTrue(deleted && deleted.deleted, @"Document was not deleted");
 }
 
 -(void) testDeleteDocumentUsingIdHasMultipleLeafNodesInTree
@@ -1721,14 +1721,14 @@
     
     CDTDocumentRevision * rev = [self.datastore createDocumentFromRevision:mutableRev error:&error];
     
-    STAssertNotNil(rev, @"Document was not created");
+    XCTAssertNotNil(rev, @"Document was not created");
     
     mutableRev = [rev  mutableCopy];
     [mutableRev.body setObject:@"objc" forKey:@"writtenIn"];
     
     CDTDocumentRevision *rev2 = [self.datastore updateDocumentFromRevision:mutableRev error:&error];
     
-    STAssertNotNil(rev2, @"Failed performing update");
+    XCTAssertNotNil(rev2, @"Failed performing update");
     
     //now need to force insert into the DB little messy though
     
@@ -1750,7 +1750,7 @@
     
     NSArray * deleted = [self.datastore deleteDocumentWithId:mutableRev.docId error:&error];
     
-    STAssertTrue([deleted count] == 2, @"Number of deletions do not match");
+    XCTAssertTrue([deleted count] == 2, @"Number of deletions do not match");
     
 }
 
@@ -1766,8 +1766,8 @@
     CDTMutableDocumentRevision *rev = [CDTMutableDocumentRevision revision];
     rev.body = [@{key1:value1} mutableCopy];
     CDTDocumentRevision *ob = [self.datastore createDocumentFromRevision:rev error:&error];
-    STAssertNil(error, @"Error creating document");
-    STAssertNotNil(ob, @"CDTDocumentRevision object was nil");
+    XCTAssertNil(error, @"Error creating document");
+    XCTAssertNotNil(ob, @"CDTDocumentRevision object was nil");
     
     NSString *key2 = @"hi";
     NSString *value2 = @"mike";
@@ -1775,11 +1775,11 @@
     rev = [ob mutableCopy];
     rev.body = [@{key2:value2} mutableCopy];
     CDTDocumentRevision *ob2 = [self.datastore updateDocumentFromRevision:rev error:&error];
-    STAssertNil(error, @"Error updating document");
-    STAssertNotNil(ob2, @"CDTDocumentRevision object was nil");
+    XCTAssertNil(error, @"Error updating document");
+    XCTAssertNotNil(ob2, @"CDTDocumentRevision object was nil");
     
     TDStatus statusResults = [self.datastore.database compact];
-    STAssertTrue([TDStatusToNSError( statusResults, nil) code] == 200, @"TDStatusAsNSError: %@", TDStatusToNSError( statusResults, nil));
+    XCTAssertTrue([TDStatusToNSError( statusResults, nil) code] == 200, @"TDStatusAsNSError: %@", TDStatusToNSError( statusResults, nil));
     
 }
 @end

--- a/Tests/Tests/DatastoreConflicts.m
+++ b/Tests/Tests/DatastoreConflicts.m
@@ -13,7 +13,7 @@
 //  either express or implied. See the License for the specific language governing permissions
 //  and limitations under the License.
 
-#import <SenTestingKit/SenTestingKit.h>
+#import <XCTest/XCTest.h>
 #import <Foundation/Foundation.h>
 
 #import "CloudantSyncTests.h"
@@ -57,7 +57,7 @@
     self.datastore = [self.factory datastoreNamed:@"conflicttests" error:&error];
     self.dbutil = [[DBQueryUtils alloc] initWithDbPath:[self pathForDBName:self.datastore.name]];
     
-    STAssertNotNil(self.datastore, @"datastore is nil");
+    XCTAssertNotNil(self.datastore, @"datastore is nil");
 }
 
 - (void)tearDown
@@ -94,7 +94,7 @@
 {
     
     
-    STAssertNotNil(anId, @"ID string is nil");
+    XCTAssertNotNil(anId, @"ID string is nil");
     
     NSError *error;
     CDTMutableDocumentRevision * mutableRevision = [CDTMutableDocumentRevision revision];
@@ -147,14 +147,14 @@
     if (TDStatusIsError(status)) {
         error = TDStatusToNSError(status, nil);
     }
-    STAssertNil(error, @"Error creating conflict %@", error);
+    XCTAssertNil(error, @"Error creating conflict %@", error);
     CDTDocumentRevision *rev2b = [[CDTDocumentRevision alloc]initWithDocId:td_rev.docID
                                                                 revisionId:td_rev.revID
                                                                       body:td_rev.body.properties
                                                                    deleted:td_rev.deleted
                                                                attachments:@{}
                                                                   sequence:td_rev.sequence];
-    STAssertNotNil(rev2b, @"CDTDocumentRevision object was nil");
+    XCTAssertNotNil(rev2b, @"CDTDocumentRevision object was nil");
     
     error = nil;
     tdbody = [[TD_Body alloc] initWithProperties:@{@"foo2.c":@"bar2.c"}];
@@ -170,14 +170,14 @@
     if (TDStatusIsError(status)) {
         error = TDStatusToNSError(status, nil);
     }
-    STAssertNil(error, @"Error creating conflict %@", error);
+    XCTAssertNil(error, @"Error creating conflict %@", error);
     CDTDocumentRevision *rev2c = [[CDTDocumentRevision alloc]initWithDocId:td_rev.docID
                                                                 revisionId:td_rev.revID
                                                                       body:td_rev.body.properties
                                                                    deleted:td_rev.deleted
                                                                attachments:@{}
                                                                   sequence:td_rev.sequence];
-    STAssertNotNil(rev2c, @"CDTDocumentRevision object was nil");
+    XCTAssertNotNil(rev2c, @"CDTDocumentRevision object was nil");
     
     
 }
@@ -214,8 +214,8 @@
     
     CDTDocumentRevision *rev = [self.datastore createDocumentFromRevision:mutableRev error:&error];
     
-    STAssertNil(error, @"Error creating document");
-    STAssertNotNil(rev, @"CDTDocumentRevision object was nil");
+    XCTAssertNil(error, @"Error creating document");
+    XCTAssertNotNil(rev, @"CDTDocumentRevision object was nil");
     
     return rev;
 }
@@ -227,7 +227,7 @@
     CDTestMutableDocumentResolver *myResolver = [[CDTestMutableDocumentResolver alloc] init];
     
     NSArray *conflictedDocs = [self.datastore getConflictedDocumentIds];
-    STAssertEquals(conflictedDocs.count, (NSUInteger)1, @"");
+    XCTAssertEqual(conflictedDocs.count, (NSUInteger)1, @"");
     
     for (NSString *docId in conflictedDocs) {
         
@@ -236,7 +236,7 @@
             [self.datastore resolveConflictsForDocument:docId
                                                resolver:myResolver
                                                   error:&error];
-            STFail(@"Exception not thrown");
+            XCTFail(@"Exception not thrown");
         } @catch (NSException *e){
             //pass yay
         }
@@ -252,28 +252,28 @@
     CDTestMutableDocumentResolver *myResolver = [[CDTestMutableDocumentResolver alloc] init];
     myResolver.selectParentRev = YES;
     NSArray *conflictedDocs = [self.datastore getConflictedDocumentIds];
-    STAssertEquals(conflictedDocs.count, (NSUInteger)1, @"");
+    XCTAssertEqual(conflictedDocs.count, (NSUInteger)1, @"");
     
     for (NSString *docId in conflictedDocs) {
         NSError *error;
-        STAssertTrue([self.datastore resolveConflictsForDocument:docId
+        XCTAssertTrue([self.datastore resolveConflictsForDocument:docId
                                                         resolver:myResolver
                                                            error:&error],
                      @"resolve failure: %@", docId);
-        STAssertNil(error, @"Error resolving document. %@", error);
+        XCTAssertNil(error, @"Error resolving document. %@", error);
     }
     
     //make sure there are no more conflicting documents
     conflictedDocs = [self.datastore getConflictedDocumentIds];
-    STAssertEquals(conflictedDocs.count, (NSUInteger)0, @"");
+    XCTAssertEqual(conflictedDocs.count, (NSUInteger)0, @"");
     
     //make sure that doc0 has the proper rev and content
     //They should have rev prefixes of 4-
     NSError *error = nil;
     CDTDocumentRevision *rev = [self.datastore getDocumentWithId:@"doc0" error:&error];
-    STAssertNil(error, @"Error getting document");
-    STAssertNotNil(rev, @"CDTDocumentRevision object was nil");
-    STAssertEquals([TD_Revision generationFromRevID:rev.revId],
+    XCTAssertNil(error, @"Error getting document");
+    XCTAssertNotNil(rev, @"CDTDocumentRevision object was nil");
+    XCTAssertEqual([TD_Revision generationFromRevID:rev.revId],
                    [TD_Revision generationFromRevID:myResolver.selectedParent.revId]+1,
                    @"Unexpected RevId: %@",
                    rev.revId);
@@ -307,17 +307,17 @@
     
     for (NSString *docId in [self.datastore getConflictedDocumentIds]) {
         NSError *error;
-        STAssertTrue([self.datastore resolveConflictsForDocument:docId
+        XCTAssertTrue([self.datastore resolveConflictsForDocument:docId
                                                         resolver:myResolver
                                                            error:&error],
                      @"resolve failure: %@", docId);
-        STAssertNil(error, @"Error resolving document. %@", error);
+        XCTAssertNil(error, @"Error resolving document. %@", error);
     }
     
     
     //make sure there are no more conflicting documents
     NSArray *conflictedDocs = [self.datastore getConflictedDocumentIds];
-    STAssertEquals(conflictedDocs.count, (NSUInteger)0, @"");
+    XCTAssertEqual(conflictedDocs.count, (NSUInteger)0, @"");
     
     //make sure that doc0 has the proper rev and content
     //The winning rev should be generation 2 and should have content of {foo2.b:bar2.b}
@@ -325,15 +325,15 @@
     NSError *error = nil;
     CDTDocumentRevision *rev = [self.datastore getDocumentWithId:@"doc0" error:&error];
     NSDictionary * expectedBody = @{ @"foo2.b":@"bar2.b", @"foo3.a":@"bar3.a"};
-    STAssertNil(error, @"Error getting document");
-    STAssertNotNil(rev, @"CDTDocumentRevision object was nil");
-    STAssertEquals([TD_Revision generationFromRevID:rev.revId],
+    XCTAssertNil(error, @"Error getting document");
+    XCTAssertNotNil(rev, @"CDTDocumentRevision object was nil");
+    XCTAssertEqual([TD_Revision generationFromRevID:rev.revId],
                    [TD_Revision generationFromRevID:myResolver.selectedParent.revId]+1,
                    @"Unexpected RevId: %@", rev.revId);
-    STAssertTrue([rev.body isEqualToDictionary:expectedBody],
+    XCTAssertTrue([rev.body isEqualToDictionary:expectedBody],
                  @"Unexpected document: %@", rev.body);
     
-    STAssertEquals((NSUInteger)1, [rev.attachments count], @"Wrong number of attachments");
+    XCTAssertEqual((NSUInteger)1, [rev.attachments count], @"Wrong number of attachments");
     
     
     NSBundle *bundle = [NSBundle bundleForClass:[self class]];
@@ -350,7 +350,7 @@
         
         MRDatabaseContentChecker *dc = [[MRDatabaseContentChecker alloc] init];
         NSError *validationError;
-        STAssertTrue([dc checkDatabase:db
+        XCTAssertTrue([dc checkDatabase:db
                                  table:@"attachments"
                                hasRows:expectedRows
                                  error:&validationError],
@@ -387,17 +387,17 @@
     
     for (NSString *docId in [self.datastore getConflictedDocumentIds]) {
         NSError *error;
-        STAssertTrue([self.datastore resolveConflictsForDocument:docId
+        XCTAssertTrue([self.datastore resolveConflictsForDocument:docId
                                                         resolver:myResolver
                                                            error:&error],
                      @"resolve failure: %@", docId);
-        STAssertNil(error, @"Error resolving document. %@", error);
+        XCTAssertNil(error, @"Error resolving document. %@", error);
     }
     
     
     //make sure there are no more conflicting documents
     NSArray *conflictedDocs = [self.datastore getConflictedDocumentIds];
-    STAssertEquals(conflictedDocs.count, (NSUInteger)0, @"");
+    XCTAssertEqual(conflictedDocs.count, (NSUInteger)0, @"");
     
     //make sure that doc0 has the proper rev and content
     //The winning rev should be generation 2 and should have content of {foo2.b:bar2.b}
@@ -405,15 +405,15 @@
     NSError *error = nil;
     CDTDocumentRevision *rev = [self.datastore getDocumentWithId:@"doc0" error:&error];
     NSDictionary * expectedBody = @{ @"foo2.b":@"bar2.b", @"foo3.a":@"bar3.a"};
-    STAssertNil(error, @"Error getting document");
-    STAssertNotNil(rev, @"CDTDocumentRevision object was nil");
-    STAssertEquals([TD_Revision generationFromRevID:rev.revId],
+    XCTAssertNil(error, @"Error getting document");
+    XCTAssertNotNil(rev, @"CDTDocumentRevision object was nil");
+    XCTAssertEqual([TD_Revision generationFromRevID:rev.revId],
                    [TD_Revision generationFromRevID:myResolver.selectedParent.revId]+1,
                    @"Unexpected RevId: %@", rev.revId);
-    STAssertTrue([rev.body isEqualToDictionary:expectedBody],
+    XCTAssertTrue([rev.body isEqualToDictionary:expectedBody],
                  @"Unexpected document: %@", rev.body);
     
-    STAssertEquals((NSUInteger)2, [rev.attachments count], @"Wrong number of attachments");
+    XCTAssertEqual((NSUInteger)2, [rev.attachments count], @"Wrong number of attachments");
     
     
     NSBundle *bundle = [NSBundle bundleForClass:[self class]];
@@ -433,7 +433,7 @@
         MRDatabaseContentChecker *dc = [[MRDatabaseContentChecker alloc] init];
         NSError *validationError;
         NSArray * orderby = @[@"sequence",@"sequence"];
-        STAssertTrue([dc checkDatabase:db
+        XCTAssertTrue([dc checkDatabase:db
                                  table:@"attachments"
                                hasRows:expectedRows
                                orderBy:orderby
@@ -468,19 +468,19 @@
         
         switch ([TD_Revision generationFromRevID:aRev.revId]) {
             case 2:
-                STAssertEqualObjects(aRev.body,
+                XCTAssertEqualObjects(aRev.body,
                                      @{@"foo2.b":@"bar2.b"},
                                      @"unexpected document: %@", aRev.body);
                 break;
                 
             case 3:
-                STAssertEqualObjects(aRev.body,
+                XCTAssertEqualObjects(aRev.body,
                                      @{@"foo3.a":@"bar3.a"},
                                      @"unexpected document: %@", aRev.body);
                 break;
                 
             default:
-                STFail(@"invalid revision generation: %@", aRev.revId);
+                XCTFail(@"invalid revision generation: %@", aRev.revId);
                 break;
         }
         
@@ -505,13 +505,13 @@
     
     
     NSSet *foundConflictedDocIds = [NSSet setWithArray:[self.datastore getConflictedDocumentIds]];
-    STAssertTrue([foundConflictedDocIds isEqualToSet:setOfConflictedDocIds],
+    XCTAssertTrue([foundConflictedDocIds isEqualToSet:setOfConflictedDocIds],
                  @"foundSet: %@", foundConflictedDocIds);
     
-    STAssertFalse([foundConflictedDocIds containsObject:rev.docId],
+    XCTAssertFalse([foundConflictedDocIds containsObject:rev.docId],
                   @"conflicts set (%@) contained non-conflicting doc %@",
                   foundConflictedDocIds, rev.docId );
-    STAssertFalse([foundConflictedDocIds containsObject:rev2.docId],
+    XCTAssertFalse([foundConflictedDocIds containsObject:rev2.docId],
                   @"conflicts set (%@) contained non-conflicting doc %@",
                   foundConflictedDocIds, rev2.docId );
     
@@ -534,7 +534,7 @@
     
     NSSet *foundConflictedDocIds = [NSSet setWithArray:[self.datastore getConflictedDocumentIds]];
     
-    STAssertTrue([foundConflictedDocIds isEqualToSet:setOfConflictedDocIds],
+    XCTAssertTrue([foundConflictedDocIds isEqualToSet:setOfConflictedDocIds],
                  @"foundSet: %@", foundConflictedDocIds);
     
     //add another set of conflicted docs to test
@@ -546,7 +546,7 @@
     
     foundConflictedDocIds = [NSSet setWithArray:[self.datastore getConflictedDocumentIds]];
     
-    STAssertTrue([foundConflictedDocIds isEqualToSet:setOfConflictedDocIds],
+    XCTAssertTrue([foundConflictedDocIds isEqualToSet:setOfConflictedDocIds],
                  @"foundSet: %@", foundConflictedDocIds);
 }
 
@@ -558,30 +558,30 @@
     CDTTestBiggestRevResolver *myResolver = [[CDTTestBiggestRevResolver alloc] init];
     
     NSArray *conflictedDocs = [self.datastore getConflictedDocumentIds];
-    STAssertEquals(conflictedDocs.count, (NSUInteger)1, @"");
+    XCTAssertEqual(conflictedDocs.count, (NSUInteger)1, @"");
     
     for (NSString *docId in conflictedDocs) {
         NSError *error;
-        STAssertTrue([self.datastore resolveConflictsForDocument:docId
+        XCTAssertTrue([self.datastore resolveConflictsForDocument:docId
                                                         resolver:myResolver
                                                            error:&error],
                      @"resolve failure: %@", docId);
-        STAssertNil(error, @"Error resolving document. %@", error);
+        XCTAssertNil(error, @"Error resolving document. %@", error);
     }
     
     //make sure there are no more conflicting documents
     conflictedDocs = [self.datastore getConflictedDocumentIds];
-    STAssertEquals(conflictedDocs.count, (NSUInteger)0, @"");
+    XCTAssertEqual(conflictedDocs.count, (NSUInteger)0, @"");
     
     //make sure that doc0 has the proper rev and content
     //They should have rev prefixes of 3-
     NSError *error = nil;
     CDTDocumentRevision *rev = [self.datastore getDocumentWithId:@"doc0" error:&error];
-    STAssertNil(error, @"Error getting document");
-    STAssertNotNil(rev, @"CDTDocumentRevision object was nil");
-    STAssertEquals([TD_Revision generationFromRevID:rev.revId], (unsigned)3,
+    XCTAssertNil(error, @"Error getting document");
+    XCTAssertNotNil(rev, @"CDTDocumentRevision object was nil");
+    XCTAssertEqual([TD_Revision generationFromRevID:rev.revId], (unsigned)3,
                    @"Unexpected RevId: %@", rev.revId);
-    STAssertTrue([rev.body isEqualToDictionary:myResolver.resolvedDocumentAsDictionary],
+    XCTAssertTrue([rev.body isEqualToDictionary:myResolver.resolvedDocumentAsDictionary],
                  @"Unexpected document: %@", rev.body);
     
 }
@@ -603,24 +603,24 @@
     
     for (NSString *docId in [self.datastore getConflictedDocumentIds]) {
         NSError *error;
-        STAssertTrue([self.datastore resolveConflictsForDocument:docId
+        XCTAssertTrue([self.datastore resolveConflictsForDocument:docId
                                                         resolver:myResolver
                                                            error:&error],
                      @"resolve failure: %@", docId);
-        STAssertNil(error, @"Error resolving document. %@", error);
+        XCTAssertNil(error, @"Error resolving document. %@", error);
     }
     
     //make sure there are the correct number of conflicting documents
     NSArray *conflictedDocs = [self.datastore getConflictedDocumentIds];
-    STAssertEquals(conflictedDocs.count, setOfConflictedDocIds.count, @"");
+    XCTAssertEqual(conflictedDocs.count, setOfConflictedDocIds.count, @"");
     
     //make sure that doc0, doc1, doc2 and doc3 are still retrieved
     for (NSString *docId in setOfConflictedDocIds) {
         
         NSError *error = nil;
         CDTDocumentRevision *rev = [self.datastore getDocumentWithId:docId error:&error];
-        STAssertNil(error, @"Error getting document");
-        STAssertNotNil(rev, @"CDTDocumentRevision object was nil.");
+        XCTAssertNil(error, @"Error getting document");
+        XCTAssertNotNil(rev, @"CDTDocumentRevision object was nil.");
         
     }
 }
@@ -644,28 +644,28 @@
     
     for (NSString *docId in [self.datastore getConflictedDocumentIds]) {
         NSError *error;
-        STAssertTrue([self.datastore resolveConflictsForDocument:docId resolver:myResolver error:&error],
+        XCTAssertTrue([self.datastore resolveConflictsForDocument:docId resolver:myResolver error:&error],
                      @"resolve failure: %@", docId);
-        STAssertNil(error, @"Error resolving document. %@", error);
+        XCTAssertNil(error, @"Error resolving document. %@", error);
     }
     
     //check conflicting documents
     NSArray *conflictedDocs = [self.datastore getConflictedDocumentIds];
-    STAssertEquals(conflictedDocs.count, (NSUInteger)2, @"");
+    XCTAssertEqual(conflictedDocs.count, (NSUInteger)2, @"");
     
     NSSet *stillConflicted = [NSSet setWithArray:@[@"doc2", @"doc3"]];
-    STAssertTrue([stillConflicted isEqualToSet:[NSSet setWithArray:conflictedDocs]],
+    XCTAssertTrue([stillConflicted isEqualToSet:[NSSet setWithArray:conflictedDocs]],
                  @"unequal sets. expected: %@, found: %@", stillConflicted, conflictedDocs);
     
     for (NSString *docId in resolvedDocs) {
         
         NSError *error = nil;
         CDTDocumentRevision *rev = [self.datastore getDocumentWithId:docId error:&error];
-        STAssertNil(error, @"Error getting document");
-        STAssertNotNil(rev, @"CDTDocumentRevision object was nil");
-        STAssertEquals([TD_Revision generationFromRevID:rev.revId], (unsigned)3,
+        XCTAssertNil(error, @"Error getting document");
+        XCTAssertNotNil(rev, @"CDTDocumentRevision object was nil");
+        XCTAssertEqual([TD_Revision generationFromRevID:rev.revId], (unsigned)3,
                        @"Unexpected RevId: %@", rev.revId);
-        STAssertTrue([rev.body isEqualToDictionary: myResolver.resolvedDocumentAsDictionary],
+        XCTAssertTrue([rev.body isEqualToDictionary: myResolver.resolvedDocumentAsDictionary],
                      @"Unexpected document: %@", rev.body);
     }
 }
@@ -679,30 +679,30 @@
     CDTTestSmallestRevResolver *myResolver = [[CDTTestSmallestRevResolver alloc] init];
     
     NSArray *conflictedDocs = [self.datastore getConflictedDocumentIds];
-    STAssertEquals(conflictedDocs.count, (NSUInteger)1, @"");
+    XCTAssertEqual(conflictedDocs.count, (NSUInteger)1, @"");
     
     for (NSString *docId in conflictedDocs) {
         NSError *error;
-        STAssertTrue([self.datastore resolveConflictsForDocument:docId
+        XCTAssertTrue([self.datastore resolveConflictsForDocument:docId
                                                         resolver:myResolver
                                                            error:&error],
                      @"resolve failure: %@", docId);
-        STAssertNil(error, @"Error resolving document. %@", error);
+        XCTAssertNil(error, @"Error resolving document. %@", error);
     }
     
     //make sure there are no more conflicting documents
     conflictedDocs = [self.datastore getConflictedDocumentIds];
-    STAssertEquals(conflictedDocs.count, (NSUInteger)0, @"");
+    XCTAssertEqual(conflictedDocs.count, (NSUInteger)0, @"");
     
     //make sure that doc0 has the proper rev and content
     //They should have rev prefixes of 2-
     NSError *error = nil;
     CDTDocumentRevision *rev = [self.datastore getDocumentWithId:@"doc0" error:&error];
-    STAssertNil(error, @"Error getting document");
-    STAssertNotNil(rev, @"CDTDocumentRevision object was nil");
-    STAssertEquals([TD_Revision generationFromRevID:rev.revId], (unsigned)2,
+    XCTAssertNil(error, @"Error getting document");
+    XCTAssertNotNil(rev, @"CDTDocumentRevision object was nil");
+    XCTAssertEqual([TD_Revision generationFromRevID:rev.revId], (unsigned)2,
                    @"Unexpected RevId: %@", rev.revId);
-    STAssertTrue([rev.body isEqualToDictionary:myResolver.resolvedDocumentAsDictionary],
+    XCTAssertTrue([rev.body isEqualToDictionary:myResolver.resolvedDocumentAsDictionary],
                  @"Unexpected document: %@", rev.body);
     
 }
@@ -736,29 +736,29 @@
     
     for (NSString *docId in [self.datastore getConflictedDocumentIds]) {
         NSError *error;
-        STAssertTrue([self.datastore resolveConflictsForDocument:docId
+        XCTAssertTrue([self.datastore resolveConflictsForDocument:docId
                                                         resolver:myResolver
                                                            error:&error],
                      @"resolve failure: %@", docId);
-        STAssertNil(error, @"Error resolving document. %@", error);
+        XCTAssertNil(error, @"Error resolving document. %@", error);
     }
     
     //make sure there are no more conflicted documents
     NSArray *conflictedDocs = [self.datastore getConflictedDocumentIds];
-    STAssertEquals(conflictedDocs.count, (NSUInteger)0, @"");
+    XCTAssertEqual(conflictedDocs.count, (NSUInteger)0, @"");
     
     //make sure that doc0 has the proper rev and content
     //The winning rev should be generation 3 and should have content of {foo3.a:bar3.a}
     //It should also have the bonsai-boston attached image.
     NSError *error = nil;
     CDTDocumentRevision *rev = [self.datastore getDocumentWithId:@"doc0" error:&error];
-    STAssertNil(error, @"Error getting document");
-    STAssertNotNil(rev, @"CDTDocumentRevision object was nil");
-    STAssertEquals([TD_Revision generationFromRevID:rev.revId], (unsigned)3,
+    XCTAssertNil(error, @"Error getting document");
+    XCTAssertNotNil(rev, @"CDTDocumentRevision object was nil");
+    XCTAssertEqual([TD_Revision generationFromRevID:rev.revId], (unsigned)3,
                    @"Unexpected RevId: %@", rev.revId);
-    STAssertTrue([rev.body isEqualToDictionary:myResolver.resolvedDocumentAsDictionary],
+    XCTAssertTrue([rev.body isEqualToDictionary:myResolver.resolvedDocumentAsDictionary],
                  @"Unexpected document: %@", rev.body);
-    STAssertTrue([rev.attachments count] == 1,
+    XCTAssertTrue([rev.attachments count] == 1,
                  @"Unexpected number of attachments. expected %d, actual %d",
                  1,
                  [rev.attachments count]);
@@ -776,7 +776,7 @@
         
         MRDatabaseContentChecker *dc = [[MRDatabaseContentChecker alloc] init];
         NSError *validationError;
-        STAssertTrue([dc checkDatabase:db
+        XCTAssertTrue([dc checkDatabase:db
                                  table:@"attachments"
                                hasRows:expectedRows
                                  error:&validationError],
@@ -813,34 +813,34 @@
     
     for (NSString *docId in [self.datastore getConflictedDocumentIds]) {
         NSError *error;
-        STAssertTrue([self.datastore resolveConflictsForDocument:docId
+        XCTAssertTrue([self.datastore resolveConflictsForDocument:docId
                                                         resolver:myResolver
                                                            error:&error],
                      @"resolve failure: %@", docId);
-        STAssertNil(error, @"Error resolving document. %@", error);
+        XCTAssertNil(error, @"Error resolving document. %@", error);
     }
     
     
     //make sure there are no more conflicting documents
     NSArray *conflictedDocs = [self.datastore getConflictedDocumentIds];
-    STAssertEquals(conflictedDocs.count, (NSUInteger)0, @"");
+    XCTAssertEqual(conflictedDocs.count, (NSUInteger)0, @"");
     
     //make sure that doc0 has the proper rev and content
     //The winning rev should be generation 2 and should have content of {foo2.b:bar2.b}
     //It should NOT have the bonsai-boston attached image.
     NSError *error = nil;
     CDTDocumentRevision *rev = [self.datastore getDocumentWithId:@"doc0" error:&error];
-    STAssertNil(error, @"Error getting document");
-    STAssertNotNil(rev, @"CDTDocumentRevision object was nil");
-    STAssertEquals([TD_Revision generationFromRevID:rev.revId], (unsigned)2,
+    XCTAssertNil(error, @"Error getting document");
+    XCTAssertNotNil(rev, @"CDTDocumentRevision object was nil");
+    XCTAssertEqual([TD_Revision generationFromRevID:rev.revId], (unsigned)2,
                    @"Unexpected RevId: %@", rev.revId);
-    STAssertTrue([rev.body isEqualToDictionary:@{@"foo2.b":@"bar2.b"}],
+    XCTAssertTrue([rev.body isEqualToDictionary:@{@"foo2.b":@"bar2.b"}],
                  @"Unexpected document: %@", rev.body);
     
     NSArray *attachments = [self.datastore attachmentsForRev:rev
                                                        error:nil];
     
-    STAssertEquals((NSUInteger)0, [attachments count], @"Wrong number of attachments");
+    XCTAssertEqual((NSUInteger)0, [attachments count], @"Wrong number of attachments");
     
     
     NSBundle *bundle = [NSBundle bundleForClass:[self class]];
@@ -856,7 +856,7 @@
         
         MRDatabaseContentChecker *dc = [[MRDatabaseContentChecker alloc] init];
         NSError *validationError;
-        STAssertTrue([dc checkDatabase:db
+        XCTAssertTrue([dc checkDatabase:db
                                  table:@"attachments"
                                hasRows:expectedRows
                                  error:&validationError],

--- a/Tests/Tests/DatastoreConflicts.m
+++ b/Tests/Tests/DatastoreConflicts.m
@@ -354,7 +354,8 @@
                                  table:@"attachments"
                                hasRows:expectedRows
                                  error:&validationError],
-                     [dc formattedErrors:validationError]);
+                      @"%@",
+                      [dc formattedErrors:validationError]);
     }];
     
     
@@ -438,7 +439,8 @@
                                hasRows:expectedRows
                                orderBy:orderby
                                  error:&validationError],
-                     [dc formattedErrors:validationError]);
+                      @"%@",
+                      [dc formattedErrors:validationError]);
     }];
     
     
@@ -780,7 +782,8 @@
                                  table:@"attachments"
                                hasRows:expectedRows
                                  error:&validationError],
-                     [dc formattedErrors:validationError]);
+                      @"%@",
+                      [dc formattedErrors:validationError]);
     }];
     
 }
@@ -860,7 +863,8 @@
                                  table:@"attachments"
                                hasRows:expectedRows
                                  error:&validationError],
-                     [dc formattedErrors:validationError]);
+                      @"%@",
+                      [dc formattedErrors:validationError]);
     }];
     
     

--- a/Tests/Tests/DatastoreManagerTests.m
+++ b/Tests/Tests/DatastoreManagerTests.m
@@ -27,12 +27,12 @@
     }
     
     NSArray * datastores = [self.factory allDatastores];
-    STAssertEquals((NSUInteger)5, [datastores count],
+    XCTAssertEqual((NSUInteger)5, [datastores count],
                    @"Wrong number of datastores returned, expected 5 got %d",
                    [datastores count]);
     
     for(NSString * dsname in array){
-        STAssertTrue([datastores containsObject:dsname], @"Object missing from datastores list");
+        XCTAssertTrue([datastores containsObject:dsname], @"Object missing from datastores list");
     }
     
 }
@@ -41,11 +41,11 @@
     
     [self.factory datastoreNamed:@"adatabase/withaslash" error:nil];
     NSArray * datastores = [self.factory allDatastores];
-    STAssertEquals((NSUInteger)1,
+    XCTAssertEqual((NSUInteger)1,
                    [datastores count],
                    @"Wrong number of datastores returned, expected 1 got %d",
                    [datastores count]);
-    STAssertEqualObjects(@"adatabase/withaslash",
+    XCTAssertEqualObjects(@"adatabase/withaslash",
                          [datastores objectAtIndex:0],
                          @"Datastore names do not match");
     
@@ -53,7 +53,7 @@
 
 -(void) testListEmptyDatastores {
     NSArray * datastores = [self.factory allDatastores];
-    STAssertEquals((NSUInteger)0, [datastores count],
+    XCTAssertEqual((NSUInteger)0, [datastores count],
                    @"Wrong number of datastores returned, expected 0 got %d",
                    [datastores count]);
 

--- a/Tests/Tests/Events/CDTDatastoreEvents.m
+++ b/Tests/Tests/Events/CDTDatastoreEvents.m
@@ -9,7 +9,7 @@
 #import "CloudantSyncTests.h"
 
 #import <CloudantSync.h>
-#import <SenTestingKit/SenTestingKit.h>
+#import <XCTest/XCTest.h>
 #import <TD_Body.h>
 #import <TD_Revision.h>
 #import <TD_Database.h>
@@ -76,7 +76,7 @@
                                                  name:CDTDatastoreChangeNotification
                                                object:other];
     
-    STAssertNotNil(self.datastore, @"datastore is nil");
+    XCTAssertNotNil(self.datastore, @"datastore is nil");
 }
 
 - (void)tearDown
@@ -91,14 +91,14 @@
     CDTMutableDocumentRevision *rev = [CDTMutableDocumentRevision revision];
     rev.body = @{@"hello": @"world"};
     
-    STAssertNotNil([self.datastore createDocumentFromRevision:rev error:nil],
+    XCTAssertNotNil([self.datastore createDocumentFromRevision:rev error:nil],
                    @"Document wasn't created");
     
     // Events happen syncronously on update
     
-    STAssertEquals(self.watcher.counter, (NSInteger)1, @"Event not fired");
-    STAssertEquals(self.globalWatcher.counter, (NSInteger)1, @"Event not fired");
-    STAssertEquals(self.otherWatcher.counter, (NSInteger)0, @"Event incorrectly fired");
+    XCTAssertEqual(self.watcher.counter, (NSInteger)1, @"Event not fired");
+    XCTAssertEqual(self.globalWatcher.counter, (NSInteger)1, @"Event not fired");
+    XCTAssertEqual(self.otherWatcher.counter, (NSInteger)0, @"Event incorrectly fired");
 }
 
 - (void)testEventFiredOnUpdate
@@ -107,22 +107,22 @@
     mutableRev.body = @{@"hello": @"world"};
     CDTDocumentRevision *rev1 = [self.datastore createDocumentFromRevision:mutableRev error:nil];
     
-    STAssertNotNil(rev1, @"Document wasn't created");
+    XCTAssertNotNil(rev1, @"Document wasn't created");
     
     // Events happen syncronously on update
     
-    STAssertEquals(self.watcher.counter, (NSInteger)1, @"Event not fired");
-    STAssertEquals(self.globalWatcher.counter, (NSInteger)1, @"Event not fired");
-    STAssertEquals(self.otherWatcher.counter, (NSInteger)0, @"Event incorrectly fired");
+    XCTAssertEqual(self.watcher.counter, (NSInteger)1, @"Event not fired");
+    XCTAssertEqual(self.globalWatcher.counter, (NSInteger)1, @"Event not fired");
+    XCTAssertEqual(self.otherWatcher.counter, (NSInteger)0, @"Event incorrectly fired");
     
     mutableRev = rev1.mutableCopy;
     mutableRev.body = @{@"hello2": @"world2"};
-    STAssertNotNil([self.datastore updateDocumentFromRevision:mutableRev error:nil],
+    XCTAssertNotNil([self.datastore updateDocumentFromRevision:mutableRev error:nil],
                    @"Document wasn't updated");
     
-    STAssertEquals(self.watcher.counter, (NSInteger)2, @"Event not fired");
-    STAssertEquals(self.globalWatcher.counter, (NSInteger)2, @"Event not fired");
-    STAssertEquals(self.otherWatcher.counter, (NSInteger)0, @"Event incorrectly fired");
+    XCTAssertEqual(self.watcher.counter, (NSInteger)2, @"Event not fired");
+    XCTAssertEqual(self.globalWatcher.counter, (NSInteger)2, @"Event not fired");
+    XCTAssertEqual(self.otherWatcher.counter, (NSInteger)0, @"Event incorrectly fired");
 }
 
 - (void)testEventFiredOnDelete
@@ -131,20 +131,20 @@
     mutableRev.body = @{@"hello": @"world"};
     CDTDocumentRevision *rev1 = [self.datastore createDocumentFromRevision:mutableRev error:nil];
     
-    STAssertNotNil(rev1, @"Document wasn't created");
+    XCTAssertNotNil(rev1, @"Document wasn't created");
     
     // Events happen syncronously on update
     
-    STAssertEquals(self.watcher.counter, (NSInteger)1, @"Event not fired");
-    STAssertEquals(self.globalWatcher.counter, (NSInteger)1, @"Event not fired");
-    STAssertEquals(self.otherWatcher.counter, (NSInteger)0, @"Event incorrectly fired");
+    XCTAssertEqual(self.watcher.counter, (NSInteger)1, @"Event not fired");
+    XCTAssertEqual(self.globalWatcher.counter, (NSInteger)1, @"Event not fired");
+    XCTAssertEqual(self.otherWatcher.counter, (NSInteger)0, @"Event incorrectly fired");
     
-    STAssertNotNil([self.datastore deleteDocumentFromRevision:rev1 error:nil],
+    XCTAssertNotNil([self.datastore deleteDocumentFromRevision:rev1 error:nil],
                    @"Document wasn't updated");
     
-    STAssertEquals(self.watcher.counter, (NSInteger)2, @"Event not fired");
-    STAssertEquals(self.globalWatcher.counter, (NSInteger)2, @"Event not fired");
-    STAssertEquals(self.otherWatcher.counter, (NSInteger)0, @"Event incorrectly fired");
+    XCTAssertEqual(self.watcher.counter, (NSInteger)2, @"Event not fired");
+    XCTAssertEqual(self.globalWatcher.counter, (NSInteger)2, @"Event not fired");
+    XCTAssertEqual(self.otherWatcher.counter, (NSInteger)0, @"Event incorrectly fired");
 }
 
 - (void)testEventFiredOnMultipleDelete
@@ -156,7 +156,7 @@
     
     CDTDocumentRevision * rev = [self.datastore createDocumentFromRevision:mutableRev error:&error];
     
-    STAssertNotNil(rev, @"Document was not created");
+    XCTAssertNotNil(rev, @"Document was not created");
     
     mutableRev = [rev  mutableCopy];
     [mutableRev.body setObject:@"objc" forKey:@"writtenIn"];
@@ -183,9 +183,9 @@
    [self.datastore deleteDocumentWithId:mutableRev.docId error:&error];
 
     //3 notifications get fired for the set up, another one for the double delete
-    STAssertEquals(self.watcher.counter, (NSInteger)4, @"Event not fired");
-    STAssertEquals(self.globalWatcher.counter, (NSInteger)4, @"Event not fired");
-    STAssertEquals(self.otherWatcher.counter, (NSInteger)0, @"Event incorrectly fired");
+    XCTAssertEqual(self.watcher.counter, (NSInteger)4, @"Event not fired");
+    XCTAssertEqual(self.globalWatcher.counter, (NSInteger)4, @"Event not fired");
+    XCTAssertEqual(self.otherWatcher.counter, (NSInteger)0, @"Event incorrectly fired");
     
 }
 

--- a/Tests/Tests/IndexManagerTests.h
+++ b/Tests/Tests/IndexManagerTests.h
@@ -6,7 +6,7 @@
 //
 //
 
-#import <SenTestingKit/SenTestingKit.h>
+#import <XCTest/XCTest.h>
 #import "CloudantSyncTests.h"
 #import "CDTIndexer.h"
 

--- a/Tests/Tests/IndexManagerTests.m
+++ b/Tests/Tests/IndexManagerTests.m
@@ -27,7 +27,7 @@
     NSError *err = nil;
     
     CDTIndexManager *im = [[CDTIndexManager alloc] initWithDatastore:self.datastore error:&err];
-    STAssertNotNil(im, @"indexManager is nil");
+    XCTAssertNotNil(im, @"indexManager is nil");
 }
 
 - (void)testAddFieldIndex
@@ -37,8 +37,8 @@
     CDTIndexManager *im = [[CDTIndexManager alloc] initWithDatastore:self.datastore error:&err];
     
     BOOL ok = [im ensureIndexedWithIndexName:@"index1" fieldName:@"name" error:&err];
-    STAssertTrue(ok, @"ensureIndexedWithIndexName did not return true");
-    STAssertNil(err, @"error is not nil");
+    XCTAssertTrue(ok, @"ensureIndexedWithIndexName did not return true");
+    XCTAssertNil(err, @"error is not nil");
 }
 
 - (void)testAddInvalidFieldIndex
@@ -48,8 +48,8 @@
     CDTIndexManager *im = [[CDTIndexManager alloc] initWithDatastore:self.datastore error:&err];
     
     BOOL ok = [im ensureIndexedWithIndexName:@"abc123^&*^&%^^*^&(; drop table customer;" fieldName:@"name" error:&err];
-    STAssertFalse(ok, @"ensureIndexedWithIndexName did not return false");
-    STAssertNotNil(err, @"error is nil");
+    XCTAssertFalse(ok, @"ensureIndexedWithIndexName did not return false");
+    XCTAssertNotNil(err, @"error is nil");
 }
 
 
@@ -61,13 +61,13 @@
     
     NSError *error1 = nil;
     BOOL ok1 = [im ensureIndexedWithIndexName:@"index1" fieldName:@"name" error:&error1];
-    STAssertTrue(ok1, @"ensureIndexedWithIndexName did not return true");
-    STAssertNil(error1, @"error is not nil");
+    XCTAssertTrue(ok1, @"ensureIndexedWithIndexName did not return true");
+    XCTAssertNil(error1, @"error is not nil");
     
     NSError *error2 = nil;
     BOOL ok2 = [im ensureIndexedWithIndexName:@"index1" fieldName:@"name" error:&error2];
-    STAssertFalse(ok2, @"ensureIndexedWithIndexName did not return false");
-    STAssertNotNil(error2, @"error is nil");
+    XCTAssertFalse(ok2, @"ensureIndexedWithIndexName did not return false");
+    XCTAssertNotNil(error2, @"error is nil");
 }
 
 - (void)testDeleteNonexistantIndex
@@ -77,8 +77,8 @@
     CDTIndexManager *im = [[CDTIndexManager alloc] initWithDatastore:self.datastore error:&err];
     
     BOOL ok = [im deleteIndexWithIndexName:@"index1" error:&err];
-    STAssertFalse(ok, @"ensureIndexedWithIndexName did not return false");
-    STAssertNotNil(err, @"error is nil");
+    XCTAssertFalse(ok, @"ensureIndexedWithIndexName did not return false");
+    XCTAssertNotNil(err, @"error is nil");
 }
 
 - (void)testIndexSomeDocuments
@@ -97,8 +97,8 @@
     
     NSError *error1 = nil;
     BOOL ok1 = [im ensureIndexedWithIndexName:@"index1" fieldName:@"name" error:&error1];
-    STAssertTrue(ok1, @"ensureIndexedWithIndexName did not return true");
-    STAssertNil(error1, @"error is not nil");
+    XCTAssertTrue(ok1, @"ensureIndexedWithIndexName did not return true");
+    XCTAssertNil(error1, @"error is not nil");
 }
 
 - (void)testIndexSomeDocumentsWithUpdate
@@ -117,8 +117,8 @@
     
     NSError *error1 = nil;
     BOOL ok1 = [im ensureIndexedWithIndexName:@"index1" fieldName:@"name" error:&error1];
-    STAssertTrue(ok1, @"ensureIndexedWithIndexName did not return true");
-    STAssertNil(error1, @"error is not nil");
+    XCTAssertTrue(ok1, @"ensureIndexedWithIndexName did not return true");
+    XCTAssertNil(error1, @"error is not nil");
     
     // create some more docs after creating index
     nDocs = 1000;
@@ -134,8 +134,8 @@
     unsigned long count1 = [[res1 documentIds] count];
     unsigned long count2 = [[res2 documentIds] count];
     
-    STAssertEquals(count1, 1000UL, @"Query should return 1000 documents");
-    STAssertEquals(count2, 1000UL, @"Query should return 1000 documents");
+    XCTAssertEqual(count1, 1000UL, @"Query should return 1000 documents");
+    XCTAssertEqual(count2, 1000UL, @"Query should return 1000 documents");
 }
 
 - (void)testIndexSingleCriteria
@@ -168,7 +168,7 @@
     
     CDTQueryResult *res = [im queryWithDictionary:@{@"name":@"Tom"} error:&error];
     unsigned long count = [[res documentIds] count];
-    STAssertEquals(count, 3UL, @"Query should return 3 documents");
+    XCTAssertEqual(count, 3UL, @"Query should return 3 documents");
 }
 
 - (void)testIndexMultipleCriteria
@@ -200,7 +200,7 @@
     [im ensureIndexedWithIndexName:@"surname" fieldName:@"surname" error:&error];
     
     CDTQueryResult *res = [im queryWithDictionary:@{@"name":@"Tom",@"surname":@"Blench"} error:&error];
-    STAssertEquals([[res documentIds] count], (NSUInteger)1, @"Query should return 1 document");
+    XCTAssertEqual([[res documentIds] count], (NSUInteger)1, @"Query should return 1 document");
 }
 
 
@@ -249,7 +249,7 @@
     //    NSLog(@"end query");
     unsigned long count=[[res documentIds] count];
     // NB this is dependent on lrand48 implementation
-    STAssertEquals(count, 98UL, @"Query should return 98 documents");
+    XCTAssertEqual(count, 98UL, @"Query should return 98 documents");
 }
 
 - (void)testResultEnumerator
@@ -268,14 +268,14 @@
     
     NSError *error1 = nil;
     BOOL ok1 = [im ensureIndexedWithIndexName:@"index1" fieldName:@"name" error:&error1];
-    STAssertTrue(ok1, @"ensureIndexedWithIndexName did not return true");
-    STAssertNil(error1, @"error is not nil");
+    XCTAssertTrue(ok1, @"ensureIndexedWithIndexName did not return true");
+    XCTAssertNil(error1, @"error is not nil");
     
     CDTQueryResult *res = [im queryWithDictionary:@{@"index1":@"tom"} error:&error];
     
     // helper fn countResults is a for loop which tests enumerator
     int count=[self countResults:res];
-    STAssertEquals(count, nDocs, @"counts not equal");
+    XCTAssertEqual(count, nDocs, @"counts not equal");
 }
 
 - (void)testCreateAndDeleteIndex
@@ -289,8 +289,8 @@
     [im ensureIndexedWithIndexName:@"name" fieldName:@"name" error:&error1];
     [im deleteIndexWithIndexName:@"name" error:&error2];
     
-    STAssertNil(error1, @"ensureIndexedWithIndexName should not return error");
-    STAssertNil(error2, @"deleteIndexWithIndexName should not return error");
+    XCTAssertNil(error1, @"ensureIndexedWithIndexName should not return error");
+    XCTAssertNil(error2, @"deleteIndexWithIndexName should not return error");
 }
 
 - (void)test2IndexManagers
@@ -303,8 +303,8 @@
         
         NSError *error1 = nil;
         BOOL ok1 = [im1 ensureIndexedWithIndexName:@"index1" fieldName:@"name" error:&error1];
-        STAssertTrue(ok1, @"ensureIndexedWithIndexName did not return true");
-        STAssertNil(error1, @"error is not nil");
+        XCTAssertTrue(ok1, @"ensureIndexedWithIndexName did not return true");
+        XCTAssertNil(error1, @"error is not nil");
     }
     
     {
@@ -312,8 +312,8 @@
         
         NSError *error2 = nil;
         BOOL ok2 = [im2 ensureIndexedWithIndexName:@"index1" fieldName:@"name" error:&error2];
-        STAssertTrue(ok2, @"ensureIndexedWithIndexName did not return true");
-        STAssertNil(error2, @"error is not nil");
+        XCTAssertTrue(ok2, @"ensureIndexedWithIndexName did not return true");
+        XCTAssertNil(error2, @"error is not nil");
     }
 }
 
@@ -355,9 +355,9 @@
     unsigned long count1=[[res1 documentIds] count];
     unsigned long count2=[[res2 documentIds] count];
     
-    STAssertEquals(count1, 1UL, @"Query for prefix 'd' should return 1 document");
+    XCTAssertEqual(count1, 1UL, @"Query for prefix 'd' should return 1 document");
     
-    STAssertEquals(count2, 2UL, @"Query for prefix 'du' should return 2 documents");
+    XCTAssertEqual(count2, 2UL, @"Query for prefix 'du' should return 2 documents");
 }
 
 - (void)testNumericIndexers
@@ -404,8 +404,8 @@
     unsigned long count1=[[res1 documentIds] count];
     unsigned long count2=[[res2 documentIds] count];
     
-    STAssertEquals(count1, 3UL, @"Didn't get expected number of results");
-    STAssertEquals(count2, 6UL, @"Didn't get expected number of results");
+    XCTAssertEqual(count1, 3UL, @"Didn't get expected number of results");
+    XCTAssertEqual(count2, 6UL, @"Didn't get expected number of results");
 }
 
 - (void)testUniqueValues
@@ -454,8 +454,8 @@
     unsigned long count1=[res1 count];
     unsigned long count2=[res2 count];
     
-    STAssertEquals(count1, 6UL, @"Didn't get expected number of results");
-    STAssertEquals(count2, 9UL, @"Didn't get expected number of results");
+    XCTAssertEqual(count1, 6UL, @"Didn't get expected number of results");
+    XCTAssertEqual(count2, 9UL, @"Didn't get expected number of results");
 }
 
 - (void)testComplexQuery
@@ -480,7 +480,7 @@
                                             error:&error];
     
     unsigned long count=[[res documentIds] count];
-    STAssertEquals(count, 1UL, @"Didn't get expected number of results");
+    XCTAssertEqual(count, 1UL, @"Didn't get expected number of results");
 }
 
 - (void)testOrderQuery1
@@ -500,12 +500,12 @@
                                             error:&error];
     int lastVal = 100000000;
     
-    STAssertTrue([[res documentIds] count] > 0, @"Query yielded nothing!");
+    XCTAssertTrue([[res documentIds] count] > 0, @"Query yielded nothing!");
     
     for(CDTDocumentRevision *doc in res) {
         NSNumber *val = [doc.body objectForKey:@"area"];
         int valInt = [val intValue];
-        STAssertTrue(valInt <= lastVal, @"Not sorted");
+        XCTAssertTrue(valInt <= lastVal, @"Not sorted");
         lastVal = valInt;
     }
 }
@@ -527,12 +527,12 @@
                                             error:&error];
     NSString *lastName = @"Zzzzzzzzistan"; // probably the last country in the alphabet
     
-    STAssertTrue([[res documentIds] count] > 0, @"Query yielded nothing!");
+    XCTAssertTrue([[res documentIds] count] > 0, @"Query yielded nothing!");
     
     for(CDTDocumentRevision *doc in res) {
         NSString *val = [doc.body objectForKey:@"name"];
         
-        STAssertTrue([val compare:lastName] < 0, @"Not sorted correctly");
+        XCTAssertTrue([val compare:lastName] < 0, @"Not sorted correctly");
         lastName = val;
     }
 }
@@ -586,14 +586,14 @@
     unsigned long count7=[[res7 documentIds] count];
     unsigned long count8=[[res8 documentIds] count];
     
-    STAssertEquals(count1, 10UL, @"Didn't get expected number of results");
-    STAssertEquals(count2, 4UL, @"Didn't get expected number of results");
-    STAssertEquals(count3, 1UL, @"Didn't get expected number of results");
-    STAssertEquals(count4, 0UL, @"Didn't get expected number of results");
-    STAssertEquals(count5, 0UL, @"Didn't get expected number of results");
-    STAssertEquals(count6, 184UL, @"Didn't get expected number of results");
-    STAssertEquals(count7, 194UL, @"Didn't get expected number of results");
-    STAssertEquals(count8, 0UL, @"Didn't get expected number of results");
+    XCTAssertEqual(count1, 10UL, @"Didn't get expected number of results");
+    XCTAssertEqual(count2, 4UL, @"Didn't get expected number of results");
+    XCTAssertEqual(count3, 1UL, @"Didn't get expected number of results");
+    XCTAssertEqual(count4, 0UL, @"Didn't get expected number of results");
+    XCTAssertEqual(count5, 0UL, @"Didn't get expected number of results");
+    XCTAssertEqual(count6, 184UL, @"Didn't get expected number of results");
+    XCTAssertEqual(count7, 194UL, @"Didn't get expected number of results");
+    XCTAssertEqual(count8, 0UL, @"Didn't get expected number of results");
 }
 
 - (void)testQueryError1
@@ -607,8 +607,8 @@
     CDTQueryResult *res = [im queryWithDictionary:@{@"index2": @"value"}
                                             error:&error];
     
-    STAssertEquals([error code], CDTIndexErrorIndexDoesNotExist, @"Did not get CDTIndexErrorIndexDoesNotExist error");
-    STAssertNil(res, @"Result was not nil");
+    XCTAssertEqual([error code], CDTIndexErrorIndexDoesNotExist, @"Did not get CDTIndexErrorIndexDoesNotExist error");
+    XCTAssertNil(res, @"Result was not nil");
 }
 
 - (void)testQueryError2
@@ -622,8 +622,8 @@
     CDTQueryResult *res = [im queryWithDictionary:@{@"abc123^&*^&%^^*^&(; drop table customer": @"value"}
                                             error:&error];
     
-    STAssertEquals([error code], CDTIndexErrorInvalidIndexName, @"Did not get CDTIndexErrorInvalidIndexName error");
-    STAssertNil(res, @"Result was not nil");
+    XCTAssertEqual([error code], CDTIndexErrorInvalidIndexName, @"Did not get CDTIndexErrorInvalidIndexName error");
+    XCTAssertNil(res, @"Result was not nil");
 }
 
 - (void)testQueryError3
@@ -638,8 +638,8 @@
                                           options:@{kCDTQueryOptionSortBy: @"index2"}
                                             error:&error];
     
-    STAssertEquals([error code], CDTIndexErrorIndexDoesNotExist, @"Did not get CDTIndexErrorIndexDoesNotExist error");
-    STAssertNil(res, @"Result was not nil");
+    XCTAssertEqual([error code], CDTIndexErrorIndexDoesNotExist, @"Did not get CDTIndexErrorIndexDoesNotExist error");
+    XCTAssertNil(res, @"Result was not nil");
 }
 
 - (void)testQueryError4
@@ -654,8 +654,8 @@
                                           options:@{kCDTQueryOptionSortBy: @"abc123^&*^&%^^*^&(; drop table customer"}
                                             error:&error];
     
-    STAssertEquals([error code], CDTIndexErrorInvalidIndexName, @"Did not get CDTIndexErrorInvalidIndexName error");
-    STAssertNil(res, @"Result was not nil");
+    XCTAssertEqual([error code], CDTIndexErrorInvalidIndexName, @"Did not get CDTIndexErrorInvalidIndexName error");
+    XCTAssertNil(res, @"Result was not nil");
 }
 
 - (void)testIndexerTypes
@@ -683,30 +683,30 @@
     // standard string query
     CDTQueryResult *res1 = [im queryWithDictionary:@{@"string": @"Ipsem lorem"}
                                              error:&error];
-    STAssertNil(error, @"Error was not nil");
-    STAssertEquals([[res1 documentIds] count], (NSUInteger)1, @"Didn't get expected number of results");
+    XCTAssertNil(error, @"Error was not nil");
+    XCTAssertEqual([[res1 documentIds] count], (NSUInteger)1, @"Didn't get expected number of results");
     
     // test that "2" converts to string
     CDTQueryResult *res2 = [im queryWithDictionary:@{@"number": @[@1,@2]}
                                              error:&error];
-    STAssertNil(error, @"Error was not nil");
-    STAssertEquals([[res2 documentIds] count], (NSUInteger)2, @"Didn't get expected number of results");
+    XCTAssertNil(error, @"Error was not nil");
+    XCTAssertEqual([[res2 documentIds] count], (NSUInteger)2, @"Didn't get expected number of results");
     
     // test that array indexed correctly
     CDTQueryResult *res3 = [im queryWithDictionary:@{@"list": @[@"a",@"b",@"d"]}
                                              error:&error];
-    STAssertNil(error, @"Error was not nil");
-    STAssertEquals([[res3 documentIds] count], (NSUInteger)2, @"Didn't get expected number of results");
+    XCTAssertNil(error, @"Error was not nil");
+    XCTAssertEqual([[res3 documentIds] count], (NSUInteger)2, @"Didn't get expected number of results");
     
     // nothing should be indexed for a dictionary
     NSArray *res4 = [im uniqueValuesForIndex:@"dictionary" error:&error];
-    STAssertNil(error, @"Error was not nil");
-    STAssertEquals([res4 count], (NSUInteger)0, @"Didn't get expected number of results");
+    XCTAssertNil(error, @"Error was not nil");
+    XCTAssertEqual([res4 count], (NSUInteger)0, @"Didn't get expected number of results");
     
     // nothing should be indexed since we can't convert string to int
     NSArray *res5 = [im uniqueValuesForIndex:@"stringAsInt" error:&error];
-    STAssertNil(error, @"Error was not nil");
-    STAssertEquals([res5 count], (NSUInteger)0, @"Didn't get expected number of results");
+    XCTAssertNil(error, @"Error was not nil");
+    XCTAssertEqual([res5 count], (NSUInteger)0, @"Didn't get expected number of results");
 }
 
 - (void)testQueryingForDeletedItem
@@ -743,10 +743,10 @@
     count = 0;
     for (CDTDocumentRevision *result in [im queryWithDictionary:@{@"name": @"Zambia"} error:&error]) {
         // Check we don't get a deleted document
-        STAssertFalse(result.deleted, @"Query returned deleted document");
+        XCTAssertFalse(result.deleted, @"Query returned deleted document");
         count++;
     }
-    STAssertEquals(count, 1, @"Query returned the wrong number of results");
+    XCTAssertEqual(count, 1, @"Query returned the wrong number of results");
 }
 
 - (void)testIndexManagerConcurrentUpdated
@@ -767,7 +767,7 @@
             usleep(500*1000);
         }
     }
-    STAssertEquals([[[im queryWithDictionary:@{@"name": @"made in thread"} error:nil] documentIds] count], (NSUInteger)500, @"Query returned the wrong number of results");
+    XCTAssertEqual([[[im queryWithDictionary:@{@"name": @"made in thread"} error:nil] documentIds] count], (NSUInteger)500, @"Query returned the wrong number of results");
 }
 
 
@@ -792,13 +792,13 @@
     
     CDTMutableDocumentRevision * rev = [CDTMutableDocumentRevision revision];
     rev.body = @{@"name": @"mike"};
-    STAssertNotNil([datastore createDocumentFromRevision:rev error:nil], @"Doc not created");
+    XCTAssertNotNil([datastore createDocumentFromRevision:rev error:nil], @"Doc not created");
     
     resultCount = 0;
     CDTQueryResult *result = [im queryWithDictionary:@{@"name": @"mike"}
                                                error:nil];
     for (_ in result) { resultCount++; }
-    STAssertEquals(resultCount, 1, @"Query didn't find the document");
+    XCTAssertEqual(resultCount, 1, @"Query didn't find the document");
     
     // Tear down the original datastore objects
     [im shutdown];
@@ -806,25 +806,25 @@
     // Fire up a new indexManager without the objects
     CDTIndexManager *im2 = [[CDTIndexManager alloc] initWithDatastore:datastore error:nil];
     
-    STAssertNotNil([datastore createDocumentFromRevision:rev error:nil], @"Doc not created");
+    XCTAssertNotNil([datastore createDocumentFromRevision:rev error:nil], @"Doc not created");
     
     [im2 ensureIndexedWithIndexName:@"name" fieldName:@"name" error:nil];
     
     CDTMutableDocumentRevision * mutableRev = [CDTMutableDocumentRevision revision];
     mutableRev.body = @{@"name": @"fred"};
-    STAssertNotNil([datastore createDocumentFromRevision:mutableRev error:nil], @"Doc not created");
+    XCTAssertNotNil([datastore createDocumentFromRevision:mutableRev error:nil], @"Doc not created");
     
     resultCount = 0;
     result = [im2 queryWithDictionary:@{@"name": @"mike"}
                                 error:nil];
     for (_ in result) { resultCount++; }
-    STAssertEquals(resultCount, 2, @"Query didn't find the document");
+    XCTAssertEqual(resultCount, 2, @"Query didn't find the document");
     
     resultCount = 0;
     result = [im2 queryWithDictionary:@{@"name": @"fred"}
                                 error:nil];
     for (_ in result) { resultCount++; }
-    STAssertEquals(resultCount, 1, @"Query didn't find the document");
+    XCTAssertEqual(resultCount, 1, @"Query didn't find the document");
     
     // Still broken even if we updateAllIndexes
     [im2 updateAllIndexes:nil];
@@ -833,7 +833,7 @@
     result = [im2 queryWithDictionary:@{@"name": @"mike"}
                                 error:nil];
     for (_ in result) { resultCount++; }
-    STAssertEquals(resultCount, 2, @"Query didn't find the document");
+    XCTAssertEqual(resultCount, 2, @"Query didn't find the document");
     
     
     [[NSFileManager defaultManager] removeItemAtPath:factoryPath error:nil];
@@ -1096,7 +1096,7 @@
     [super setUp];
     NSError *error = nil;
     self.datastore = [self.factory datastoreNamed:@"test" error:&error];
-    STAssertNotNil(self.datastore, @"datastore is nil");
+    XCTAssertNotNil(self.datastore, @"datastore is nil");
 }
 
 - (void)tearDown

--- a/Tests/Tests/SetUpDatastore.m
+++ b/Tests/Tests/SetUpDatastore.m
@@ -13,7 +13,7 @@
 //  either express or implied. See the License for the specific language governing permissions
 //  and limitations under the License.
 
-#import <SenTestingKit/SenTestingKit.h>
+#import <XCTest/XCTest.h>
 
 #import "CloudantSyncTests.h"
 
@@ -39,7 +39,7 @@
  */
 - (void)testSetupAndTeardownDatastoreFactory
 {
-    STAssertNotNil(self.factory, @"Factory is nil");
+    XCTAssertNotNil(self.factory, @"Factory is nil");
 }
 
 /**
@@ -51,7 +51,7 @@
 {
     NSError *error;
     CDTDatastore *datastore = [self.factory datastoreNamed:@"test" error:&error];
-    STAssertNotNil(datastore, @"datastore is nil");
+    XCTAssertNotNil(datastore, @"datastore is nil");
 }
 
 /**
@@ -62,8 +62,8 @@
     NSError *error;
     CDTDatastore *datastore1 = [self.factory datastoreNamed:@"test" error:&error];
     CDTDatastore *datastore2 = [self.factory datastoreNamed:@"test2" error:&error];
-    STAssertNotNil(datastore1, @"datastore1 is nil");
-    STAssertNotNil(datastore2, @"datastore2 is nil");
+    XCTAssertNotNil(datastore1, @"datastore1 is nil");
+    XCTAssertNotNil(datastore2, @"datastore2 is nil");
 }
 
 /**
@@ -73,8 +73,8 @@
 {
     NSError *error;
     CDTDatastore *datastore = [self.factory datastoreNamed:@"_test" error:&error];
-    STAssertNil(datastore, @"datastore is not nil");
-    STAssertNotNil(error, @"error is nil");
+    XCTAssertNil(datastore, @"datastore is not nil");
+    XCTAssertNotNil(error, @"error is nil");
 }
 
 /**
@@ -88,7 +88,7 @@
     
     // setup datastore and indexmanager
     CDTDatastore *datastore = [self.factory datastoreNamed:dbName error:&error];
-    STAssertNil(datastore, @"datastore is not nil");
+    XCTAssertNil(datastore, @"datastore is not nil");
 }
 
 /**
@@ -112,17 +112,17 @@
     NSString *dir = [[[datastore database] path] stringByDeletingLastPathComponent];
     
     // check various files/dirs exist
-    STAssertTrue([fm fileExistsAtPath:[dir stringByAppendingPathComponent:dbNameFull]], @"db file does not exist");
-    STAssertTrue([fm fileExistsAtPath:[dir stringByAppendingPathComponent:dbNameExtensions]], @"extensions dir does not exist");
-    STAssertTrue([fm fileExistsAtPath:[dir stringByAppendingPathComponent:dbNameAttachments]], @"attachments dir does not exist");
+    XCTAssertTrue([fm fileExistsAtPath:[dir stringByAppendingPathComponent:dbNameFull]], @"db file does not exist");
+    XCTAssertTrue([fm fileExistsAtPath:[dir stringByAppendingPathComponent:dbNameExtensions]], @"extensions dir does not exist");
+    XCTAssertTrue([fm fileExistsAtPath:[dir stringByAppendingPathComponent:dbNameAttachments]], @"attachments dir does not exist");
     
     // delete datastore
-    STAssertTrue([self.factory deleteDatastoreNamed:dbName error:&error], @"deleteDatastoreNamed did not return true");
+    XCTAssertTrue([self.factory deleteDatastoreNamed:dbName error:&error], @"deleteDatastoreNamed did not return true");
 
     // check various files/dirs have been deleted
-    STAssertFalse([fm fileExistsAtPath:[dir stringByAppendingPathComponent:dbNameFull]], @"db file was not deleted");
-    STAssertFalse([fm fileExistsAtPath:[dir stringByAppendingPathComponent:dbNameExtensions]], @"extensions dir was not deleted");
-    STAssertFalse([fm fileExistsAtPath:[dir stringByAppendingPathComponent:dbNameAttachments]], @"attachments dir was not deleted");
+    XCTAssertFalse([fm fileExistsAtPath:[dir stringByAppendingPathComponent:dbNameFull]], @"db file was not deleted");
+    XCTAssertFalse([fm fileExistsAtPath:[dir stringByAppendingPathComponent:dbNameExtensions]], @"extensions dir was not deleted");
+    XCTAssertFalse([fm fileExistsAtPath:[dir stringByAppendingPathComponent:dbNameAttachments]], @"attachments dir was not deleted");
 }
 
 @end

--- a/Tests/Tests/TDCanonicalJSONTests.m
+++ b/Tests/Tests/TDCanonicalJSONTests.m
@@ -31,9 +31,9 @@
 //    NSLog(@"%@ --> `%@`", [obj description], [json my_UTF8ToString]);
     NSError* error;
     id reconstituted = [NSJSONSerialization JSONObjectWithData: json options:NSJSONReadingAllowFragments error: &error];
-    STAssertNotNil(reconstituted, @"Canonical JSON `%@` was unparseable: %@",
+    XCTAssertNotNil(reconstituted, @"Canonical JSON `%@` was unparseable: %@",
             [json my_UTF8ToString], error);
-    STAssertEqualObjects(reconstituted, obj, @"Canonical JSON object and reconstructed objec were not equal in %s", __PRETTY_FUNCTION__);
+    XCTAssertEqualObjects(reconstituted, obj, @"Canonical JSON object and reconstructed objec were not equal in %s", __PRETTY_FUNCTION__);
 }
 
 - (void)roundtripFloat:(double) n
@@ -41,19 +41,19 @@
     NSData* json = [TDCanonicalJSON canonicalData: @(n)];
     NSError* error;
     id reconstituted = [NSJSONSerialization JSONObjectWithData: json options:NSJSONReadingAllowFragments error: &error];
-    STAssertNotNil(reconstituted, @"`%@` was unparseable: %@",
+    XCTAssertNotNil(reconstituted, @"`%@` was unparseable: %@",
             [json my_UTF8ToString], error);
     double delta = [reconstituted doubleValue] / n - 1.0;
 //    NSLog(@"%g --> `%@` (error = %g)", n, [json my_UTF8ToString], delta);
-    STAssertTrue(fabs(delta) < 1.0e-15, @"`%@` had floating point roundoff error of %g (%g vs %g)",
+    XCTAssertTrue(fabs(delta) < 1.0e-15, @"`%@` had floating point roundoff error of %g (%g vs %g)",
             [json my_UTF8ToString], delta, [reconstituted doubleValue], n);
 }
 
 - (void)testEncoding
 {
-    STAssertEqualObjects([TDCanonicalJSON canonicalString: $true], @"true", @"Canonical JSON $true is not \"true\" in %s", __PRETTY_FUNCTION__);
-    STAssertEqualObjects([TDCanonicalJSON canonicalString: $false], @"false", @"Canonical JSON $false is not \"false\" in %s", __PRETTY_FUNCTION__);
-    STAssertEqualObjects([TDCanonicalJSON canonicalString: $null], @"null", @"Canonical JSON $null is not \"null\" in %s", __PRETTY_FUNCTION__);
+    XCTAssertEqualObjects([TDCanonicalJSON canonicalString: $true], @"true", @"Canonical JSON $true is not \"true\" in %s", __PRETTY_FUNCTION__);
+    XCTAssertEqualObjects([TDCanonicalJSON canonicalString: $false], @"false", @"Canonical JSON $false is not \"false\" in %s", __PRETTY_FUNCTION__);
+    XCTAssertEqualObjects([TDCanonicalJSON canonicalString: $null], @"null", @"Canonical JSON $null is not \"null\" in %s", __PRETTY_FUNCTION__);
 }
 
 - (void)testReconstruction

--- a/Tests/Tests/TDCollateJSONTests.m
+++ b/Tests/Tests/TDCollateJSONTests.m
@@ -34,7 +34,7 @@ extern char convertEscape(const char**);
     // encodes an object to a C string in JSON format. JSON fragments are allowed.
     NSString* str = [TDJSON stringWithJSONObject: obj
                                          options: TDJSONWritingAllowFragments error: NULL];
-    STAssertNotNil(str, @"string object is nil in %s", __PRETTY_FUNCTION__);
+    XCTAssertNotNil(str, @"string object is nil in %s", __PRETTY_FUNCTION__);
     return [str UTF8String];
 }
 
@@ -43,9 +43,9 @@ extern char convertEscape(const char**);
 - (void)escapeTest:(const char*) source decodeChar:(char)decoded
 {
     const char* pos = source;
-    STAssertEquals(convertEscape(&pos), decoded,
+    XCTAssertEqual(convertEscape(&pos), decoded,
                    @"Decoder characters aren't equal (%c, %c) in %s", convertEscape(&pos), decoded, __PRETTY_FUNCTION__);
-    STAssertEquals((size_t)pos, (size_t)(source + strlen(source) - 1),
+    XCTAssertEqual((size_t)pos, (size_t)(source + strlen(source) - 1),
                    @"Decoder character positions aren't equal in %s", __PRETTY_FUNCTION__);
 }
 
@@ -77,7 +77,7 @@ extern char convertEscape(const char**);
 
 - (void)scalarTest:(void *)mode str1:(const char *)str1 str2:(const char *)str2 retVal:(int)val arrayLimit:(unsigned)arrayLimit
 {
-    STAssertEquals([self collateLimited:mode str1:(const void*)str1 str2:(const void*)str2 arrayLimit:arrayLimit],
+    XCTAssertEqual([self collateLimited:mode str1:(const void*)str1 str2:(const void*)str2 arrayLimit:arrayLimit],
                    val,
                    @"with mode:%d and arrayLimit:%d, %s and %s do not collate to %d in %s", *(unsigned*)mode, arrayLimit, str1, str2, val, __PRETTY_FUNCTION__);
     

--- a/Tests/Tests/TDMiscTests.m
+++ b/Tests/Tests/TDMiscTests.m
@@ -27,17 +27,17 @@
 
 - (void)quoteStringTest:(NSString *)str1 str2:(NSString *)str2
 {
-    STAssertEqualObjects(TDQuoteString(str1), str2, @"TDQuoteString test failed for str1:%@ and str2:%@ in %s", str1, str2, __PRETTY_FUNCTION__);
+    XCTAssertEqualObjects(TDQuoteString(str1), str2, @"TDQuoteString test failed for str1:%@ and str2:%@ in %s", str1, str2, __PRETTY_FUNCTION__);
 }
 
 - (void)unquoteStringTest:(NSString *)str1 str2:(NSString *)str2
 {
-    STAssertEqualObjects(TDUnquoteString(str1), str2, @"TDUnquoteString test failed for str1:%@ and str2:%@ in %s", str1, str2,__PRETTY_FUNCTION__);
+    XCTAssertEqualObjects(TDUnquoteString(str1), str2, @"TDUnquoteString test failed for str1:%@ and str2:%@ in %s", str1, str2,__PRETTY_FUNCTION__);
 }
 
 - (void)escapeIDTest:(NSString *)str1 str2:(NSString *)str2
 {
-    STAssertEqualObjects(TDEscapeID(str1), str2, @"TDEscapeID test failed for str1:%@ and str2:%@ in %s", str1, str2, __PRETTY_FUNCTION__);
+    XCTAssertEqualObjects(TDEscapeID(str1), str2, @"TDEscapeID test failed for str1:%@ and str2:%@ in %s", str1, str2, __PRETTY_FUNCTION__);
 }
 
 

--- a/Tests/Tests/TDMultiStreamWriterTests.m
+++ b/Tests/Tests/TDMultiStreamWriterTests.m
@@ -98,7 +98,7 @@
 - (void)testCreateWriter
 {
     TDMultiStreamWriter* stream = [self createWriter:128];
-    STAssertEquals(stream.length, (SInt64)self.expectedOutputString.length, @"unexpected string length in %s", __PRETTY_FUNCTION__);
+    XCTAssertEqual(stream.length, (SInt64)self.expectedOutputString.length, @"unexpected string length in %s", __PRETTY_FUNCTION__);
 }
 
 - (void)testSynchronousWriter
@@ -106,12 +106,12 @@
     for (unsigned bufSize = 1; bufSize < 128; ++bufSize) {
 //        NSLog(@"Buffer size = %u", bufSize);
         TDMultiStreamWriter* mp = [self createWriter:bufSize];
-        STAssertNotNil(mp, @"multistream writer is nil in %s", __PRETTY_FUNCTION__);
+        XCTAssertNotNil(mp, @"multistream writer is nil in %s", __PRETTY_FUNCTION__);
         NSData* outputBytes = [mp allOutput];
-        STAssertEqualObjects(outputBytes.my_UTF8ToString, self.expectedOutputString, @"unexpected string in %s", __PRETTY_FUNCTION__);
+        XCTAssertEqualObjects(outputBytes.my_UTF8ToString, self.expectedOutputString, @"unexpected string in %s", __PRETTY_FUNCTION__);
         // Run it a second time to make sure re-opening works:
         outputBytes = [mp allOutput];
-        STAssertEqualObjects(outputBytes.my_UTF8ToString, self.expectedOutputString, @"unexpected string (2) in %s", __PRETTY_FUNCTION__);
+        XCTAssertEqualObjects(outputBytes.my_UTF8ToString, self.expectedOutputString, @"unexpected string (2) in %s", __PRETTY_FUNCTION__);
     }
 }
 
@@ -120,7 +120,7 @@
     TDMultiStreamWriter* writer = [self createWriter:16];
     //NSLog(@"writer output %@", [[writer allOutput] my_UTF8ToString] );
     NSInputStream* input = [writer openForInputStream];
-    STAssertNotNil(input, @"NSInputStream is NIL in %s", __PRETTY_FUNCTION__);
+    XCTAssertNotNil(input, @"NSInputStream is NIL in %s", __PRETTY_FUNCTION__);
     MyMultiStreamWriterTester *tester = [[MyMultiStreamWriterTester alloc] initWithStream: input];
     NSRunLoop* rl = [NSRunLoop currentRunLoop];
     [input scheduleInRunLoop: rl forMode: NSDefaultRunLoopMode];
@@ -136,7 +136,7 @@
 //    NSLog(@"Closing stream");
     [input close];
     [writer close];
-    STAssertEqualObjects(tester->_output.my_UTF8ToString, self.expectedOutputString, @"unexpected string in %s", __PRETTY_FUNCTION__);
+    XCTAssertEqualObjects(tester->_output.my_UTF8ToString, self.expectedOutputString, @"unexpected string in %s", __PRETTY_FUNCTION__);
 }
 
 

--- a/Tests/Tests/TDMultipartDownloaderTests.m
+++ b/Tests/Tests/TDMultipartDownloaderTests.m
@@ -47,23 +47,23 @@
                                  requestHeaders: nil
                                    onCompletion: ^(id result, NSError * error)
       {
-          STAssertNil(error, @"NSError is not nil after alloc init of TDMultipartDownloader in %s", __PRETTY_FUNCTION__);
+          XCTAssertNil(error, @"NSError is not nil after alloc init of TDMultipartDownloader in %s", __PRETTY_FUNCTION__);
           TDMultipartDownloader* request = result;
 //          NSLog(@"Got document: %@", request.document);
           NSDictionary* attachments = (request.document)[@"_attachments"];
-          STAssertTrue(attachments.count >= 1, @"attachments.count >= 1 fails in %s", __PRETTY_FUNCTION__);
-          STAssertEquals(db.attachmentStore.count, 0u, @"db.attachmentStore.count is not 0u in %s", __PRETTY_FUNCTION__);
+          XCTAssertTrue(attachments.count >= 1, @"attachments.count >= 1 fails in %s", __PRETTY_FUNCTION__);
+          XCTAssertEqual(db.attachmentStore.count, 0u, @"db.attachmentStore.count is not 0u in %s", __PRETTY_FUNCTION__);
           for (NSDictionary* attachment in attachments.allValues) {
               TDBlobStoreWriter* writer = [db attachmentWriterForAttachment: attachment];
-              STAssertNotNil(writer, @"TDBlobStoreWriter is nil in %s", __PRETTY_FUNCTION__);
-              STAssertTrue([writer install], @"TDBlobStoreWriter install returned NO in %s", __PRETTY_FUNCTION__);
+              XCTAssertNotNil(writer, @"TDBlobStoreWriter is nil in %s", __PRETTY_FUNCTION__);
+              XCTAssertTrue([writer install], @"TDBlobStoreWriter install returned NO in %s", __PRETTY_FUNCTION__);
               NSData* blob = [db.attachmentStore blobForKey: writer.blobKey];
 //              NSLog(@"Found %u bytes of data for attachment %@", (unsigned)blob.length, attachment);
               NSNumber* lengthObj = attachment[@"encoded_length"] ?: attachment[@"length"];
-              STAssertEquals(blob.length, [lengthObj unsignedLongLongValue], @"blob length and object length are not equal in %s", __PRETTY_FUNCTION__);
-              STAssertEquals(writer.length, blob.length, @"writer length and blog length are not equal in %s", __PRETTY_FUNCTION__);
+              XCTAssertEqual(blob.length, [lengthObj unsignedLongLongValue], @"blob length and object length are not equal in %s", __PRETTY_FUNCTION__);
+              XCTAssertEqual(writer.length, blob.length, @"writer length and blog length are not equal in %s", __PRETTY_FUNCTION__);
           }
-          STAssertEquals(db.attachmentStore.count, attachments.count, @"db.attachmentStore.count and attachments.count are not equal in %s", __PRETTY_FUNCTION__);
+          XCTAssertEqual(db.attachmentStore.count, attachments.count, @"db.attachmentStore.count and attachments.count are not equal in %s", __PRETTY_FUNCTION__);
           done = YES;
       }] start];
     

--- a/Tests/Tests/TDMultipartReaderTests.m
+++ b/Tests/Tests/TDMultipartReaderTests.m
@@ -68,16 +68,16 @@
 {
     //NSLog(@"TDMultpartReader_Types");
     TDMultipartReader* reader = [[TDMultipartReader alloc] initWithContentType: @"multipart/related; boundary=\"BOUNDARY\"" delegate: nil];
-    STAssertEqualObjects(reader.boundary, [@"\r\n--BOUNDARY" dataUsingEncoding: NSUTF8StringEncoding], @"Quotation escaped Boundary objects not equal in %s", __PRETTY_FUNCTION__);
+    XCTAssertEqualObjects(reader.boundary, [@"\r\n--BOUNDARY" dataUsingEncoding: NSUTF8StringEncoding], @"Quotation escaped Boundary objects not equal in %s", __PRETTY_FUNCTION__);
     
     reader = [[TDMultipartReader alloc] initWithContentType: @"multipart/related; boundary=BOUNDARY" delegate: nil];
-    STAssertEqualObjects(reader.boundary, [@"\r\n--BOUNDARY" dataUsingEncoding: NSUTF8StringEncoding], @"No quotation Boundary objects not equal in %s", __PRETTY_FUNCTION__);
+    XCTAssertEqualObjects(reader.boundary, [@"\r\n--BOUNDARY" dataUsingEncoding: NSUTF8StringEncoding], @"No quotation Boundary objects not equal in %s", __PRETTY_FUNCTION__);
     
     reader = [[TDMultipartReader alloc] initWithContentType: @"multipart/related; boundary=\"BOUNDARY" delegate: nil];
-    STAssertNil(reader, @"TDMultipartReader not nil with improper initialization in %s", __PRETTY_FUNCTION__);
+    XCTAssertNil(reader, @"TDMultipartReader not nil with improper initialization in %s", __PRETTY_FUNCTION__);
     
     reader = [[TDMultipartReader alloc] initWithContentType: @"multipart/related;boundary=X" delegate: nil];
-    STAssertEqualObjects(reader.boundary, [@"\r\n--X" dataUsingEncoding: NSUTF8StringEncoding], @"No quotation Arbitrary objects not equal in %s", __PRETTY_FUNCTION__);
+    XCTAssertEqualObjects(reader.boundary, [@"\r\n--X" dataUsingEncoding: NSUTF8StringEncoding], @"No quotation Arbitrary objects not equal in %s", __PRETTY_FUNCTION__);
     
 }
 
@@ -96,18 +96,18 @@
 //        NSLog(@"--- chunkSize = %u", (unsigned)chunkSize);
         MyMultipartReaderDelegate* delegate = [[MyMultipartReaderDelegate alloc] init];
         TDMultipartReader* reader = [[TDMultipartReader alloc] initWithContentType: @"multipart/related; boundary=\"BOUNDARY\"" delegate: delegate];
-        STAssertFalse(reader.finished, @"Premature finished reading data in %s", __PRETTY_FUNCTION__);
+        XCTAssertFalse(reader.finished, @"Premature finished reading data in %s", __PRETTY_FUNCTION__);
         
         NSRange r = {0, 0};
         do {
-            STAssertTrue(r.location < mime.length, @"Parser didn't stop at end in %s", __PRETTY_FUNCTION__ );
+            XCTAssertTrue(r.location < mime.length, @"Parser didn't stop at end in %s", __PRETTY_FUNCTION__ );
             r.length = MIN(chunkSize, mime.length - r.location);
             [reader appendData: [mime subdataWithRange: r]];
-            STAssertTrue(!reader.error, @"Reader got a parse error: %@ in %s", reader.error, __PRETTY_FUNCTION__ );
+            XCTAssertTrue(!reader.error, @"Reader got a parse error: %@ in %s", reader.error, __PRETTY_FUNCTION__ );
             r.location += chunkSize;
         } while (!reader.finished);
-        STAssertEqualObjects(delegate.partList, expectedParts, @"Unexpected part in Delegate in %s",  __PRETTY_FUNCTION__ );
-        STAssertEqualObjects(delegate.headerList, expectedHeaders, @"Unexpected Headers in Delegate in %s", __PRETTY_FUNCTION__ );
+        XCTAssertEqualObjects(delegate.partList, expectedParts, @"Unexpected part in Delegate in %s",  __PRETTY_FUNCTION__ );
+        XCTAssertEqualObjects(delegate.headerList, expectedHeaders, @"Unexpected Headers in Delegate in %s", __PRETTY_FUNCTION__ );
     }
 
 }

--- a/Tests/Tests/TDMultipartWriterTests.m
+++ b/Tests/Tests/TDMultipartWriterTests.m
@@ -34,16 +34,16 @@
         TDMultipartWriter* mp = [[TDMultipartWriter alloc] initWithContentType: @"foo/bar"
                                                                       boundary: @"BOUNDARY"];
         
-        STAssertEqualObjects(mp.contentType, @"foo/bar; boundary=\"BOUNDARY\"", @"ContentType not equal in %s", __PRETTY_FUNCTION__);
-        STAssertEqualObjects(mp.boundary, @"BOUNDARY", @"Boundary not equal in %s", __PRETTY_FUNCTION__);
+        XCTAssertEqualObjects(mp.contentType, @"foo/bar; boundary=\"BOUNDARY\"", @"ContentType not equal in %s", __PRETTY_FUNCTION__);
+        XCTAssertEqualObjects(mp.boundary, @"BOUNDARY", @"Boundary not equal in %s", __PRETTY_FUNCTION__);
         
         [mp addData: [@"<part the first>" dataUsingEncoding: NSUTF8StringEncoding]];
         [mp setNextPartsHeaders: $dict({@"Content-Type", @"something"})];
         [mp addData: [@"<2nd part>" dataUsingEncoding: NSUTF8StringEncoding]];
 
-        STAssertEquals((NSUInteger)mp.length, expectedOutput.length, @"Unexpected Writer output length in %s", __PRETTY_FUNCTION__);
+        XCTAssertEqual((NSUInteger)mp.length, expectedOutput.length, @"Unexpected Writer output length in %s", __PRETTY_FUNCTION__);
         
-        STAssertEqualObjects([[mp allOutput] my_UTF8ToString], expectedOutput, @"Unexpected Writer output content in %s", __PRETTY_FUNCTION__);
+        XCTAssertEqualObjects([[mp allOutput] my_UTF8ToString], expectedOutput, @"Unexpected Writer output content in %s", __PRETTY_FUNCTION__);
         [mp close];
     }
 

--- a/Tests/Tests/TDPusherTests.m
+++ b/Tests/Tests/TDPusherTests.m
@@ -33,10 +33,10 @@ extern int findCommonAncestor(TD_Revision* rev, NSArray* possibleRevIDs);
 {
     NSDictionary* revDict = $dict({@"ids", @[@"second", @"first"]}, {@"start", @2});
     TD_Revision* rev = [TD_Revision revisionWithProperties: $dict({@"_revisions", revDict})];
-    STAssertEquals(findCommonAncestor(rev, @[]), 0, @"Did not find zero common ancestors in empty rev dictionary in %s", __PRETTY_FUNCTION__);
-    STAssertEquals(findCommonAncestor(rev, @[@"3-noway", @"1-nope"]), 0, @"Did not find zero common ancestors in incorrect rev dictionary in %s", __PRETTY_FUNCTION__);
-    STAssertEquals(findCommonAncestor(rev, @[@"3-noway", @"1-first"]), 1, @"Did not find common ancestor 1-first in rev dictionary in %s", __PRETTY_FUNCTION__);
-    STAssertEquals(findCommonAncestor(rev, @[@"3-noway", @"2-second", @"1-first"]), 2, @"Did not find common ancestor 2-second in rev dictionary in %s", __PRETTY_FUNCTION__);
+    XCTAssertEqual(findCommonAncestor(rev, @[]), 0, @"Did not find zero common ancestors in empty rev dictionary in %s", __PRETTY_FUNCTION__);
+    XCTAssertEqual(findCommonAncestor(rev, @[@"3-noway", @"1-nope"]), 0, @"Did not find zero common ancestors in incorrect rev dictionary in %s", __PRETTY_FUNCTION__);
+    XCTAssertEqual(findCommonAncestor(rev, @[@"3-noway", @"1-first"]), 1, @"Did not find common ancestor 1-first in rev dictionary in %s", __PRETTY_FUNCTION__);
+    XCTAssertEqual(findCommonAncestor(rev, @[@"3-noway", @"2-second", @"1-first"]), 2, @"Did not find common ancestor 2-second in rev dictionary in %s", __PRETTY_FUNCTION__);
 
 //    STFail(@"test failing");
 }

--- a/Tests/Tests/TDReachabilityTests.m
+++ b/Tests/Tests/TDReachabilityTests.m
@@ -30,9 +30,9 @@
 {
 //    NSLog(@"Test reachability of %@ ...", hostname);
     TDReachability* r = [[TDReachability alloc] initWithHostName: hostname];
-    STAssertNotNil(r, @"TDReachbility instance is nil in %s:@%", __PRETTY_FUNCTION__, hostname);
+    XCTAssertNotNil(r, @"TDReachbility instance is nil in %s:@%", __PRETTY_FUNCTION__, hostname);
 //    NSLog(@"TDReachability = %@", r);
-    STAssertEqualObjects(r.hostName, hostname, @"TDReachbility instance hostname (@%) is not %@ in %s:@%", r.hostName, hostname, __PRETTY_FUNCTION__, hostname);
+    XCTAssertEqualObjects(r.hostName, hostname, @"TDReachbility instance hostname (@%) is not %@ in %s:@%", r.hostName, hostname, __PRETTY_FUNCTION__, hostname);
     __block BOOL resolved = NO;
     
     __weak TDReachability *weakR = r;
@@ -44,7 +44,7 @@
         if (strongR.reachabilityKnown)
             resolved = YES;
     };
-    STAssertTrue([r start], @"TDReachability failed to start in %s:@%", __PRETTY_FUNCTION__, hostname);
+    XCTAssertTrue([r start], @"TDReachability failed to start in %s:@%", __PRETTY_FUNCTION__, hostname);
     
     BOOL known = r.reachabilityKnown;
 //    NSLog(@"Initially: known=%d, flags=%x --> reachable=%d", known, r.reachabilityFlags, r.reachable);

--- a/Tests/Tests/TDSequenceMapTests.m
+++ b/Tests/Tests/TDSequenceMapTests.m
@@ -30,43 +30,43 @@
 {
     TDSequenceMap *map = [[TDSequenceMap alloc] init];
 
-    STAssertEquals(map.checkpointedSequence, (SequenceNumber)0, @"TDSequenceMap.checkpointedSequence (%d), is not 0 in %s", map.checkpointedSequence, __PRETTY_FUNCTION__);
-    STAssertEqualObjects(map.checkpointedValue, nil, @"TDSequenceMap.checkpointedValue is not nil in %s", __PRETTY_FUNCTION__);
-    STAssertTrue(map.isEmpty, @"TDSequenceMap.isEmpty is not true in %s", __PRETTY_FUNCTION__);
+    XCTAssertEqual(map.checkpointedSequence, (SequenceNumber)0, @"TDSequenceMap.checkpointedSequence (%d), is not 0 in %s", map.checkpointedSequence, __PRETTY_FUNCTION__);
+    XCTAssertEqualObjects(map.checkpointedValue, nil, @"TDSequenceMap.checkpointedValue is not nil in %s", __PRETTY_FUNCTION__);
+    XCTAssertTrue(map.isEmpty, @"TDSequenceMap.isEmpty is not true in %s", __PRETTY_FUNCTION__);
     
-    STAssertEquals([map addValue: @"one"], (SequenceNumber)1, @"TDSequenceMap.addValue did not return 1 in %s", __PRETTY_FUNCTION__);
-    STAssertEquals(map.checkpointedSequence, (SequenceNumber)0, @"TDSequenceMap.checkpointedSequence is not 0 after addValue:@\"one\" in %s", __PRETTY_FUNCTION__);
-    STAssertEqualObjects(map.checkpointedValue, nil, @"TDSequenceMap.checkpointedValue is not nil after addValue \"one\"  in %s", __PRETTY_FUNCTION__);
-    STAssertTrue(!map.isEmpty, @"TDSequenceMap.isEmpty is true in %s", __PRETTY_FUNCTION__);
+    XCTAssertEqual([map addValue: @"one"], (SequenceNumber)1, @"TDSequenceMap.addValue did not return 1 in %s", __PRETTY_FUNCTION__);
+    XCTAssertEqual(map.checkpointedSequence, (SequenceNumber)0, @"TDSequenceMap.checkpointedSequence is not 0 after addValue:@\"one\" in %s", __PRETTY_FUNCTION__);
+    XCTAssertEqualObjects(map.checkpointedValue, nil, @"TDSequenceMap.checkpointedValue is not nil after addValue \"one\"  in %s", __PRETTY_FUNCTION__);
+    XCTAssertTrue(!map.isEmpty, @"TDSequenceMap.isEmpty is true in %s", __PRETTY_FUNCTION__);
     
-    STAssertEquals([map addValue: @"two"], (SequenceNumber)2, @"TDSequenceMap.addValue did not return 2 in %s", __PRETTY_FUNCTION__);
-    STAssertEquals(map.checkpointedSequence, (SequenceNumber)0, @"TDSequenceMap.checkpointedSequence is not 0 after addValue:@\"two\" in %s", __PRETTY_FUNCTION__);
-    STAssertEqualObjects(map.checkpointedValue, nil, @"TDSequenceMap.checkpointedValue is not nil after addValue \"two\" in %s", __PRETTY_FUNCTION__);
+    XCTAssertEqual([map addValue: @"two"], (SequenceNumber)2, @"TDSequenceMap.addValue did not return 2 in %s", __PRETTY_FUNCTION__);
+    XCTAssertEqual(map.checkpointedSequence, (SequenceNumber)0, @"TDSequenceMap.checkpointedSequence is not 0 after addValue:@\"two\" in %s", __PRETTY_FUNCTION__);
+    XCTAssertEqualObjects(map.checkpointedValue, nil, @"TDSequenceMap.checkpointedValue is not nil after addValue \"two\" in %s", __PRETTY_FUNCTION__);
     
-    STAssertEquals([map addValue: @"three"], (SequenceNumber)3, @"TTDSequenceMap.addValue did not return 3 in %s", __PRETTY_FUNCTION__);
-    STAssertEquals(map.checkpointedSequence, (SequenceNumber)0, @"TDSequenceMap.checkpointedSequence is not 0 after addValue:@\"three\" in %s", __PRETTY_FUNCTION__);
-    STAssertEqualObjects(map.checkpointedValue, nil, @"TDSequenceMap.checkpointedValue is not nil after addValue \"two\" in %s", __PRETTY_FUNCTION__);
+    XCTAssertEqual([map addValue: @"three"], (SequenceNumber)3, @"TTDSequenceMap.addValue did not return 3 in %s", __PRETTY_FUNCTION__);
+    XCTAssertEqual(map.checkpointedSequence, (SequenceNumber)0, @"TDSequenceMap.checkpointedSequence is not 0 after addValue:@\"three\" in %s", __PRETTY_FUNCTION__);
+    XCTAssertEqualObjects(map.checkpointedValue, nil, @"TDSequenceMap.checkpointedValue is not nil after addValue \"two\" in %s", __PRETTY_FUNCTION__);
     
     [map removeSequence: 2];
-    STAssertEquals(map.checkpointedSequence, (SequenceNumber)0, @"TDSequenceMap.checkpointedSequence is not 0 after removeSequnce:2 in %s", __PRETTY_FUNCTION__);
-    STAssertEqualObjects(map.checkpointedValue, nil, @"TDSequenceMap.checkpointedValue is not nil after removeSequnce:2 in %s", __PRETTY_FUNCTION__);
+    XCTAssertEqual(map.checkpointedSequence, (SequenceNumber)0, @"TDSequenceMap.checkpointedSequence is not 0 after removeSequnce:2 in %s", __PRETTY_FUNCTION__);
+    XCTAssertEqualObjects(map.checkpointedValue, nil, @"TDSequenceMap.checkpointedValue is not nil after removeSequnce:2 in %s", __PRETTY_FUNCTION__);
     
     [map removeSequence: 1];
-    STAssertEquals(map.checkpointedSequence, (SequenceNumber)2, @"TDSequenceMap.checkpointedSequence is not 2 after removeSequnce:1 in %s", __PRETTY_FUNCTION__);
-    STAssertEqualObjects(map.checkpointedValue, @"two", @"TDSequenceMap.checkpointedValue is not @\"two\" after removeSequnce:1 in %s", __PRETTY_FUNCTION__);
+    XCTAssertEqual(map.checkpointedSequence, (SequenceNumber)2, @"TDSequenceMap.checkpointedSequence is not 2 after removeSequnce:1 in %s", __PRETTY_FUNCTION__);
+    XCTAssertEqualObjects(map.checkpointedValue, @"two", @"TDSequenceMap.checkpointedValue is not @\"two\" after removeSequnce:1 in %s", __PRETTY_FUNCTION__);
     
-    STAssertEquals([map addValue: @"four"], (SequenceNumber)4, @"TTTDSequenceMap.addValue did not return 4 in %s", __PRETTY_FUNCTION__);
-    STAssertEquals(map.checkpointedSequence, (SequenceNumber)2, @"TDSequenceMap.checkpointedSequence is not 2 after addValue:@\"four\" in %s", __PRETTY_FUNCTION__);
-    STAssertEqualObjects(map.checkpointedValue, @"two", @"TDSequenceMap.checkpointedValue is not @\"two\" after addValue:@\"four\" in %s", __PRETTY_FUNCTION__);
+    XCTAssertEqual([map addValue: @"four"], (SequenceNumber)4, @"TTTDSequenceMap.addValue did not return 4 in %s", __PRETTY_FUNCTION__);
+    XCTAssertEqual(map.checkpointedSequence, (SequenceNumber)2, @"TDSequenceMap.checkpointedSequence is not 2 after addValue:@\"four\" in %s", __PRETTY_FUNCTION__);
+    XCTAssertEqualObjects(map.checkpointedValue, @"two", @"TDSequenceMap.checkpointedValue is not @\"two\" after addValue:@\"four\" in %s", __PRETTY_FUNCTION__);
     
     [map removeSequence: 3];
-    STAssertEquals(map.checkpointedSequence, (SequenceNumber)3, @"TDSequenceMap.checkpointedSequence is not 3 after removeSequnce:3 in %s", __PRETTY_FUNCTION__);
-    STAssertEqualObjects(map.checkpointedValue, @"three", @"TDSequenceMap.checkpointedValue is not @\"three\" after removeSequnce:3 in %s", __PRETTY_FUNCTION__);
+    XCTAssertEqual(map.checkpointedSequence, (SequenceNumber)3, @"TDSequenceMap.checkpointedSequence is not 3 after removeSequnce:3 in %s", __PRETTY_FUNCTION__);
+    XCTAssertEqualObjects(map.checkpointedValue, @"three", @"TDSequenceMap.checkpointedValue is not @\"three\" after removeSequnce:3 in %s", __PRETTY_FUNCTION__);
     
     [map removeSequence: 4];
-    STAssertEquals(map.checkpointedSequence, (SequenceNumber)4, @"TDSequenceMap.checkpointedSequence is not 4 after removeSequnce:4 in %s", __PRETTY_FUNCTION__);
-    STAssertEqualObjects(map.checkpointedValue, @"four", @"TDSequenceMap.checkpointedValue is not @\"four\" after removeSequnce:4 in %s", __PRETTY_FUNCTION__);
-    STAssertTrue(map.isEmpty, @"TDSequenceMap.isEmpty is not true in %s", __PRETTY_FUNCTION__);
+    XCTAssertEqual(map.checkpointedSequence, (SequenceNumber)4, @"TDSequenceMap.checkpointedSequence is not 4 after removeSequnce:4 in %s", __PRETTY_FUNCTION__);
+    XCTAssertEqualObjects(map.checkpointedValue, @"four", @"TDSequenceMap.checkpointedValue is not @\"four\" after removeSequnce:4 in %s", __PRETTY_FUNCTION__);
+    XCTAssertTrue(map.isEmpty, @"TDSequenceMap.isEmpty is not true in %s", __PRETTY_FUNCTION__);
 
 }
 

--- a/Tests/Tests/TD_DatabaseManagerTests.m
+++ b/Tests/Tests/TD_DatabaseManagerTests.m
@@ -34,20 +34,20 @@
     TD_DatabaseManager* dbm = [TD_DatabaseManager createEmptyAtTemporaryPath: @"TD_DatabaseManagerTest"];
     TD_Database* db = [dbm databaseNamed: @"foo"];
     
-    STAssertNotNil(db, @"TD_Database is nil in %s", __PRETTY_FUNCTION__);
-    STAssertEqualObjects(db.name, @"foo", @"TD_Database.name is not \"foo\" in %s", __PRETTY_FUNCTION__);
-    STAssertEqualObjects(db.path.stringByDeletingLastPathComponent, dbm.directory, @"TD_Database path is not equal to path supplied by TD_DatabaseManager in %s", __PRETTY_FUNCTION__);
+    XCTAssertNotNil(db, @"TD_Database is nil in %s", __PRETTY_FUNCTION__);
+    XCTAssertEqualObjects(db.name, @"foo", @"TD_Database.name is not \"foo\" in %s", __PRETTY_FUNCTION__);
+    XCTAssertEqualObjects(db.path.stringByDeletingLastPathComponent, dbm.directory, @"TD_Database path is not equal to path supplied by TD_DatabaseManager in %s", __PRETTY_FUNCTION__);
     
-    STAssertTrue(!db.exists, @"TD_Database already exists in %s", __PRETTY_FUNCTION__);
+    XCTAssertTrue(!db.exists, @"TD_Database already exists in %s", __PRETTY_FUNCTION__);
     
-    STAssertEquals([dbm databaseNamed: @"foo"], db, @"TD_DatabaseManager is not aware of a database named \"foo\" in %s", __PRETTY_FUNCTION__);
+    XCTAssertEqual([dbm databaseNamed: @"foo"], db, @"TD_DatabaseManager is not aware of a database named \"foo\" in %s", __PRETTY_FUNCTION__);
     
-    STAssertEqualObjects(dbm.allDatabaseNames, @[], @"TD_DatabaseManager reports some database already exists in %s", __PRETTY_FUNCTION__);    // because foo doesn't exist yet
+    XCTAssertEqualObjects(dbm.allDatabaseNames, @[], @"TD_DatabaseManager reports some database already exists in %s", __PRETTY_FUNCTION__);    // because foo doesn't exist yet
     
-    STAssertTrue([db open], @"TD_Database.open returned NO in %s", __PRETTY_FUNCTION__);
-    STAssertTrue(db.exists, @"TD_Database does not exist in %s", __PRETTY_FUNCTION__);
+    XCTAssertTrue([db open], @"TD_Database.open returned NO in %s", __PRETTY_FUNCTION__);
+    XCTAssertTrue(db.exists, @"TD_Database does not exist in %s", __PRETTY_FUNCTION__);
     
-    STAssertEqualObjects(dbm.allDatabaseNames, @[@"foo"], @"TD_DatabaseManager reports some database other than \"foo\" in %s", __PRETTY_FUNCTION__);  // because foo should now exist and be the only database here
+    XCTAssertEqualObjects(dbm.allDatabaseNames, @[@"foo"], @"TD_DatabaseManager reports some database other than \"foo\" in %s", __PRETTY_FUNCTION__);  // because foo should now exist and be the only database here
 }
 
 

--- a/Tests/Tests/TD_DatabaseTests.m
+++ b/Tests/Tests/TD_DatabaseTests.m
@@ -36,14 +36,14 @@ extern NSDictionary* makeRevisionHistoryDict(NSArray* history);
 - (void) testRevisionDictionary
 {
     NSArray* revs = @[[self mkrev:@"4-jkl"], [self mkrev:@"3-ghi"], [self mkrev:@"2-def"]];
-    STAssertEqualObjects(makeRevisionHistoryDict(revs), $dict({@"ids", @[@"jkl", @"ghi", @"def"]},
+    XCTAssertEqualObjects(makeRevisionHistoryDict(revs), $dict({@"ids", @[@"jkl", @"ghi", @"def"]},
                                                       {@"start", @4}), @"4-3-2 revs failed in %s", __PRETTY_FUNCTION__);
     
     revs = @[[self mkrev:@"4-jkl"], [self mkrev:@"2-def"]];
-    STAssertEqualObjects(makeRevisionHistoryDict(revs), $dict({@"ids", @[@"4-jkl", @"2-def"]}), @"4-2 revs failed in %s", __PRETTY_FUNCTION__);
+    XCTAssertEqualObjects(makeRevisionHistoryDict(revs), $dict({@"ids", @[@"4-jkl", @"2-def"]}), @"4-2 revs failed in %s", __PRETTY_FUNCTION__);
     
     revs = @[[self mkrev:@"12345"], [self mkrev:@"6789"]];
-    STAssertEqualObjects(makeRevisionHistoryDict(revs), $dict({@"ids", @[@"12345", @"6789"]}), @"12345-6789 revs failed in %s", __PRETTY_FUNCTION__);
+    XCTAssertEqualObjects(makeRevisionHistoryDict(revs), $dict({@"ids", @[@"12345", @"6789"]}), @"12345-6789 revs failed in %s", __PRETTY_FUNCTION__);
 }
 
 

--- a/Tests/Tests/TD_RevisionTests.m
+++ b/Tests/Tests/TD_RevisionTests.m
@@ -30,7 +30,7 @@
 {
     int gen;
     NSString* suffix;
-    STAssertFalse([TD_Revision parseRevID: aRev intoGeneration: &gen andSuffix: &suffix],
+    XCTAssertFalse([TD_Revision parseRevID: aRev intoGeneration: &gen andSuffix: &suffix],
                   @"parsing rev: %@ did not fail in %s", aRev, __PRETTY_FUNCTION__);
 }
 
@@ -39,11 +39,11 @@
     int localgen;
     NSString* localsuffix;
 
-    STAssertTrue([TD_Revision parseRevID: aRev intoGeneration: &localgen andSuffix: &localsuffix],
+    XCTAssertTrue([TD_Revision parseRevID: aRev intoGeneration: &localgen andSuffix: &localsuffix],
                  @"%@ did not fail in %s", aRev, __PRETTY_FUNCTION__);
     
-    STAssertEquals(gen, localgen, @"generation number is not 1 in %s", __PRETTY_FUNCTION__);
-    STAssertEqualObjects(suffix, localsuffix,
+    XCTAssertEqual(gen, localgen, @"generation number is not 1 in %s", __PRETTY_FUNCTION__);
+    XCTAssertEqualObjects(suffix, localsuffix,
                          @"Revision suffix is not \"%@\" in %s", suffix, __PRETTY_FUNCTION__);
     
 }
@@ -69,7 +69,7 @@
 
 - (void)runCollateRevEqualsTest:(const char*)rev1 rev2:(const char*)rev2 val:(int)val
 {
-    STAssertEquals(TDCollateRevIDs(NULL, (int)strlen(rev1), rev1, (int)strlen(rev2), rev2),
+    XCTAssertEqual(TDCollateRevIDs(NULL, (int)strlen(rev1), rev1, (int)strlen(rev2), rev2),
                    val,
                    @"TDCollateRevIDs rev1:%s, rev2:%2 does not return %d in %s", rev1, rev2, val, __PRETTY_FUNCTION__);
 }


### PR DESCRIPTION
This PR updates all tests for CDTDatastore (Both replication acceptance and Unit tests) to use XCTest instead of SenTest. It also changes the schemes from Tests for both OS X and iOS to Tests for just iOS and Tests OS X for OS X. This also updates the RakeFile to allow OS X tests to be run on travis again.  