### PR TITLE
43494 last sequence not written to remote checkpoint doc

### DIFF
--- a/Classes/common/touchdb/TDReplicator.h
+++ b/Classes/common/touchdb/TDReplicator.h
@@ -122,4 +122,7 @@ extern NSString* TDReplicatorStoppedNotification;
 /** JSON-compatible array of status info about active remote HTTP requests. */
 @property (readonly) NSArray* activeRequestsStatus;
 
+/** Exposed for testing. Returns the doc ID for the checkpoint document. */
+- (NSString *)remoteCheckpointDocID;
+
 @end


### PR DESCRIPTION
Fixes bug where a replicator was not writing the last sequence
value to the remote checkpoint document because it's thread was
quiting before the request was made.

Additionally, a change was made to TDReplciator -setError to prevent 
overwriting the error when it is for a local database 
being deleted. Otherwise, the error was being overwritten by a generic
"TDHTTP" Intenal Server error (code = 500), which was causing a 
previously written test to fail (testPullErrorsWhenLocalDatabaseIsDeleted)

Finally, the TDReplicator -clearDbRef method was removed. This method 
seemed to be appropriate when all replications were executed on a main 
replication thread. Now, it could interfere with proper synchronization 
of the last sequence value betweent the local and remote checkpoint documents.
    
Additionally, the pointer to the TD_Database is now set to nil after the 
replicator's thread has exited its runloop. Setting the pointer to nil is 
still necessary since it's the mechanism to make each TDReplicator 
object only useable once.