### PR TITLE
Adds TDURLConnectionChangeTracker class.

### DIFF
--- a/CDTDatastore.xcworkspace/contents.xcworkspacedata
+++ b/CDTDatastore.xcworkspace/contents.xcworkspacedata
@@ -185,6 +185,12 @@
                <FileRef
                   location = "group:TDSocketChangeTracker.h">
                </FileRef>
+               <FileRef
+                  location = "group:TDURLConnectionChangeTracker.m">
+               </FileRef>
+               <FileRef
+                  location = "group:TDURLConnectionChangeTracker.h">
+               </FileRef>
             </Group>
             <FileRef
                location = "group:TD_Database+Attachments.h">

--- a/Classes/common/touchdb/ChangeTracker/TDChangeTracker.h
+++ b/Classes/common/touchdb/ChangeTracker/TDChangeTracker.h
@@ -28,7 +28,7 @@ typedef enum TDChangeTrackerMode { kOneShot, kLongPoll, kContinuous } TDChangeTr
 
 /** Reads the continuous-mode _changes feed of a database, and sends the individual change entries
  * to its client.  */
-@interface TDChangeTracker : NSObject <NSStreamDelegate> {
+@interface TDChangeTracker : NSObject {
    @protected
     NSURL* _databaseURL;
     id<TDChangeTrackerClient> __weak _client;

--- a/Classes/common/touchdb/ChangeTracker/TDChangeTracker.m
+++ b/Classes/common/touchdb/ChangeTracker/TDChangeTracker.m
@@ -19,6 +19,7 @@
 
 #import "TDChangeTracker.h"
 #import "TDSocketChangeTracker.h"
+#import "TDURLConnectionChangeTracker.h"
 #import "TDAuthorizer.h"
 #import "TDMisc.h"
 #import "TDStatus.h"
@@ -54,11 +55,11 @@
     if (self) {
         if ([self class] == [TDChangeTracker class]) {
             // TDChangeTracker is abstract; instantiate a concrete subclass instead.
-            return [[TDSocketChangeTracker alloc] initWithDatabaseURL:databaseURL
-                                                                 mode:mode
-                                                            conflicts:includeConflicts
-                                                         lastSequence:lastSequenceID
-                                                               client:client];
+            return [[TDURLConnectionChangeTracker alloc] initWithDatabaseURL:databaseURL
+                                                                        mode:mode
+                                                                   conflicts:includeConflicts
+                                                                lastSequence:lastSequenceID
+                                                                      client:client];
         }
         _databaseURL = databaseURL;
         _client = client;

--- a/Classes/common/touchdb/ChangeTracker/TDSocketChangeTracker.h
+++ b/Classes/common/touchdb/ChangeTracker/TDSocketChangeTracker.h
@@ -10,7 +10,7 @@
 
 /** TDChangeTracker implementation that uses a raw TCP socket to read the chunk-mode HTTP response.
  */
-@interface TDSocketChangeTracker : TDChangeTracker {
+@interface TDSocketChangeTracker : TDChangeTracker <NSStreamDelegate> {
    @private
     NSInputStream* _trackingInput;
 

--- a/Classes/common/touchdb/ChangeTracker/TDURLConnectionChangeTracker.h
+++ b/Classes/common/touchdb/ChangeTracker/TDURLConnectionChangeTracker.h
@@ -1,0 +1,17 @@
+//
+//  TDURLConnectionChangeTracker.h
+//  
+//
+//  Created by Adam Cox on 1/5/15.
+//
+//
+
+#import "TDChangeTracker.h"
+
+@interface TDURLConnectionChangeTracker : TDChangeTracker <NSURLConnectionDataDelegate>
+
+// used only for testing and debugging. counts the total number of retry attempts and
+// is not reset to zero with each separate request (unlike TDChangeTracker retryCount).
+@property (nonatomic, readonly) NSUInteger totalRetries;
+
+@end

--- a/Classes/common/touchdb/ChangeTracker/TDURLConnectionChangeTracker.m
+++ b/Classes/common/touchdb/ChangeTracker/TDURLConnectionChangeTracker.m
@@ -87,7 +87,7 @@
 
     if (!self.connection) {
         CDTLogError(CDTREPLICATION_LOG_CONTEXT, @"%@: GET %@ failed to create NSURLConnection",
-                   self, url.resourceSpecifier);
+                   self, TDCleanURLtoString(url));
         return NO;
     }
     [self.connection scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
@@ -96,8 +96,7 @@
     self.inputBuffer = [NSMutableData dataWithCapacity:0];
         
     self.startTime = [NSDate date];
-    CDTLogInfo(CDTREPLICATION_LOG_CONTEXT, @"%@: Started... <%@>", self, self.changesFeedURL);
-    CDTLogVerbose(CDTREPLICATION_LOG_CONTEXT, @"%@: GET %@", self, url.resourceSpecifier);
+    CDTLogInfo(CDTREPLICATION_LOG_CONTEXT, @"%@: Started... <%@>", self, TDCleanURLtoString(url));
 
     return YES;
 }
@@ -315,7 +314,8 @@
     
     if (!match) {
         CDTLogError(CDTREPLICATION_LOG_CONTEXT, @"%@: Unparseable response from %@. Did not find "
-                    @"start of the expected response: %@", self, self.request.URL, prefixString);
+                    @"start of the expected response: %@", self,
+                    TDCleanURLtoString(self.request.URL), prefixString);
     }
     
     return match;

--- a/Classes/common/touchdb/ChangeTracker/TDURLConnectionChangeTracker.m
+++ b/Classes/common/touchdb/ChangeTracker/TDURLConnectionChangeTracker.m
@@ -1,0 +1,324 @@
+//
+//  TDURLConnectionChangeTracker.m
+//  
+//
+//  Created by Adam Cox on 1/5/15.
+//  Copyright (c) 2015 IBM.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+// <http://wiki.apache.org/couchdb/HTTP_database_API#Changes>
+//
+
+#import "TDURLConnectionChangeTracker.h"
+#import "TDRemoteRequest.h"
+#import "TDAuthorizer.h"
+#import "TDStatus.h"
+#import "TDBase64.h"
+#import "MYBlockUtils.h"
+#import "MYURLUtils.h"
+#import <string.h>
+#import "TDJSON.h"
+#import "CDTLogging.h"
+#import "TDMisc.h"
+
+#define kMaxRetries 6
+#define kInitialRetryDelay 0.2
+
+@interface TDURLConnectionChangeTracker()
+@property (strong, nonatomic) NSMutableData* inputBuffer;
+@property (strong, nonatomic) NSURLConnection *connection;
+@property (strong, nonatomic) NSMutableURLRequest *request;
+@property (strong, nonatomic) NSDate* startTime;
+@property (nonatomic, readwrite) NSUInteger totalRetries;
+@end
+
+@implementation TDURLConnectionChangeTracker
+
+- (BOOL)start
+{
+    if (self.connection) return NO;
+    
+    CDTLogInfo(CDTREPLICATION_LOG_CONTEXT, @"%@: Starting...", [self class]);
+    [super start];
+    
+    NSURL* url = self.changesFeedURL;
+    self.request = [[NSMutableURLRequest alloc] initWithURL:url];
+    self.request.cachePolicy = NSURLRequestReloadIgnoringLocalCacheData;
+    self.request.HTTPMethod = @"GET";
+    
+    // Add headers from my .requestHeaders property:
+    for(NSString *key in self.requestHeaders) {
+        [self.request setValue:self.requestHeaders[key] forHTTPHeaderField:key];
+    }
+    
+    // Add cookie headers from the NSHTTPCookieStorage:
+    NSArray* cookies = [[NSHTTPCookieStorage sharedHTTPCookieStorage] cookiesForURL:url];
+    NSDictionary* cookieHeaders = [NSHTTPCookie requestHeaderFieldsWithCookies:cookies];
+    NSArray *requestHeadersKeys = [self.requestHeaders allKeys];
+    for (NSString* headerName in cookieHeaders) {
+        if ([requestHeadersKeys containsObject:headerName]) {
+            CDTLogWarn(CDTREPLICATION_LOG_CONTEXT, @"%@ Overwriting '%@' header with value %@",
+                       self, headerName, cookieHeaders[headerName]);
+        }
+        [self.request setValue:cookieHeaders[headerName] forHTTPHeaderField:headerName];
+    }
+
+    if (self.authorizer) {
+        NSString* authHeader = [self.authorizer authorizeURLRequest:self.request forRealm:nil];
+        if (authHeader) {
+            if ([requestHeadersKeys containsObject:@"Authorization"]) {
+                CDTLogWarn(CDTREPLICATION_LOG_CONTEXT, @"%@ Overwriting 'Authorization' header with "
+                           @"value %@", self, authHeader);
+            }
+            [self.request setValue: authHeader forHTTPHeaderField:@"Authorization"];
+        }
+    }
+    
+    self.connection = [[NSURLConnection alloc] initWithRequest:self.request
+                                                      delegate:self
+                                              startImmediately:NO];
+
+    if (!self.connection) {
+        CDTLogError(CDTREPLICATION_LOG_CONTEXT, @"%@: GET %@ failed to create NSURLConnection",
+                   self, url.resourceSpecifier);
+        return NO;
+    }
+    [self.connection scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
+    [self.connection start];
+    
+    self.inputBuffer = [NSMutableData dataWithCapacity:0];
+        
+    self.startTime = [NSDate date];
+    CDTLogInfo(CDTREPLICATION_LOG_CONTEXT, @"%@: Started... <%@>", self, self.changesFeedURL);
+    CDTLogVerbose(CDTREPLICATION_LOG_CONTEXT, @"%@: GET %@", self, url.resourceSpecifier);
+
+    return YES;
+}
+
+- (void)clearConnection
+{
+    [self.connection cancel];
+    [self.connection unscheduleFromRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
+    self.connection = nil;
+    self.inputBuffer = nil;
+}
+
+- (void)stop
+{
+    [NSObject cancelPreviousPerformRequestsWithTarget:self
+                                             selector:@selector(start)
+                                               object:nil];  // cancel pending retries
+    if (self.connection) {
+        CDTLogInfo(CDTREPLICATION_LOG_CONTEXT, @"%@: stop", [self class]);
+        [self clearConnection];
+    }
+    [super stop];
+}
+
+- (void)retryOrError:(NSError*)error
+{
+    CDTLogInfo(CDTREPLICATION_LOG_CONTEXT, @"%@: retryOrError: %@", [self class], error);
+    if (++_retryCount <= kMaxRetries && TDMayBeTransientError(error)) {
+        self.totalRetries++;
+        [self clearConnection];
+        NSTimeInterval retryDelay = kInitialRetryDelay * (1 << (_retryCount - 1));
+        [self performSelector:@selector(start) withObject:nil afterDelay:retryDelay];
+    } else {
+        CDTLogError(CDTREPLICATION_LOG_CONTEXT, @"%@: Can't connect, giving up: %@", self, error);
+        
+        self.error = error;
+        [self stop];
+    }
+}
+
+#pragma mark - NSURLConnectionDataDelegate delegate:
+
+- (void)connection:(NSURLConnection *)connection willSendRequestForAuthenticationChallenge:
+    (NSURLAuthenticationChallenge *)challenge
+{
+    id<NSURLAuthenticationChallengeSender> sender = challenge.sender;
+    NSURLProtectionSpace *space = challenge.protectionSpace;
+    NSString *authMethod = space.authenticationMethod;
+    CDTLogVerbose(CDTREPLICATION_LOG_CONTEXT, @"Got challenge for %@: method=%@, proposed=%@, err=%@",
+                  [self class], authMethod, challenge.proposedCredential, challenge.error);
+    
+    if ($equal(authMethod, NSURLAuthenticationMethodHTTPBasic)) {
+        // On basic auth challenge, use proposed credential on first attempt. On second attempt,
+        // or if there's no proposed credential, look one up. After that, continue without
+        // credential and see what happens (probably a 401)
+        
+        if (challenge.previousFailureCount <= 1) {
+
+            NSURLCredential *cred = challenge.proposedCredential;
+            if (cred == nil || challenge.previousFailureCount > 0) {
+                cred = [self.request.URL my_credentialForRealm:space.realm
+                                          authenticationMethod:authMethod];
+            }
+            if (cred) {
+                CDTLogVerbose(CDTREPLICATION_LOG_CONTEXT, @"%@ challenge: useCredential: %@",
+                              [self class], cred);
+                [sender useCredential:cred forAuthenticationChallenge:challenge];
+                // Update my authorizer so my owner (the replicator) can pick it up when I'm done
+                _authorizer = [[TDBasicAuthorizer alloc] initWithCredential:cred];
+                return;
+            }
+        }
+        
+        CDTLogVerbose(CDTREPLICATION_LOG_CONTEXT, @"%@ challenge: continueWithoutCredential",
+                      [self class]);
+        [sender continueWithoutCredentialForAuthenticationChallenge:challenge];
+    }
+    else if ($equal(authMethod, NSURLAuthenticationMethodServerTrust)) {
+        
+        SecTrustRef trust = space.serverTrust;
+        if ([TDRemoteRequest checkTrust:trust forHost:space.host]) {
+            
+            CDTLogVerbose(CDTTD_REMOTE_REQUEST_CONTEXT, @"%@ useCredential for trust: %@",
+                          self, trust);
+            NSURLCredential *cred = [NSURLCredential credentialForTrust:trust];
+            [sender useCredential:cred forAuthenticationChallenge:challenge];
+            
+        }
+        else {
+            CDTLogWarn(CDTTD_REMOTE_REQUEST_CONTEXT, @"%@ challenge: cancel", self);
+            [sender cancelAuthenticationChallenge:challenge];
+        }
+    }
+    else {
+        CDTLogWarn(CDTREPLICATION_LOG_CONTEXT, @"%@ challenge: performDefaultHandling", self);
+        [sender performDefaultHandlingForAuthenticationChallenge:challenge];
+    }
+    
+}
+
+-(void) connection:(NSURLConnection *)connection didReceiveResponse:(NSURLResponse *)response
+{
+    NSHTTPURLResponse *httpresponse = (NSHTTPURLResponse *)response;
+    TDStatus status = (TDStatus)httpresponse.statusCode;
+    CDTLogVerbose(CDTREPLICATION_LOG_CONTEXT, @"%@: didReceiveResponse, status %ld", [self class], (long)status);
+    
+    [self.inputBuffer setLength:0];
+
+    if (TDStatusIsError(status)) {
+        
+        NSDictionary* errorInfo = nil;
+        if (status == 401 || status == 407) {
+            
+            NSString* authorization = [self.requestHeaders objectForKey:@"Authorization"];
+            NSString* authResponse = [httpresponse allHeaderFields][@"WWW-Authenticate"];
+            
+            CDTLogError(CDTREPLICATION_LOG_CONTEXT,
+                       @"%@: HTTP auth failed; sent Authorization: %@  ;  got WWW-Authenticate: %@", [self class],
+                       authorization, authResponse);
+            errorInfo = $dict({ @"HTTPAuthorization", authorization },
+                              { @"HTTPAuthenticateHeader", authResponse });
+        }
+        
+        //retryOrError will only retry if the error seems to be a transient error.
+        //otherwise, retryOrError will set the error and stop.
+        [self retryOrError:TDStatusToNSErrorWithInfo(status, self.changesFeedURL, errorInfo)];
+    }
+    
+}
+
+-(void) connection:(NSURLConnection *)connection didReceiveData:(NSData *)data
+{
+    CDTLogVerbose(CDTREPLICATION_LOG_CONTEXT, @"%@: didReceiveData: %ld bytes",
+                  [self class], (unsigned long)[data length]);
+    
+    [self.inputBuffer appendData:data];
+}
+
+-(void) connectionDidFinishLoading:(NSURLConnection *)connection
+{
+    //parse the input buffer into JSON (or NSArray of changes?)
+    CDTLogVerbose(CDTREPLICATION_LOG_CONTEXT, @"%@: didFinishLoading, %u bytes", self,
+               (unsigned)self.inputBuffer.length);
+    
+    BOOL restart = NO;
+    NSString* errorMessage = nil;
+    NSInteger numChanges = [self receivedPollResponse:self.inputBuffer errorMessage:&errorMessage];
+    
+    if (numChanges < 0) {
+        // unparseable response. See if it gets special handling:
+        if ([self receivedDataBeginsCorrectly]) {
+            
+            // The response at least starts out as what we'd expect, so it looks like the connection
+            // was closed unexpectedly before the full response was sent.
+            NSTimeInterval elapsed = [self.startTime timeIntervalSinceNow] * -1.0;
+            CDTLogError(CDTREPLICATION_LOG_CONTEXT, @"%@: connection closed unexpectedly after "
+                        @"%.1f sec. will retry", self, elapsed);
+            
+            [self retryOrError:[NSError errorWithDomain:NSURLErrorDomain
+                                                   code:NSURLErrorNetworkConnectionLost
+                                               userInfo:nil]];
+            
+            return;
+        }
+        
+        // Otherwise report an upstream unparseable-response error
+        [self setUpstreamError:errorMessage];
+    }
+    else {
+        // Poll again if there was no error, and it looks like we
+        // ran out of changes due to a _limit rather than because we hit the end.
+        restart = numChanges == (NSInteger)_limit;
+    }
+    
+    [self clearConnection];
+    
+    if (restart)
+        [self start];  // Next poll...
+    else
+        [self stopped];
+    
+}
+
+-(void) connection:(NSURLConnection *)connection didFailWithError:(NSError *)error
+{
+    [self retryOrError:error];
+}
+
+- (BOOL)receivedDataBeginsCorrectly
+{
+    NSString *prefixString = @"{\"results\":";
+    NSData *prefixData = [prefixString dataUsingEncoding:NSUTF8StringEncoding];
+    NSUInteger prefixLength = [prefixData length];
+    NSUInteger inputLength = [self.inputBuffer length];
+    BOOL match = NO;
+    
+    for (NSUInteger index = 0; index < inputLength; index++)
+    {
+        char currentChar;
+        NSRange currentCharRange = NSMakeRange(index, 1);
+        [self.inputBuffer getBytes:&currentChar range:currentCharRange];
+        
+        // If it's the opening {, check for valid start JSON
+        if (currentChar == '{') {
+            NSRange r = NSMakeRange(index, prefixLength);
+            char buf[prefixLength];
+            
+            if (inputLength >= (index + prefixLength)) {  // enough data left
+                [self.inputBuffer getBytes:buf range:r];
+                match = (memcmp(buf, prefixData.bytes, prefixLength) == 0);
+            }
+            break;  // once we've seen a {, break always as can't succeed if we've not already.
+        }
+    }
+    
+    if (!match) {
+        CDTLogError(CDTREPLICATION_LOG_CONTEXT, @"%@: Unparseable response from %@. Did not find "
+                    @"start of the expected response: %@", self, self.request.URL, prefixString);
+    }
+    
+    return match;
+}
+
+@end

--- a/ReplicationAcceptance/ReplicationAcceptance.xcodeproj/project.pbxproj
+++ b/ReplicationAcceptance/ReplicationAcceptance.xcodeproj/project.pbxproj
@@ -41,9 +41,15 @@
 		4510BA04F5FB481E882AF5EE /* libPods-ios.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C61CF9A9D4564F53BC1F7321 /* libPods-ios.a */; };
 		86A30343408047EEBBF8EC4C /* libPods-ios.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C61CF9A9D4564F53BC1F7321 /* libPods-ios.a */; };
 		8E89B680A5F347559033D1B3 /* libPods-osx.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 97F72706FFD44D88B6E5E667 /* libPods-osx.a */; };
+		9F8CA2C71A639AB000A0E91C /* ChangeTrackerNSURLProtocolTimedOut.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F8CA2C61A639AB000A0E91C /* ChangeTrackerNSURLProtocolTimedOut.m */; };
+		9F8CA2C81A639AB000A0E91C /* ChangeTrackerNSURLProtocolTimedOut.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F8CA2C61A639AB000A0E91C /* ChangeTrackerNSURLProtocolTimedOut.m */; };
+		9F8CA2C91A639AB000A0E91C /* ChangeTrackerNSURLProtocolTimedOut.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F8CA2C61A639AB000A0E91C /* ChangeTrackerNSURLProtocolTimedOut.m */; };
 		9F8CA2CC1A64E63F00A0E91C /* CDTRunBlocksForReplicatorDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F8CA2CB1A64E63F00A0E91C /* CDTRunBlocksForReplicatorDelegate.m */; };
 		9F8CA2CD1A64E63F00A0E91C /* CDTRunBlocksForReplicatorDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F8CA2CB1A64E63F00A0E91C /* CDTRunBlocksForReplicatorDelegate.m */; };
 		9F8CA2CE1A64E63F00A0E91C /* CDTRunBlocksForReplicatorDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F8CA2CB1A64E63F00A0E91C /* CDTRunBlocksForReplicatorDelegate.m */; };
+		9F95598F1A5F184000435808 /* ChangeTrackerDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F95598E1A5F184000435808 /* ChangeTrackerDelegate.m */; };
+		9F9559901A5F184000435808 /* ChangeTrackerDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F95598E1A5F184000435808 /* ChangeTrackerDelegate.m */; };
+		9F9559911A5F184000435808 /* ChangeTrackerDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F95598E1A5F184000435808 /* ChangeTrackerDelegate.m */; };
 		9FC2F12C19F070710032A074 /* ReplicatorURLProtocol.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FC2F12B19F070710032A074 /* ReplicatorURLProtocol.m */; };
 		9FC2F12D19F070710032A074 /* ReplicatorURLProtocol.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FC2F12B19F070710032A074 /* ReplicatorURLProtocol.m */; };
 		9FC2F13119F72B710032A074 /* ReplicatorURLProtocolTester.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FC2F13019F72B710032A074 /* ReplicatorURLProtocolTester.m */; };
@@ -101,8 +107,12 @@
 		5E90CA923A123284AF6B8CE0 /* Pods-osx.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-osx.release.xcconfig"; path = "Pods/Target Support Files/Pods-osx/Pods-osx.release.xcconfig"; sourceTree = "<group>"; };
 		6A9AF7E2659CCF39B5454D35 /* Pods-ios.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ios.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ios/Pods-ios.debug.xcconfig"; sourceTree = "<group>"; };
 		97F72706FFD44D88B6E5E667 /* libPods-osx.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-osx.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		9F8CA2C51A639AB000A0E91C /* ChangeTrackerNSURLProtocolTimedOut.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ChangeTrackerNSURLProtocolTimedOut.h; sourceTree = "<group>"; };
+		9F8CA2C61A639AB000A0E91C /* ChangeTrackerNSURLProtocolTimedOut.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ChangeTrackerNSURLProtocolTimedOut.m; sourceTree = "<group>"; };
 		9F8CA2CA1A64E63F00A0E91C /* CDTRunBlocksForReplicatorDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDTRunBlocksForReplicatorDelegate.h; sourceTree = "<group>"; };
 		9F8CA2CB1A64E63F00A0E91C /* CDTRunBlocksForReplicatorDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTRunBlocksForReplicatorDelegate.m; sourceTree = "<group>"; };
+		9F95598D1A5F184000435808 /* ChangeTrackerDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ChangeTrackerDelegate.h; sourceTree = "<group>"; };
+		9F95598E1A5F184000435808 /* ChangeTrackerDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ChangeTrackerDelegate.m; sourceTree = "<group>"; };
 		9FC2F12B19F070710032A074 /* ReplicatorURLProtocol.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ReplicatorURLProtocol.m; sourceTree = "<group>"; };
 		9FC2F12E19F070950032A074 /* ReplicatorURLProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ReplicatorURLProtocol.h; sourceTree = "<group>"; };
 		9FC2F12F19F72B710032A074 /* ReplicatorURLProtocolTester.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ReplicatorURLProtocolTester.h; sourceTree = "<group>"; };
@@ -218,8 +228,12 @@
 				277992B718A24F0900BAB6ED /* ReplicationAcceptance+CRUD.m */,
 				9F8CA2CA1A64E63F00A0E91C /* CDTRunBlocksForReplicatorDelegate.h */,
 				9F8CA2CB1A64E63F00A0E91C /* CDTRunBlocksForReplicatorDelegate.m */,
+				9F95598D1A5F184000435808 /* ChangeTrackerDelegate.h */,
+				9F95598E1A5F184000435808 /* ChangeTrackerDelegate.m */,
 				9FC2F12E19F070950032A074 /* ReplicatorURLProtocol.h */,
 				9FC2F12B19F070710032A074 /* ReplicatorURLProtocol.m */,
+				9F8CA2C51A639AB000A0E91C /* ChangeTrackerNSURLProtocolTimedOut.h */,
+				9F8CA2C61A639AB000A0E91C /* ChangeTrackerNSURLProtocolTimedOut.m */,
 				9FC2F12F19F72B710032A074 /* ReplicatorURLProtocolTester.h */,
 				9FC2F13019F72B710032A074 /* ReplicatorURLProtocolTester.m */,
 			);
@@ -567,8 +581,10 @@
 				277992B818A24F0900BAB6ED /* ReplicationAcceptance+CRUD.m in Sources */,
 				27A7E6B118997673007FAF1C /* ReplicationAcceptance.m in Sources */,
 				9F8CA2CC1A64E63F00A0E91C /* CDTRunBlocksForReplicatorDelegate.m in Sources */,
+				9F95598F1A5F184000435808 /* ChangeTrackerDelegate.m in Sources */,
 				9FC2F12C19F070710032A074 /* ReplicatorURLProtocol.m in Sources */,
 				27A7E6AF189975B2007FAF1C /* CloudantReplicationBase.m in Sources */,
+				9F8CA2C71A639AB000A0E91C /* ChangeTrackerNSURLProtocolTimedOut.m in Sources */,
 				27DFEEB718DB4A0D0052D487 /* Attachments.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -582,8 +598,10 @@
 				277992B918A24F0900BAB6ED /* ReplicationAcceptance+CRUD.m in Sources */,
 				27A7E6B218997677007FAF1C /* ReplicationAcceptance.m in Sources */,
 				9F8CA2CD1A64E63F00A0E91C /* CDTRunBlocksForReplicatorDelegate.m in Sources */,
+				9F9559901A5F184000435808 /* ChangeTrackerDelegate.m in Sources */,
 				9FC2F12D19F070710032A074 /* ReplicatorURLProtocol.m in Sources */,
 				27A7E6B0189975B2007FAF1C /* CloudantReplicationBase.m in Sources */,
+				9F8CA2C81A639AB000A0E91C /* ChangeTrackerNSURLProtocolTimedOut.m in Sources */,
 				27DFEEB818DB4A0D0052D487 /* Attachments.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -607,6 +625,8 @@
 				27ED10AD192CF8FF00F75E95 /* CloudantReplicationBase.m in Sources */,
 				27ED10AE192CF8FF00F75E95 /* CloudantReplicationBase+CompareDb.m in Sources */,
 				27ED10AF192CF8FF00F75E95 /* ReplicationAcceptance+CRUD.m in Sources */,
+				9F8CA2C91A639AB000A0E91C /* ChangeTrackerNSURLProtocolTimedOut.m in Sources */,
+				9F9559911A5F184000435808 /* ChangeTrackerDelegate.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ReplicationAcceptance/ReplicationAcceptance/ChangeTrackerDelegate.h
+++ b/ReplicationAcceptance/ReplicationAcceptance/ChangeTrackerDelegate.h
@@ -1,0 +1,23 @@
+//
+//  ChangeTrackerDelegate.h
+//  ReplicationAcceptance
+//
+//  Created by Adam Cox on 1/8/15.
+//
+//
+
+#import <Foundation/Foundation.h>
+#import "TDChangeTracker.h"
+
+typedef void (^changeTrackerReceivedChangesBlock)(NSArray *changes);
+typedef void (^changeTrackerReceivedChangeBlock)(NSDictionary *change);
+typedef void (^changeTrackerStoppedBlock)(TDChangeTracker *tracker);
+
+
+@interface ChangeTrackerDelegate : NSObject <TDChangeTrackerClient>
+
+@property (nonatomic, copy) changeTrackerReceivedChangesBlock changesBlock;
+@property (nonatomic, copy) changeTrackerReceivedChangeBlock changeBlock;
+@property (nonatomic, copy) changeTrackerStoppedBlock stoppedBlock;
+
+@end

--- a/ReplicationAcceptance/ReplicationAcceptance/ChangeTrackerDelegate.m
+++ b/ReplicationAcceptance/ReplicationAcceptance/ChangeTrackerDelegate.m
@@ -1,0 +1,35 @@
+//
+//  ChangeTrackerDelegate.m
+//  ReplicationAcceptance
+//
+//  Created by Adam Cox on 1/8/15.
+//
+//
+
+#import "ChangeTrackerDelegate.h"
+#import "TDURLConnectionChangeTracker.h"
+
+@implementation ChangeTrackerDelegate
+
+- (void)changeTrackerReceivedChanges:(NSArray*)changes
+{
+    if (self.changesBlock) {
+        self.changesBlock(changes);
+    }
+}
+
+- (void)changeTrackerStopped:(TDChangeTracker*)tracker
+{
+    if (self.stoppedBlock) {
+        self.stoppedBlock(tracker);
+    }
+}
+
+-(void)changeTrackerReceivedChange:(NSDictionary*)change
+{
+    if (self.changeBlock) {
+        self.changeBlock(change);
+    }
+}
+
+@end

--- a/ReplicationAcceptance/ReplicationAcceptance/ChangeTrackerNSURLProtocolTimedOut.h
+++ b/ReplicationAcceptance/ReplicationAcceptance/ChangeTrackerNSURLProtocolTimedOut.h
@@ -1,0 +1,13 @@
+//
+//  ChangeTrackerNSURLProtocolTimedOut.h
+//  ReplicationAcceptance
+//
+//  Created by Adam Cox on 1/11/15.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+@interface ChangeTrackerNSURLProtocolTimedOut : NSURLProtocol
++(void)setURL:(NSURL*) url;
+@end

--- a/ReplicationAcceptance/ReplicationAcceptance/ChangeTrackerNSURLProtocolTimedOut.m
+++ b/ReplicationAcceptance/ReplicationAcceptance/ChangeTrackerNSURLProtocolTimedOut.m
@@ -1,0 +1,45 @@
+//
+//  ChangeTrackerNSURLProtocolTimedOut.m
+//  ReplicationAcceptance
+//
+//  Created by Adam Cox on 1/11/15.
+//
+//
+
+#import "ChangeTrackerNSURLProtocolTimedOut.h"
+
+static NSURL* gChangeTrackerNSURLProtocolTimedOut_url = nil;
+
+@implementation ChangeTrackerNSURLProtocolTimedOut
+
++ (BOOL)canInitWithRequest:(NSURLRequest *)request
+{
+    return [request.URL isEqual:gChangeTrackerNSURLProtocolTimedOut_url];
+}
+
++ (NSURLRequest *)canonicalRequestForRequest:(NSURLRequest *)request
+{
+    return request;
+}
+
++(void)setURL:(NSURL*) url;
+{
+    gChangeTrackerNSURLProtocolTimedOut_url = url;
+}
+
+- (void)startLoading
+{
+    id <NSURLProtocolClient> client = self.client;
+    
+    NSError *error = [NSError errorWithDomain:NSURLErrorDomain
+                                         code:NSURLErrorTimedOut
+                                     userInfo:nil];
+    
+    [client URLProtocol:self didFailWithError:error];
+}
+
+- (void)stopLoading
+{
+    
+}
+@end


### PR DESCRIPTION
Modifies TDPuller to propertly set headers so that the User-Agent
header isn't overwritten.

Adds a few new ChangeTracker tests.

TDChangeTracker init method returns TDURLConnectionChangeTracker object.