### PR TITLE
44625 merge query into cdt datastore

### DIFF
--- a/CDTDatastore.xcworkspace/contents.xcworkspacedata
+++ b/CDTDatastore.xcworkspace/contents.xcworkspacedata
@@ -54,6 +54,85 @@
                location = "group:Classes/common/Indexing/CDTQueryBuilder.m">
             </FileRef>
          </Group>
+         <Group
+            location = "container:"
+            name = "Query">
+            <FileRef
+               location = "group:Classes/common/query/CDTDatastore+Query.h">
+            </FileRef>
+            <FileRef
+               location = "group:Classes/common/query/CDTDatastore+Query.m">
+            </FileRef>
+            <FileRef
+               location = "group:Classes/common/query/CDTQIndexCreator.h">
+            </FileRef>
+            <FileRef
+               location = "group:Classes/common/query/CDTQIndexCreator.m">
+            </FileRef>
+            <FileRef
+               location = "group:Classes/common/query/CDTQIndexManager.h">
+            </FileRef>
+            <FileRef
+               location = "group:Classes/common/query/CDTQIndexManager.m">
+            </FileRef>
+            <FileRef
+               location = "group:Classes/common/query/CDTQIndexUpdater.h">
+            </FileRef>
+            <FileRef
+               location = "group:Classes/common/query/CDTQIndexUpdater.m">
+            </FileRef>
+            <FileRef
+               location = "group:Classes/common/query/CDTQLogging.h">
+            </FileRef>
+            <FileRef
+               location = "group:Classes/common/query/CDTQProjectedDocumentRevision.h">
+            </FileRef>
+            <FileRef
+               location = "group:Classes/common/query/CDTQProjectedDocumentRevision.m">
+            </FileRef>
+            <FileRef
+               location = "group:Classes/common/query/CDTQQueryConstants.h">
+            </FileRef>
+            <FileRef
+               location = "group:Classes/common/query/CDTQQueryConstants.m">
+            </FileRef>
+            <FileRef
+               location = "group:Classes/common/query/CDTQQueryExecutor.h">
+            </FileRef>
+            <FileRef
+               location = "group:Classes/common/query/CDTQQueryExecutor.m">
+            </FileRef>
+            <FileRef
+               location = "group:Classes/common/query/CDTQQuerySqlTranslator.h">
+            </FileRef>
+            <FileRef
+               location = "group:Classes/common/query/CDTQQuerySqlTranslator.m">
+            </FileRef>
+            <FileRef
+               location = "group:Classes/common/query/CDTQQueryValidator.h">
+            </FileRef>
+            <FileRef
+               location = "group:Classes/common/query/CDTQQueryValidator.m">
+            </FileRef>
+            <FileRef
+               location = "group:Classes/common/query/CDTQResultSet.h">
+            </FileRef>
+            <FileRef
+               location = "group:Classes/common/query/CDTQResultSet.m">
+            </FileRef>
+            <FileRef
+               location = "group:Classes/common/query/CDTQUnindexedMatcher.h">
+            </FileRef>
+            <FileRef
+               location = "group:Classes/common/query/CDTQUnindexedMatcher.m">
+            </FileRef>
+            <FileRef
+               location = "group:Classes/common/query/CDTQValueExtractor.h">
+            </FileRef>
+            <FileRef
+               location = "group:Classes/common/query/CDTQValueExtractor.m">
+            </FileRef>
+         </Group>
          <FileRef
             location = "group:CDTSQLiteHelpers.h">
          </FileRef>

--- a/Classes/common/CloudantSync.h
+++ b/Classes/common/CloudantSync.h
@@ -31,3 +31,6 @@
 
 #import "CDTIndexManager.h"
 #import "CDTIndexer.h"
+
+#import "CDTDatastore+Query.h"
+#import "CDTQResultSet.h"

--- a/Classes/common/query/CDTDatastore+Query.h
+++ b/Classes/common/query/CDTDatastore+Query.h
@@ -1,0 +1,105 @@
+//
+//  CDTDatastore+Query.h
+//
+//  Created by Rhys Short on 19/11/2014.
+//
+//  Copyright (c) 2014 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+#import <Foundation/Foundation.h>
+#import "CDTDatastore.h"
+#import "CDTQIndexManager.h"
+
+/**
+ This category adds query capabilities to CDTDatastore.
+ 
+ The query interface is based on Cloudant Query, which has a query
+ syntax loosely modelled on MongoDB's query selector.
+ */
+@interface CDTDatastore (Query)
+
+/**
+ Return a list of the indexes defined.
+ 
+ This is returned in a dictionary structure:
+ 
+     { "indexName": { "fields": [ "field1", "field2" ],
+                      "type": "json",
+                      "name": "indexName" },
+       ...
+     }
+ */
+- (NSDictionary * /* NSString -> NSArray[NSString]*/)listIndexes;
+
+/**
+ Create a new index over a set of fields.
+ 
+ Fields in sub-documents can be specified using dotted notation.
+ 
+ An example:
+ 
+     { "name": "mike", "address": { "street": "Any Road" } }
+ 
+ The field name "name" would index "mike", while the field name
+ "address.street" would index "Any Road".
+ 
+ Indexing an array will add each value in the array to the index.
+ There may only be one array field per index.
+ 
+ @return The name of the index if it's created successfully.
+ */
+- (NSString *)ensureIndexed:(NSArray * /* NSString */)fieldNames
+                   withName:(NSString *)indexName;
+
+/**
+ Delete an index.
+ */
+- (BOOL)deleteIndexNamed:(NSString *)indexName;
+
+/**
+ Bring indexes up to date with the contents of the datastore.
+ 
+ This happens automatically before queries happen, but if you
+ know there are a lot of updates to process, explicitly calling
+ -updateAllIndexes will save time during the next query. It's
+ useful to call when a replication completes, for example.
+ */
+- (BOOL)updateAllIndexes;
+
+/**
+ Find documents matching a query.
+ 
+ See -find:skip:limit:fields:sort: for more details.
+ 
+ Failures during query (e.g., invalid query) are logged rather than
+ error being returned.
+ 
+ @return Set of documents, or `nil` if there was an error.
+ */
+- (CDTQResultSet *)find:(NSDictionary *)query;
+
+/**
+ Find document matching a query.
+ 
+ See https://github.com/cloudant/CloudantQueryObjc for details of the
+ query syntax and option meanings.
+ 
+ Failures during query (e.g., invalid query) are logged rather than
+ error being returned.
+ 
+ @return Set of documents, or `nil` if there was an error.
+ */
+- (CDTQResultSet *)find:(NSDictionary *)query
+                   skip:(NSUInteger)skip
+                  limit:(NSUInteger)limit
+                 fields:(NSArray *)fields
+                   sort:(NSArray *)sortDocument;
+
+@end

--- a/Classes/common/query/CDTDatastore+Query.m
+++ b/Classes/common/query/CDTDatastore+Query.m
@@ -1,0 +1,71 @@
+//
+//  CDTDatastore+Query.m
+//
+//  Created by Rhys Short on 19/11/2014.
+//
+//  Copyright (c) 2014 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+#import "CDTDatastore+Query.h"
+#import <objc/runtime.h>
+
+@implementation CDTDatastore (Query)
+
+- (CDTQIndexManager *)CDTQManager
+{
+    if (objc_getAssociatedObject(self, @selector(CDTQManager)) == nil) {
+        @synchronized(self)
+        {
+            if (objc_getAssociatedObject(self, @selector(CDTQManager)) == nil) {
+                CDTQIndexManager *m = [CDTQIndexManager managerUsingDatastore:self error:nil];
+                objc_setAssociatedObject(self, @selector(CDTQManager), m,
+                                         OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+            }
+        }
+    }
+
+    return objc_getAssociatedObject(self, @selector(CDTQManager));
+}
+
+- (NSDictionary *)listIndexes
+{
+    return [self.CDTQManager listIndexes];
+}
+
+- (NSString *)ensureIndexed:(NSArray *)fieldNames withName:(NSString *)indexName
+{
+    return [self.CDTQManager ensureIndexed:fieldNames withName:indexName];
+}
+
+- (CDTQResultSet *)find:(NSDictionary *)query
+{
+    return [self.CDTQManager find:query];
+}
+
+- (CDTQResultSet *)find:(NSDictionary *)query
+                   skip:(NSUInteger)skip
+                  limit:(NSUInteger)limit
+                 fields:(NSArray *)fields
+                   sort:(NSArray *)sortDocument
+{
+    return [self.CDTQManager find:query skip:skip limit:limit fields:fields sort:sortDocument];
+}
+
+- (BOOL)deleteIndexNamed:(NSString *)indexName
+{
+    return [self.CDTQManager deleteIndexNamed:indexName];
+}
+
+- (BOOL)updateAllIndexes
+{
+    return [self.CDTQManager updateAllIndexes];
+}
+
+@end

--- a/Classes/common/query/CDTQIndexCreator.h
+++ b/Classes/common/query/CDTQIndexCreator.h
@@ -1,0 +1,51 @@
+//
+//  CDTQIndexCreator.h
+//
+//  Created by Michael Rhodes on 29/09/2014.
+//  Copyright (c) 2014 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+@class FMDatabaseQueue;
+@class CDTDatastore;
+@class CDTQSqlParts;
+
+@interface CDTQIndexCreator : NSObject
+
+/**
+ Add a single, possibly compound, index for the given field names.
+
+ @param fieldNames List of fieldnames in the sort format
+ @param indexName Name of index to create.
+ @returns name of created index
+ */
++ (NSString *)ensureIndexed:(NSArray * /* NSString */)fieldNames
+                   withName:(NSString *)indexName
+                       type:(NSString *)type
+                 inDatabase:(FMDatabaseQueue *)database
+              fromDatastore:(CDTDatastore *)datastore;
+
++ (NSArray /*NSDictionary or NSString*/ *)removeDirectionsFromFields:(NSArray *)fieldNames;
+
++ (BOOL)validFieldName:(NSString *)fieldName;
+
++ (NSArray /*CDTQSqlParts*/ *)insertMetadataStatementsForIndexName:(NSString *)indexName
+                                                              type:(NSString *)indexType
+                                                        fieldNames:
+                                                            (NSArray /*NSString*/ *)fieldNames;
+
++ (CDTQSqlParts *)createIndexTableStatementForIndexName:(NSString *)indexName
+                                             fieldNames:(NSArray /*NSString*/ *)fieldNames;
+
++ (CDTQSqlParts *)createIndexIndexStatementForIndexName:(NSString *)indexName
+                                             fieldNames:(NSArray /*NSString*/ *)fieldNames;
+
+@end

--- a/Classes/common/query/CDTQIndexCreator.m
+++ b/Classes/common/query/CDTQIndexCreator.m
@@ -1,0 +1,287 @@
+//
+//  CDTQIndexCreator.m
+//
+//  Created by Michael Rhodes on 29/09/2014.
+//  Copyright (c) 2014 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+#import "CDTQIndexCreator.h"
+
+#import "CDTQIndexManager.h"
+#import "CDTQIndexUpdater.h"
+#import "CDTQLogging.h"
+
+#import "CloudantSync.h"
+#import "FMDB.h"
+
+@interface CDTQIndexCreator ()
+
+@property (nonatomic, strong) FMDatabaseQueue *database;
+@property (nonatomic, strong) CDTDatastore *datastore;
+
+@end
+
+@implementation CDTQIndexCreator
+
+- (instancetype)initWithDatabase:(FMDatabaseQueue *)database datastore:(CDTDatastore *)datastore
+{
+    self = [super init];
+    if (self) {
+        _database = database;
+        _datastore = datastore;
+    }
+    return self;
+}
+
+#pragma mark Convenience methods
+
++ (NSString *)ensureIndexed:(NSArray * /* NSString */)fieldNames
+                   withName:(NSString *)indexName
+                       type:(NSString *)indexType
+                 inDatabase:(FMDatabaseQueue *)database
+              fromDatastore:(CDTDatastore *)datastore
+{
+    CDTQIndexCreator *executor =
+        [[CDTQIndexCreator alloc] initWithDatabase:database datastore:datastore];
+    return [executor ensureIndexed:fieldNames withName:indexName type:indexType];
+}
+
+#pragma mark Instance methods
+
+/**
+ Add a single, possibly compound, index for the given field names.
+
+ @param fieldNames List of fieldnames in the sort format
+ @param indexName Name of index to create.
+ @returns name of created index
+ */
+- (NSString *)ensureIndexed:(NSArray * /* NSString */)fieldNames
+                   withName:(NSString *)indexName
+                       type:(NSString *)indexType
+{
+    if (!fieldNames || fieldNames.count == 0) {
+        LogError(@"No fieldnames were passed to ensureIndexed");
+        return nil;
+    }
+
+    if (!indexName) {
+        LogError(@"No index name was passed to ensureIndexed");
+        return nil;
+    }
+
+    fieldNames = [CDTQIndexCreator removeDirectionsFromFields:fieldNames];
+
+    for (NSString *fieldName in fieldNames) {
+        if (![CDTQIndexCreator validFieldName:fieldName]) {
+            return nil;
+        }
+    }
+
+    // Check there are no duplicate field names in the array
+    NSSet *uniqueNames = [NSSet setWithArray:fieldNames];
+    if (uniqueNames.count != fieldNames.count) {
+        LogError(@"Cannot create index with duplicated field names %@", fieldNames);
+        return nil;
+    }
+
+    // Prepend _id and _rev if it's not in the array
+    if (![fieldNames containsObject:@"_rev"]) {
+        NSMutableArray *tmp = [NSMutableArray arrayWithObject:@"_rev"];
+        [tmp addObjectsFromArray:fieldNames];
+        fieldNames = [NSArray arrayWithArray:tmp];
+    }
+
+    if (![fieldNames containsObject:@"_id"]) {
+        NSMutableArray *tmp = [NSMutableArray arrayWithObject:@"_id"];
+        [tmp addObjectsFromArray:fieldNames];
+        fieldNames = [NSArray arrayWithArray:tmp];
+    }
+
+    // Does the index already exist; return success if it does and is same, else fail
+    NSDictionary *existingIndexes = [CDTQIndexManager listIndexesInDatabaseQueue:self.database];
+    if (existingIndexes[indexName] != nil) {
+        NSDictionary *index = existingIndexes[indexName];
+        NSString *existingType = index[@"type"];
+        NSSet *existingFields = [NSSet setWithArray:index[@"fields"]];
+        NSSet *newFields = [NSSet setWithArray:fieldNames];
+
+        if ([existingType isEqualToString:indexType] && [existingFields isEqualToSet:newFields]) {
+            BOOL success = [CDTQIndexUpdater updateIndex:indexName
+                                              withFields:fieldNames
+                                              inDatabase:_database
+                                           fromDatastore:_datastore
+                                                   error:nil];
+            return success ? indexName : nil;
+        } else {
+            return nil;
+        }
+    }
+
+    __block BOOL success = YES;
+
+    [_database inTransaction:^(FMDatabase *db, BOOL *rollback) {
+
+        // Insert metadata table entries
+        NSArray *inserts = [CDTQIndexCreator insertMetadataStatementsForIndexName:indexName
+                                                                             type:indexType
+                                                                       fieldNames:fieldNames];
+        for (CDTQSqlParts *sql in inserts) {
+            success = success && [db executeUpdate:sql.sqlWithPlaceholders
+                                     withArgumentsInArray:sql.placeholderValues];
+        }
+
+        // Create the table for the index
+        CDTQSqlParts *createTable =
+            [CDTQIndexCreator createIndexTableStatementForIndexName:indexName
+                                                         fieldNames:fieldNames];
+        success = success && [db executeUpdate:createTable.sqlWithPlaceholders
+                                 withArgumentsInArray:createTable.placeholderValues];
+
+        // Create the SQLite index on the index table
+
+        CDTQSqlParts *createIndex =
+            [CDTQIndexCreator createIndexIndexStatementForIndexName:indexName
+                                                         fieldNames:fieldNames];
+        success = success && [db executeUpdate:createIndex.sqlWithPlaceholders
+                                 withArgumentsInArray:createIndex.placeholderValues];
+
+        if (!success) {
+            *rollback = YES;
+        }
+    }];
+
+    // Update the new index if it's been created
+    if (success) {
+        success = success && [CDTQIndexUpdater updateIndex:indexName
+                                                withFields:fieldNames
+                                                inDatabase:_database
+                                             fromDatastore:_datastore
+                                                     error:nil];
+    }
+
+    return success ? indexName : nil;
+}
+
+/**
+ Validate the field name string is usable.
+
+ The only restriction so far is that the parts don't start with
+ a $ sign, as this makes the query language ambiguous.
+ */
++ (BOOL)validFieldName:(NSString *)fieldName
+{
+    NSArray *parts = [fieldName componentsSeparatedByString:@"."];
+    for (NSString *part in parts) {
+        if ([part hasPrefix:@"$"]) {
+            LogError(@"Field names cannot start with a $ in field %@", fieldName);
+            return NO;
+        }
+    }
+    return YES;
+}
+
+/**
+ We don't support directions on field names, but they are an optimisation so
+ we can discard them safely.
+ */
++ (NSArray /*NSDictionary or NSString*/ *)removeDirectionsFromFields:(NSArray *)fieldNames
+{
+    NSMutableArray *result = [NSMutableArray array];
+
+    for (NSObject *field in fieldNames) {
+        if ([field isKindOfClass:[NSDictionary class]]) {
+            NSDictionary *specifier = (NSDictionary *)field;
+            if (specifier.count == 1) {
+                NSString *fieldName = [specifier allKeys][0];
+                [result addObject:fieldName];
+            }
+        } else if ([field isKindOfClass:[NSString class]]) {
+            [result addObject:field];
+        }
+    }
+
+    return result;
+}
+
++ (NSArray /*CDTQSqlParts*/ *)insertMetadataStatementsForIndexName:(NSString *)indexName
+                                                              type:(NSString *)indexType
+                                                        fieldNames:
+                                                            (NSArray /*NSString*/ *)fieldNames
+{
+    if (!indexName) {
+        return nil;
+    }
+
+    if (!fieldNames || fieldNames.count == 0) {
+        return nil;
+    }
+
+    NSMutableArray *result = [NSMutableArray array];
+    for (NSString *fieldName in fieldNames) {
+        NSString *sql = @"INSERT INTO %@ "
+                         "(index_name, index_type, field_name, last_sequence) "
+                         "VALUES (?, ?, ?, 0);";
+        sql = [NSString stringWithFormat:sql, kCDTQIndexMetadataTableName];
+
+        CDTQSqlParts *parts =
+            [CDTQSqlParts partsForSql:sql parameters:@[ indexName, indexType, fieldName ]];
+        [result addObject:parts];
+    }
+    return result;
+}
+
++ (CDTQSqlParts *)createIndexTableStatementForIndexName:(NSString *)indexName
+                                             fieldNames:(NSArray /*NSString*/ *)fieldNames
+{
+    if (!indexName) {
+        return nil;
+    }
+
+    if (!fieldNames || fieldNames.count == 0) {
+        return nil;
+    }
+
+    NSString *tableName = [CDTQIndexManager tableNameForIndex:indexName];
+    NSMutableArray *clauses = [NSMutableArray array];
+    for (NSString *fieldName in fieldNames) {
+        NSString *clause = [NSString stringWithFormat:@"\"%@\" NONE", fieldName];
+        [clauses addObject:clause];
+    }
+
+    NSString *sql = [NSString stringWithFormat:@"CREATE TABLE %@ ( %@ );", tableName,
+                                               [clauses componentsJoinedByString:@", "]];
+    return [CDTQSqlParts partsForSql:sql parameters:@[]];
+}
+
++ (CDTQSqlParts *)createIndexIndexStatementForIndexName:(NSString *)indexName
+                                             fieldNames:(NSArray /*NSString*/ *)fieldNames
+{
+    if (!indexName) {
+        return nil;
+    }
+
+    if (!fieldNames || fieldNames.count == 0) {
+        return nil;
+    }
+
+    NSString *tableName = [CDTQIndexManager tableNameForIndex:indexName];
+    NSString *sqlIndexName = [tableName stringByAppendingString:@"_index"];
+
+    NSMutableArray *clauses = [NSMutableArray array];
+    for (NSString *fieldName in fieldNames) {
+        [clauses addObject:[NSString stringWithFormat:@"\"%@\"", fieldName]];
+    }
+
+    NSString *sql = [NSString stringWithFormat:@"CREATE INDEX %@ ON %@ ( %@ );", sqlIndexName,
+                                               tableName, [clauses componentsJoinedByString:@", "]];
+    return [CDTQSqlParts partsForSql:sql parameters:@[]];
+}
+
+@end

--- a/Classes/common/query/CDTQIndexManager.h
+++ b/Classes/common/query/CDTQIndexManager.h
@@ -1,0 +1,108 @@
+//
+//  CDTQIndexManager.h
+//
+//  Created by Mike Rhodes on 2014-09-27
+//  Copyright (c) 2014 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+extern NSString *const CDTQIndexManagerErrorDomain;
+extern NSString *const kCDTQIndexTablePrefix;
+extern NSString *const kCDTQIndexMetadataTableName;
+
+@class CDTDatastore;
+@class CDTQResultSet;
+@class CDTDocumentRevision;
+@class FMDatabaseQueue;
+@class FMDatabase;
+
+@interface CDTQSqlParts : NSObject
+
+@property (nonatomic, strong) NSString *sqlWithPlaceholders;
+@property (nonatomic, strong) NSArray *placeholderValues;
+
++ (CDTQSqlParts *)partsForSql:(NSString *)sql parameters:(NSArray *)parameters;
+
+@end
+
+/**
+ * Indexing and query erors.
+ */
+typedef NS_ENUM(NSInteger, CDTQQueryError) {
+    /**
+     * Index name not valid. Names can only contain letters,
+     * digits and underscores. They must not start with a digit.
+     */
+    CDTQIndexErrorInvalidIndexName = 1,
+    /**
+     * An SQL error occurred during indexing or querying.
+     */
+    CDTQIndexErrorSqlError = 2,
+    /**
+     * No index with this name was found.
+     */
+    CDTQIndexErrorIndexDoesNotExist = 3
+};
+
+/**
+ Main interface to Cloudant query.
+
+ Use the manager to:
+
+ - create indexes
+ - delete indexes
+ - execute queries
+ - update indexes (usually done automatically)
+ */
+@interface CDTQIndexManager : NSObject
+
+@property (nonatomic, strong) CDTDatastore *datastore;
+@property (nonatomic, strong) FMDatabaseQueue *database;
+
+/**
+ Constructs a new CDTQIndexManager which indexes documents in `datastore`
+ */
++ (CDTQIndexManager *)managerUsingDatastore:(CDTDatastore *)datastore
+                                      error:(NSError *__autoreleasing *)error;
+
+- (instancetype)initUsingDatastore:(CDTDatastore *)datastore
+                             error:(NSError *__autoreleasing *)error;
+
+- (NSDictionary * /* NSString -> NSArray[NSString]*/)listIndexes;
+
+/** Internal */
++ (NSDictionary /* NSString -> NSArray[NSString]*/ *)listIndexesInDatabaseQueue:
+        (FMDatabaseQueue *)db;
+/** Internal */
++ (NSDictionary /* NSString -> NSArray[NSString]*/ *)listIndexesInDatabase:(FMDatabase *)db;
+
+- (NSString *)ensureIndexed:(NSArray * /* NSString */)fieldNames withName:(NSString *)indexName;
+
+- (NSString *)ensureIndexed:(NSArray * /* NSString */)fieldNames
+                   withName:(NSString *)indexName
+                       type:(NSString *)type;
+
+- (BOOL)deleteIndexNamed:(NSString *)indexName;
+
+- (BOOL)updateAllIndexes;
+
+- (CDTQResultSet *)find:(NSDictionary *)query;
+
+- (CDTQResultSet *)find:(NSDictionary *)query
+                   skip:(NSUInteger)skip
+                  limit:(NSUInteger)limit
+                 fields:(NSArray *)fields
+                   sort:(NSArray *)sortDocument;
+
+/** Internal */
++ (NSString *)tableNameForIndex:(NSString *)indexName;
+
+@end

--- a/Classes/common/query/CDTQIndexManager.m
+++ b/Classes/common/query/CDTQIndexManager.m
@@ -1,0 +1,390 @@
+//
+//  CDTQIndexManager.m
+//
+//  Created by Mike Rhodes on 2014-09-27
+//  Copyright (c) 2014 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+//
+// The metadata for an index is represented in the database table as follows:
+//
+//   index_name  |  index_type  |  field_name  |  last_sequence
+//   -----------------------------------------------------------
+//     name      |  json        |   _id        |     0
+//     name      |  json        |   _rev       |     0
+//     name      |  json        |   firstName  |     0
+//     name      |  json        |   lastName   |     0
+//     age       |  json        |   age        |     0
+//
+// The index itself is a single table, with a colum for docId and each of the indexed fields:
+//
+//      _id      |   _rev      |  firstName   |  lastName
+//   --------------------------------------------------------
+//     miker     |  1-blah     |  Mike        |  Rhodes
+//     johna     |  3-blob     |  John        |  Appleseed
+//     joeb      |  2-blip     |  Joe         |  Bloggs
+//
+// There is a single SQLite index created on all columns of this table.
+//
+// N.b.: _id and _rev are automatically added to all indexes to allow them to be used to
+// project CDTDocumentRevisions without the need to load a document from the datastore.
+//
+
+#import "CDTQIndexManager.h"
+
+#import "CDTQResultSet.h"
+#import "CDTQIndexUpdater.h"
+#import "CDTQQueryExecutor.h"
+#import "CDTQIndexCreator.h"
+#import "CDTQLogging.h"
+
+#import "TD_Database.h"
+#import "TD_Body.h"
+
+#import <CloudantSync.h>
+#import <FMDB.h>
+
+NSString *const CDTQIndexManagerErrorDomain = @"CDTIndexManagerErrorDomain";
+
+NSString *const kCDTQIndexTablePrefix = @"_t_cloudant_sync_query_index_";
+NSString *const kCDTQIndexMetadataTableName = @"_t_cloudant_sync_query_metadata";
+
+static NSString *const kCDTQExtensionName = @"com.cloudant.sync.query";
+static NSString *const kCDTQIndexFieldNamePattern = @"^[a-zA-Z][a-zA-Z0-9_]*$";
+
+static const int VERSION = 1;
+
+@interface CDTQIndexManager ()
+
+@property (nonatomic, strong) NSRegularExpression *validFieldName;
+
+@end
+
+@implementation CDTQSqlParts
+
++ (CDTQSqlParts *)partsForSql:(NSString *)sql parameters:(NSArray *)parameters
+{
+    CDTQSqlParts *parts = [[CDTQSqlParts alloc] init];
+    parts.sqlWithPlaceholders = sql;
+    parts.placeholderValues = parameters;
+    return parts;
+}
+
+- (NSString *)description
+{
+    return [NSString
+        stringWithFormat:@"sql: %@ vals: %@", self.sqlWithPlaceholders, self.placeholderValues];
+}
+
+@end
+
+@implementation CDTQIndexManager
+
++ (CDTQIndexManager *)managerUsingDatastore:(CDTDatastore *)datastore
+                                      error:(NSError *__autoreleasing *)error
+{
+    return [[CDTQIndexManager alloc] initUsingDatastore:datastore error:error];
+}
+
+- (instancetype)initUsingDatastore:(CDTDatastore *)datastore error:(NSError *__autoreleasing *)error
+{
+    self = [super init];
+    if (self) {
+        _datastore = datastore;
+        _validFieldName = [[NSRegularExpression alloc] initWithPattern:kCDTQIndexFieldNamePattern
+                                                               options:0
+                                                                 error:error];
+
+        NSString *dir = [datastore extensionDataFolder:kCDTQExtensionName];
+        [[NSFileManager defaultManager] createDirectoryAtPath:dir
+                                  withIntermediateDirectories:TRUE
+                                                   attributes:nil
+                                                        error:nil];
+        NSString *filename = [NSString pathWithComponents:@[ dir, @"indexes.sqlite" ]];
+        _database = [[FMDatabaseQueue alloc] initWithPath:filename];
+        if (!_database) {
+            if (error) {
+                NSDictionary *userInfo = @{
+                    NSLocalizedDescriptionKey :
+                        NSLocalizedString(@"Problem opening or creating database.", nil)
+                };
+                *error = [NSError errorWithDomain:CDTQIndexManagerErrorDomain
+                                             code:CDTQIndexErrorSqlError
+                                         userInfo:userInfo];
+            }
+            return nil;
+        }
+
+        if (![self updateSchema:VERSION]) {
+            if (error) {
+                NSDictionary *userInfo = @{
+                    NSLocalizedDescriptionKey :
+                        NSLocalizedString(@"Problem updating database schema.", nil)
+                };
+                *error = [NSError errorWithDomain:CDTQIndexManagerErrorDomain
+                                             code:CDTQIndexErrorSqlError
+                                         userInfo:userInfo];
+            }
+            return nil;
+        }
+    }
+    return self;
+}
+
+#pragma mark List indexes
+
+/**
+ Returns:
+
+ { indexName: { type: json,
+                name: indexName,
+                fields: [field1, field2]
+ }
+ */
+- (NSDictionary * /* NSString -> NSArray[NSString]*/)listIndexes
+{
+    return [CDTQIndexManager listIndexesInDatabaseQueue:_database];
+}
+
++ (NSDictionary /* NSString -> NSArray[NSString]*/ *)listIndexesInDatabaseQueue:
+                                                         (FMDatabaseQueue *)db
+{
+    // Accumulate indexes and definitions into a dictionary
+
+    __block NSDictionary *indexes;
+
+    [db inDatabase:^(FMDatabase *db) { indexes = [self listIndexesInDatabase:db]; }];
+
+    return indexes;
+}
+
++ (NSDictionary /* NSString -> NSArray[NSString]*/ *)listIndexesInDatabase:(FMDatabase *)db
+{
+    // Accumulate indexes and definitions into a dictionary
+
+    NSMutableDictionary *indexes = [NSMutableDictionary dictionary];
+
+    NSString *sql = @"SELECT index_name, index_type, field_name FROM %@;";
+    sql = [NSString stringWithFormat:sql, kCDTQIndexMetadataTableName];
+    FMResultSet *rs = [db executeQuery:sql];
+    while ([rs next]) {
+        NSString *rowIndex = [rs stringForColumn:@"index_name"];
+        NSString *rowType = [rs stringForColumn:@"index_type"];
+        NSString *rowField = [rs stringForColumn:@"field_name"];
+
+        if (indexes[rowIndex] == nil) {
+            indexes[rowIndex] = @{
+                @"type" : rowType,
+                @"name" : rowIndex,
+                @"fields" : [NSMutableArray array]
+            };
+        }
+
+        [indexes[rowIndex][@"fields"] addObject:rowField];
+    }
+    [rs close];
+
+    // Now we need to make the return value immutable
+
+    for (NSString *indexName in [indexes allKeys]) {
+        NSMutableDictionary *details = indexes[indexName];
+        indexes[indexName] = @{
+            @"type" : details[@"type"],
+            @"name" : details[@"name"],
+            @"fields" : [details[@"fields"] copy]  // -copy makes arrays immutable
+        };
+    }
+
+    return [NSDictionary dictionaryWithDictionary:indexes];  // make dictionary immutable
+}
+
+#pragma mark Create Indexes
+
+/**
+ Add a single, possibly compound, index for the given field names.
+
+ This function generates a name for the new index.
+
+ @param fieldNames List of fieldnames in the sort format
+ @returns name of created index
+ */
+- (NSString *)ensureIndexed:(NSArray * /* NSString */)fieldNames
+{
+    LogError(@"-ensureIndexed: not implemented");
+    return nil;
+}
+
+/**
+ Add a single, possibly compound, index for the given field names.
+
+ @param fieldNames List of fieldnames in the sort format
+ @param indexName Name of index to create.
+ @returns name of created index
+ */
+- (NSString *)ensureIndexed:(NSArray * /* NSString */)fieldNames withName:(NSString *)indexName
+{
+    return [self ensureIndexed:fieldNames withName:indexName type:@"json"];
+}
+
+/**
+ Add a single, possibly compound, index for the given field names.
+
+ @param fieldNames List of fieldnames in the sort format
+ @param indexName Name of index to create.
+ @param type "json" is the only supported type for now
+ @returns name of created index
+ */
+- (NSString *)ensureIndexed:(NSArray * /* NSString */)fieldNames
+                   withName:(NSString *)indexName
+                       type:(NSString *)type
+{
+    if (fieldNames.count == 0) {
+        return nil;
+    }
+
+    if (!indexName) {
+        return nil;
+    }
+
+    if (![type isEqualToString:@"json"]) {
+        return nil;
+    }
+
+    return [CDTQIndexCreator ensureIndexed:fieldNames
+                                  withName:indexName
+                                      type:type
+                                inDatabase:_database
+                             fromDatastore:_datastore];
+}
+
+#pragma mark Delete Indexes
+
+- (BOOL)deleteIndexNamed:(NSString *)indexName
+{
+    __block BOOL success = YES;
+
+    [_database inTransaction:^(FMDatabase *db, BOOL *rollback) {
+
+        NSString *tableName = [CDTQIndexManager tableNameForIndex:indexName];
+        NSString *sql;
+
+        // Drop the index table
+        sql = [NSString stringWithFormat:@"DROP TABLE \"%@\";", tableName];
+        success = success && [db executeUpdate:sql withArgumentsInArray:@[]];
+
+        // Delete the metadata entries
+        sql = [NSString
+            stringWithFormat:@"DELETE FROM %@ WHERE index_name = ?", kCDTQIndexMetadataTableName];
+        success = success && [db executeUpdate:sql withArgumentsInArray:@[ indexName ]];
+
+        if (!success) {
+            LogError(@"Failed to delete index: %@", indexName);
+            *rollback = YES;
+        }
+    }];
+
+    return success;
+}
+
+#pragma mark Update indexes
+
+- (BOOL)updateAllIndexes
+{
+    // TODO
+
+    // To start with, assume top-level fields only
+
+    NSDictionary *indexes = [self listIndexes];
+    return
+        [CDTQIndexUpdater updateAllIndexes:indexes inDatabase:_database fromDatastore:_datastore];
+}
+
+#pragma mark Query indexes
+
+- (CDTQResultSet *)find:(NSDictionary *)query
+{
+    return [self find:query skip:0 limit:0 fields:nil sort:nil];
+}
+
+- (CDTQResultSet *)find:(NSDictionary *)query
+                   skip:(NSUInteger)skip
+                  limit:(NSUInteger)limit
+                 fields:(NSArray *)fields
+                   sort:(NSArray *)sortDocument
+{
+    if (!query) {
+        LogError(@"-find called with nil selector; bailing.");
+        return nil;
+    }
+
+    if (![self updateAllIndexes]) {
+        return nil;
+    }
+
+    CDTQQueryExecutor *queryExecutor =
+        [[CDTQQueryExecutor alloc] initWithDatabase:_database datastore:_datastore];
+    return [queryExecutor find:query
+                  usingIndexes:[self listIndexes]
+                          skip:skip
+                         limit:limit
+                        fields:fields
+                          sort:sortDocument];
+}
+
+#pragma mark Utilities
+
++ (NSString *)tableNameForIndex:(NSString *)indexName
+{
+    return [kCDTQIndexTablePrefix stringByAppendingString:indexName];
+}
+
+#pragma mark Setup methods
+
+- (BOOL)updateSchema:(int)currentVersion
+{
+    __block BOOL success = YES;
+
+    // get current version
+    [_database inTransaction:^(FMDatabase *db, BOOL *rollback) {
+        int version = 0;
+
+        FMResultSet *rs = [db executeQuery:@"pragma user_version;"];
+        while ([rs next]) {
+            version = [rs intForColumnIndex:0];
+            break;  // should only be a single result, so may as well break
+        }
+        [rs close];
+
+        if (version < 1) {
+            success = [self migrate_0_1:db];
+        }
+
+        // Set user_version unconditionally
+        NSString *sql = [NSString stringWithFormat:@"pragma user_version = %d", currentVersion];
+        success = success && [db executeUpdate:sql];
+
+        if (!success) {
+            LogError(@"Failed to update schema");
+            *rollback = YES;
+        }
+    }];
+
+    return success;
+}
+
+- (BOOL)migrate_0_1:(FMDatabase *)db
+{
+    NSString *SCHEMA_INDEX = @"CREATE TABLE _t_cloudant_sync_query_metadata ( "
+        @"        index_name TEXT NOT NULL, " @"        index_type TEXT NOT NULL, "
+        @"        field_name TEXT NOT NULL, " @"        last_sequence INTEGER NOT NULL);";
+    return [db executeUpdate:SCHEMA_INDEX];
+}
+
+@end

--- a/Classes/common/query/CDTQIndexUpdater.h
+++ b/Classes/common/query/CDTQIndexUpdater.h
@@ -1,0 +1,93 @@
+//
+//  CDTQIndexUpdater.h
+//
+//  Created by Mike Rhodes on 2014-09-29
+//  Copyright (c) 2014 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+#import "TD_Database.h"
+
+@class CDTDocumentRevision;
+@class CDTDatastore;
+
+@class CDTQSqlParts;
+@class FMDatabaseQueue;
+
+/**
+ Handles updating indexes for a given datastore.
+ */
+@interface CDTQIndexUpdater : NSObject
+
+/**
+ Update all the indexes in a set.
+
+ The indexes are assumed to already exist.
+ */
++ (BOOL)updateAllIndexes:(NSDictionary /*NSString -> NSArray[NSString]*/ *)indexes
+              inDatabase:(FMDatabaseQueue *)database
+           fromDatastore:(CDTDatastore *)datastore;
+
+/**
+ Update a single index.
+
+ The index is assumed to already exist.
+ */
++ (BOOL)updateIndex:(NSString *)indexName
+         withFields:(NSArray /* NSString */ *)fieldNames
+         inDatabase:(FMDatabaseQueue *)database
+      fromDatastore:(CDTDatastore *)datastore
+              error:(NSError *__autoreleasing *)error;
+
+/**
+ Constructs a new CDTQQueryExecutor using the indexes in `database` to index documents from
+ `datastore`.
+ */
+- (instancetype)initWithDatabase:(FMDatabaseQueue *)database datastore:(CDTDatastore *)datastore;
+
+/**
+ Update all the indexes in a set.
+
+ The indexes are assumed to already exist.
+ */
+- (BOOL)updateAllIndexes:(NSDictionary /*NSString -> NSArray[NSString]*/ *)indexes;
+
+/**
+ Update a single index.
+
+ The index is assumed to already exist.
+ */
+- (BOOL)updateIndex:(NSString *)indexName
+         withFields:(NSArray /* NSString */ *)fieldNames
+              error:(NSError *__autoreleasing *)error;
+
+/**
+ Generate the DELETE statement to remove a documents entries from an index.
+ */
++ (CDTQSqlParts *)partsToDeleteIndexEntriesForDocId:(NSString *)docId
+                                          fromIndex:(NSString *)indexName;
+
+/**
+ Generate the INSERT statement to add a document to an index.
+ */
++ (NSArray /*CDTQSqlParts*/ *)partsToIndexRevision:(CDTDocumentRevision *)rev
+                                           inIndex:(NSString *)indexName
+                                    withFieldNames:(NSArray *)fieldNames;
+
+/**
+ Return the sequence number for the given index
+
+ This is the sequence number from this index's datastore that the
+ index is up to date with.
+ */
+- (SequenceNumber)sequenceNumberForIndex:(NSString *)indexName;
+
+@end

--- a/Classes/common/query/CDTQIndexUpdater.m
+++ b/Classes/common/query/CDTQIndexUpdater.m
@@ -1,0 +1,401 @@
+//
+//  CDTQIndexUpdater.m
+//
+//  Created by Mike Rhodes on 2014-09-29
+//  Copyright (c) 2014 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+#import "CDTQIndexUpdater.h"
+
+#import "CDTQIndexManager.h"
+#import "CDTQResultSet.h"
+#import "CDTQValueExtractor.h"
+
+#import "CloudantSync.h"
+
+#import "FMDB.h"
+
+#import "TD_Database.h"
+#import "TD_Body.h"
+
+#import "CDTQLogging.h"
+
+@interface CDTQIndexUpdater ()
+
+@property (nonatomic, strong) FMDatabaseQueue *database;
+@property (nonatomic, strong) CDTDatastore *datastore;
+
+@end
+
+@implementation CDTQIndexUpdater
+
+- (instancetype)initWithDatabase:(FMDatabaseQueue *)database datastore:(CDTDatastore *)datastore
+{
+    self = [super init];
+    if (self) {
+        _database = database;
+        _datastore = datastore;
+    }
+    return self;
+}
+
+#pragma mark Convenience methods
+
+/**
+ Update all the indexes in a set.
+
+ The indexes are assumed to already exist.
+ */
++ (BOOL)updateAllIndexes:(NSDictionary /*NSString -> NSArray[NSString]*/ *)indexes
+              inDatabase:(FMDatabaseQueue *)database
+           fromDatastore:(CDTDatastore *)datastore
+{
+    CDTQIndexUpdater *updater =
+        [[CDTQIndexUpdater alloc] initWithDatabase:database datastore:datastore];
+    BOOL success = [updater updateAllIndexes:indexes];
+    return success;
+}
+
+/**
+ Update a single index.
+
+ The index is assumed to already exist.
+ */
++ (BOOL)updateIndex:(NSString *)indexName
+         withFields:(NSArray /* NSString */ *)fieldNames
+         inDatabase:(FMDatabaseQueue *)database
+      fromDatastore:(CDTDatastore *)datastore
+              error:(NSError *__autoreleasing *)error
+{
+    CDTQIndexUpdater *updater =
+        [[CDTQIndexUpdater alloc] initWithDatabase:database datastore:datastore];
+    BOOL success = [updater updateIndex:indexName withFields:fieldNames error:error];
+    return success;
+}
+
+#pragma mark Instance methods
+
+- (BOOL)updateAllIndexes:(NSDictionary /*NSString -> NSArray[NSString]*/ *)indexes
+{
+    BOOL success = YES;
+
+    for (NSString *indexName in [indexes allKeys]) {
+        NSArray *fields = indexes[indexName][@"fields"];
+        success = [self updateIndex:indexName withFields:fields error:nil];
+    }
+
+    return success;
+}
+
+- (BOOL)updateIndex:(NSString *)indexName
+         withFields:(NSArray /* NSString */ *)fieldNames
+              error:(NSError *__autoreleasing *)error
+{
+    BOOL success = YES;
+    TDChangesOptions options = {.limit = 10000,
+                                .contentOptions = 0,
+                                .includeDocs = YES,
+                                .includeConflicts = NO,
+                                .sortBySequence = YES};
+
+    TD_RevisionList *changes;
+    SequenceNumber lastSequence = [self sequenceNumberForIndex:indexName];
+
+    do {
+        @autoreleasepool {
+            changes = [self.datastore.database changesSinceSequence:lastSequence
+                                                            options:&options
+                                                             filter:nil
+                                                             params:nil];
+            success = success && [self updateIndex:indexName
+                                        withFields:fieldNames
+                                           changes:changes
+                                      lastSequence:&lastSequence];
+        }
+    } while (success && [changes count] > 0);
+
+    // raise error
+    if (!success) {
+        if (error) {
+            NSDictionary *userInfo = @{
+                NSLocalizedDescriptionKey : NSLocalizedString(@"Problem updating index.", nil)
+            };
+            *error = [NSError errorWithDomain:CDTQIndexManagerErrorDomain
+                                         code:CDTIndexErrorSqlError
+                                     userInfo:userInfo];
+            LogError(@"Problem updating index %@", indexName);
+        }
+    }
+
+    return success;
+}
+
+- (BOOL)updateIndex:(NSString *)indexName
+         withFields:(NSArray /* NSString */ *)fieldNames
+            changes:(TD_RevisionList *)changes
+       lastSequence:(SequenceNumber *)lastSequence
+{
+    __block bool success = YES;
+
+    [_database inTransaction:^(FMDatabase *db, BOOL *rollback) {
+
+        for (TD_Revision *rev in changes) {
+            
+            @autoreleasepool {
+            
+                // Delete existing values
+                CDTQSqlParts *parts =
+                [CDTQIndexUpdater partsToDeleteIndexEntriesForDocId:rev.docID fromIndex:indexName];
+                [db executeUpdate:parts.sqlWithPlaceholders
+             withArgumentsInArray:parts.placeholderValues];
+                
+                // Insert new values if the rev isn't deleted
+                if (!rev.deleted) {
+                    // Ignoring the attachments seems reasonable right now as we don't index them.
+                    CDTDocumentRevision *cdtRev =
+                    [[CDTDocumentRevision alloc] initWithDocId:rev.docID
+                                                    revisionId:rev.revID
+                                                          body:rev.body.properties
+                                                       deleted:rev.deleted
+                                                   attachments:@{}
+                                                      sequence:rev.sequence];
+                    
+                    // If we are indexing a document where one field is an array, we
+                    // have multiple rows to insert into the index.
+                    NSArray *insertStatements = [CDTQIndexUpdater partsToIndexRevision:cdtRev
+                                                                               inIndex:indexName
+                                                                        withFieldNames:fieldNames];
+                    
+                    for (CDTQSqlParts *insert in insertStatements) {
+                        // partsToIndexRevision:... returns nil if there are no applicable fields to
+                        // index
+                        if (insert) {
+                            success = success && [db executeUpdate:insert.sqlWithPlaceholders
+                                              withArgumentsInArray:insert.placeholderValues];
+                        }
+                        
+                        if (!success) {
+                            LogError(@"Updating index %@ failed, CDTSqlParts: %@", indexName, insert);
+                        }
+                    }
+                }
+                if (!success) {
+                    // TODO fill in error
+                    *rollback = YES;
+                    break;
+                }
+                *lastSequence = [rev sequence];
+                
+            }
+        }
+    }];
+
+    // if there was a problem, we rolled back, so the sequence won't be updated
+    if (success) {
+        return [self updateMetadataForIndex:indexName lastSequence:*lastSequence];
+    } else {
+        return NO;
+    }
+}
+
++ (CDTQSqlParts *)partsToDeleteIndexEntriesForDocId:(NSString *)docId
+                                          fromIndex:(NSString *)indexName
+{
+    if (!docId) {
+        return nil;
+    }
+
+    if (!indexName) {
+        return nil;
+    }
+
+    NSString *tableName = [CDTQIndexManager tableNameForIndex:indexName];
+
+    NSString *sqlDelete = @"DELETE FROM %@ WHERE _id = ?;";
+    sqlDelete = [NSString stringWithFormat:sqlDelete, tableName];
+
+    return [CDTQSqlParts partsForSql:sqlDelete parameters:@[ docId ]];
+}
+
+/**
+ Returns an array of insert statements to index a document in an index.
+
+ For most revisions, a single insert statement will be returned. If a field
+ is an array, however, multiple statements are required.
+ */
++ (NSArray /*CDTQSqlParts*/ *)partsToIndexRevision:(CDTDocumentRevision *)rev
+                                           inIndex:(NSString *)indexName
+                                    withFieldNames:(NSArray *)fieldNames
+{
+    if (!rev) {
+        return nil;
+    }
+
+    if (!indexName) {
+        return nil;
+    }
+
+    if (!fieldNames) {
+        return nil;
+    }
+
+    // Field names will equal column names.
+    // Therefore need to end up with an array something like:
+    // INSERT INTO index_table (_id, fieldName1, fieldName2) VALUES ("abc", "mike", "rhodes")
+    // @[ docId, val1, val2 ]
+    // INSERT INTO index_table (_id, fieldName1, fieldName2) VALUES ( ?, ?, ? )
+
+    // First work out whether there are array fields. If there is a single array field,
+    // we produce an index row for each value of that array. If there is more than one
+    // array field, we need to error so as not to explode the size of the index.
+
+    NSInteger n_arrays = 0;
+    NSString *arrayFieldName;  // only record the last, as error if more than one
+    for (NSString *fieldName in fieldNames) {
+        NSObject *value =
+            [CDTQValueExtractor extractValueForFieldName:fieldName fromDictionary:rev.body];
+        if ([value isKindOfClass:[NSArray class]]) {
+            n_arrays++;
+            arrayFieldName = fieldName;
+        }
+    }
+
+    if (n_arrays > 1) {
+        LogError(
+            @"Indexing %@ in index %@ includes >1 array field; only array field per index allowed",
+            rev.docId, indexName);
+        return nil;
+    }
+
+    if (n_arrays == 0) {
+        // The are no arrays in the values we are indexing. We just need to index the fields
+        // in the index. _id and _rev are special fields in that they don't appear in the
+        // body, so they need special-casing to get the values.
+
+        CDTQSqlParts *parts = [CDTQIndexUpdater createPartsForFieldNames:fieldNames
+                                                   initialIncludedFields:@[ @"_id", @"_rev" ]
+                                                     initialPlaceholders:@[ @"?", @"?" ]
+                                                             initialArgs:@[ rev.docId, rev.revId ]
+                                                               indexName:indexName
+                                                                revision:rev];
+        return @[ parts ];
+
+    } else {
+        // We know the value is an array, we found this out in the check above
+        NSArray *arrayFieldValues = (NSArray *)
+            [CDTQValueExtractor extractValueForFieldName:arrayFieldName fromDictionary:rev.body];
+
+        // Create an insert statement for each value in the array
+        NSMutableArray *insertStatements = [NSMutableArray array];
+
+        for (NSObject *value in arrayFieldValues) {
+            // For each value in the array we create a row. We put this value at the start
+            // of the INSERT statement along with _id and _rev, followed by the other fields.
+
+            NSArray *placeholders = @[ @"?", @"?", @"?" ];
+            NSArray *includedFieldNames = @[ @"_id", @"_rev", arrayFieldName ];
+            NSArray *args = @[ rev.docId, rev.revId, value ];
+
+            CDTQSqlParts *parts = [CDTQIndexUpdater createPartsForFieldNames:fieldNames
+                                                       initialIncludedFields:includedFieldNames
+                                                         initialPlaceholders:placeholders
+                                                                 initialArgs:args
+                                                                   indexName:indexName
+                                                                    revision:rev];
+
+            [insertStatements addObject:parts];
+        }
+
+        return insertStatements;
+    }
+}
+
++ (CDTQSqlParts *)createPartsForFieldNames:(NSArray *)fieldNames
+                     initialIncludedFields:(NSArray *)initialIncludedFields
+                       initialPlaceholders:(NSArray *)initialPlaceholders
+                               initialArgs:(NSArray *)initialArgs
+                                 indexName:(NSString *)indexName
+                                  revision:(CDTDocumentRevision *)rev
+{
+    NSMutableArray *includedFieldNames = [initialIncludedFields mutableCopy];
+    NSMutableArray *placeholders = [initialPlaceholders mutableCopy];
+    NSMutableArray *args = [initialArgs mutableCopy];
+
+    for (NSString *fieldName in fieldNames) {
+        // Fields in initialIncludedFields already have placeholders and
+        // values in the other two initial* arrays, so they need not be
+        // included again.
+        if ([initialIncludedFields containsObject:fieldName]) {
+            continue;
+        }
+
+        NSObject *value =
+            [CDTQValueExtractor extractValueForFieldName:fieldName fromDictionary:rev.body];
+
+        if (value) {
+            [includedFieldNames addObject:fieldName];
+            [args addObject:value];
+            [placeholders addObject:@"?"];
+
+            // TODO validate here whether the derived value is suitable for indexing
+            //      in addition to its presence.
+        }
+    }
+
+    NSMutableArray *sqlSafeFieldNames = [NSMutableArray array];
+    for (NSString *fieldName in includedFieldNames) {
+        [sqlSafeFieldNames addObject:[NSString stringWithFormat:@"\"%@\"", fieldName]];
+    }
+
+    // If there are no fields, we just index blank for the doc ID
+    NSString *sql;
+    sql = @"INSERT INTO %@ ( %@ ) VALUES ( %@ );";
+    sql = [NSString stringWithFormat:sql, [CDTQIndexManager tableNameForIndex:indexName],
+                                     [sqlSafeFieldNames componentsJoinedByString:@", "],
+                                     [placeholders componentsJoinedByString:@", "]];
+
+    return [CDTQSqlParts partsForSql:sql parameters:args];
+}
+
+- (SequenceNumber)sequenceNumberForIndex:(NSString *)indexName
+{
+    __block SequenceNumber result = 0;
+
+    // get current version
+    [_database inDatabase:^(FMDatabase *db) {
+        NSString *sql = @"SELECT last_sequence FROM %@ WHERE index_name = ?";
+        sql = [NSString stringWithFormat:sql, kCDTQIndexMetadataTableName];
+        FMResultSet *rs = [db executeQuery:sql withArgumentsInArray:@[ indexName ]];
+        while ([rs next]) {
+            result = [rs longForColumnIndex:0];
+            break;  // All rows for a given index will have the same last_sequence, so break
+        }
+        [rs close];
+    }];
+
+    return result;
+}
+
+- (BOOL)updateMetadataForIndex:(NSString *)indexName lastSequence:(SequenceNumber)lastSequence
+{
+    __block BOOL success = TRUE;
+
+    NSDictionary *v = @{ @"name" : indexName, @"last_sequence" : @(lastSequence) };
+    NSString *template = @"UPDATE %@ SET last_sequence = :last_sequence where index_name = :name;";
+    NSString *sql = [NSString stringWithFormat:template, kCDTQIndexMetadataTableName];
+
+    [_database inDatabase:^(FMDatabase *db) {
+        success = [db executeUpdate:sql withParameterDictionary:v];
+    }];
+
+    return success;
+}
+
+@end

--- a/Classes/common/query/CDTQLogging.h
+++ b/Classes/common/query/CDTQLogging.h
@@ -1,0 +1,41 @@
+//
+//  CDTQueryLogging.h
+//
+//  Created by Rhys Short on 07/10/2014.
+//  Copyright (c) 2014 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+#ifndef Pods_CDTQueryLogging_h
+#define Pods_CDTQueryLogging_h
+
+#import "CocoaLumberjack.h"
+
+#define CDTQ_LOGGING_CONTEXT 17  // one level higher than CDT logger myabe should be 20?
+static DDLogLevel CDTQLogLevel = DDLogLevelWarning;
+
+#define LogError(frmt, ...)                                                                     \
+    LOG_MAYBE(NO, CDTQLogLevel, DDLogFlagError, CDTQ_LOGGING_CONTEXT, nil, __PRETTY_FUNCTION__, \
+              frmt, ##__VA_ARGS__)
+#define LogWarn(frmt, ...)                                                                         \
+    LOG_MAYBE(YES, CDTQLogLevel, DDLogFlagWarning, CDTQ_LOGGING_CONTEXT, nil, __PRETTY_FUNCTION__, \
+              frmt, ##__VA_ARGS__)
+#define LogInfo(frmt, ...)                                                                      \
+    LOG_MAYBE(YES, CDTQLogLevel, DDLogFlagInfo, CDTQ_LOGGING_CONTEXT, nil, __PRETTY_FUNCTION__, \
+              frmt, ##__VA_ARGS__)
+#define LogDebug(frmt, ...)                                                                      \
+    LOG_MAYBE(YES, CDTQLogLevel, DDLogFlagDebug, CDTQ_LOGGING_CONTEXT, nil, __PRETTY_FUNCTION__, \
+              frmt, ##__VA_ARGS__)
+#define LogVerbose(frmt, ...)                                                                      \
+    LOG_MAYBE(YES, CDTQLogLevel, DDLogFlagVerbose, CDTQ_LOGGING_CONTEXT, nil, __PRETTY_FUNCTION__, \
+              frmt, ##__VA_ARGS__)
+
+#define CDTQChangeLogLevel(level) CDTQLogLevel = level
+
+#endif

--- a/Classes/common/query/CDTQProjectedDocumentRevision.h
+++ b/Classes/common/query/CDTQProjectedDocumentRevision.h
@@ -1,0 +1,39 @@
+//
+//  CDTQProjectedDocumentRevision.h
+//
+//  Created by Michael Rhodes on 18/10/2014.
+//  Copyright (c) 2014 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+#import "CDTDocumentRevision.h"
+
+@class CDTDatastore;
+
+/**
+ A document revision that has been projected.
+
+ This class implements a version of mutableCopy which returns the full
+ document when called, to prevent accidental data loss which might come
+ from saving a projected document.
+ */
+@interface CDTQProjectedDocumentRevision : CDTDocumentRevision
+
+/**
+ Initialise with a datastore so mutableCopy can return a full document.
+ */
+- (id)initWithDocId:(NSString *)docId
+         revisionId:(NSString *)revId
+               body:(NSDictionary *)body
+            deleted:(BOOL)deleted
+        attachments:(NSDictionary *)attachments
+           sequence:(SequenceNumber)sequence
+          datastore:(CDTDatastore *)datastore;
+
+@end

--- a/Classes/common/query/CDTQProjectedDocumentRevision.m
+++ b/Classes/common/query/CDTQProjectedDocumentRevision.m
@@ -1,0 +1,62 @@
+//
+//  CDTQProjectedDocumentRevision.m
+//
+//  Created by Michael Rhodes on 18/10/2014.
+//  Copyright (c) 2014 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+#import "CDTQProjectedDocumentRevision.h"
+
+#import <CloudantSync.h>
+
+@interface CDTQProjectedDocumentRevision ()
+
+@property (nonatomic, strong) CDTDatastore *datastore;
+
+@end
+
+@implementation CDTQProjectedDocumentRevision
+
+- (id)initWithDocId:(NSString *)docId
+         revisionId:(NSString *)revId
+               body:(NSDictionary *)body
+            deleted:(BOOL)deleted
+        attachments:(NSDictionary *)attachments
+           sequence:(SequenceNumber)sequence
+          datastore:(CDTDatastore *)datastore
+{
+    self = [self initWithDocId:docId
+                    revisionId:revId
+                          body:body
+                       deleted:deleted
+                   attachments:attachments
+                      sequence:sequence];
+    if (self != nil) {
+        _datastore = datastore;
+    }
+    return self;
+}
+
+- (CDTMutableDocumentRevision *)mutableCopy
+{
+    CDTDocumentRevision *rev = [self.datastore getDocumentWithId:self.docId error:nil];
+    if (rev == nil) {
+        return nil;
+    }
+
+    // Don't want to return an updated version, breaks contract of mutableCopy
+    if (![rev.revId isEqualToString:self.revId]) {
+        return nil;
+    }
+
+    return [rev mutableCopy];
+}
+
+@end

--- a/Classes/common/query/CDTQQueryConstants.h
+++ b/Classes/common/query/CDTQQueryConstants.h
@@ -1,0 +1,37 @@
+//
+//  CDTQQueryConstants.h
+//
+//  Created by Al Finkelstein on 03/10/2015.
+//  Copyright (c) 2015 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+extern NSString *const AND;
+
+extern NSString *const OR;
+
+extern NSString *const NOT;
+
+extern NSString *const EXISTS;
+
+extern NSString *const EQ;
+
+extern NSString *const NE;
+
+extern NSString *const LT;
+
+extern NSString *const LTE;
+
+extern NSString *const GT;
+
+extern NSString *const GTE;
+
+extern NSString *const IN;
+
+extern NSString *const NIN;

--- a/Classes/common/query/CDTQQueryConstants.m
+++ b/Classes/common/query/CDTQQueryConstants.m
@@ -1,0 +1,39 @@
+//
+//  CDTQQueryConstants.m
+//
+//  Created by Al Finkelstein on 03/10/2015.
+//  Copyright (c) 2015 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+#import "CDTQQueryConstants.h"
+
+NSString *const AND = @"$and";
+
+NSString *const OR = @"$or";
+
+NSString *const NOT = @"$not";
+
+NSString *const EXISTS = @"$exists";
+
+NSString *const EQ = @"$eq";
+
+NSString *const NE = @"$ne";
+
+NSString *const LT = @"$lt";
+
+NSString *const LTE = @"$lte";
+
+NSString *const GT = @"$gt";
+
+NSString *const GTE = @"$gte";
+
+NSString *const IN = @"$in";
+
+NSString *const NIN = @"$nin";

--- a/Classes/common/query/CDTQQueryExecutor.h
+++ b/Classes/common/query/CDTQQueryExecutor.h
@@ -1,0 +1,64 @@
+//
+//  CDTQQueryExecutor.h
+//
+//  Created by Mike Rhodes on 2014-09-29
+//  Copyright (c) 2014 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+@class CDTDatastore;
+@class CDTQResultSet;
+@class CDTQSqlParts;
+@class FMDatabaseQueue;
+
+/**
+ Handles querying indexes for a given datastore.
+ */
+@interface CDTQQueryExecutor : NSObject
+
+/**
+ Constructs a new CDTQQueryExecutor using the indexes in `database` to find documents from
+ `datastore`.
+ */
+- (instancetype)initWithDatabase:(FMDatabaseQueue *)database datastore:(CDTDatastore *)datastore;
+
+/**
+ Execute the query passed using the selection of index definition provided.
+
+ The index definitions are presumed to already exist and be up to date for the
+ datastore and database passed to the constructor.
+
+ @param query query to execute.
+ @param indexes indexes to use (this method will select the most appropriate).
+ @param skip how many results to skip before returning results to caller
+ @param limit number of documents the result should be limited to
+ @param fields fields to project from the result documents
+ @param sortDocument document specifying the order to return results, nil to have no sorting
+ */
+- (CDTQResultSet *)find:(NSDictionary *)query
+           usingIndexes:(NSDictionary *)indexes
+                   skip:(NSUInteger)skip
+                  limit:(NSUInteger)limit
+                 fields:(NSArray *)fields
+                   sort:(NSArray *)sortDocument;
+
+/**
+ Return SQL to get ordered list of docIds.
+
+ @param sortDocument Array of ordering definitions `@[ @{"fieldName": "asc"}, @{@"fieldName2",
+ @"asc"} ]`
+ @param indexes dictionary of indexes
+ */
++ (CDTQSqlParts *)sqlToSortIds:(NSSet /*NSString*/ *)docIdSet
+                    usingOrder:(NSArray /*NSDictionary*/ *)sortDocument
+                       indexes:(NSDictionary *)indexes;
+
+@end

--- a/Classes/common/query/CDTQQueryExecutor.m
+++ b/Classes/common/query/CDTQQueryExecutor.m
@@ -1,0 +1,417 @@
+//
+//  CDTQQueryExecutor.m
+//
+//  Created by Mike Rhodes on 2014-09-29
+//  Copyright (c) 2014 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+#import "CDTQQueryExecutor.h"
+
+#import "CDTQIndexManager.h"
+#import "CDTQResultSet.h"
+#import "CDTQQuerySqlTranslator.h"
+#import "CDTQLogging.h"
+#import "CDTQUnindexedMatcher.h"
+#import "CDTDatastore.h"
+#import "CDTDocumentRevision.h"
+#import "CDTQQueryValidator.h"
+
+#import "FMDB.h"
+
+const NSUInteger kSmallResultSetSizeThreshold = 500;
+
+@interface CDTQQueryExecutor ()
+
+@property (nonatomic, strong) FMDatabaseQueue *database;
+@property (nonatomic, strong) CDTDatastore *datastore;
+
+@end
+
+@implementation CDTQQueryExecutor
+
+- (instancetype)initWithDatabase:(FMDatabaseQueue *)database datastore:(CDTDatastore *)datastore
+{
+    self = [super init];
+    if (self) {
+        _database = database;
+        _datastore = datastore;
+    }
+    return self;
+}
+
+#pragma mark Instance methods
+
+- (CDTQResultSet *)find:(NSDictionary *)query
+           usingIndexes:(NSDictionary *)indexes
+                   skip:(NSUInteger)skip
+                  limit:(NSUInteger)limit
+                 fields:(NSArray *)fields
+                   sort:(NSArray *)sortDocument
+{
+    //
+    // Validate inputs
+    //
+
+    if (![CDTQQueryExecutor validateSortDocument:sortDocument]) {
+        return nil;  // validate logs the error if doc is invalid
+    }
+
+    fields = [CDTQQueryExecutor normaliseFields:fields];
+
+    if (![CDTQQueryExecutor validateFields:fields]) {
+        return nil;  // validate logs error message
+    }
+
+    // normailse and validate query by passing into the executors
+
+    query = [CDTQQueryValidator normaliseAndValidateQuery:query];
+
+    if (!query) {
+        return nil;
+    }
+
+    //
+    // Execute the query
+    //
+
+    // YES if we need to run posthoc matcher
+    BOOL indexesCoverQuery;
+
+    CDTQChildrenQueryNode *root;
+    root = [self translateQuery:query indexes:indexes indexesCoverQuery:&indexesCoverQuery];
+
+    if (!root) {
+        return nil;
+    }
+
+    __block NSArray *docIds;
+
+    [_database inTransaction:^(FMDatabase *db, BOOL *rollback) {
+        NSSet *docIdSet = [self executeQueryTree:root inDatabase:db];
+
+        // sorting
+        if (sortDocument != nil && sortDocument.count > 0) {
+            docIds = [CDTQQueryExecutor sortIds:docIdSet
+                                      usingSort:sortDocument
+                                        indexes:indexes
+                                     inDatabase:db];
+        } else {
+            docIds = [docIdSet allObjects];
+        }
+    }];
+
+    // nil if an error during sorting
+    if (docIds == nil) {
+        return nil;
+    }
+
+    CDTQUnindexedMatcher *matcher = [self matcherForIndexCoverage:indexesCoverQuery selector:query];
+
+    if (matcher) {
+        LogWarn(@"Query could not be executed using indexes alone; falling back to filtering "
+                @"documents themselves. This will be VERY SLOW as each candidate document is "
+                @"loaded from the datastore and matched against the query selector.");
+    }
+
+    CDTDatastore *ds = self.datastore;
+    return [CDTQResultSet resultSetWithBlock:^(CDTQResultSetBuilder *b) {
+        b.docIds = docIds;
+        b.datastore = ds;
+        b.fields = fields;
+        b.skip = skip;
+        b.limit = limit;
+        b.matcher = matcher;
+    }];
+}
+
+// Method exists so we can override it in testing (to force indexesCoverQuery to false)
+- (CDTQChildrenQueryNode *)translateQuery:(NSDictionary *)query
+                                  indexes:(NSDictionary *)indexes
+                        indexesCoverQuery:(BOOL *)indexesCoverQuery
+{
+    CDTQChildrenQueryNode *root =
+        (CDTQChildrenQueryNode *)[CDTQQuerySqlTranslator translateQuery:query
+                                                           toUseIndexes:indexes
+                                                      indexesCoverQuery:indexesCoverQuery];
+    return root;
+}
+
+// Method exists so we can override it in testing (to force matcher to always be nil)
+- (CDTQUnindexedMatcher *)matcherForIndexCoverage:(BOOL)indexesCoverQuery
+                                         selector:(NSDictionary *)selector
+{
+    return indexesCoverQuery ? nil : [CDTQUnindexedMatcher matcherWithSelector:selector];
+}
+
+#pragma mark Validation helpers
+
++ (BOOL)validateSortDocument:(NSArray /*NSDictionary*/ *)sortDocument
+{
+    if (sortDocument == nil || sortDocument.count == 0) {
+        return YES;  // empty or ni l sort docs just mean "don't sort", so are valid
+    }
+
+    for (NSDictionary *clause in sortDocument) {
+        if (![clause isKindOfClass:[NSDictionary class]]) {
+            LogError(@"Sort clauses must be dict, e.g., {name: asc}. Did you just use a string?");
+            return NO;
+        }
+
+        if (clause.count > 1) {
+            LogError(@"Each order clause can only be a single field, %@", clause);
+            return NO;
+        }
+
+        NSString *fieldName = [clause allKeys][0];
+        NSString *direction = clause[fieldName];
+
+        if (![fieldName isKindOfClass:[NSString class]]) {
+            LogError(@"Field names in sort clause must be strings, %@", fieldName);
+            return NO;
+        }
+
+        if (![@[ @"ASC", @"DESC" ] containsObject:[direction uppercaseString]]) {
+            LogError(@"Order direction %@ not valid, use `asc` or `desc`", direction);
+            return NO;
+        }
+    }
+
+    return YES;
+}
+
+/**
+ Checks if the fields are valid.
+ */
++ (BOOL)validateFields:(NSArray *)fields
+{
+    for (NSString *field in fields) {
+        if (![field isKindOfClass:[NSString class]]) {
+            LogError(@"Projection field should be string object: %@", [field description]);
+            return NO;
+        }
+
+        if ([field rangeOfString:@"."].location != NSNotFound) {
+            LogError(@"Projection field cannot use dotted notation: %@", [field description]);
+            return NO;
+        }
+    };
+
+    return YES;
+}
+
++ (NSArray *)normaliseFields:(NSArray *)fields
+{
+    if (fields.count == 0) {
+        LogWarn(@"Projection fields array is empty, disabling project for this query");
+        return nil;
+    }
+
+    return fields;
+}
+
+#pragma mark Tree walking
+
+- (NSSet *)executeQueryTree:(CDTQQueryNode *)node inDatabase:(FMDatabase *)db
+{
+    if ([node isKindOfClass:[CDTQAndQueryNode class]]) {
+        NSMutableSet *accumulator = nil;
+
+        CDTQAndQueryNode *andNode = (CDTQAndQueryNode *)node;
+        for (CDTQQueryNode *node in andNode.children) {
+            NSSet *childIds = [self executeQueryTree:node inDatabase:db];
+            if (!accumulator) {
+                accumulator = [NSMutableSet setWithSet:childIds];
+            } else {
+                [accumulator intersectSet:childIds];
+            }
+
+            // TODO optimisation is to bail here if accumlator is empty
+        }
+
+        return [NSSet setWithSet:accumulator];
+    }
+    if ([node isKindOfClass:[CDTQOrQueryNode class]]) {
+        NSMutableSet *accumulator = nil;
+
+        CDTQOrQueryNode *andNode = (CDTQOrQueryNode *)node;
+        for (CDTQQueryNode *node in andNode.children) {
+            NSSet *childIds = [self executeQueryTree:node inDatabase:db];
+            if (!accumulator) {
+                accumulator = [NSMutableSet setWithSet:childIds];
+            } else {
+                [accumulator unionSet:childIds];
+            }
+        }
+
+        return [NSSet setWithSet:accumulator];
+
+    } else if ([node isKindOfClass:[CDTQSqlQueryNode class]]) {
+        CDTQSqlQueryNode *sqlNode = (CDTQSqlQueryNode *)node;
+        CDTQSqlParts *sqlParts = sqlNode.sql;
+
+        NSMutableArray *docIds = [NSMutableArray array];
+
+        FMResultSet *rs = [db executeQuery:sqlParts.sqlWithPlaceholders
+                      withArgumentsInArray:sqlParts.placeholderValues];
+        while ([rs next]) {
+            [docIds addObject:[rs stringForColumn:@"_id"]];
+        }
+
+        [rs close];
+
+        return [NSSet setWithArray:docIds];
+
+    } else {
+        return nil;
+    }
+}
+
+#pragma mark Sorting
+
+/**
+ Return ordered list of document IDs using provided indexes.
+
+ Method assumes `sortDocument` is valid.
+
+ @param docIdSet Set of current results which are sorted
+ @param sortDocument Array of ordering definitions
+                     `@[ @{"fieldName": "asc"}, @{@"fieldName2", @"desc"} ]`
+ @param indexes dictionary of indexes
+ @param db database containing `indexes` to use when sorting documents
+ */
+
++ (NSArray *)sortIds:(NSSet /*NSString*/ *)docIdSet
+           usingSort:(NSArray /*NSDictionary*/ *)sortDocument
+             indexes:(NSDictionary *)indexes
+          inDatabase:(FMDatabase *)db
+{
+    BOOL smallResultSet = (docIdSet.count < kSmallResultSetSizeThreshold);
+    CDTQSqlParts *orderBy =
+        [CDTQQueryExecutor sqlToSortIds:docIdSet usingOrder:sortDocument indexes:indexes];
+    NSArray *sortedIds;
+
+    if (orderBy != nil) {
+        NSMutableArray *sortedDocIds = [NSMutableArray array];
+
+        // The query will iterate through a sorted list of docIds.
+        // This means that if we create a new array and add entries
+        // to that array as we iterate through the result set which
+        // are part of the query's results, we'll end up with an
+        // ordered set of results.
+        FMResultSet *rs = [db executeQuery:orderBy.sqlWithPlaceholders
+                      withArgumentsInArray:orderBy.placeholderValues];
+
+        // The while loop is duplicated to avoid checking the smallResultSet variable every loop
+        if (smallResultSet) {
+            while ([rs next]) {
+                NSString *candidateId = [rs stringForColumnIndex:0];
+                [sortedDocIds addObject:candidateId];
+            }
+        } else {
+            while ([rs next]) {
+                NSString *candidateId = [rs stringForColumnIndex:0];
+                if ([docIdSet containsObject:candidateId]) {
+                    [sortedDocIds addObject:candidateId];
+                }
+            }
+        }
+        [rs close];
+        sortedIds = [NSArray arrayWithArray:sortedDocIds];
+    } else {
+        sortedIds = nil;  // error doing the ordering
+    }
+
+    return sortedIds;
+}
+
+/**
+ Return SQL to get ordered list of docIds.
+
+ Method assumes `sortDocument` is valid.
+
+ @param sortDocument Array of ordering definitions
+    `@[ @{"fieldName": "asc"}, @{@"fieldName2", @"desc"} ]`
+ @param indexes dictionary of indexes
+ */
++ (CDTQSqlParts *)sqlToSortIds:(NSSet /*NSString*/ *)docIdSet
+                    usingOrder:(NSArray /*NSDictionary*/ *)sortDocument
+                       indexes:(NSDictionary *)indexes
+{
+    NSString *chosenIndex = [CDTQQueryExecutor chooseIndexForSort:sortDocument fromIndexes:indexes];
+    if (chosenIndex == nil) {
+        LogError(@"No single index can satisfy order %@", sortDocument);
+        return nil;
+    }
+
+    NSString *indexTable = [CDTQIndexManager tableNameForIndex:chosenIndex];
+
+    // for small result sets:
+    // SELECT _id FROM idx WHERE _id IN (?, ?) ORDER BY fieldName ASC, fieldName2 DESC;
+    // for large result sets:
+    // SELECT _id FROM idx ORDER BY fieldName ASC, fieldName2 DESC;
+
+    NSMutableArray *orderClauses = [NSMutableArray array];
+    for (NSDictionary *orderClause in sortDocument) {
+        NSString *fieldName = [orderClause allKeys][0];
+        NSString *direction = orderClause[fieldName];
+
+        NSString *orderClause =
+            [NSString stringWithFormat:@"\"%@\" %@", fieldName, [direction uppercaseString]];
+        [orderClauses addObject:orderClause];
+    }
+
+    // If we have few results, it's more efficient to reduce the search space
+    // for SQLite. 500 placeholders should be a safe value.
+    NSMutableArray *parameters = [NSMutableArray array];
+
+    NSString *whereClause = @"";
+    if (docIdSet.count < kSmallResultSetSizeThreshold) {
+        NSMutableArray *placeholders = [NSMutableArray array];
+        for (NSString *docId in docIdSet) {
+            [placeholders addObject:@"?"];
+            [parameters addObject:docId];
+        }
+        whereClause = [NSString
+            stringWithFormat:@"WHERE _id IN (%@)", [placeholders componentsJoinedByString:@", "]];
+    }
+
+    NSString *sql =
+        [NSString stringWithFormat:@"SELECT DISTINCT _id FROM %@ %@ ORDER BY %@;", indexTable,
+                                   whereClause, [orderClauses componentsJoinedByString:@", "]];
+    return [CDTQSqlParts partsForSql:sql parameters:parameters];
+}
+
++ (NSString *)chooseIndexForSort:(NSArray /*NSDictionary*/ *)sortDocument
+                     fromIndexes:(NSDictionary *)indexes
+{
+    NSMutableSet *neededFields = [NSMutableSet set];
+    [sortDocument enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+        // This is validated and normalised already to be a dictionary with one key.
+        NSDictionary *orderSpecifier = (NSDictionary *)obj;
+        [neededFields addObject:[orderSpecifier allKeys][0]];
+    }];
+
+    if (neededFields.count == 0) {
+        return nil;  // no point in querying empty set of fields
+    }
+
+    NSString *chosenIndex = nil;
+    for (NSString *indexName in indexes) {
+        NSSet *providedFields = [NSSet setWithArray:indexes[indexName][@"fields"]];
+        if ([neededFields isSubsetOfSet:providedFields]) {
+            chosenIndex = indexName;
+            break;
+        }
+    }
+
+    return chosenIndex;
+}
+
+@end

--- a/Classes/common/query/CDTQQuerySqlTranslator.h
+++ b/Classes/common/query/CDTQQuerySqlTranslator.h
@@ -1,0 +1,162 @@
+//
+//  CDTQQuerySqlTranslator.h
+//
+//  Created by Michael Rhodes on 03/10/2014.
+//  Copyright (c) 2014 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+@class CDTQSqlParts;
+
+@interface CDTQQueryNode : NSObject
+
+@end
+
+@interface CDTQChildrenQueryNode : CDTQQueryNode
+
+@property (nonatomic, strong) NSMutableArray *children;
+
+@end
+
+@interface CDTQAndQueryNode : CDTQChildrenQueryNode
+
+@end
+
+@interface CDTQOrQueryNode : CDTQChildrenQueryNode
+
+@end
+
+@interface CDTQSqlQueryNode : CDTQQueryNode
+
+@property (nonatomic, strong) CDTQSqlParts *sql;
+
+@end
+
+/**
+ This class translates Cloudant Query selectors into the SQL we need to use
+ to query our indexes.
+
+ It creates a tree structure which contains AND/OR nodes, along with the SQL which
+ needs to be used to get a list of document IDs for each level. This tree structure
+ is passed back out of the translation process for execution by an interpreter which
+ can perform the needed AND and OR operations between the document ID sets returned
+ by the SQL queries.
+
+ This merging of results in code allows use to make more intelligent use of indexes
+ within the SQLite database. As SQLite allows us to use just a single index per query,
+ performing several queries over indexes and then using set operations works out
+ more flexible and likely more efficient.
+
+ The SQL must be executed separately so we can do it in a transaction so we're doing
+ it over a consistent view of the index.
+
+ The translator is a simple depth-first, recursive decent parser over the selector
+ dictionary.
+
+ Some examples:
+
+ AND : [ { x: X }, { y: Y } ]
+
+ This can be represented by a single SQL query and AND tree node:
+
+    AND
+     |
+    sql
+
+
+ OR : [ { x: X }, { y: Y } ]
+
+ This is a single OR node and two SQL queries:
+
+       OR
+       / \
+     sql  sql
+
+ The interpreter then unions the results.
+
+
+ OR : [ { AND : [ { x: X }, { y: Y } ] }, { y: Y } ]
+
+ This requires a more complex tree:
+
+          OR
+         /   \
+       AND    sql
+        |
+       sql
+
+ We could collapse out the extra AND node.
+
+
+ AND : [ { OR : [ { x: X }, { y: Y } ] }, { y: Y } ]
+
+ This is really the most complex situation:
+
+         AND
+         /  \
+       OR   sql
+      / |
+    sql sql
+
+ These basic patterns can be composed into more complicate structures.
+ */
+@interface CDTQQuerySqlTranslator : NSObject
+
++ (CDTQQueryNode *)translateQuery:(NSDictionary *)query
+                     toUseIndexes:(NSDictionary *)indexes
+                indexesCoverQuery:(BOOL *)indexesCoverQuery;
+
+/**
+ Expand implicit operators in a query.
+ */
+//+ (NSDictionary *)normaliseQuery:(NSDictionary *)query;
+
+/**
+ Extract fields from an AND clause
+
+ `fieldName` and so on from:
+
+ ```
+ @[@{@"fieldName": @"mike"}, ...]
+ ```
+ */
++ (NSArray *)fieldsForAndClause:(NSArray *)clause;
+
+/**
+ Selects an index to use for a given query from the set provided.
+
+ Here we're looking for the index which supports all the fields used in the query.
+
+ @param query full query provided by user.
+ @param indexes index list of the form @{indexName: @[fieldName1, fieldName2]}
+ @return name of index from `indexes` to ues for `query`, or `nil` if none found.
+ */
++ (NSString *)chooseIndexForAndClause:(NSArray *)clause fromIndexes:(NSDictionary *)indexes;
+
+/**
+ Selects an index to use for a set of fields.
+ */
++ (NSString *)chooseIndexForFields:(NSSet *)neededFields fromIndexes:(NSDictionary *)indexes;
+
+/**
+ Returns the SQL WHERE clause for a query.
+ */
++ (CDTQSqlParts *)wherePartsForAndClause:(NSArray *)clause usingIndex:(NSString *)indexName;
+
+/**
+ Returns the SQL statement to find document IDs matching query.
+
+ @param query the query being executed.
+ @param indexName the index selected for use in this query
+ */
++ (CDTQSqlParts *)selectStatementForAndClause:(NSArray *)clause usingIndex:(NSString *)indexName;
+
+@end

--- a/Classes/common/query/CDTQQuerySqlTranslator.m
+++ b/Classes/common/query/CDTQQuerySqlTranslator.m
@@ -1,0 +1,489 @@
+//
+//  CDTQQuerySqlTranslator.m
+//
+//  Created by Michael Rhodes on 03/10/2014.
+//  Copyright (c) 2014 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+#import "CDTQQuerySqlTranslator.h"
+#import "CDTQQueryConstants.h"
+
+#import "CDTQQueryExecutor.h"
+#import "CDTQIndexManager.h"
+#import "CDTQLogging.h"
+#import "CDTQQueryValidator.h"
+
+@interface CDTQTranslatorState : NSObject
+
+@property (nonatomic) BOOL atLeastOneIndexUsed;       // if NO, need to generate a return all query
+@property (nonatomic) BOOL atLeastOneIndexMissing;    // i.e., we need to use posthoc matcher
+@property (nonatomic) BOOL atLeastOneORIndexMissing;  //       we need to use posthoc matcher
+
+@end
+
+@implementation CDTQQueryNode
+
+@end
+
+@implementation CDTQChildrenQueryNode
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        _children = [NSMutableArray array];
+    }
+    return self;
+}
+
+@end
+
+@implementation CDTQAndQueryNode
+
+@end
+
+@implementation CDTQOrQueryNode
+
+@end
+
+@implementation CDTQSqlQueryNode
+
+@end
+
+@implementation CDTQTranslatorState
+
+@end
+
+@implementation CDTQQuerySqlTranslator
+
+
++ (CDTQQueryNode *)translateQuery:(NSDictionary *)query
+                     toUseIndexes:(NSDictionary *)indexes
+                indexesCoverQuery:(BOOL *)indexesCoverQuery
+{
+    CDTQTranslatorState *state = [[CDTQTranslatorState alloc] init];
+
+    CDTQQueryNode *node =
+        [CDTQQuerySqlTranslator translateQuery:query toUseIndexes:indexes state:state];
+
+    // If we haven't used a single index, we need to return a query
+    // which returns every document, so the posthoc matcher can
+    // run over every document to manually carry out the query.
+    if (!state.atLeastOneIndexUsed || state.atLeastOneORIndexMissing) {
+        NSSet *neededFields = [NSSet setWithObject:@"_id"];
+        NSString *allDocsIndex =
+            [CDTQQuerySqlTranslator chooseIndexForFields:neededFields fromIndexes:indexes];
+
+        if (!allDocsIndex) {
+            LogError(@"No indexes defined, cannot execute query for all documents");
+            return nil;
+        }
+
+        NSString *tableName = [CDTQIndexManager tableNameForIndex:allDocsIndex];
+
+        NSString *sql = @"SELECT _id FROM %@;";
+        sql = [NSString stringWithFormat:sql, tableName];
+        CDTQSqlParts *parts = [CDTQSqlParts partsForSql:sql parameters:@[]];
+
+        CDTQSqlQueryNode *sqlNode = [[CDTQSqlQueryNode alloc] init];
+        sqlNode.sql = parts;
+
+        CDTQAndQueryNode *root = [[CDTQAndQueryNode alloc] init];
+        [root.children addObject:sqlNode];
+
+        *indexesCoverQuery = NO;
+        return root;
+    } else {
+        *indexesCoverQuery = !state.atLeastOneIndexMissing;
+        return node;
+    }
+}
+
++ (CDTQQueryNode *)translateQuery:(NSDictionary *)query
+                     toUseIndexes:(NSDictionary *)indexes
+                            state:(CDTQTranslatorState *)state
+{
+    // At this point we will have a root compound predicate, AND or OR, and
+    // the query will be reduced to a single entry:
+    // @{ @"$and": @[ ... predicates (possibly compound) ... ] }
+    // @{ @"$or": @[ ... predicates (possibly compound) ... ] }
+
+    CDTQChildrenQueryNode *root;
+    NSArray *clauses;
+
+    if (query[AND]) {
+        clauses = query[AND];
+        root = [[CDTQAndQueryNode alloc] init];
+    } else if (query[OR]) {
+        clauses = query[OR];
+        root = [[CDTQOrQueryNode alloc] init];
+    }
+
+    //
+    // First handle the simple @"field": @{ @"$operator": @"value" } clauses. These are
+    // handled differently for AND and OR parents, so we need to have the conditional
+    // logic below.
+    //
+
+    NSMutableArray *basicClauses = [NSMutableArray array];
+
+    [clauses enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+        NSDictionary *clause = (NSDictionary *)obj;
+        NSString *field = clause.allKeys[0];
+        if (![field hasPrefix:@"$"]) {
+            [basicClauses addObject:clauses[idx]];
+        }
+    }];
+
+    if (basicClauses.count > 0) {
+        if (query[AND]) {
+            // For an AND query, we require a single compound index and we generate a
+            // single SQL statement to use that index to satisfy the clauses.
+            
+            NSString *chosenIndex =
+            [CDTQQuerySqlTranslator chooseIndexForAndClause:basicClauses fromIndexes:indexes];
+            if (!chosenIndex) {
+                state.atLeastOneIndexMissing = YES;
+                
+                LogWarn(@"No single index contains all of %@; add index for these fields to "
+                        @"query efficiently.",
+                        basicClauses);
+            } else {
+                state.atLeastOneIndexUsed = YES;
+                
+                // Execute SQL on that index with appropriate values
+                CDTQSqlParts *select = [CDTQQuerySqlTranslator selectStatementForAndClause:
+                                        basicClauses usingIndex:chosenIndex];
+                
+                if (!select) {
+                    LogError(@"Error generating SELECT clause for %@", basicClauses);
+                    return nil;
+                }
+                
+                CDTQSqlQueryNode *sql = [[CDTQSqlQueryNode alloc] init];
+                sql.sql = select;
+                
+                [root.children addObject:sql];
+            }
+            
+        } else if (query[OR]) {
+            // OR nodes require a query for each clause.
+            //
+            // We want to allow OR clauses to use separate indexes, unlike for AND, to allow
+            // users to query over multiple indexes during a single query. This prevents users
+            // having to create a single huge index just because one query in their application
+            // requires it, slowing execution of all the other queries down.
+            //
+            // We could optimise for OR parts where we have an appropriate compound index,
+            // but we don't for now.
+            
+            for (NSDictionary *clause in basicClauses) {
+                NSArray *wrappedClause = @[ clause ];
+                
+                NSString *chosenIndex =
+                [CDTQQuerySqlTranslator chooseIndexForAndClause:wrappedClause fromIndexes:indexes];
+                if (!chosenIndex) {
+                    state.atLeastOneIndexMissing = YES;
+                    state.atLeastOneORIndexMissing = YES;
+                    
+                    LogWarn(@"No single index contains all of %@; add index for these fields to "
+                            @"query efficiently.",
+                            basicClauses);
+                } else {
+                    state.atLeastOneIndexUsed = YES;
+                    
+                    // Execute SQL on that index with appropriate values
+                    CDTQSqlParts *select =
+                    [CDTQQuerySqlTranslator selectStatementForAndClause:wrappedClause
+                                                             usingIndex:chosenIndex];
+                    
+                    if (!select) {
+                        LogError(@"Error generating SELECT clause for %@", basicClauses);
+                        return nil;
+                    }
+                    
+                    CDTQSqlQueryNode *sql = [[CDTQSqlQueryNode alloc] init];
+                    sql.sql = select;
+                    
+                    [root.children addObject:sql];
+                }
+            }
+        }
+    }
+
+    //
+    // AND and OR subclauses are handled identically whatever the parent is.
+    // We go through the query twice to order the OR clauses before the AND
+    // clauses, for predictability.
+    //
+
+    // Add subclauses that are OR
+    [clauses enumerateObjectsUsingBlock:^void(id obj, NSUInteger idx, BOOL *stop) {
+        NSDictionary *clause = (NSDictionary *)obj;
+        NSString *field = clause.allKeys[0];
+        if ([field isEqualToString:OR]) {
+            CDTQQueryNode *orNode = [CDTQQuerySqlTranslator translateQuery:clauses[idx]
+                                                              toUseIndexes:indexes
+                                                                     state:state];
+            [root.children addObject:orNode];
+        }
+    }];
+
+    // Add subclauses that are AND
+    [clauses enumerateObjectsUsingBlock:^void(id obj, NSUInteger idx, BOOL *stop) {
+        NSDictionary *clause = (NSDictionary *)obj;
+        NSString *field = clause.allKeys[0];
+        if ([field isEqualToString:AND]) {
+            CDTQQueryNode *andNode = [CDTQQuerySqlTranslator translateQuery:clauses[idx]
+                                                               toUseIndexes:indexes
+                                                                      state:state];
+            [root.children addObject:andNode];
+        }
+    }];
+
+    return root;
+}
+
+#pragma mark Process single AND clause with no sub-clauses
+
++ (NSArray *)fieldsForAndClause:(NSArray *)clause
+{
+    NSMutableArray *fieldNames = [NSMutableArray array];
+    for (NSDictionary *term in clause) {
+        if (term.count == 1) {
+            [fieldNames addObject:term.allKeys[0]];
+        }
+    }
+    return [NSArray arrayWithArray:fieldNames];
+}
+
++ (NSString *)chooseIndexForAndClause:(NSArray *)clause fromIndexes:(NSDictionary *)indexes
+{
+    NSSet *neededFields = [NSSet setWithArray:[self fieldsForAndClause:clause]];
+
+    if (neededFields.count == 0) {
+        LogError(@"Invalid clauses in $and clause %@", clause);
+        return nil;  // no point in querying empty set of fields
+    }
+
+    return [CDTQQuerySqlTranslator chooseIndexForFields:neededFields fromIndexes:indexes];
+}
+
++ (NSString *)chooseIndexForFields:(NSSet *)neededFields fromIndexes:(NSDictionary *)indexes
+{
+    NSString *chosenIndex = nil;
+    for (NSString *indexName in indexes) {
+        NSSet *providedFields = [NSSet setWithArray:indexes[indexName][@"fields"]];
+        if ([neededFields isSubsetOfSet:providedFields]) {
+            chosenIndex = indexName;
+            break;
+        }
+    }
+
+    return chosenIndex;
+}
+
++ (CDTQSqlParts *)wherePartsForAndClause:(NSArray *)clause usingIndex:(NSString *)indexName
+{
+    if (clause.count == 0) {
+        return nil;  // no point in querying empty set of fields
+    }
+
+    // @[@{@"fieldName": @"mike"}, ...]
+
+    NSMutableArray *sqlClauses = [NSMutableArray array];
+    NSMutableArray *sqlParameters = [NSMutableArray array];
+    NSDictionary *operatorMap = @{
+        EQ : @"=",
+        GT : @">",
+        GTE : @">=",
+        LT : @"<",
+        LTE : @"<=",
+        IN : @"IN"
+    };
+
+    for (NSDictionary *component in clause) {
+        if (component.count != 1) {
+            LogError(@"Expected single predicate per clause dictionary, got %@", component);
+            return nil;
+        }
+
+        NSString *fieldName = component.allKeys[0];
+        NSDictionary *predicate = component[fieldName];
+
+        if (predicate.count != 1) {
+            LogError(@"Expected single operator per predicate dictionary, got %@", component);
+            return nil;
+        }
+
+        NSString *operator= predicate.allKeys[0];
+
+        // $not specifies ALL documents NOT in the set of documents that match the operator.
+        if ([operator isEqualToString:NOT]) {
+            NSDictionary *negatedPredicate = predicate[NOT];
+
+            if (negatedPredicate.count != 1) {
+                LogError(@"Expected single operator per predicate dictionary, got %@", component);
+                return nil;
+            }
+
+            NSString *operator= negatedPredicate.allKeys[0];
+            NSObject *predicateValue = nil;
+
+            if([operator isEqualToString:EXISTS]){
+                // what we do here depends on the value of the exists are
+                predicateValue = negatedPredicate[operator];
+
+                BOOL exists = ![(NSNumber *)predicateValue boolValue];
+                // since this clause is negated we need to negate the bool value
+                [sqlClauses
+                    addObject:[self convertExistsToSqlClauseForFieldName:fieldName exists:exists]];
+                    [sqlParameters addObject:negatedPredicate[operator]];
+
+            } else {
+                NSString *sqlClause;
+                NSString *sqlOperator = operatorMap[operator];
+                NSString *tableName = [CDTQIndexManager tableNameForIndex:indexName];
+                NSString *placeholder;
+                if ([operator isEqualToString:IN]) {
+                    // The predicate dictionary value must be an NSArray here.
+                    // This was validated during normalization.
+                    NSArray *inList = negatedPredicate[operator];
+                    placeholder =
+                        [CDTQQuerySqlTranslator placeholdersForList:inList
+                                            updatingParameterValues:sqlParameters];
+                } else {
+                    // The predicate dictionary value must be either a
+                    // NSString or a NSNumber here.
+                    // This was validated during normalization.
+                    predicateValue = negatedPredicate[operator];
+                    placeholder = @"?";
+                    [sqlParameters addObject:predicateValue];
+                }
+
+                sqlClause = [CDTQQuerySqlTranslator whereClauseForNot:fieldName
+                                                        usingOperator:sqlOperator
+                                                             forTable:tableName
+                                                           forOperand:placeholder];
+                [sqlClauses addObject:sqlClause];
+            }
+        } else {
+            if ([operator isEqualToString:EXISTS]){
+                    BOOL  exists = [(NSNumber *)predicate[operator] boolValue];
+                    [sqlClauses addObject:[self convertExistsToSqlClauseForFieldName:fieldName
+                                                                              exists:exists]];
+                    [sqlParameters addObject:predicate[operator]];
+
+            } else {
+                NSString *sqlClause;
+                NSString *sqlOperator = operatorMap[operator];
+                NSString *placeholder;
+                if ([operator isEqualToString:IN]) {
+                    // The predicate dictionary value must be an NSArray here.
+                    // This was validated during normalization.
+                    NSArray *inList = predicate[operator];
+                    placeholder =
+                        [CDTQQuerySqlTranslator placeholdersForList:inList
+                                            updatingParameterValues:sqlParameters];
+                } else {
+                    NSObject * predicateValue = predicate[operator];
+                    placeholder = @"?";
+                    [sqlParameters addObject:predicateValue];
+                }
+
+                sqlClause = [NSString stringWithFormat:@"\"%@\" %@ %@", fieldName,
+                                                                        sqlOperator,
+                                                                        placeholder];
+                [sqlClauses addObject:sqlClause];
+            }
+        }
+    }
+
+    return [CDTQSqlParts partsForSql:[sqlClauses componentsJoinedByString:@" AND "]
+                          parameters:sqlParameters];
+}
+
++ (NSString *)placeholdersForList:(NSArray *)values
+            updatingParameterValues:(NSMutableArray *)sqlParameters
+{
+    NSMutableArray *operands = [NSMutableArray array];
+    for (NSObject *value in values) {
+        [operands addObject:@"?"];
+        [sqlParameters addObject:value];
+    }
+    
+    NSString *joined = [operands componentsJoinedByString:@", "];
+    return [NSString stringWithFormat:@"( %@ )", joined];
+}
+
+/**
+ * WHERE clause representation of $not must be handled by using a
+ * sub-SELECT statement of the operator which is then applied to
+ * _id NOT IN (...).  This is because this process is the only
+ * way that we can ensure that documents that contain arrays are
+ * handled correctly.
+ *
+ */
++ (NSString *)whereClauseForNot:(NSString *)fieldName
+                  usingOperator:(NSString *)sqlOperator
+                       forTable:(NSString *)tableName
+                     forOperand:(NSString *)operand;
+{
+    NSString *whereForSubSelect = [NSString stringWithFormat:@"\"%@\" %@ %@",
+                                   fieldName,
+                                   sqlOperator,
+                                   operand];
+    NSString *subSelect = [NSString stringWithFormat:@"SELECT _id FROM %@ WHERE %@",
+                           tableName,
+                           whereForSubSelect];
+    
+    return [NSString stringWithFormat:@"_id NOT IN (%@)", subSelect];
+}
+
++ (NSString *)convertExistsToSqlClauseForFieldName:(NSString *)fieldName exists:(BOOL)exists
+{
+    NSString *sqlClause;
+    if (exists) {
+        // so this field needs to exist
+        sqlClause = [NSString stringWithFormat:@"(\"%@\" IS NOT NULL)", fieldName];
+    } else {
+        // must not exist
+        sqlClause = [NSString stringWithFormat:@"(\"%@\" IS NULL)", fieldName];
+    }
+    return sqlClause;
+}
+
++ (CDTQSqlParts *)selectStatementForAndClause:(NSArray *)clause usingIndex:(NSString *)indexName
+{
+    if (clause.count == 0) {
+        return nil;  // no query here
+    }
+
+    if (!indexName) {
+        return nil;
+    }
+
+    CDTQSqlParts *where = [CDTQQuerySqlTranslator wherePartsForAndClause:clause
+                                                              usingIndex:indexName];
+
+    if (!where) {
+        return nil;
+    }
+
+    NSString *tableName = [CDTQIndexManager tableNameForIndex:indexName];
+
+    NSString *sql = @"SELECT _id FROM %@ WHERE %@;";
+    sql = [NSString stringWithFormat:sql, tableName, where.sqlWithPlaceholders];
+
+    CDTQSqlParts *parts = [CDTQSqlParts partsForSql:sql parameters:where.placeholderValues];
+    return parts;
+}
+
+@end

--- a/Classes/common/query/CDTQQueryValidator.h
+++ b/Classes/common/query/CDTQQueryValidator.h
@@ -1,0 +1,26 @@
+//
+//  CDTQQueryValidator.h
+//
+//  Created by Rhys Short on 06/11/2014.
+//  Copyright (c) 2014 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+// This class contains common validation options for the
+// two different implementations of query
+@interface CDTQQueryValidator : NSObject
+
+/**
+ Expand implicit operators in a query, and validate
+ */
++ (NSDictionary *)normaliseAndValidateQuery:(NSDictionary *)query;
+
+@end

--- a/Classes/common/query/CDTQQueryValidator.m
+++ b/Classes/common/query/CDTQQueryValidator.m
@@ -1,0 +1,445 @@
+//
+//  CDTQQueryValidator.m
+//
+//  Created by Rhys Short on 06/11/2014.
+//  Copyright (c) 2014 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+#import "CDTQQueryValidator.h"
+#import "CDTQQueryConstants.h"
+
+#import "CDTQLogging.h"
+
+@implementation CDTQQueryValidator
+
+// negatedShortHand is used for operator shorthand processing.
+// A shorthand operator like $ne has a longhand representation
+// that is { "$not" : { "$eq" : ... } }.  Therefore the negation
+// of the $ne operator is $eq.
++ (NSDictionary *)negatedShortHand
+{
+    static NSDictionary *negatedShortHandDict = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        negatedShortHandDict = @{ NE : EQ ,
+                                  NIN : IN };
+    });
+    return negatedShortHandDict;
+}
+
++ (NSDictionary *)normaliseAndValidateQuery:(NSDictionary *)query
+{
+    bool isWildCard = [query count] == 0;
+
+    // First expand the query to include a leading compound predicate
+    // if there isn't one already.
+    query = [CDTQQueryValidator addImplicitAnd:query];
+
+    // At this point we will have a single entry dict, key AND or OR,
+    // forming the compound predicate.
+    NSString *compoundOperator = [query allKeys][0];
+    NSArray *predicates = query[compoundOperator];
+    if ([predicates isKindOfClass:[NSArray class]]) {
+        // Next make sure all the predicates have an operator -- the EQ
+        // operator is implicit and we need to add it if there isn't one.
+        // Take
+        //     [ {"field1": "mike"}, ... ]
+        // and make
+        //     [ {"field1": { "$eq": "mike"} }, ... ]
+        predicates = [CDTQQueryValidator addImplicitEq:predicates];
+        
+        // Then all shorthand operators like $ne, if present, need to be
+        // converted to their logical longhand equivalent.
+        // Take
+        //     [ { "field1": { "$ne": "mike"} }, ... ]
+        // and make
+        //     [ { "field1": { "$not" : { "$eq": "mike"} } }, ... ]
+        predicates = [CDTQQueryValidator handleShortHandOperators:predicates];
+        
+        // Now in the event that extraneous $not operators exist in the query,
+        // these operators must be compressed down to the their logical equivalent.
+        // Take
+        //     [ { "field1": { "$not" : { $"not" : { "$eq": "mike"} } } }, ... ]
+        // and make
+        //     [ { "field1": { "$eq": "mike"} }, ... ]
+        predicates = [CDTQQueryValidator compressMultipleNotOperators:predicates];
+    }
+
+    NSDictionary *selector = @{compoundOperator : predicates};
+    if (isWildCard) {
+        return selector;
+    } else if ([CDTQQueryValidator validateSelector:selector]) {
+        return selector;
+    }
+
+    return nil;
+}
+
+#pragma mark Normalization methods
++ (NSDictionary *)addImplicitAnd:(NSDictionary *)query
+{
+    // query is:
+    //  either @{ @"field1": @"value1", ... } -- we need to add $and
+    //  or     @{ @"$and": @[ ... ] } -- we don't
+    //  or     @{ @"$or": @[ ... ] } -- we don't
+
+    if (query.count == 1 && (query[AND] || query[OR])) {
+        return query;
+    } else {
+        // Take
+        //     @{"field1": @"mike", ...}
+        //     @{"field1": @[ @"mike", @"bob" ], ...}
+        // and make
+        //     @[ @{"field1": @"mike"}, ... ]
+        //     @[ @{"field1": @[ @"mike", @"bob" ]}, ... ]
+
+        NSMutableArray *andClause = [NSMutableArray array];
+        for (NSString *k in query) {
+            NSObject *predicate = query[k];
+            [andClause addObject:@{k : predicate}];
+        }
+        return @{AND : [NSArray arrayWithArray:andClause]};
+    }
+}
+
++ (NSArray *)addImplicitEq:(NSArray *)andClause
+{
+    NSMutableArray *accumulator = [NSMutableArray array];
+
+    for (NSDictionary *fieldClause in andClause) {
+        // fieldClause is:
+        //  either @{ @"field1": @"mike"} -- we need to add the $eq operator
+        //  or     @{ @"field1": @{ @"$operator": @"value" } -- we don't
+        //  or     @{ @"$and": @[ ... ] } -- we don't
+        //  or     @{ @"$or": @[ ... ] } -- we don't
+        NSObject *predicate = nil;
+        NSString *fieldName = nil;
+        if ([fieldClause isKindOfClass:[NSDictionary class]] && [fieldClause count] != 0) {
+            fieldName = fieldClause.allKeys[0];
+            predicate = fieldClause[fieldName];
+        } else {
+            // if this isn't a dictionary, we don't know what to do so add the clause
+            // to the accumulator to be dealt with later as part of the final selector
+            // validation.
+            [accumulator addObject:fieldClause];
+            continue;
+        }
+
+        // If the clause isn't a special clause (the field name starts with
+        // $, e.g., $and), we need to check whether the clause already
+        // has an operator. If not, we need to add the implicit $eq.
+        if (![fieldName hasPrefix:@"$"]) {
+            if (![predicate isKindOfClass:[NSDictionary class]]) {
+                predicate = @{EQ : predicate};
+            }
+        } else if ([predicate isKindOfClass:[NSArray class]]) {
+            predicate = [CDTQQueryValidator addImplicitEq:(NSArray *)predicate];
+        }
+
+        [accumulator addObject:@{fieldName : predicate}];  // can't put nil in this
+    }
+
+    return [NSArray arrayWithArray:accumulator];
+}
+
++ (NSArray *)handleShortHandOperators:(NSArray *)clause
+{
+    NSMutableArray *accumulator = [NSMutableArray array];
+    
+    for (NSDictionary *fieldClause in clause) {
+        NSObject *predicate = nil;
+        NSString *fieldName = nil;
+        if ([fieldClause isKindOfClass:[NSDictionary class]] && [fieldClause count] != 0) {
+            fieldName = fieldClause.allKeys[0];
+            predicate = fieldClause[fieldName];
+            if ([fieldName hasPrefix:@"$"] && [predicate isKindOfClass:[NSArray class]]) {
+                predicate = [CDTQQueryValidator handleShortHandOperators:(NSArray *) predicate];
+            } else if ([predicate isKindOfClass:[NSDictionary class]] &&
+                       [(NSDictionary *)predicate count] != 0) {
+                // if the clause isn't a special clause (the field name starts with
+                // $, e.g., $and), we need to check whether the clause has a shorthand
+                // operator like $ne. If it does, we need to convert it to its longhand
+                // version.
+                // Take:  { "$ne" : ... }
+                // Make:  { "$not" : { "$eq" : ... } }
+                predicate = [CDTQQueryValidator replaceWithLonghand:(NSDictionary *)predicate];
+            } else {
+                [accumulator addObject:fieldClause];
+                continue;
+            }
+        } else {
+            // if this isn't a dictionary, we don't know what to do so add the clause
+            // to the accumulator to be dealt with later as part of the final selector
+            // validation.
+            [accumulator addObject:fieldClause];
+            continue;
+        }
+        
+        [accumulator addObject:@{fieldName : predicate}];  // can't put nil in this
+    }
+    
+    return [NSArray arrayWithArray:accumulator];
+}
+
+/**
+ * This method traverses the predicate dictionary until it reaches the last operator
+ * in the tree, it then checks it for a shorthand representation.  If one exists then
+ * that shorthand representation is replaced with its longhand version.
+ * For example:   { "$ne" : ... }
+ * is replaced by { "$not" : { "$eq" : ... } }
+ */
++ (NSDictionary *)replaceWithLonghand:(NSDictionary *)predicate
+{
+    if (!predicate || [predicate count] == 0) {
+        return predicate;
+    }
+    
+    NSString *operator = predicate.allKeys[0];
+    NSObject *subPredicate = predicate[operator];
+    if ([subPredicate isKindOfClass:[NSDictionary class]]) {
+        // Recurse down nested predicates, like { $not: { $not: { $ne: "blah" } } }
+        return @{ operator: [CDTQQueryValidator replaceWithLonghand:(NSDictionary *)subPredicate] };
+    } else if ([CDTQQueryValidator negatedShortHand][operator]) {
+        // We got to the end and found an expandable operator, { $ne: "blah" }
+        return @{ NOT: @{ [CDTQQueryValidator negatedShortHand][operator] : subPredicate } };
+    } else {
+        // We got to the end and found an normal operator, { $eq: "blah" }
+        return @{ operator: subPredicate };
+    }
+    
+}
+
+/**
+ * This method takes a string of $not operators down to either none or a single $not
+ * operator.  For example:  { "$not" : { "$not" : { "$eq" : "mike" } } }
+ * should compress down to  { "$not" : { "$eq" : "mike" } }
+ */
++ (NSArray *)compressMultipleNotOperators:(NSArray *)clause
+{
+    NSMutableArray *accumulator = [NSMutableArray array];
+    
+    for (NSDictionary *fieldClause in clause) {
+        NSObject *predicate = nil;
+        NSString *fieldName = nil;
+        if ([fieldClause isKindOfClass:[NSDictionary class]] && [fieldClause count] != 0) {
+            fieldName = fieldClause.allKeys[0];
+            predicate = fieldClause[fieldName];
+        } else {
+            // if this isn't a dictionary, we don't know what to do so add the clause
+            // to the accumulator to be dealt with later as part of the final selector
+            // validation.
+            [accumulator addObject:fieldClause];
+            continue;
+        }
+        
+        if ([fieldName hasPrefix:@"$"] && [predicate isKindOfClass:[NSArray class]]) {
+            predicate = [CDTQQueryValidator compressMultipleNotOperators:(NSArray *) predicate];
+        } else {
+            NSObject *operatorPredicate = nil;
+            NSString *operator = nil;
+            if ([predicate isKindOfClass:[NSDictionary class]] &&
+                [(NSDictionary *)predicate count] != 0) {
+                operator = ((NSDictionary *)predicate).allKeys[0];
+                operatorPredicate = ((NSDictionary *)predicate)[operator];
+            } else {
+                // if this isn't a dictionary, we don't know what to do so add the clause
+                // to the accumulator to be dealt with later as part of the final selector
+                // validation.
+                [accumulator addObject:fieldClause];
+                continue;
+            }
+            if ([operator isEqualToString:NOT]) {
+                // If a $not operator is encountered we need to check for
+                // a series of nested $not operators.
+                BOOL notOpFound = YES;
+                BOOL negateOperator = NO;
+                NSObject *originalOperatorPredicate = operatorPredicate;
+                while (notOpFound) {
+                    // if a series of nested $not operators are found then they need to
+                    // be compressed down to one $not operator or in the case of an
+                    // even set of $not operators, down to zero $not operators.
+                    if ([operatorPredicate isKindOfClass:[NSDictionary class]]) {
+                        NSDictionary *notClause = (NSDictionary *)operatorPredicate;
+                        NSString *nextOperator = notClause.allKeys[0];
+                        if ([nextOperator isEqualToString:NOT]) {
+                            // Each time we find a $not operator we flip the negateOperator's
+                            // boolean value.
+                            negateOperator = !negateOperator;
+                            operatorPredicate = notClause[nextOperator];
+                        } else {
+                            notOpFound = NO;
+                        }
+                    } else {
+                        // unexpected condition - revert back to original
+                        operatorPredicate = originalOperatorPredicate;
+                        negateOperator = NO;
+                        notOpFound = NO;
+                    }
+                }
+                if (negateOperator) {
+                    NSDictionary *operatorPredicateDict = (NSDictionary *)operatorPredicate;
+                    operator = operatorPredicateDict.allKeys[0];
+                    operatorPredicate = operatorPredicateDict[operator];
+                }
+                predicate = @{ operator : operatorPredicate };
+            }
+        }
+        
+        [accumulator addObject:@{fieldName : predicate}];  // can't put nil in this
+    }
+    
+    return [NSArray arrayWithArray:accumulator];
+}
+
+#pragma validation class methods
+
++ (BOOL)validateCompoundOperatorClauses:(NSArray *)clauses
+{
+    BOOL valid = NO;
+
+    for (id obj in clauses) {
+        valid = NO;
+        if (![obj isKindOfClass:[NSDictionary class]]) {
+            LogError(@"Operator argument must be a dictionary %@", [clauses description]);
+            break;
+        }
+        NSDictionary *clause = (NSDictionary *)obj;
+        if ([clause count] != 1) {
+            LogError(@"Operator argument clause should only have one key value pair: %@",
+                     [clauses description]);
+            break;
+        }
+
+        NSString *key = [obj allKeys][0];
+        if ([@[ OR, NOT, AND ] containsObject:key]) {
+            // this should have an array as top level type
+            id compoundClauses = [obj objectForKey:key];
+            if ([CDTQQueryValidator validateCompoundOperatorOperand:compoundClauses]) {
+                // validate array
+                valid = [CDTQQueryValidator validateCompoundOperatorClauses:compoundClauses];
+            }
+        } else if (![key hasPrefix:@"$"]) {
+            // this should have a dict
+            // send this for validation
+            valid = [CDTQQueryValidator validateClause:[obj objectForKey:key]];
+        } else {
+            LogError(@"%@ operator cannot be a top level operator", key);
+            break;
+        }
+
+        if (!valid) {
+            break;  // if we have gotten here with valid being no, we should abort
+        }
+    }
+
+    return valid;
+}
+
++ (BOOL)validateClause:(NSDictionary *)clause
+{
+    // The replaceWithLonghand: method translates something like { "$ne" : "blah" }
+    // to { "$not" : { "$eq" : "blah" } } before reaching this validation.  So
+    // operators like $ne and $nin will be negated $eq and $in by the time this
+    // validation is reached.
+    NSArray *validOperators =  @[ EQ, LT, GT, EXISTS, NOT, GTE, LTE, IN ];
+
+    if ([clause count] == 1) {
+        NSString *operator= [clause allKeys][0];
+
+        if ([validOperators containsObject:operator]) {
+            // contains correct operator
+            id clauseOperand = [clause objectForKey:[clause allKeys][0]];
+            // handle special case, $not is the only op that expects a dict
+            if ([operator isEqualToString:NOT]) {
+                return [clauseOperand isKindOfClass:[NSDictionary class]] &&
+                       [CDTQQueryValidator validateClause:clauseOperand];
+
+            } else if ([operator isEqualToString:IN]) {
+                return [clauseOperand isKindOfClass:[NSArray class]] &&
+                       [CDTQQueryValidator validateListValues:clauseOperand];
+            } else {
+                return [CDTQQueryValidator validatePredicateValue:clauseOperand
+                                                      forOperator:operator];
+            }
+        }
+    }
+
+    return NO;
+}
+
++ (BOOL)validateListValues:(NSArray *)listValues
+{
+    BOOL valid = YES;
+    
+    for (NSObject *value in listValues) {
+        if (![CDTQQueryValidator validatePredicateValue:value forOperator:IN]) {
+            valid = NO;
+            break;
+        }
+    }
+    
+    return valid;
+}
+
++ (BOOL)validatePredicateValue:(NSObject *)predicateValue forOperator:(NSString *) operator
+{
+    if([operator isEqualToString:EXISTS]){
+        return [CDTQQueryValidator validateExistsArgument:predicateValue];
+    } else {
+        return (([predicateValue isKindOfClass:[NSString class]] ||
+                 [predicateValue isKindOfClass:[NSNumber class]]));
+    }
+}
+
++ (BOOL)validateExistsArgument:(NSObject *)exists
+{
+    BOOL valid = YES;
+
+    if (![exists isKindOfClass:[NSNumber class]]) {
+        valid = NO;
+        LogError(@"$exists operator expects YES or NO");
+    }
+
+    return valid;
+}
+
++ (BOOL)validateCompoundOperatorOperand:(NSObject *)operand
+{
+    if (![operand isKindOfClass:[NSArray class]]) {
+        LogError(@"Arugment to compound operator is not an NSArray: %@", [operand description]);
+        return NO;
+    }
+    return YES;
+}
+
+// we are going to need to walk the query tree to validate it before executing it
+// this isn't going to be fun :'(
+
++ (BOOL)validateSelector:(NSDictionary *)selector
+{
+    // after normalising we should have a few top level selectors
+
+    NSString *topLevelOp = [selector allKeys][0];
+
+    // top level op can only be $and after normalisation
+
+    if ([@[ AND, OR ] containsObject:topLevelOp]) {
+        // top level should be $and or $or they should have arrays
+        id topLevelArg = [selector objectForKey:topLevelOp];
+
+        if ([topLevelArg isKindOfClass:[NSArray class]]) {
+            // safe we know its an NSArray
+            return [CDTQQueryValidator validateCompoundOperatorClauses:topLevelArg];
+        }
+    }
+    return NO;
+}
+
+@end

--- a/Classes/common/query/CDTQResultSet.h
+++ b/Classes/common/query/CDTQResultSet.h
@@ -1,0 +1,63 @@
+//
+//  CDTQResultSet.h
+//
+//  Created by Mike Rhodes on 2014-09-27
+//  Copyright (c) 2014 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+@class CDTDatastore;
+@class CDTQResultSetBuilder;
+@class CDTDocumentRevision;
+@class CDTQUnindexedMatcher;
+
+typedef void (^CDTQResultSetBuilderBlock)(CDTQResultSetBuilder *configuration);
+
+/**
+ A simple object to aid construction of a CDTQResultSet.
+ */
+@interface CDTQResultSetBuilder : NSObject
+
+@property (nonatomic, strong) NSArray *docIds;
+@property (nonatomic, strong) CDTDatastore *datastore;
+@property (nonatomic, strong) NSArray *fields;
+@property (nonatomic) NSUInteger skip;
+@property (nonatomic) NSUInteger limit;
+@property (nonatomic, strong) CDTQUnindexedMatcher *matcher;
+
+@end
+
+/**
+ Enumerator over documents resulting from query.
+
+ Use -enumerateObjectsUsingBlock: to iterate results:
+ 
+ [result enumerateObjectsUsingBlock:^(CDTDocumentRevision *rev, NSUInteger idx, BOOL *stop) {
+    // rev: the result revision.
+    // idx: the index of this result.
+    // stop: set to YES to stop the iteration.
+ }];
+ */
+@interface CDTQResultSet : NSObject {
+    CDTDatastore *_datastore;
+    NSArray *_originalDocumentIds;
+}
+
++ (instancetype)resultSetWithBlock:(CDTQResultSetBuilderBlock)block;
+
+- (instancetype)initWithBuilder:(CDTQResultSetBuilder *)builder;
+
+- (void)enumerateObjectsUsingBlock:(void (^)(CDTDocumentRevision *rev, NSUInteger idx,
+                                             BOOL *stop))block;
+
+@property (nonatomic, strong, readonly) NSArray *documentIds;  // of type NSString*
+
+@end

--- a/Classes/common/query/CDTQResultSet.m
+++ b/Classes/common/query/CDTQResultSet.m
@@ -1,0 +1,155 @@
+//
+//  CDTQResultSet.m
+//
+//  Created by Mike Rhodes on 2014-09-27
+//  Copyright (c) 2014 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+#import "CDTQResultSet.h"
+#import "CDTQLogging.h"
+#import "CDTQProjectedDocumentRevision.h"
+#import "CDTQUnindexedMatcher.h"
+
+#import <CloudantSync.h>
+
+@interface CDTQResultSet ()
+@property (nonatomic, strong, readwrite) NSArray *fields;
+@property (nonatomic) NSUInteger skip;
+@property (nonatomic) NSUInteger limit;
+@property (nonatomic, strong) CDTQUnindexedMatcher *matcher;
+@end
+
+@implementation CDTQResultSetBuilder
+
+- (CDTQResultSet *)build;
+{
+    return [[CDTQResultSet alloc] initWithBuilder:self];
+}
+
+@end
+
+@implementation CDTQResultSet
+
+- (instancetype)initWithBuilder:(CDTQResultSetBuilder *)builder
+{
+    self = [super init];
+    if (self) {
+        _originalDocumentIds = builder.docIds;
+        _datastore = builder.datastore;
+        _fields = builder.fields;
+        _skip = builder.skip;
+        _limit = builder.limit;
+        _matcher = builder.matcher;
+    }
+    return self;
+}
+
++ (instancetype)resultSetWithBlock:(CDTQResultSetBuilderBlock)block
+{
+    NSParameterAssert(block);
+
+    CDTQResultSetBuilder *builder = [[CDTQResultSetBuilder alloc] init];
+    block(builder);
+    return [builder build];
+}
+
+- (NSArray /* NSString */ *)documentIds
+{
+    // This is implemented using -enumerateObjectsUsingBlock so that when we're using
+    // skip, limit or post hoc matching the documentIds array is output correctly.
+    NSMutableArray *accumulator = [NSMutableArray array];
+    [self enumerateObjectsUsingBlock:^(CDTDocumentRevision *rev, NSUInteger idx, BOOL *stop) {
+        [accumulator addObject:rev.docId];
+    }];
+    return [NSArray arrayWithArray:accumulator];
+}
+
+- (void)enumerateObjectsUsingBlock:(void (^)(CDTDocumentRevision *rev, NSUInteger idx,
+                                             BOOL *stop))block
+{
+    NSUInteger idx = 0;
+
+    NSUInteger nSkipped = 0;   // used for skip
+    NSUInteger nReturned = 0;  // used for limit
+
+    // Avoid method calls in the loop
+    NSUInteger skip = self.skip;
+    NSUInteger limit = self.limit;
+    CDTQUnindexedMatcher *matcher = self.matcher;
+    NSArray *fields = self.fields;
+
+    BOOL stop = NO;  // user stopped, or we returned `limit` results
+    NSUInteger batchSize = 50;
+    NSRange range = NSMakeRange(0, batchSize);
+    while (range.location < _originalDocumentIds.count) {
+        range.length = MIN(batchSize, _originalDocumentIds.count - range.location);
+        NSArray *batch = [_originalDocumentIds subarrayWithRange:range];
+
+        NSArray *docs = [_datastore getDocumentsWithIds:batch];
+
+        for (CDTDocumentRevision *rev in docs) {
+            CDTDocumentRevision *innerRev = rev;  // allows us to replace later if projecting
+
+            // Apply post-hoc matcher
+            if (matcher && ![matcher matches:innerRev]) {
+                continue;
+            }
+
+            // Apply skip (skip == 0 means disable)
+            if (skip > 0 && nSkipped < skip) {
+                nSkipped++;
+                continue;
+            }
+
+            // Apply projection if result matches
+            if (fields) {
+                innerRev =
+                    [CDTQResultSet projectFields:self.fields fromRevision:rev datastore:_datastore];
+            }
+
+            // Run callback
+            block(innerRev, idx, &stop);
+            if (stop) {
+                break;
+            }
+            idx++;
+
+            // Apply limit (limit == 0 means disable)
+            nReturned++;
+            if (limit > 0 && nReturned >= limit) {
+                stop = YES;
+                break;
+            }
+        }
+
+        if (stop) {
+            break;
+        }
+
+        range.location += range.length;
+    }
+}
+
++ (CDTDocumentRevision *)projectFields:(NSArray *)fields
+                          fromRevision:(CDTDocumentRevision *)rev
+                             datastore:(CDTDatastore *)datastore
+{
+    // grab the dictionary filter fields and rebuild object
+    NSDictionary *body = [rev.body dictionaryWithValuesForKeys:fields];
+    return [[CDTQProjectedDocumentRevision alloc] initWithDocId:rev.docId
+                                                     revisionId:rev.revId
+                                                           body:body
+                                                        deleted:rev.deleted
+                                                    attachments:rev.attachments
+                                                       sequence:rev.sequence
+                                                      datastore:datastore];
+}
+
+@end

--- a/Classes/common/query/CDTQUnindexedMatcher.h
+++ b/Classes/common/query/CDTQUnindexedMatcher.h
@@ -1,0 +1,100 @@
+//
+//  CDTQUnindexedMatcher.h
+//  Pods
+//
+//  Created by Michael Rhodes on 31/10/2014.
+//  Copyright (c) 2014 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+#import "CDTQQuerySqlTranslator.h"
+
+@class CDTDocumentRevision;
+
+@interface CDTQOperatorExpressionNode : CDTQQueryNode
+
+@property (nonatomic, strong) NSDictionary *expression;
+
+@end
+
+/**
+ Determine whether a document matches a selector.
+
+ This class is used when a selector cannot be satisfied using
+ indexes alone. It takes a selector, compiles it into an internal
+ representation and is able to then determine whether a document
+ matches that selector.
+
+ The matcher works by first creating a simple tree, which is then
+ executed against each document it's asked to match.
+
+
+ Some examples:
+
+ AND : [ { x: X }, { y: Y } ]
+
+ This can be represented by a two operator expressions and AND tree node:
+
+        AND
+       /   \
+ { x: X }  { y: Y }
+
+
+ OR : [ { x: X }, { y: Y } ]
+
+ This is a single OR node and two operator expressions:
+
+         OR
+       /    \
+ { x: X }  { y: Y }
+
+ The interpreter then unions the results.
+
+
+ OR : [ { AND : [ { x: X }, { y: Y } ] }, { y: Y } ]
+
+ This requires a more complex tree:
+
+               OR
+              /   \
+          AND    { y: Y }
+         /   \
+  { x: X }  { y: Y }
+
+
+ AND : [ { OR : [ { x: X }, { y: Y } ] }, { y: Y } ]
+
+ This is really the most complex situation:
+
+               AND
+              /   \
+           OR   { y: Y }
+         /    \
+  { x: X }  { y: Y }
+
+ These basic patterns can be composed into more complicate structures.
+ */
+@interface CDTQUnindexedMatcher : NSObject
+
+/**
+ Return a new initialised matcher.
+
+ Assumes selector is valid as we're calling this late in
+ the query processing.
+ */
++ (CDTQUnindexedMatcher *)matcherWithSelector:(NSDictionary *)selector;
+
+/**
+ Returns YES if a document matches this matcher's selector.
+ */
+- (BOOL)matches:(CDTDocumentRevision *)rev;
+
+@end

--- a/Classes/common/query/CDTQUnindexedMatcher.m
+++ b/Classes/common/query/CDTQUnindexedMatcher.m
@@ -1,0 +1,336 @@
+//
+//  CDTQUnindexedMatcher.m
+//  Pods
+//
+//  Created by Michael Rhodes on 31/10/2014.
+//  Copyright (c) 2014 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+#import "CDTQUnindexedMatcher.h"
+#import "CDTQQueryConstants.h"
+
+#import "CDTQQuerySqlTranslator.h"
+#import "CDTQLogging.h"
+#import "CDTQValueExtractor.h"
+#import "CDTQQueryValidator.h"
+
+#import "CDTDocumentRevision.h"
+
+@implementation CDTQOperatorExpressionNode
+
+@end
+
+@interface CDTQUnindexedMatcher ()
+
+@property (nonatomic, strong) CDTQChildrenQueryNode *root;
+
+@end
+
+@implementation CDTQUnindexedMatcher
+
+#pragma mark Creating matcher
+
++ (CDTQUnindexedMatcher *)matcherWithSelector:(NSDictionary *)selector
+{
+    CDTQChildrenQueryNode *root = [CDTQUnindexedMatcher buildExecutionTreeForSelector:selector];
+
+    if (!root) {
+        return nil;
+    }
+
+    CDTQUnindexedMatcher *matcher = [[CDTQUnindexedMatcher alloc] init];
+    matcher.root = root;
+    return matcher;
+}
+
++ (CDTQChildrenQueryNode *)buildExecutionTreeForSelector:(NSDictionary *)selector
+{
+    // At this point we will have a root compound predicate, AND or OR, and
+    // the query will be reduced to a single entry:
+    // @{ @"$and": @[ ... predicates (possibly compound) ... ] }
+    // @{ @"$or": @[ ... predicates (possibly compound) ... ] }
+
+    CDTQChildrenQueryNode *root;
+    NSArray *clauses;
+
+    if (selector[AND]) {
+        clauses = selector[AND];
+        root = [[CDTQAndQueryNode alloc] init];
+    } else if (selector[OR]) {
+        clauses = selector[OR];
+        root = [[CDTQOrQueryNode alloc] init];
+    }
+
+    //
+    // First handle the simple @"field": @{ @"$operator": @"value" } clauses.
+    //
+
+    NSMutableArray *basicClauses = [NSMutableArray array];
+
+    [clauses enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+        NSDictionary *clause = (NSDictionary *)obj;
+        NSString *field = clause.allKeys[0];
+        if (![field hasPrefix:@"$"]) {
+            [basicClauses addObject:clauses[idx]];
+        }
+    }];
+
+    // Execution step will evaluate each child node and AND or OR the results.
+    for (NSDictionary *expression in basicClauses) {
+        CDTQOperatorExpressionNode *node = [[CDTQOperatorExpressionNode alloc] init];
+        node.expression = expression;
+        [root.children addObject:node];
+    }
+
+    //
+    // AND and OR subclauses are handled identically whatever the parent is.
+    // We go through the query twice to order the OR clauses before the AND
+    // clauses, for predictability.
+    //
+
+    // Add subclauses that are OR
+    [clauses enumerateObjectsUsingBlock:^void(id obj, NSUInteger idx, BOOL *stop) {
+        NSDictionary *clause = (NSDictionary *)obj;
+        NSString *field = clause.allKeys[0];
+        if ([field isEqualToString:OR]) {
+            CDTQQueryNode *orNode =
+                [CDTQUnindexedMatcher buildExecutionTreeForSelector:clauses[idx]];
+            [root.children addObject:orNode];
+        }
+    }];
+
+    // Add subclauses that are AND
+    [clauses enumerateObjectsUsingBlock:^void(id obj, NSUInteger idx, BOOL *stop) {
+        NSDictionary *clause = (NSDictionary *)obj;
+        NSString *field = clause.allKeys[0];
+        if ([field isEqualToString:AND]) {
+            CDTQQueryNode *andNode =
+                [CDTQUnindexedMatcher buildExecutionTreeForSelector:clauses[idx]];
+            [root.children addObject:andNode];
+        }
+    }];
+
+    return root;
+}
+
+#pragma mark Matching documents
+
+- (BOOL)matches:(CDTDocumentRevision *)rev
+{
+    return [self executeSelectorTree:self.root onRevision:rev];
+}
+
+#pragma mark Tree walking
+
+- (BOOL)executeSelectorTree:(CDTQQueryNode *)node onRevision:(CDTDocumentRevision *)rev
+{
+    if ([node isKindOfClass:[CDTQAndQueryNode class]]) {
+        BOOL passed = YES;
+
+        CDTQAndQueryNode *andNode = (CDTQAndQueryNode *)node;
+
+//        if ([andNode.children count] == 0) {
+//            // well this isn't right, something has gone wrong
+//            return NO;
+//        }
+
+        for (CDTQQueryNode *child in andNode.children) {
+            passed = passed && [self executeSelectorTree:child onRevision:rev];
+        }
+
+        return passed;
+    }
+    if ([node isKindOfClass:[CDTQOrQueryNode class]]) {
+        BOOL passed = NO;
+
+        CDTQOrQueryNode *orNode = (CDTQOrQueryNode *)node;
+        for (CDTQQueryNode *child in orNode.children) {
+            passed = passed || [self executeSelectorTree:child onRevision:rev];
+        }
+
+        return passed;
+
+    } else if ([node isKindOfClass:[CDTQOperatorExpressionNode class]]) {
+        NSDictionary *expression = ((CDTQOperatorExpressionNode *)node).expression;
+
+        // Here we could have:
+        //   { fieldName: { operator: value } }
+        // or
+        //   { fieldName: { $not: { operator: value } } }
+
+        // Next evaluate the result
+        NSString *fieldName = expression.allKeys[0];
+        NSDictionary *operatorExpression = expression[fieldName];
+
+        NSString *operator= operatorExpression.allKeys[0];
+
+        // First work out whether we need to invert the result when done
+        BOOL invertResult = [operator isEqualToString:NOT];
+        if (invertResult) {
+            operatorExpression = operatorExpression[NOT];
+            operator = operatorExpression.allKeys[0];
+        }
+
+        NSObject *expected = operatorExpression[operator];
+        NSObject *actual = [CDTQValueExtractor extractValueForFieldName:fieldName fromRevision:rev];
+        // Since $in is the same as a series of $eq comparisons -
+        // Treat them the same by:
+        // - Ensuring that both expected and actual are NSArrays.
+        // - Convert the $in operator to the $eq operator.
+        if (![expected isKindOfClass:[NSArray class]]) {
+            expected = @[ expected ];
+        }
+        if (![actual isKindOfClass:[NSArray class]]) {
+            actual = actual ? @[ actual ] : @[ [NSNull null] ];
+        }
+        if ([operator isEqualToString:IN]) {
+            operator = EQ;
+        }
+        BOOL passed = NO;
+        for (NSObject *expectedItem in (NSArray *)expected) {
+            for (NSObject *actualItem in (NSArray *)actual) {
+                // OR since any actual item can match any value in the expected NSArray
+                passed = passed || [self actualValue:actualItem
+                                     matchesOperator:operator
+                                    andExpectedValue:expectedItem];
+            }
+        }
+
+        return invertResult ? !passed : passed;
+    } else {
+        // We constructed the tree, so shouldn't end up here; error if we do.
+        LogError(@"Found unexpected selector execution tree: %@", node);
+        return NO;
+    }
+}
+
+- (BOOL)actualValue:(NSObject *)actual
+     matchesOperator:(NSString *) operator
+    andExpectedValue:(NSObject *)expected
+{
+    BOOL passed = NO;
+
+    if ([operator isEqualToString:EQ]) {
+        passed = [self eqL:actual R:expected];
+
+    } else if ([operator isEqualToString:LT]) {
+        passed = [self ltL:actual R:expected];
+
+    } else if ([operator isEqualToString:LTE]) {
+        passed = [self lteL:actual R:expected];
+
+    } else if ([operator isEqualToString:GT]) {
+        passed = [self gtL:actual R:expected];
+
+    } else if ([operator isEqualToString:GTE]) {
+        passed = [self gteL:actual R:expected];
+
+    } else if ([operator isEqualToString:EXISTS]) {
+        BOOL expectedBool = [((NSNumber *)expected)boolValue];
+        BOOL exists = (![actual isEqual:[NSNull null]]);
+        passed = (exists == expectedBool);
+
+    } else {
+        LogWarn(@"Found unexpected operator in selector: %@", operator);
+        passed = NO;  // didn't understand
+    }
+
+    return passed;
+}
+
+#pragma mark matchers
+
+- (BOOL)eqL:(NSObject *)l R:(NSObject *)r { return [l isEqual:r]; }
+
+//
+// Try to respect SQLite's ordering semantics:
+//  1. NULL
+//  2. INT/REAL
+//  3. TEXT
+//  4. BLOB
+- (BOOL)ltL:(NSObject *)l R:(NSObject *)r
+{
+    if ([l isEqual:[NSNull null]]) {
+        return NO;  // NSNull fails all lt/gt/lte/gte tests
+
+    } else if (!([l isKindOfClass:[NSString class]] || [l isKindOfClass:[NSNumber class]])) {
+        LogWarn(@"Value in document not NSNumber or NSString: %@", l);
+        return NO;  // Not sure how to compare values that are not numbers or strings
+
+    } else if ([l isKindOfClass:[NSString class]]) {
+        if ([r isKindOfClass:[NSNumber class]]) {
+            return NO;  // INT < STRING
+        }
+
+        NSString *lStr = (NSString *)l;
+        NSString *rStr = (NSString *)r;
+
+        NSComparisonResult result = [lStr compare:rStr];
+        return (result == NSOrderedAscending);
+
+    } else if ([l isKindOfClass:[NSNumber class]]) {
+        if ([r isKindOfClass:[NSString class]]) {
+            return YES;  // INT < STRING
+        }
+
+        NSNumber *lNum = (NSNumber *)l;
+        NSNumber *rNum = (NSNumber *)r;
+
+        NSComparisonResult result = [lNum compare:rNum];
+        return (result == NSOrderedAscending);
+
+    } else {
+        return NO;  // Catch all which we cannot reach
+    }
+}
+
+- (BOOL)lteL:(NSObject *)l R:(NSObject *)r
+{
+    if ([l isEqual:[NSNull null]]) {
+        return NO;  // NSNull fails all lt/gt/lte/gte tests
+    }
+
+    if (!([l isKindOfClass:[NSString class]] || [l isKindOfClass:[NSNumber class]])) {
+        LogWarn(@"Value in document not NSNumber or NSString: %@", l);
+        return NO;  // Not sure how to compare values that are not numbers or strings
+    }
+
+    return [self ltL:l R:r] || [l isEqual:r];
+}
+
+- (BOOL)gtL:(NSObject *)l R:(NSObject *)r
+{
+    if ([l isEqual:[NSNull null]]) {
+        return NO;  // NSNull fails all lt/gt/lte/gte tests
+    }
+
+    if (!([l isKindOfClass:[NSString class]] || [l isKindOfClass:[NSNumber class]])) {
+        LogWarn(@"Value in document not NSNumber or NSString: %@", l);
+        return NO;  // Not sure how to compare values that are not numbers or strings
+    }
+
+    return ![self lteL:l R:r];
+}
+
+- (BOOL)gteL:(NSObject *)l R:(NSObject *)r
+{
+    if ([l isEqual:[NSNull null]]) {
+        return NO;  // NSNull fails all lt/gt/lte/gte tests
+    }
+
+    if (!([l isKindOfClass:[NSString class]] || [l isKindOfClass:[NSNumber class]])) {
+        LogWarn(@"Value in document not NSNumber or NSString: %@", l);
+        return NO;  // Not sure how to compare values that are not numbers or strings
+    }
+
+    return ![self ltL:l R:r];
+}
+
+@end

--- a/Classes/common/query/CDTQValueExtractor.h
+++ b/Classes/common/query/CDTQValueExtractor.h
@@ -1,0 +1,29 @@
+//
+//  CDTQValueExtractor.h
+//
+//  Created by Michael Rhodes on 01/10/2014.
+//  Copyright (c) 2014 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+@class CDTDocumentRevision;
+
+/**
+ Extracts values from dictionaries using a field name.
+ */
+@interface CDTQValueExtractor : NSObject
+
++ (NSObject *)extractValueForFieldName:(NSString *)possiblyDottedField
+                          fromRevision:(CDTDocumentRevision *)rev;
+
++ (NSObject *)extractValueForFieldName:(NSString *)fieldName fromDictionary:(NSDictionary *)body;
+
+@end

--- a/Classes/common/query/CDTQValueExtractor.m
+++ b/Classes/common/query/CDTQValueExtractor.m
@@ -1,0 +1,67 @@
+//
+//  CDTQValueExtractor.m
+//
+//  Created by Michael Rhodes on 01/10/2014.
+//  Copyright (c) 2014 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+#import "CDTQValueExtractor.h"
+#import "CDTQLogging.h"
+
+#import <CDTDocumentRevision.h>
+
+@implementation CDTQValueExtractor
+
++ (NSObject *)extractValueForFieldName:(NSString *)possiblyDottedField
+                          fromRevision:(CDTDocumentRevision *)rev
+{
+    // _id and _rev are special fields which come from attributes
+    // of the revision and not its body.
+    if ([possiblyDottedField isEqualToString:@"_id"]) {
+        return rev.docId;
+    } else if ([possiblyDottedField isEqualToString:@"_rev"]) {
+        return rev.revId;
+    } else {
+        return [CDTQValueExtractor extractValueForFieldName:possiblyDottedField
+                                             fromDictionary:rev.body];
+    }
+}
+
++ (NSObject *)extractValueForFieldName:(NSString *)possiblyDottedField
+                        fromDictionary:(NSDictionary *)body
+{
+    // The algorithm here is to split the fields into a "path" and a "lastSegment".
+    // The path leads us to the final sub-document. We know that if we have either
+    // nil or a non-dictionary object while traversing path that the body doesn't
+    // have the right fields for this field selector -- it allows us to make sure
+    // that each level of the `path` results in a document rather than a value,
+    // because if it's a value, we can't continue the selection process.
+
+    NSArray *fields = [possiblyDottedField componentsSeparatedByString:@"."];
+
+    NSRange pathLen;
+    pathLen.location = 0;
+    pathLen.length = fields.count - 1;
+    NSArray *path = [fields subarrayWithRange:pathLen];
+    NSString *lastSegment = [fields lastObject];
+
+    NSDictionary *currentLevel = body;
+    for (NSString *field in path) {
+        currentLevel = currentLevel[field];
+        if (currentLevel == nil || ![currentLevel isKindOfClass:[NSDictionary class]]) {
+            LogVerbose(@"Could not extract field %@ from document %@", possiblyDottedField, body);
+            return nil;  // we ran out of stuff before we reached the full path length
+        }
+    }
+
+    return currentLevel[lastSegment];
+}
+
+@end

--- a/README.md
+++ b/README.md
@@ -244,18 +244,16 @@ the appropriate indexes are set up, querying is as follows:
 
 ```objc
 NSDictionary *query = @{
-    @"name": @"John",       // name equals John
-    @"age": @{@"min": @25}  // age greater than 25
+    @"name": @"John",         // name equals John
+    @"age": @{ @"$gt" : @25}  // age greater than 25
 };
-CDTQueryResult *result = [indexManager queryWithDictionary:query
-                                                     error:nil];
-
-for(CDTDocumentRevision *revision in result) {
+CDTQResultSet *result = [datastore find:query];
+[result enumerateObjectsUsingBlock:^(CDTDocumentRevision *rev, NSUInteger idx, BOOL *stop) {
     // do something
-}
+}];
 ```
 
-See [Index and Querying Data](https://github.com/cloudant/CDTDatastore/blob/master/doc/index-query.md).
+See [Index and Querying Data](https://github.com/cloudant/CDTDatastore/blob/master/doc/query.md).
 
 ### Conflicts
 

--- a/Tests/Podfile
+++ b/Tests/Podfile
@@ -6,6 +6,8 @@ source 'https://github.com/CocoaPods/Specs.git'
 def import_pods
     pod "CDTDatastore", :path => "../"
     pod "MRDatabaseContentChecker"
+    pod 'Specta', :git => 'https://github.com/specta/specta.git', :tag => 'v0.3.0.beta1'
+    pod 'Expecta'
 end
 
 target :ios do

--- a/Tests/Tests OSX/Tests OSX-Prefix.pch
+++ b/Tests/Tests OSX/Tests OSX-Prefix.pch
@@ -6,4 +6,6 @@
 
 #ifdef __OBJC__
     #import <Cocoa/Cocoa.h>
+    #import <Specta/Specta.h>
+    #import <Expecta/Expecta.h>
 #endif

--- a/Tests/Tests.xcodeproj/project.pbxproj
+++ b/Tests/Tests.xcodeproj/project.pbxproj
@@ -76,6 +76,46 @@
 		9F95D61118CF6A580006D349 /* DBQueryUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F95D60F18CF6A580006D349 /* DBQueryUtils.m */; };
 		9FC082981913378F0024EA1E /* DatastoreConflictResolvers.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FC082971913378F0024EA1E /* DatastoreConflictResolvers.m */; };
 		9FC082991913378F0024EA1E /* DatastoreConflictResolvers.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FC082971913378F0024EA1E /* DatastoreConflictResolvers.m */; };
+		EC0C833C1AB217290051042F /* CDTDatastoreQueryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C831F1AB217290051042F /* CDTDatastoreQueryTests.m */; };
+		EC0C833D1AB217290051042F /* CDTDatastoreQueryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C831F1AB217290051042F /* CDTDatastoreQueryTests.m */; };
+		EC0C833E1AB217290051042F /* CDTQFilterFieldsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C83201AB217290051042F /* CDTQFilterFieldsTest.m */; };
+		EC0C833F1AB217290051042F /* CDTQFilterFieldsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C83201AB217290051042F /* CDTQFilterFieldsTest.m */; };
+		EC0C83401AB217290051042F /* CDTQIndexCreatorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C83211AB217290051042F /* CDTQIndexCreatorTests.m */; };
+		EC0C83411AB217290051042F /* CDTQIndexCreatorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C83211AB217290051042F /* CDTQIndexCreatorTests.m */; };
+		EC0C83421AB217290051042F /* CDTQIndexManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C83221AB217290051042F /* CDTQIndexManagerTests.m */; };
+		EC0C83431AB217290051042F /* CDTQIndexManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C83221AB217290051042F /* CDTQIndexManagerTests.m */; };
+		EC0C83441AB217290051042F /* CDTQIndexUpdaterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C83231AB217290051042F /* CDTQIndexUpdaterTests.m */; };
+		EC0C83451AB217290051042F /* CDTQIndexUpdaterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C83231AB217290051042F /* CDTQIndexUpdaterTests.m */; };
+		EC0C83461AB217290051042F /* CDTQInvalidQuerySyntax.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C83241AB217290051042F /* CDTQInvalidQuerySyntax.m */; };
+		EC0C83471AB217290051042F /* CDTQInvalidQuerySyntax.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C83241AB217290051042F /* CDTQInvalidQuerySyntax.m */; };
+		EC0C83481AB217290051042F /* CDTQPerformanceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C83251AB217290051042F /* CDTQPerformanceTests.m */; };
+		EC0C83491AB217290051042F /* CDTQPerformanceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C83251AB217290051042F /* CDTQPerformanceTests.m */; };
+		EC0C834A1AB217290051042F /* CDTQQueryExecutorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C83261AB217290051042F /* CDTQQueryExecutorTests.m */; };
+		EC0C834B1AB217290051042F /* CDTQQueryExecutorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C83261AB217290051042F /* CDTQQueryExecutorTests.m */; };
+		EC0C834C1AB217290051042F /* CDTQQuerySortTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C83271AB217290051042F /* CDTQQuerySortTests.m */; };
+		EC0C834D1AB217290051042F /* CDTQQuerySortTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C83271AB217290051042F /* CDTQQuerySortTests.m */; };
+		EC0C834E1AB217290051042F /* CDTQQuerySqlTranslatorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C83281AB217290051042F /* CDTQQuerySqlTranslatorTests.m */; };
+		EC0C834F1AB217290051042F /* CDTQQuerySqlTranslatorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C83281AB217290051042F /* CDTQQuerySqlTranslatorTests.m */; };
+		EC0C83501AB217290051042F /* CDTQUnindexedMatcherTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C83291AB217290051042F /* CDTQUnindexedMatcherTests.m */; };
+		EC0C83511AB217290051042F /* CDTQUnindexedMatcherTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C83291AB217290051042F /* CDTQUnindexedMatcherTests.m */; };
+		EC0C83521AB217290051042F /* CDTQValueExtractorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C832A1AB217290051042F /* CDTQValueExtractorTests.m */; };
+		EC0C83531AB217290051042F /* CDTQValueExtractorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C832A1AB217290051042F /* CDTQValueExtractorTests.m */; };
+		EC0C83541AB217290051042F /* CDTQContainsAllElementsMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C832D1AB217290051042F /* CDTQContainsAllElementsMatcher.m */; };
+		EC0C83551AB217290051042F /* CDTQContainsAllElementsMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C832D1AB217290051042F /* CDTQContainsAllElementsMatcher.m */; };
+		EC0C83561AB217290051042F /* CDTQEitherMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C832F1AB217290051042F /* CDTQEitherMatcher.m */; };
+		EC0C83571AB217290051042F /* CDTQEitherMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C832F1AB217290051042F /* CDTQEitherMatcher.m */; };
+		EC0C83581AB217290051042F /* CDTQQueryMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C83311AB217290051042F /* CDTQQueryMatcher.m */; };
+		EC0C83591AB217290051042F /* CDTQQueryMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C83311AB217290051042F /* CDTQQueryMatcher.m */; };
+		EC0C835A1AB217290051042F /* CDTQMatcherIndexManager.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C83341AB217290051042F /* CDTQMatcherIndexManager.m */; };
+		EC0C835B1AB217290051042F /* CDTQMatcherIndexManager.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C83341AB217290051042F /* CDTQMatcherIndexManager.m */; };
+		EC0C835C1AB217290051042F /* CDTQMatcherQueryExecutor.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C83361AB217290051042F /* CDTQMatcherQueryExecutor.m */; };
+		EC0C835D1AB217290051042F /* CDTQMatcherQueryExecutor.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C83361AB217290051042F /* CDTQMatcherQueryExecutor.m */; };
+		EC0C835E1AB217290051042F /* CDTQSQLOnlyIndexManager.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C83381AB217290051042F /* CDTQSQLOnlyIndexManager.m */; };
+		EC0C835F1AB217290051042F /* CDTQSQLOnlyIndexManager.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C83381AB217290051042F /* CDTQSQLOnlyIndexManager.m */; };
+		EC0C83601AB217290051042F /* CDTQSQLOnlyQueryExecutor.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C833A1AB217290051042F /* CDTQSQLOnlyQueryExecutor.m */; };
+		EC0C83611AB217290051042F /* CDTQSQLOnlyQueryExecutor.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C833A1AB217290051042F /* CDTQSQLOnlyQueryExecutor.m */; };
+		EC0C83621AB217290051042F /* Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C833B1AB217290051042F /* Tests.m */; };
+		EC0C83631AB217290051042F /* Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C833B1AB217290051042F /* Tests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -135,6 +175,33 @@
 		9FC082971913378F0024EA1E /* DatastoreConflictResolvers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DatastoreConflictResolvers.m; sourceTree = "<group>"; };
 		BBD8D50209E84CD981F3FA7A /* libPods-osx.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-osx.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C0D0295E40984E2788387EEE /* libPods-ios.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ios.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		EC0C831F1AB217290051042F /* CDTDatastoreQueryTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTDatastoreQueryTests.m; sourceTree = "<group>"; };
+		EC0C83201AB217290051042F /* CDTQFilterFieldsTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTQFilterFieldsTest.m; sourceTree = "<group>"; };
+		EC0C83211AB217290051042F /* CDTQIndexCreatorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTQIndexCreatorTests.m; sourceTree = "<group>"; };
+		EC0C83221AB217290051042F /* CDTQIndexManagerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTQIndexManagerTests.m; sourceTree = "<group>"; };
+		EC0C83231AB217290051042F /* CDTQIndexUpdaterTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTQIndexUpdaterTests.m; sourceTree = "<group>"; };
+		EC0C83241AB217290051042F /* CDTQInvalidQuerySyntax.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTQInvalidQuerySyntax.m; sourceTree = "<group>"; };
+		EC0C83251AB217290051042F /* CDTQPerformanceTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTQPerformanceTests.m; sourceTree = "<group>"; };
+		EC0C83261AB217290051042F /* CDTQQueryExecutorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTQQueryExecutorTests.m; sourceTree = "<group>"; };
+		EC0C83271AB217290051042F /* CDTQQuerySortTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTQQuerySortTests.m; sourceTree = "<group>"; };
+		EC0C83281AB217290051042F /* CDTQQuerySqlTranslatorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTQQuerySqlTranslatorTests.m; sourceTree = "<group>"; };
+		EC0C83291AB217290051042F /* CDTQUnindexedMatcherTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTQUnindexedMatcherTests.m; sourceTree = "<group>"; };
+		EC0C832A1AB217290051042F /* CDTQValueExtractorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTQValueExtractorTests.m; sourceTree = "<group>"; };
+		EC0C832C1AB217290051042F /* CDTQContainsAllElementsMatcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDTQContainsAllElementsMatcher.h; sourceTree = "<group>"; };
+		EC0C832D1AB217290051042F /* CDTQContainsAllElementsMatcher.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTQContainsAllElementsMatcher.m; sourceTree = "<group>"; };
+		EC0C832E1AB217290051042F /* CDTQEitherMatcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDTQEitherMatcher.h; sourceTree = "<group>"; };
+		EC0C832F1AB217290051042F /* CDTQEitherMatcher.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTQEitherMatcher.m; sourceTree = "<group>"; };
+		EC0C83301AB217290051042F /* CDTQQueryMatcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDTQQueryMatcher.h; sourceTree = "<group>"; };
+		EC0C83311AB217290051042F /* CDTQQueryMatcher.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTQQueryMatcher.m; sourceTree = "<group>"; };
+		EC0C83331AB217290051042F /* CDTQMatcherIndexManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDTQMatcherIndexManager.h; sourceTree = "<group>"; };
+		EC0C83341AB217290051042F /* CDTQMatcherIndexManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTQMatcherIndexManager.m; sourceTree = "<group>"; };
+		EC0C83351AB217290051042F /* CDTQMatcherQueryExecutor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDTQMatcherQueryExecutor.h; sourceTree = "<group>"; };
+		EC0C83361AB217290051042F /* CDTQMatcherQueryExecutor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTQMatcherQueryExecutor.m; sourceTree = "<group>"; };
+		EC0C83371AB217290051042F /* CDTQSQLOnlyIndexManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDTQSQLOnlyIndexManager.h; sourceTree = "<group>"; };
+		EC0C83381AB217290051042F /* CDTQSQLOnlyIndexManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTQSQLOnlyIndexManager.m; sourceTree = "<group>"; };
+		EC0C83391AB217290051042F /* CDTQSQLOnlyQueryExecutor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDTQSQLOnlyQueryExecutor.h; sourceTree = "<group>"; };
+		EC0C833A1AB217290051042F /* CDTQSQLOnlyQueryExecutor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTQSQLOnlyQueryExecutor.m; sourceTree = "<group>"; };
+		EC0C833B1AB217290051042F /* Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Tests.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -197,6 +264,21 @@
 		27389E15185345FD0027A404 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				EC0C831F1AB217290051042F /* CDTDatastoreQueryTests.m */,
+				EC0C83201AB217290051042F /* CDTQFilterFieldsTest.m */,
+				EC0C83211AB217290051042F /* CDTQIndexCreatorTests.m */,
+				EC0C83221AB217290051042F /* CDTQIndexManagerTests.m */,
+				EC0C83231AB217290051042F /* CDTQIndexUpdaterTests.m */,
+				EC0C83241AB217290051042F /* CDTQInvalidQuerySyntax.m */,
+				EC0C83251AB217290051042F /* CDTQPerformanceTests.m */,
+				EC0C83261AB217290051042F /* CDTQQueryExecutorTests.m */,
+				EC0C83271AB217290051042F /* CDTQQuerySortTests.m */,
+				EC0C83281AB217290051042F /* CDTQQuerySqlTranslatorTests.m */,
+				EC0C83291AB217290051042F /* CDTQUnindexedMatcherTests.m */,
+				EC0C832A1AB217290051042F /* CDTQValueExtractorTests.m */,
+				EC0C832B1AB217290051042F /* Matchers */,
+				EC0C83321AB217290051042F /* Mocks */,
+				EC0C833B1AB217290051042F /* Tests.m */,
 				98BB73FE19E5927600C57866 /* CloudantTests.h */,
 				98DDEB9E1A41CD3400767178 /* DatastoreManagerTests.m */,
 				98BB73FF19E5927600C57866 /* CloudantTests.m */,
@@ -308,6 +390,34 @@
 				03034DD60492427AC73C43CD /* Pods-osx.release.xcconfig */,
 			);
 			name = Pods;
+			sourceTree = "<group>";
+		};
+		EC0C832B1AB217290051042F /* Matchers */ = {
+			isa = PBXGroup;
+			children = (
+				EC0C832C1AB217290051042F /* CDTQContainsAllElementsMatcher.h */,
+				EC0C832D1AB217290051042F /* CDTQContainsAllElementsMatcher.m */,
+				EC0C832E1AB217290051042F /* CDTQEitherMatcher.h */,
+				EC0C832F1AB217290051042F /* CDTQEitherMatcher.m */,
+				EC0C83301AB217290051042F /* CDTQQueryMatcher.h */,
+				EC0C83311AB217290051042F /* CDTQQueryMatcher.m */,
+			);
+			path = Matchers;
+			sourceTree = "<group>";
+		};
+		EC0C83321AB217290051042F /* Mocks */ = {
+			isa = PBXGroup;
+			children = (
+				EC0C83331AB217290051042F /* CDTQMatcherIndexManager.h */,
+				EC0C83341AB217290051042F /* CDTQMatcherIndexManager.m */,
+				EC0C83351AB217290051042F /* CDTQMatcherQueryExecutor.h */,
+				EC0C83361AB217290051042F /* CDTQMatcherQueryExecutor.m */,
+				EC0C83371AB217290051042F /* CDTQSQLOnlyIndexManager.h */,
+				EC0C83381AB217290051042F /* CDTQSQLOnlyIndexManager.m */,
+				EC0C83391AB217290051042F /* CDTQSQLOnlyQueryExecutor.h */,
+				EC0C833A1AB217290051042F /* CDTQSQLOnlyQueryExecutor.m */,
+			);
+			path = Mocks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -479,29 +589,49 @@
 				9F0D2408188E378700D3D04E /* TDCanonicalJSONTests.m in Sources */,
 				9F0D23F1188B4FA900D3D04E /* TDMultipartReaderTests.m in Sources */,
 				9F0D23FF188DF96600D3D04E /* TD_DatabaseManagerTests.m in Sources */,
+				EC0C834A1AB217290051042F /* CDTQQueryExecutorTests.m in Sources */,
+				EC0C83521AB217290051042F /* CDTQValueExtractorTests.m in Sources */,
+				EC0C834C1AB217290051042F /* CDTQQuerySortTests.m in Sources */,
 				9F0D240E188F01DD00D3D04E /* TDMiscTests.m in Sources */,
+				EC0C835E1AB217290051042F /* CDTQSQLOnlyIndexManager.m in Sources */,
+				EC0C83421AB217290051042F /* CDTQIndexManagerTests.m in Sources */,
 				9F0D23F7188DF30D00D3D04E /* TDMultiStreamWriterTests.m in Sources */,
 				9985C74919AE5D8300636AB6 /* CDTQueryBuilderTests.m in Sources */,
 				27389E3618534E050027A404 /* DatastoreActions.m in Sources */,
 				27389E3518534E050027A404 /* CloudantSyncTests.m in Sources */,
 				9F0D24111890AD0C00D3D04E /* TDMultipartDownloaderTests.m in Sources */,
 				27F43D4918E99C31003E8422 /* AmazonMD5Util.m in Sources */,
+				EC0C83501AB217290051042F /* CDTQUnindexedMatcherTests.m in Sources */,
+				EC0C83481AB217290051042F /* CDTQPerformanceTests.m in Sources */,
+				EC0C835C1AB217290051042F /* CDTQMatcherQueryExecutor.m in Sources */,
 				989E6E22198799AE00FB8510 /* DatastoreCRUD.m in Sources */,
 				9F0D241A18932DA700D3D04E /* TDSequenceMapTests.m in Sources */,
 				9FC082981913378F0024EA1E /* DatastoreConflictResolvers.m in Sources */,
+				EC0C83621AB217290051042F /* Tests.m in Sources */,
 				9F0D23FA188DF36800D3D04E /* TD_DatabaseTests.m in Sources */,
+				EC0C833C1AB217290051042F /* CDTDatastoreQueryTests.m in Sources */,
 				985F84D4198BD3A4004D8713 /* AttachmentCRUD.m in Sources */,
 				98DDEB9F1A41CD3400767178 /* DatastoreManagerTests.m in Sources */,
 				9F4E646B19DC815B00FE37E1 /* CDTReplicationTests.m in Sources */,
+				EC0C83461AB217290051042F /* CDTQInvalidQuerySyntax.m in Sources */,
 				98BB740019E5927600C57866 /* CloudantTests.m in Sources */,
 				9F0D2402188DFE8600D3D04E /* TD_RevisionTests.m in Sources */,
+				EC0C833E1AB217290051042F /* CDTQFilterFieldsTest.m in Sources */,
 				9F4E646D19DC815B00FE37E1 /* SetUpDatastore.m in Sources */,
+				EC0C83541AB217290051042F /* CDTQContainsAllElementsMatcher.m in Sources */,
 				985A188A19D2CCEB000283E9 /* DatastoreConflicts.m in Sources */,
 				985A188719D2CC54000283E9 /* CDTDatastoreEvents.m in Sources */,
 				9F0D240B188E3C3A00D3D04E /* TDCollateJSONTests.m in Sources */,
+				EC0C83601AB217290051042F /* CDTQSQLOnlyQueryExecutor.m in Sources */,
 				9F0D24171893161000D3D04E /* TDReachabilityTests.m in Sources */,
+				EC0C834E1AB217290051042F /* CDTQQuerySqlTranslatorTests.m in Sources */,
+				EC0C835A1AB217290051042F /* CDTQMatcherIndexManager.m in Sources */,
+				EC0C83581AB217290051042F /* CDTQQueryMatcher.m in Sources */,
+				EC0C83561AB217290051042F /* CDTQEitherMatcher.m in Sources */,
 				985FEFFF19CC597400EA5392 /* IndexManagerTests.m in Sources */,
+				EC0C83401AB217290051042F /* CDTQIndexCreatorTests.m in Sources */,
 				9F95D61018CF6A580006D349 /* DBQueryUtils.m in Sources */,
+				EC0C83441AB217290051042F /* CDTQIndexUpdaterTests.m in Sources */,
 				9F0D23F4188B4FFF00D3D04E /* TDMultipartWriterTests.m in Sources */,
 				9F0D24141892E9B800D3D04E /* TDPusherTests.m in Sources */,
 			);
@@ -514,29 +644,49 @@
 				270ED44E19D165BB007E08C4 /* CDTQueryBuilderTests.m in Sources */,
 				985F84D5198BDA6D004D8713 /* AttachmentCRUD.m in Sources */,
 				9F0D2409188E378700D3D04E /* TDCanonicalJSONTests.m in Sources */,
+				EC0C834B1AB217290051042F /* CDTQQueryExecutorTests.m in Sources */,
+				EC0C83531AB217290051042F /* CDTQValueExtractorTests.m in Sources */,
+				EC0C834D1AB217290051042F /* CDTQQuerySortTests.m in Sources */,
 				9F0D23F2188B4FA900D3D04E /* TDMultipartReaderTests.m in Sources */,
+				EC0C835F1AB217290051042F /* CDTQSQLOnlyIndexManager.m in Sources */,
+				EC0C83431AB217290051042F /* CDTQIndexManagerTests.m in Sources */,
 				9F0D2400188DF96600D3D04E /* TD_DatabaseManagerTests.m in Sources */,
 				9F0D240F188F01DD00D3D04E /* TDMiscTests.m in Sources */,
 				9F0D23F8188DF30D00D3D04E /* TDMultiStreamWriterTests.m in Sources */,
 				27CCEDD7187AD719006F3C66 /* DatastoreActions.m in Sources */,
 				9F0D24121890AD0C00D3D04E /* TDMultipartDownloaderTests.m in Sources */,
 				27F43D4A18E99C31003E8422 /* AmazonMD5Util.m in Sources */,
+				EC0C83511AB217290051042F /* CDTQUnindexedMatcherTests.m in Sources */,
+				EC0C83491AB217290051042F /* CDTQPerformanceTests.m in Sources */,
+				EC0C835D1AB217290051042F /* CDTQMatcherQueryExecutor.m in Sources */,
 				989E6E23198799AE00FB8510 /* DatastoreCRUD.m in Sources */,
 				9F0D241B18932DA700D3D04E /* TDSequenceMapTests.m in Sources */,
 				9FC082991913378F0024EA1E /* DatastoreConflictResolvers.m in Sources */,
+				EC0C83631AB217290051042F /* Tests.m in Sources */,
 				9F0D23FB188DF36800D3D04E /* TD_DatabaseTests.m in Sources */,
+				EC0C833D1AB217290051042F /* CDTDatastoreQueryTests.m in Sources */,
 				9F0D2403188DFE8600D3D04E /* TD_RevisionTests.m in Sources */,
 				98DDEBA01A41CD3400767178 /* DatastoreManagerTests.m in Sources */,
 				9F4E646C19DC815B00FE37E1 /* CDTReplicationTests.m in Sources */,
+				EC0C83471AB217290051042F /* CDTQInvalidQuerySyntax.m in Sources */,
 				98BB740119E5927600C57866 /* CloudantTests.m in Sources */,
 				985A188B19D2CCEB000283E9 /* DatastoreConflicts.m in Sources */,
+				EC0C833F1AB217290051042F /* CDTQFilterFieldsTest.m in Sources */,
 				9F4E646E19DC815B00FE37E1 /* SetUpDatastore.m in Sources */,
+				EC0C83551AB217290051042F /* CDTQContainsAllElementsMatcher.m in Sources */,
 				985A188819D2CC54000283E9 /* CDTDatastoreEvents.m in Sources */,
 				9F0D240C188E3C3A00D3D04E /* TDCollateJSONTests.m in Sources */,
 				9F0D24181893161000D3D04E /* TDReachabilityTests.m in Sources */,
+				EC0C83611AB217290051042F /* CDTQSQLOnlyQueryExecutor.m in Sources */,
 				985FF00019CC597400EA5392 /* IndexManagerTests.m in Sources */,
+				EC0C834F1AB217290051042F /* CDTQQuerySqlTranslatorTests.m in Sources */,
+				EC0C835B1AB217290051042F /* CDTQMatcherIndexManager.m in Sources */,
+				EC0C83591AB217290051042F /* CDTQQueryMatcher.m in Sources */,
+				EC0C83571AB217290051042F /* CDTQEitherMatcher.m in Sources */,
 				9F95D61118CF6A580006D349 /* DBQueryUtils.m in Sources */,
+				EC0C83411AB217290051042F /* CDTQIndexCreatorTests.m in Sources */,
 				27CCEDD6187AD70C006F3C66 /* CloudantSyncTests.m in Sources */,
+				EC0C83451AB217290051042F /* CDTQIndexUpdaterTests.m in Sources */,
 				9F0D23F5188B4FFF00D3D04E /* TDMultipartWriterTests.m in Sources */,
 				9F0D24151892E9B800D3D04E /* TDPusherTests.m in Sources */,
 			);

--- a/Tests/Tests/CDTDatastoreQueryTests.m
+++ b/Tests/Tests/CDTDatastoreQueryTests.m
@@ -1,0 +1,118 @@
+//
+//  CDTDatastore+QueryTests.m
+//  CloudantQueryObjc
+//
+//  Created by Rhys Short on 19/11/2014.
+//  Copyright (c) 2014 Michael Rhodes. All rights reserved.
+//
+
+#import <CloudantSync.h>
+#import <CDTDatastore+Query.h>
+#import <CDTQResultSet.h>
+#import <objc/runtime.h>
+
+SpecBegin(CDTDatastoreQuery) describe(@"When using datastore query", ^{
+
+    __block NSString *factoryPath;
+    __block CDTDatastoreManager *factory;
+    __block CDTDatastore *ds;
+
+    beforeEach(^{
+        // Create a new CDTDatastoreFactory at a temp path
+
+        NSString *tempDirectoryTemplate = [NSTemporaryDirectory()
+            stringByAppendingPathComponent:@"cloudant_sync_ios_tests.XXXXXX"];
+        const char *tempDirectoryTemplateCString = [tempDirectoryTemplate fileSystemRepresentation];
+        char *tempDirectoryNameCString = (char *)malloc(strlen(tempDirectoryTemplateCString) + 1);
+        strcpy(tempDirectoryNameCString, tempDirectoryTemplateCString);
+
+        char *result = mkdtemp(tempDirectoryNameCString);
+        expect(result).to.beTruthy();
+
+        factoryPath = [[NSFileManager defaultManager]
+            stringWithFileSystemRepresentation:tempDirectoryNameCString
+                                        length:strlen(result)];
+        free(tempDirectoryNameCString);
+
+        NSError *error;
+        factory = [[CDTDatastoreManager alloc] initWithDirectory:factoryPath error:&error];
+
+        ds = [factory datastoreNamed:@"test" error:nil];
+        expect(ds).toNot.beNil();
+
+        // create some docs
+
+        CDTMutableDocumentRevision *rev = [CDTMutableDocumentRevision revision];
+
+        rev.docId = @"mike12";
+        rev.body = @{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" };
+        [ds createDocumentFromRevision:rev error:nil];
+
+        rev.docId = @"mike34";
+        rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"dog" };
+        [ds createDocumentFromRevision:rev error:nil];
+
+        rev.docId = @"mike72";
+        rev.body = @{ @"name" : @"mike", @"age" : @67, @"pet" : @"cat" };
+        [ds createDocumentFromRevision:rev error:nil];
+
+        [ds ensureIndexed:@[ @"name" ] withName:@"name"];
+    });
+
+    afterEach(^{
+        // Delete the databases we used
+        factory = nil;
+        NSError *error;
+        [[NSFileManager defaultManager] removeItemAtPath:factoryPath error:&error];
+    });
+
+    it(@"creates different index managers for different datastores", ^{
+        CDTDatastore *ds2 = [factory datastoreNamed:@"test2" error:nil];
+        expect([ds2 ensureIndexed:@[ @"name", @"age" ] withName:@"pet"]).toNot.beNil();
+
+        CDTQIndexManager *im = objc_getAssociatedObject(ds, @selector(CDTQManager));
+        CDTQIndexManager *im2 = objc_getAssociatedObject(ds2, @selector(CDTQManager));
+
+        expect([im listIndexes]).toNot.equal([im2 listIndexes]);
+    });
+
+    it(@"can find documents", ^{
+        NSDictionary *query = @{ @"name" : @"mike" };
+        CDTQResultSet *results = [ds find:query];
+        expect(results).toNot.beNil();
+        expect([results.documentIds count]).to.equal(3);
+    });
+
+    it(@"can find documents with all params", ^{
+        NSDictionary *query = @{ @"name" : @"mike" };
+        CDTQResultSet *results = [ds find:query skip:0 limit:NSUIntegerMax fields:nil sort:nil];
+        expect(results).toNot.beNil();
+        expect([results.documentIds count]).to.equal(3);
+    });
+
+    it(@" can delete an index", ^{
+        [ds ensureIndexed:@[ @"name", @"address" ] withName:@"basic"];
+        expect([ds listIndexes][@"basic"]).toNot.beNil();
+
+        [ds deleteIndexNamed:@"basic"];
+        expect([ds listIndexes][@"basic"]).to.beNil();
+    });
+
+    it(@"can list indexes", ^{
+        NSDictionary *indexes = [ds listIndexes];
+        expect(indexes).toNot.beNil();
+        expect([indexes count]).to.equal(1);
+    });
+
+    it(@"can update indexes", ^{
+        NSDictionary *query = @{ @"name" : @"mike" };
+        CDTQResultSet *results = [ds find:query];
+        expect(results).toNot.beNil();
+        CDTMutableDocumentRevision *rev = [CDTMutableDocumentRevision revision];
+        rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"dolhpin" };
+        [ds createDocumentFromRevision:rev error:nil];
+        expect([ds updateAllIndexes]).to.beTruthy();
+    });
+});
+
+SpecEnd

--- a/Tests/Tests/CDTQFilterFieldsTest.m
+++ b/Tests/Tests/CDTQFilterFieldsTest.m
@@ -1,0 +1,220 @@
+//
+//  CDTQFilterFieldsTest.m
+//  CloudantQueryObjc
+//
+//  Created by Rhys Short on 16/10/2014.
+//  Copyright (c) 2014 Michael Rhodes. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "Specta.h"
+#import "Expecta.h"
+#import <CloudantSync.h>
+#import <CDTQIndexManager.h>
+#import <CDTQIndexUpdater.h>
+#import <CDTQIndexCreator.h>
+#import <CDTQResultSet.h>
+#import <CDTQQueryExecutor.h>
+
+SpecBegin(CDTQFilterFieldsTest)
+
+    describe(@"When filtering fields on find ", ^{
+
+        __block NSString *factoryPath;
+        __block CDTDatastoreManager *factory;
+        __block CDTDatastore *ds;
+        __block CDTQIndexManager *im;
+
+        beforeEach(^{
+            // Create a new CDTDatastoreFactory at a temp path
+
+            NSString *tempDirectoryTemplate = [NSTemporaryDirectory()
+                stringByAppendingPathComponent:@"cloudant_sync_ios_tests.XXXXXX"];
+            const char *tempDirectoryTemplateCString =
+                [tempDirectoryTemplate fileSystemRepresentation];
+            char *tempDirectoryNameCString =
+                (char *)malloc(strlen(tempDirectoryTemplateCString) + 1);
+            strcpy(tempDirectoryNameCString, tempDirectoryTemplateCString);
+
+            char *result = mkdtemp(tempDirectoryNameCString);
+            expect(result).to.beTruthy();
+
+            factoryPath = [[NSFileManager defaultManager]
+                stringWithFileSystemRepresentation:tempDirectoryNameCString
+                                            length:strlen(result)];
+            free(tempDirectoryNameCString);
+
+            NSError *error;
+            factory = [[CDTDatastoreManager alloc] initWithDirectory:factoryPath error:&error];
+
+            ds = [factory datastoreNamed:@"test" error:nil];
+            expect(ds).toNot.beNil();
+
+            CDTMutableDocumentRevision *rev = [CDTMutableDocumentRevision revision];
+
+            rev.docId = @"mike12";
+            rev.body = @{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" };
+            [ds createDocumentFromRevision:rev error:nil];
+
+            rev.docId = @"mike34";
+            rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"dog" };
+            [ds createDocumentFromRevision:rev error:nil];
+
+            rev.docId = @"mike72";
+            rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"cat" };
+            [ds createDocumentFromRevision:rev error:nil];
+
+            rev.docId = @"fred34";
+            rev.body = @{ @"name" : @"fred", @"age" : @34, @"pet" : @"cat" };
+            [ds createDocumentFromRevision:rev error:nil];
+
+            rev.docId = @"fred12";
+            rev.body = @{ @"name" : @"fred", @"age" : @12 };
+            [ds createDocumentFromRevision:rev error:nil];
+
+            im = [CDTQIndexManager managerUsingDatastore:ds error:nil];
+            expect(im).toNot.beNil();
+
+            expect([im ensureIndexed:@[ @"name", @"age" ] withName:@"basic"]).toNot.beNil();
+            expect([im ensureIndexed:@[ @"name", @"pet" ] withName:@"pet"]).toNot.beNil();
+        });
+
+        afterEach(^{
+            // Delete the databases we used
+            factory = nil;
+            NSError *error;
+            [[NSFileManager defaultManager] removeItemAtPath:factoryPath error:&error];
+        });
+
+        it(@"returns only field specified in fields param in the document body", ^{
+            NSDictionary *query = @{ @"name" : @"mike" };
+            CDTQResultSet *result =
+                [im find:query skip:0 limit:NSUIntegerMax fields:@[ @"name" ] sort:nil];
+            expect(result).toNot.beNil();
+
+            [result enumerateObjectsUsingBlock:^(CDTDocumentRevision *rev, NSUInteger i, BOOL *s) {
+                expect([rev.body count]).to.equal(1);
+                expect([rev.body objectForKey:@"name"]).to.equal(@"mike");
+            }];
+        });
+
+        it(@"returns all fields when fields array is empty", ^{
+            NSDictionary *query = @{ @"name" : @"mike" };
+            CDTQResultSet *result = [im find:query skip:0 limit:NSUIntegerMax fields:@[] sort:nil];
+            expect(result).toNot.beNil();
+
+            [result enumerateObjectsUsingBlock:^(CDTDocumentRevision *rev, NSUInteger i, BOOL *s) {
+                expect([rev.body count]).to.equal(3);
+                expect([rev.body objectForKey:@"name"]).toNot.beNil();
+                expect([rev.body objectForKey:@"pet"]).toNot.beNil();
+                expect([rev.body objectForKey:@"age"]).toNot.beNil();
+            }];
+        });
+
+        it(@"returns all fields when fields array is nil", ^{
+            NSDictionary *query = @{ @"name" : @"mike" };
+            CDTQResultSet *result = [im find:query skip:0 limit:NSUIntegerMax fields:@[] sort:nil];
+            expect(result).toNot.beNil();
+
+            [result enumerateObjectsUsingBlock:^(CDTDocumentRevision *rev, NSUInteger i, BOOL *s) {
+                expect([rev.body count]).to.equal(3);
+                expect([rev.body objectForKey:@"name"]).toNot.beNil();
+                expect([rev.body objectForKey:@"pet"]).toNot.beNil();
+                expect([rev.body objectForKey:@"age"]).toNot.beNil();
+            }];
+        });
+
+        it(@"returns nil when fields array contains a type other than NSString", ^{
+            NSDictionary *query = @{ @"name" : @"mike" };
+            CDTQResultSet *result =
+                [im find:query skip:0 limit:NSUIntegerMax fields:@[ @{} ] sort:nil];
+            expect(result).to.beNil();
+        });
+
+        it(@"returns nil when using dotted notation", ^{
+            NSDictionary *query = @{ @"name" : @"mike" };
+            CDTQResultSet *result =
+                [im find:query skip:0 limit:NSUIntegerMax fields:@[ @"name.blah" ] sort:nil];
+            expect(result).to.beNil();
+        });
+
+        it(@"returns only pet and name fields in a document revision, when they are specfied in "
+           @"fields",
+           ^{
+            NSDictionary *query = @{ @"name" : @"mike" };
+            CDTQResultSet *result =
+                [im find:query skip:0 limit:NSUIntegerMax fields:@[ @"name", @"pet" ] sort:nil];
+            expect(result).toNot.beNil();
+
+            [result enumerateObjectsUsingBlock:^(CDTDocumentRevision *rev, NSUInteger i, BOOL *s) {
+                expect([rev.body count]).to.equal(2);
+                expect([rev.body objectForKey:@"name"]).toNot.beNil();
+                expect([rev.body objectForKey:@"pet"]).toNot.beNil();
+            }];
+        });
+
+        context(@"mutableCopy of projected doc", ^{
+
+            it(@"returns full doc", ^{
+                NSDictionary *query = @{ @"name" : @"mike", @"age" : @12 };
+                CDTQResultSet *result =
+                    [im find:query skip:0 limit:NSUIntegerMax fields:@[ @"name" ] sort:nil];
+                expect(result.documentIds.count).to.equal(1);
+
+                [result
+                    enumerateObjectsUsingBlock:^(CDTDocumentRevision *rev, NSUInteger i, BOOL *s) {
+                        expect(rev.body.count).to.equal(1);
+                        expect(rev.body[@"name"]).to.equal(@"mike");
+
+                        CDTMutableDocumentRevision *mutable = [rev mutableCopy];
+                        expect(mutable.body.count).to.equal(3);
+                        expect(mutable.body[@"name"]).to.equal(@"mike");
+                        expect(mutable.body[@"age"]).to.equal(@12);
+                        expect(mutable.body[@"pet"]).to.equal(@"cat");
+                    }];
+            });
+
+            it(@"returns nil when doc updated", ^{
+                NSDictionary *query = @{ @"name" : @"mike", @"age" : @12 };
+                CDTQResultSet *result =
+                    [im find:query skip:0 limit:NSUIntegerMax fields:@[ @"name" ] sort:nil];
+                expect(result.documentIds.count).to.equal(1);
+
+                [result
+                    enumerateObjectsUsingBlock:^(CDTDocumentRevision *rev, NSUInteger i, BOOL *s) {
+                        expect(rev.body.count).to.equal(1);
+                        expect(rev.body[@"name"]).to.equal(@"mike");
+
+                        CDTDocumentRevision *original = [ds getDocumentWithId:rev.docId error:nil];
+                        CDTMutableDocumentRevision *update = [original mutableCopy];
+                        update.body[@"name"] = @"charles";
+                        expect([ds updateDocumentFromRevision:update error:nil]).toNot.beNil();
+
+                        CDTMutableDocumentRevision *mutable = [rev mutableCopy];
+                        expect(mutable).to.beNil();
+                    }];
+            });
+
+            it(@"returns nil when doc deleted", ^{
+                NSDictionary *query = @{ @"name" : @"mike", @"age" : @12 };
+                CDTQResultSet *result =
+                    [im find:query skip:0 limit:NSUIntegerMax fields:@[ @"name" ] sort:nil];
+                expect(result.documentIds.count).to.equal(1);
+
+                [result
+                    enumerateObjectsUsingBlock:^(CDTDocumentRevision *rev, NSUInteger i, BOOL *s) {
+                        expect(rev.body.count).to.equal(1);
+                        expect(rev.body[@"name"]).to.equal(@"mike");
+
+                        expect([ds deleteDocumentFromRevision:rev error:nil]).toNot.beNil();
+
+                        CDTMutableDocumentRevision *mutable = [rev mutableCopy];
+                        expect(mutable).to.beNil();
+                    }];
+            });
+
+        });
+
+    });
+
+SpecEnd

--- a/Tests/Tests/CDTQIndexCreatorTests.m
+++ b/Tests/Tests/CDTQIndexCreatorTests.m
@@ -1,0 +1,478 @@
+//
+//  CloudantQueryObjcTests.m
+//  CloudantQueryObjcTests
+//
+//  Created by Michael Rhodes on 09/27/2014.
+//  Copyright (c) 2014 Michael Rhodes. All rights reserved.
+//
+
+#import <CloudantSync.h>
+#import <CDTQIndexManager.h>
+#import <CDTQIndexUpdater.h>
+#import <CDTQIndexCreator.h>
+#import <CDTQResultSet.h>
+#import <CDTQQueryExecutor.h>
+
+SpecBegin(CDTQIndexCreator)
+
+    describe(@"cloudant query", ^{
+
+        __block NSString *factoryPath;
+        __block CDTDatastoreManager *factory;
+
+        beforeEach(^{
+            // Create a new CDTDatastoreFactory at a temp path
+
+            NSString *tempDirectoryTemplate = [NSTemporaryDirectory()
+                stringByAppendingPathComponent:@"cloudant_sync_ios_tests.XXXXXX"];
+            const char *tempDirectoryTemplateCString =
+                [tempDirectoryTemplate fileSystemRepresentation];
+            char *tempDirectoryNameCString =
+                (char *)malloc(strlen(tempDirectoryTemplateCString) + 1);
+            strcpy(tempDirectoryNameCString, tempDirectoryTemplateCString);
+
+            char *result = mkdtemp(tempDirectoryNameCString);
+            expect(result).to.beTruthy();
+
+            factoryPath = [[NSFileManager defaultManager]
+                stringWithFileSystemRepresentation:tempDirectoryNameCString
+                                            length:strlen(result)];
+            free(tempDirectoryNameCString);
+
+            NSError *error;
+            factory = [[CDTDatastoreManager alloc] initWithDirectory:factoryPath error:&error];
+        });
+
+        afterEach(^{
+            // Delete the databases we used
+
+            factory = nil;
+            NSError *error;
+            [[NSFileManager defaultManager] removeItemAtPath:factoryPath error:&error];
+        });
+
+        describe(@"when creating indexes", ^{
+
+            __block CDTDatastore *ds;
+            __block CDTQIndexManager *im;
+
+            beforeEach(^{
+                ds = [factory datastoreNamed:@"test" error:nil];
+                expect(ds).toNot.beNil();
+                im = [CDTQIndexManager managerUsingDatastore:ds error:nil];
+                expect(im).toNot.beNil();
+            });
+
+            it(@"doesn't create an index on no fields", ^{
+                NSString *name = [im ensureIndexed:@[] withName:@"basic"];
+                expect(name).to.equal(nil);
+
+                NSDictionary *indexes = [im listIndexes];
+                expect(indexes.allKeys.count).to.equal(0);
+            });
+
+            it(@"doesn't create an index if duplicate fields", ^{
+                NSString *name = [im ensureIndexed:@[ @"age", @"pet", @"age" ] withName:@"basic"];
+                expect(name).to.equal(nil);
+
+                NSDictionary *indexes = [im listIndexes];
+                expect(indexes.allKeys.count).to.equal(0);
+            });
+
+            it(@"doesn't create an index on nil fields", ^{
+                NSString *name = [im ensureIndexed:nil withName:@"basic"];
+                expect(name).to.equal(nil);
+
+                NSDictionary *indexes = [im listIndexes];
+                expect(indexes.allKeys.count).to.equal(0);
+            });
+
+            it(@"doesn't create an index without a name", ^{
+                NSString *name = [im ensureIndexed:@[ @"name" ] withName:nil];
+                expect(name).to.equal(nil);
+
+                NSDictionary *indexes = [im listIndexes];
+                expect(indexes.allKeys.count).to.equal(0);
+            });
+
+            it(@"can create an index over one fields", ^{
+                NSString *name = [im ensureIndexed:@[ @"name" ] withName:@"basic"];
+                expect(name).to.equal(@"basic");
+
+                NSDictionary *indexes = [im listIndexes];
+                expect(indexes.allKeys.count).to.equal(1);
+                expect(indexes.allKeys).to.contain(@"basic");
+
+                expect([indexes[@"basic"][@"fields"] count]).to.equal(3);
+                expect(indexes[@"basic"][@"fields"]).to.equal(@[ @"_id", @"_rev", @"name" ]);
+            });
+
+            it(@"can create an index over two fields", ^{
+                NSString *name = [im ensureIndexed:@[ @"name", @"age" ] withName:@"basic"];
+                expect(name).to.equal(@"basic");
+
+                NSDictionary *indexes = [im listIndexes];
+                expect(indexes.allKeys.count).to.equal(1);
+                expect(indexes.allKeys).to.contain(@"basic");
+
+                expect([indexes[@"basic"][@"fields"] count]).to.equal(4);
+                expect(indexes[@"basic"][@"fields"])
+                    .to.beSupersetOf(@[ @"_id", @"_rev", @"name", @"age" ]);
+            });
+
+            it(@"can create an index using dotted notation", ^{
+                NSString *name =
+                    [im ensureIndexed:@[ @"name.first", @"age.years" ] withName:@"basic"];
+                expect(name).to.equal(@"basic");
+
+                NSDictionary *indexes = [im listIndexes];
+                expect(indexes.allKeys).to.equal(@[ @"basic" ]);
+                expect(indexes[@"basic"][@"fields"])
+                    .to.equal(@[ @"_id", @"_rev", @"name.first", @"age.years" ]);
+            });
+
+            it(@"can create more than one index", ^{
+                [im ensureIndexed:@[ @"name", @"age" ] withName:@"basic"];
+                [im ensureIndexed:@[ @"name", @"age" ] withName:@"another"];
+                [im ensureIndexed:@[ @"cat" ] withName:@"petname"];
+
+                NSDictionary *indexes = [im listIndexes];
+                expect(indexes.allKeys.count).to.equal(3);
+                expect(indexes.allKeys).to.beSupersetOf(@[ @"basic", @"another", @"petname" ]);
+
+                expect([indexes[@"basic"][@"fields"] count]).to.equal(4);
+                expect(indexes[@"basic"][@"fields"])
+                    .to.beSupersetOf(@[ @"_id", @"_rev", @"name", @"age" ]);
+
+                expect([indexes[@"another"][@"fields"] count]).to.equal(4);
+                expect(indexes[@"another"][@"fields"])
+                    .to.beSupersetOf(@[ @"_id", @"_rev", @"name", @"age" ]);
+
+                expect([indexes[@"petname"][@"fields"] count]).to.equal(3);
+                expect(indexes[@"petname"][@"fields"])
+                    .to.beSupersetOf(@[ @"_id", @"_rev", @"cat" ]);
+            });
+
+            it(@"can create indexes specified with asc/desc", ^{
+                NSString *name =
+                    [im ensureIndexed:@[ @{ @"name" : @"asc" }, @{
+                        @"age" : @"desc"
+                    } ] withName:@"basic"];
+                expect(name).to.equal(@"basic");
+
+                NSDictionary *indexes = [im listIndexes];
+                expect(indexes.allKeys.count).to.equal(1);
+                expect(indexes.allKeys).to.contain(@"basic");
+
+                expect([indexes[@"basic"][@"fields"] count]).to.equal(4);
+                expect(indexes[@"basic"][@"fields"])
+                    .to.beSupersetOf(@[ @"_id", @"_rev", @"name", @"age" ]);
+            });
+
+        });
+
+        describe(@"when calling ensureIndexed on an index name that already exists", ^{
+
+            __block CDTQIndexManager *im;
+
+            beforeEach(^{
+                CDTDatastore *ds = [factory datastoreNamed:@"test" error:nil];
+                expect(ds).toNot.beNil();
+                im = [CDTQIndexManager managerUsingDatastore:ds error:nil];
+                expect(im).toNot.beNil();
+
+                NSString *name =
+                    [im ensureIndexed:@[ @{ @"name" : @"asc" }, @{
+                        @"age" : @"desc"
+                    } ] withName:@"basic"];
+                expect(name).to.equal(@"basic");
+            });
+
+            it(@"succeeds when the index definition is the same", ^{
+                NSString *name =
+                    [im ensureIndexed:@[ @{ @"name" : @"asc" }, @{
+                        @"age" : @"desc"
+                    } ] withName:@"basic"];
+                expect(name).to.equal(@"basic");
+            });
+
+            it(@"fails when the index definition is different", ^{
+                NSString *name =
+                    [im ensureIndexed:@[ @{ @"name" : @"asc" }, @{
+                        @"pet" : @"desc"
+                    } ] withName:@"basic"];
+                expect(name).to.beNil();
+            });
+
+        });
+
+        describe(@"when creating indexes with a type", ^{
+
+            __block CDTQIndexManager *im;
+
+            beforeEach(^{
+                CDTDatastore *ds = [factory datastoreNamed:@"test" error:nil];
+                expect(ds).toNot.beNil();
+                im = [CDTQIndexManager managerUsingDatastore:ds error:nil];
+                expect(im).toNot.beNil();
+            });
+
+            it(@"supports using the json type", ^{
+                NSString *name =
+                    [im ensureIndexed:@[ @{ @"name" : @"asc" }, @{
+                        @"age" : @"desc"
+                    } ] withName:@"basic"
+                                 type:@"json"];
+                expect(name).to.equal(@"basic");
+            });
+
+            it(@"doesn't support using the text type", ^{
+                NSString *name =
+                    [im ensureIndexed:@[ @{ @"name" : @"asc" }, @{
+                        @"age" : @"desc"
+                    } ] withName:@"basic"
+                                 type:@"text"];
+                expect(name).to.beNil();
+            });
+
+            it(@"doesn't support using the geo type", ^{
+                NSString *name =
+                    [im ensureIndexed:@[ @{ @"name" : @"asc" }, @{
+                        @"age" : @"desc"
+                    } ] withName:@"basic"
+                                 type:@"geo"];
+                expect(name).to.beNil();
+            });
+
+            it(@"doesn't support using the unplanned type", ^{
+                NSString *name =
+                    [im ensureIndexed:@[ @{ @"name" : @"asc" }, @{
+                        @"age" : @"desc"
+                    } ] withName:@"basic"
+                                 type:@"frog"];
+                expect(name).to.beNil();
+            });
+
+        });
+
+        describe(@"when using non-ascii text", ^{
+
+            __block CDTDatastore *ds;
+            __block CDTQIndexManager *im;
+
+            beforeEach(^{
+                ds = [factory datastoreNamed:@"test" error:nil];
+                expect(ds).toNot.beNil();
+
+                im = [CDTQIndexManager managerUsingDatastore:ds error:nil];
+                expect(im).toNot.beNil();
+            });
+
+            it(@"can create indexes successfully", ^{
+                expect(
+                    [im ensureIndexed:@[ @"اسم", @"@datatype", @"ages" ] withName:@"nonascii"])
+                    .toNot.beNil();
+            });
+        });
+
+        describe(@"when normalising index fields", ^{
+
+            it(@"removes directions from the field specifiers", ^{
+                NSArray *fields = [CDTQIndexCreator
+                    removeDirectionsFromFields:
+                        @[ @{ @"name" : @"asc" }, @{ @"pet" : @"asc" }, @"age" ]];
+                expect(fields).to.equal(@[ @"name", @"pet", @"age" ]);
+            });
+
+        });
+
+        describe(@"when validating field names", ^{
+
+            __block CDTDatastore *ds;
+            __block CDTQIndexManager *im;
+
+            beforeEach(^{
+                ds = [factory datastoreNamed:@"test" error:nil];
+                expect(ds).toNot.beNil();
+
+                im = [CDTQIndexManager managerUsingDatastore:ds error:nil];
+                expect(im).toNot.beNil();
+            });
+
+            it(@"rejects indexes with $ at start", ^{
+                expect([im ensureIndexed:@[ @"$name", @"@datatype" ] withName:@"nonascii"])
+                    .to.beNil();
+            });
+
+            it(@"rejects indexes with $ in but not at start", ^{
+                expect([im ensureIndexed:@[ @"na$me", @"@datatype$" ] withName:@"nonascii"])
+                    .toNot.beNil();
+            });
+
+            it(@"allows single fields",
+               ^{ expect([CDTQIndexCreator validFieldName:@"name"]).to.beTruthy(); });
+
+            it(@"allows dotted notation fields", ^{
+                expect([CDTQIndexCreator validFieldName:@"name.first"]).to.beTruthy();
+                expect([CDTQIndexCreator validFieldName:@"name.first.prefix"]).to.beTruthy();
+            });
+
+            it(@"allows dollars in positions other than first letter of a part", ^{
+                expect([CDTQIndexCreator validFieldName:@"na$me"]).to.beTruthy();
+                expect([CDTQIndexCreator validFieldName:@"name.fir$t"]).to.beTruthy();
+                expect([CDTQIndexCreator validFieldName:@"name.fir$t.pref$x"]).to.beTruthy();
+                expect([CDTQIndexCreator validFieldName:@"name.fir$t.pref$x"]).to.beTruthy();
+            });
+
+            it(@"rejects dollars in first letter of a part", ^{
+                expect([CDTQIndexCreator validFieldName:@"$name"]).to.beFalsy();
+                expect([CDTQIndexCreator validFieldName:@"name.$first"]).to.beFalsy();
+                expect([CDTQIndexCreator validFieldName:@"name.$first.$prefix"]).to.beFalsy();
+                expect([CDTQIndexCreator validFieldName:@"name.first.$prefix"]).to.beFalsy();
+                expect([CDTQIndexCreator validFieldName:@"name.first.$pr$efix"]).to.beFalsy();
+                expect([CDTQIndexCreator validFieldName:@"name.$$$$.prefix"]).to.beFalsy();
+            });
+
+        });
+
+        describe(@"when SQL statements to create indexes", ^{
+
+            // INSERT INTO metdata table
+
+            it(@"doesn't create insert statements when there are no fields", ^{
+                NSArray *fieldNames = @[];
+                NSArray *parts = [CDTQIndexCreator insertMetadataStatementsForIndexName:@"anIndex"
+                                                                                   type:@"json"
+                                                                             fieldNames:fieldNames];
+                expect(parts).to.beNil();
+            });
+
+            it(@"can create insert statements for an index with one field", ^{
+                NSArray *fieldNames = @[ @"_id", @"name" ];
+                NSArray *parts = [CDTQIndexCreator insertMetadataStatementsForIndexName:@"anIndex"
+                                                                                   type:@"json"
+                                                                             fieldNames:fieldNames];
+
+                CDTQSqlParts *part;
+
+                part = parts[0];
+                expect(part.sqlWithPlaceholders)
+                    .to.equal(@"INSERT INTO _t_cloudant_sync_query_metadata"
+                               " (index_name, index_type, field_name, last_sequence) "
+                               "VALUES (?, ?, ?, 0);");
+                expect(part.placeholderValues).to.equal(@[ @"anIndex", @"json", @"_id" ]);
+
+                part = parts[1];
+                expect(part.sqlWithPlaceholders)
+                    .to.equal(@"INSERT INTO _t_cloudant_sync_query_metadata"
+                               " (index_name, index_type, field_name, last_sequence) "
+                               "VALUES (?, ?, ?, 0);");
+                expect(part.placeholderValues).to.equal(@[ @"anIndex", @"json", @"name" ]);
+            });
+
+            it(@"can create insert statements for an index with many fields", ^{
+                NSArray *fieldNames = @[ @"_id", @"name", @"age", @"pet" ];
+                NSArray *parts = [CDTQIndexCreator insertMetadataStatementsForIndexName:@"anIndex"
+                                                                                   type:@"json"
+                                                                             fieldNames:fieldNames];
+
+                CDTQSqlParts *part;
+
+                part = parts[0];
+                expect(part.sqlWithPlaceholders)
+                    .to.equal(@"INSERT INTO _t_cloudant_sync_query_metadata"
+                               " (index_name, index_type, field_name, last_sequence) "
+                               "VALUES (?, ?, ?, 0);");
+                expect(part.placeholderValues).to.equal(@[ @"anIndex", @"json", @"_id" ]);
+
+                part = parts[1];
+                expect(part.sqlWithPlaceholders)
+                    .to.equal(@"INSERT INTO _t_cloudant_sync_query_metadata"
+                               " (index_name, index_type, field_name, last_sequence) "
+                               "VALUES (?, ?, ?, 0);");
+                expect(part.placeholderValues).to.equal(@[ @"anIndex", @"json", @"name" ]);
+
+                part = parts[2];
+                expect(part.sqlWithPlaceholders)
+                    .to.equal(@"INSERT INTO _t_cloudant_sync_query_metadata"
+                               " (index_name, index_type, field_name, last_sequence) "
+                               "VALUES (?, ?, ?, 0);");
+                expect(part.placeholderValues).to.equal(@[ @"anIndex", @"json", @"age" ]);
+
+                part = parts[3];
+                expect(part.sqlWithPlaceholders)
+                    .to.equal(@"INSERT INTO _t_cloudant_sync_query_metadata"
+                               " (index_name, index_type, field_name, last_sequence) "
+                               "VALUES (?, ?, ?, 0);");
+                expect(part.placeholderValues).to.equal(@[ @"anIndex", @"json", @"pet" ]);
+            });
+
+            // CREATE TABLE for Cloudant Query index
+
+            it(@"doesn't create table statements when there are no fields", ^{
+                NSArray *fieldNames = @[];
+                CDTQSqlParts *parts =
+                    [CDTQIndexCreator createIndexTableStatementForIndexName:@"anIndex"
+                                                                 fieldNames:fieldNames];
+                expect(parts).to.beNil();
+            });
+
+            it(@"can create table statements for an index with many fields", ^{
+                NSArray *fieldNames = @[ @"_id", @"name" ];
+                CDTQSqlParts *parts =
+                    [CDTQIndexCreator createIndexTableStatementForIndexName:@"anIndex"
+                                                                 fieldNames:fieldNames];
+                expect(parts.sqlWithPlaceholders)
+                    .to.equal(@"CREATE TABLE _t_cloudant_sync_query_index_anIndex"
+                               " ( \"_id\" NONE, \"name\" NONE );");
+                expect(parts.placeholderValues).to.equal(@[]);
+            });
+
+            it(@"can create table statements for an index with many fields", ^{
+                NSArray *fieldNames = @[ @"_id", @"name", @"age", @"pet" ];
+                CDTQSqlParts *parts =
+                    [CDTQIndexCreator createIndexTableStatementForIndexName:@"anIndex"
+                                                                 fieldNames:fieldNames];
+                expect(parts.sqlWithPlaceholders)
+                    .to.equal(@"CREATE TABLE _t_cloudant_sync_query_index_anIndex"
+                               " ( \"_id\" NONE, \"name\" NONE, \"age\" NONE, \"pet\" NONE );");
+                expect(parts.placeholderValues).to.equal(@[]);
+            });
+
+            // CREATE INDEX for Cloudant Query index
+
+            it(@"doesn't create table index statements when there are no fields", ^{
+                NSArray *fieldNames = @[];
+                CDTQSqlParts *parts =
+                    [CDTQIndexCreator createIndexIndexStatementForIndexName:@"anIndex"
+                                                                 fieldNames:fieldNames];
+                expect(parts).to.beNil();
+            });
+
+            it(@"can create table index statements for an index with many fields", ^{
+                NSArray *fieldNames = @[ @"_id", @"name" ];
+                CDTQSqlParts *parts =
+                    [CDTQIndexCreator createIndexIndexStatementForIndexName:@"anIndex"
+                                                                 fieldNames:fieldNames];
+                expect(parts.sqlWithPlaceholders)
+                    .to.equal(@"CREATE INDEX _t_cloudant_sync_query_index_anIndex_index "
+                               "ON _t_cloudant_sync_query_index_anIndex"
+                               " ( \"_id\", \"name\" );");
+                expect(parts.placeholderValues).to.equal(@[]);
+            });
+
+            it(@"can create table index statements for an index with many fields", ^{
+                NSArray *fieldNames = @[ @"_id", @"name", @"age", @"pet" ];
+                CDTQSqlParts *parts =
+                    [CDTQIndexCreator createIndexIndexStatementForIndexName:@"anIndex"
+                                                                 fieldNames:fieldNames];
+                expect(parts.sqlWithPlaceholders)
+                    .to.equal(@"CREATE INDEX _t_cloudant_sync_query_index_anIndex_index "
+                               "ON _t_cloudant_sync_query_index_anIndex"
+                               " ( \"_id\", \"name\", \"age\", \"pet\" );");
+                expect(parts.placeholderValues).to.equal(@[]);
+            });
+        });
+    });
+
+SpecEnd

--- a/Tests/Tests/CDTQIndexManagerTests.m
+++ b/Tests/Tests/CDTQIndexManagerTests.m
@@ -1,0 +1,185 @@
+//
+//  CloudantQueryObjcTests.m
+//  CloudantQueryObjcTests
+//
+//  Created by Michael Rhodes on 09/27/2014.
+//  Copyright (c) 2014 Michael Rhodes. All rights reserved.
+//
+
+#import <CloudantSync.h>
+#import <CDTQIndexManager.h>
+#import <CDTQIndexUpdater.h>
+#import <CDTQIndexCreator.h>
+#import <CDTQResultSet.h>
+#import <CDTQQueryExecutor.h>
+
+SpecBegin(CDTQIndexManager)
+
+    describe(@"deletes", ^{
+
+        __block NSString *factoryPath;
+        __block CDTDatastoreManager *factory;
+        __block CDTDatastore *ds;
+        __block CDTQIndexManager *im;
+
+        beforeEach(^{
+            // Create a new CDTDatastoreFactory at a temp path
+
+            NSString *tempDirectoryTemplate = [NSTemporaryDirectory()
+                stringByAppendingPathComponent:@"cloudant_sync_ios_tests.XXXXXX"];
+            const char *tempDirectoryTemplateCString =
+                [tempDirectoryTemplate fileSystemRepresentation];
+            char *tempDirectoryNameCString =
+                (char *)malloc(strlen(tempDirectoryTemplateCString) + 1);
+            strcpy(tempDirectoryNameCString, tempDirectoryTemplateCString);
+
+            char *result = mkdtemp(tempDirectoryNameCString);
+            expect(result).to.beTruthy();
+
+            factoryPath = [[NSFileManager defaultManager]
+                stringWithFileSystemRepresentation:tempDirectoryNameCString
+                                            length:strlen(result)];
+            free(tempDirectoryNameCString);
+
+            NSError *error;
+            factory = [[CDTDatastoreManager alloc] initWithDirectory:factoryPath error:&error];
+
+            ds = [factory datastoreNamed:@"test" error:nil];
+            expect(ds).toNot.beNil();
+            im = [CDTQIndexManager managerUsingDatastore:ds error:nil];
+            expect(im).toNot.beNil();
+        });
+
+        afterEach(^{
+            // Delete the databases we used
+
+            factory = nil;
+            NSError *error;
+            [[NSFileManager defaultManager] removeItemAtPath:factoryPath error:&error];
+        });
+
+        it(@"empty index", ^{
+
+            [im ensureIndexed:@[ @"name", @"address" ] withName:@"basic"];
+            expect([im listIndexes][@"basic"]).toNot.beNil();
+
+            [im deleteIndexNamed:@"basic"];
+            expect([im listIndexes][@"basic"]).to.beNil();
+
+        });
+
+        it(@"the right empty index", ^{
+
+            [im ensureIndexed:@[ @"name", @"address" ] withName:@"basic"];
+            [im ensureIndexed:@[ @"name", @"age" ] withName:@"basic2"];
+            [im ensureIndexed:@[ @"name" ] withName:@"basic3"];
+            expect([im listIndexes][@"basic"]).toNot.beNil();
+
+            [im deleteIndexNamed:@"basic2"];
+            expect([im listIndexes][@"basic"]).toNot.beNil();
+            expect([im listIndexes][@"basic2"]).to.beNil();
+            expect([im listIndexes][@"basic3"]).toNot.beNil();
+
+        });
+
+        it(@"non-empty index", ^{
+
+            CDTMutableDocumentRevision *rev = [CDTMutableDocumentRevision revision];
+
+            rev.body = @{
+                @"name" : @"mike",
+                @"age" : @12,
+                @"pet" : @{@"species" : @"cat", @"name" : @"mike"}
+            };
+            [ds createDocumentFromRevision:rev error:nil];
+
+            rev.body = @{
+                @"name" : @"mike",
+                @"age" : @12,
+                @"pet" : @{@"species" : @"cat", @"name" : @"mike"}
+            };
+            [ds createDocumentFromRevision:rev error:nil];
+
+            rev.body = @{
+                @"name" : @"mike",
+                @"age" : @12,
+                @"pet" : @{@"species" : @"cat", @"name" : @"mike"}
+            };
+            [ds createDocumentFromRevision:rev error:nil];
+
+            rev.body = @{
+                @"name" : @"mike",
+                @"age" : @12,
+                @"pet" : @{@"species" : @"cat", @"name" : @"mike"}
+            };
+            [ds createDocumentFromRevision:rev error:nil];
+
+            rev.body = @{
+                @"name" : @"mike",
+                @"age" : @12,
+                @"pet" : @{@"species" : @"cat", @"name" : @"mike"}
+            };
+            [ds createDocumentFromRevision:rev error:nil];
+
+            [im ensureIndexed:@[ @"name", @"address" ] withName:@"basic"];
+            expect([im listIndexes][@"basic"]).toNot.beNil();
+
+            [im deleteIndexNamed:@"basic"];
+            expect([im listIndexes][@"basic"]).to.beNil();
+
+        });
+
+        it(@"the right non-empty index", ^{
+
+            CDTMutableDocumentRevision *rev = [CDTMutableDocumentRevision revision];
+
+            rev.body = @{
+                @"name" : @"mike",
+                @"age" : @12,
+                @"pet" : @{@"species" : @"cat", @"name" : @"mike"}
+            };
+            [ds createDocumentFromRevision:rev error:nil];
+
+            rev.body = @{
+                @"name" : @"mike",
+                @"age" : @12,
+                @"pet" : @{@"species" : @"cat", @"name" : @"mike"}
+            };
+            [ds createDocumentFromRevision:rev error:nil];
+
+            rev.body = @{
+                @"name" : @"mike",
+                @"age" : @12,
+                @"pet" : @{@"species" : @"cat", @"name" : @"mike"}
+            };
+            [ds createDocumentFromRevision:rev error:nil];
+
+            rev.body = @{
+                @"name" : @"mike",
+                @"age" : @12,
+                @"pet" : @{@"species" : @"cat", @"name" : @"mike"}
+            };
+            [ds createDocumentFromRevision:rev error:nil];
+
+            rev.body = @{
+                @"name" : @"mike",
+                @"age" : @12,
+                @"pet" : @{@"species" : @"cat", @"name" : @"mike"}
+            };
+            [ds createDocumentFromRevision:rev error:nil];
+
+            [im ensureIndexed:@[ @"name", @"address" ] withName:@"basic"];
+            [im ensureIndexed:@[ @"name", @"age" ] withName:@"basic2"];
+            [im ensureIndexed:@[ @"name" ] withName:@"basic3"];
+            expect([im listIndexes][@"basic"]).toNot.beNil();
+
+            [im deleteIndexNamed:@"basic2"];
+            expect([im listIndexes][@"basic"]).toNot.beNil();
+            expect([im listIndexes][@"basic2"]).to.beNil();
+            expect([im listIndexes][@"basic3"]).toNot.beNil();
+
+        });
+
+    });
+
+SpecEnd

--- a/Tests/Tests/CDTQIndexUpdaterTests.m
+++ b/Tests/Tests/CDTQIndexUpdaterTests.m
@@ -1,0 +1,340 @@
+//
+//  CloudantQueryObjcTests.m
+//  CloudantQueryObjcTests
+//
+//  Created by Michael Rhodes on 09/27/2014.
+//  Copyright (c) 2014 Michael Rhodes. All rights reserved.
+//
+
+#import <CloudantSync.h>
+#import <CDTQIndexManager.h>
+#import <CDTQIndexUpdater.h>
+#import <CDTQIndexCreator.h>
+#import <CDTQResultSet.h>
+#import <CDTQQueryExecutor.h>
+
+SpecBegin(CDTQIndexUpdater)
+
+    describe(@"cloudant query", ^{
+
+        __block NSString *factoryPath;
+        __block CDTDatastoreManager *factory;
+        __block CDTDatastore *ds;
+
+        beforeEach(^{
+            // Create a new CDTDatastoreFactory at a temp path
+
+            NSString *tempDirectoryTemplate = [NSTemporaryDirectory()
+                stringByAppendingPathComponent:@"cloudant_sync_ios_tests.XXXXXX"];
+            const char *tempDirectoryTemplateCString =
+                [tempDirectoryTemplate fileSystemRepresentation];
+            char *tempDirectoryNameCString =
+                (char *)malloc(strlen(tempDirectoryTemplateCString) + 1);
+            strcpy(tempDirectoryNameCString, tempDirectoryTemplateCString);
+
+            char *result = mkdtemp(tempDirectoryNameCString);
+            expect(result).to.beTruthy();
+
+            factoryPath = [[NSFileManager defaultManager]
+                stringWithFileSystemRepresentation:tempDirectoryNameCString
+                                            length:strlen(result)];
+            free(tempDirectoryNameCString);
+
+            NSError *error;
+            factory = [[CDTDatastoreManager alloc] initWithDirectory:factoryPath error:&error];
+
+            ds = [factory datastoreNamed:@"test" error:nil];
+        });
+
+        afterEach(^{
+            // Delete the databases we used
+
+            factory = nil;
+            NSError *error;
+            [[NSFileManager defaultManager] removeItemAtPath:factoryPath error:&error];
+        });
+
+        describe(@"when generating DELETE index entries statements", ^{
+
+            it(@"returns nil for no _id", ^{
+                CDTQSqlParts *parts =
+                    [CDTQIndexUpdater partsToDeleteIndexEntriesForDocId:nil fromIndex:@"anIndex"];
+                expect(parts).to.beNil();
+            });
+
+            it(@"returns nil for no index name", ^{
+                CDTQSqlParts *parts =
+                    [CDTQIndexUpdater partsToDeleteIndexEntriesForDocId:@"123" fromIndex:nil];
+                expect(parts).to.beNil();
+            });
+
+            it(@"returns correctly for document", ^{
+                CDTQSqlParts *parts =
+                    [CDTQIndexUpdater partsToDeleteIndexEntriesForDocId:@"123"
+                                                              fromIndex:@"anIndex"];
+                NSString *sql = @"DELETE FROM _t_cloudant_sync_query_index_anIndex WHERE _id = ?;";
+                expect(parts.sqlWithPlaceholders).to.equal(sql);
+                expect(parts.placeholderValues).to.equal(@[ @"123" ]);
+            });
+
+        });
+
+        describe(@"when generating INSERT statements", ^{
+
+            it(@"returns correctly for single field", ^{
+                CDTMutableDocumentRevision *rev = [CDTMutableDocumentRevision revision];
+                rev.docId = @"id123";
+                rev.body = @{ @"name" : @"mike" };
+                CDTDocumentRevision *saved = [ds createDocumentFromRevision:rev error:nil];
+                CDTQSqlParts *parts = [CDTQIndexUpdater partsToIndexRevision:saved
+                                                                     inIndex:@"anIndex"
+                                                              withFieldNames:@[ @"name" ]][0];
+
+                NSString *sql = @"INSERT INTO _t_cloudant_sync_query_index_anIndex "
+                                 "( \"_id\", \"_rev\", \"name\" ) VALUES ( ?, ?, ? );";
+                expect(parts.sqlWithPlaceholders).to.equal(sql);
+                expect(parts.placeholderValues).to.equal(@[ @"id123", saved.revId, @"mike" ]);
+            });
+
+            it(@"returns correctly for two fields", ^{
+                CDTMutableDocumentRevision *rev = [CDTMutableDocumentRevision revision];
+                rev.docId = @"id123";
+                rev.body = @{ @"name" : @"mike", @"age" : @12 };
+                CDTDocumentRevision *saved = [ds createDocumentFromRevision:rev error:nil];
+                CDTQSqlParts *parts =
+                    [CDTQIndexUpdater partsToIndexRevision:saved
+                                                   inIndex:@"anIndex"
+                                            withFieldNames:@[ @"age", @"name" ]][0];
+
+                NSString *sql = @"INSERT INTO _t_cloudant_sync_query_index_anIndex "
+                                 "( \"_id\", \"_rev\", \"age\", \"name\" ) VALUES ( ?, ?, ?, ? );";
+                expect(parts.sqlWithPlaceholders).to.equal(sql);
+                expect(parts.placeholderValues).to.equal(@[ @"id123", saved.revId, @12, @"mike" ]);
+            });
+
+            it(@"returns correctly for multiple fields", ^{
+                CDTMutableDocumentRevision *rev = [CDTMutableDocumentRevision revision];
+                rev.docId = @"id123";
+                rev.body = @{
+                    @"name" : @"mike",
+                    @"age" : @12,
+                    @"pet" : @"cat",
+                    @"car" : @"mini",
+                    @"ignored" : @"something"
+                };
+                CDTDocumentRevision *saved = [ds createDocumentFromRevision:rev error:nil];
+                CDTQSqlParts *parts =
+                    [CDTQIndexUpdater partsToIndexRevision:saved
+                                                   inIndex:@"anIndex"
+                                            withFieldNames:@[ @"age", @"name", @"pet", @"car" ]][0];
+
+                NSString *sql = @"INSERT INTO _t_cloudant_sync_query_index_anIndex "
+                                 "( \"_id\", \"_rev\", \"age\", \"name\", \"pet\", \"car\" ) "
+                                 "VALUES ( ?, ?, ?, ?, ?, ? );";
+                expect(parts.sqlWithPlaceholders).to.equal(sql);
+                expect(parts.placeholderValues)
+                    .to.equal(@[ @"id123", saved.revId, @12, @"mike", @"cat", @"mini" ]);
+            });
+
+            it(@"returns correctly for missing fields", ^{
+                CDTMutableDocumentRevision *rev = [CDTMutableDocumentRevision revision];
+                rev.docId = @"id123";
+                rev.body = @{ @"name" : @"mike", @"pet" : @"cat", @"ignored" : @"something" };
+                CDTDocumentRevision *saved = [ds createDocumentFromRevision:rev error:nil];
+                CDTQSqlParts *parts =
+                    [CDTQIndexUpdater partsToIndexRevision:saved
+                                                   inIndex:@"anIndex"
+                                            withFieldNames:@[ @"age", @"name", @"pet", @"car" ]][0];
+
+                NSString *sql = @"INSERT INTO _t_cloudant_sync_query_index_anIndex "
+                                 "( \"_id\", \"_rev\", \"name\", \"pet\" ) VALUES ( ?, ?, ?, ? );";
+                expect(parts.sqlWithPlaceholders).to.equal(sql);
+                expect(parts.placeholderValues)
+                    .to.equal(@[ @"id123", saved.revId, @"mike", @"cat" ]);
+            });
+
+            it(@"still indexes a blank row if no fields", ^{
+                CDTMutableDocumentRevision *rev = [CDTMutableDocumentRevision revision];
+                rev.docId = @"id123";
+                rev.body = @{ @"name" : @"mike", @"pet" : @"cat", @"ignored" : @"something" };
+                CDTDocumentRevision *saved = [ds createDocumentFromRevision:rev error:nil];
+                CDTQSqlParts *parts =
+                    [CDTQIndexUpdater partsToIndexRevision:saved
+                                                   inIndex:@"anIndex"
+                                            withFieldNames:@[ @"car", @"van" ]][0];
+                NSString *sql = @"INSERT INTO _t_cloudant_sync_query_index_anIndex "
+                                 "( \"_id\", \"_rev\" ) VALUES ( ?, ? );";
+                expect(parts.sqlWithPlaceholders).to.equal(sql);
+                expect(parts.placeholderValues).to.equal(@[ @"id123", saved.revId ]);
+            });
+
+            context(@"when indexing arrays", ^{
+
+                it(@"indexes a single array field", ^{
+                    CDTMutableDocumentRevision *rev = [CDTMutableDocumentRevision revision];
+                    rev.docId = @"id123";
+                    rev.body = @{ @"name" : @"mike", @"pet" : @[ @"cat", @"dog", @"parrot" ] };
+                    CDTDocumentRevision *saved = [ds createDocumentFromRevision:rev error:nil];
+                    NSArray *statements =
+                        [CDTQIndexUpdater partsToIndexRevision:saved
+                                                       inIndex:@"anIndex"
+                                                withFieldNames:@[ @"name", @"pet" ]];
+                    expect(statements.count).to.equal(3);
+
+                    CDTQSqlParts *parts;
+                    NSString *sql;
+
+                    parts = statements[0];
+                    sql = @"INSERT INTO _t_cloudant_sync_query_index_anIndex "
+                           "( \"_id\", \"_rev\", \"pet\", \"name\" ) VALUES ( ?, ?, ?, ? );";
+                    expect(parts.sqlWithPlaceholders).to.equal(sql);
+                    expect(parts.placeholderValues)
+                        .to.equal(@[ @"id123", saved.revId, @"cat", @"mike" ]);
+
+                    parts = statements[1];
+                    sql = @"INSERT INTO _t_cloudant_sync_query_index_anIndex "
+                           "( \"_id\", \"_rev\", \"pet\", \"name\" ) VALUES ( ?, ?, ?, ? );";
+                    expect(parts.sqlWithPlaceholders).to.equal(sql);
+                    expect(parts.placeholderValues)
+                        .to.equal(@[ @"id123", saved.revId, @"dog", @"mike" ]);
+
+                    parts = statements[2];
+                    sql = @"INSERT INTO _t_cloudant_sync_query_index_anIndex "
+                           "( \"_id\", \"_rev\", \"pet\", \"name\" ) VALUES ( ?, ?, ?, ? );";
+                    expect(parts.sqlWithPlaceholders).to.equal(sql);
+                    expect(parts.placeholderValues)
+                        .to.equal(@[ @"id123", saved.revId, @"parrot", @"mike" ]);
+                });
+
+                it(@"indexes a single array field in subdoc", ^{
+                    CDTMutableDocumentRevision *rev = [CDTMutableDocumentRevision revision];
+                    rev.docId = @"id123";
+                    rev.body = @{ @"name" : @"mike", @"pet" : @{@"species" : @[ @"cat", @"dog" ]} };
+                    CDTDocumentRevision *saved = [ds createDocumentFromRevision:rev error:nil];
+                    NSArray *statements =
+                        [CDTQIndexUpdater partsToIndexRevision:saved
+                                                       inIndex:@"anIndex"
+                                                withFieldNames:@[ @"name", @"pet.species" ]];
+                    expect(statements.count).to.equal(2);
+
+                    CDTQSqlParts *parts;
+                    NSString *sql;
+
+                    parts = statements[0];
+                    sql =
+                        @"INSERT INTO _t_cloudant_sync_query_index_anIndex "
+                         "( \"_id\", \"_rev\", \"pet.species\", \"name\" ) VALUES ( ?, ?, ?, ? );";
+                    expect(parts.sqlWithPlaceholders).to.equal(sql);
+                    expect(parts.placeholderValues)
+                        .to.equal(@[ @"id123", saved.revId, @"cat", @"mike" ]);
+
+                    parts = statements[1];
+                    sql =
+                        @"INSERT INTO _t_cloudant_sync_query_index_anIndex "
+                         "( \"_id\", \"_rev\", \"pet.species\", \"name\" ) VALUES ( ?, ?, ?, ? );";
+                    expect(parts.sqlWithPlaceholders).to.equal(sql);
+                    expect(parts.placeholderValues)
+                        .to.equal(@[ @"id123", saved.revId, @"dog", @"mike" ]);
+                });
+
+                it(@"rejects multiple array fields", ^{
+                    CDTMutableDocumentRevision *rev = [CDTMutableDocumentRevision revision];
+                    rev.docId = @"id123";
+                    rev.body = @{
+                        @"name" : @"mike",
+                        @"pet" : @[ @"cat", @"dog", @"parrot" ],
+                        @"pet2" : @[ @"cat", @"dog", @"parrot" ]
+                    };
+                    CDTDocumentRevision *saved = [ds createDocumentFromRevision:rev error:nil];
+                    NSArray *statements =
+                        [CDTQIndexUpdater partsToIndexRevision:saved
+                                                       inIndex:@"anIndex"
+                                                withFieldNames:@[ @"name", @"pet", @"pet2" ]];
+                    expect(statements).to.beNil();
+                });
+
+            });
+
+        });
+
+        describe(@"when setting sequence numbers", ^{
+
+            __block CDTDatastore *ds;
+            __block CDTQIndexManager *im;
+
+            beforeEach(^{
+                ds = [factory datastoreNamed:@"test" error:nil];
+                expect(ds).toNot.beNil();
+
+                CDTMutableDocumentRevision *rev = [CDTMutableDocumentRevision revision];
+
+                rev.docId = @"mike12";
+                rev.body = @{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" };
+                [ds createDocumentFromRevision:rev error:nil];
+
+                rev.docId = @"mike23";
+                rev.body = @{ @"name" : @"mike", @"age" : @23, @"pet" : @"parrot" };
+                [ds createDocumentFromRevision:rev error:nil];
+
+                rev.docId = @"mike34";
+                rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"dog" };
+                [ds createDocumentFromRevision:rev error:nil];
+
+                rev.docId = @"john72";
+                rev.body = @{ @"name" : @"john", @"age" : @34, @"pet" : @"fish" };
+                [ds createDocumentFromRevision:rev error:nil];
+
+                rev.docId = @"fred34";
+                rev.body = @{ @"name" : @"fred", @"age" : @43, @"pet" : @"snake" };
+                [ds createDocumentFromRevision:rev error:nil];
+
+                rev.docId = @"fred12";
+                rev.body = @{ @"name" : @"fred", @"age" : @12 };
+                [ds createDocumentFromRevision:rev error:nil];
+
+                im = [CDTQIndexManager managerUsingDatastore:ds error:nil];
+                expect(im).toNot.beNil();
+
+            });
+
+            it(@"sets correct sequence number", ^{
+
+                expect([im ensureIndexed:@[ @"age", @"pet", @"name" ] withName:@"basic"])
+                    .toNot.beNil();
+
+                FMDatabaseQueue *queue =
+                    (FMDatabaseQueue *)[im performSelector:@selector(database)];
+
+                CDTQIndexUpdater *updater =
+                    [[CDTQIndexUpdater alloc] initWithDatabase:queue datastore:ds];
+                expect([updater sequenceNumberForIndex:@"basic"]).to.equal(6);
+
+                expect([updater updateAllIndexes:[im listIndexes]]).to.beTruthy();
+
+                expect([updater sequenceNumberForIndex:@"basic"]).to.equal(6);
+
+            });
+
+            it(@"sets correct sequence number after update", ^{
+                expect([im ensureIndexed:@[ @"age", @"pet", @"name" ] withName:@"basic"])
+                    .toNot.beNil();
+                FMDatabaseQueue *queue =
+                    (FMDatabaseQueue *)[im performSelector:@selector(database)];
+                CDTQIndexUpdater *updater =
+                    [[CDTQIndexUpdater alloc] initWithDatabase:queue datastore:ds];
+
+                CDTMutableDocumentRevision *rev = [CDTMutableDocumentRevision revision];
+                rev.docId = @"newdoc";
+                rev.body = @{ @"name" : @"fred", @"age" : @12 };
+                [ds createDocumentFromRevision:rev error:nil];
+
+                expect([updater updateAllIndexes:[im listIndexes]]).to.beTruthy();
+
+                expect([updater sequenceNumberForIndex:@"basic"]).to.equal(7);
+
+            });
+
+        });
+    });
+
+SpecEnd

--- a/Tests/Tests/CDTQInvalidQuerySyntax.m
+++ b/Tests/Tests/CDTQInvalidQuerySyntax.m
@@ -1,0 +1,158 @@
+//
+//  CDTQInvalidQuerySyntax.m
+//  CloudantQueryObjc
+//
+//  Created by Rhys Short on 14/10/2014.
+//  Copyright (c) 2014 Michael Rhodes. All rights reserved.
+//
+
+#import <CloudantSync.h>
+#import <CDTQIndexManager.h>
+#import <CDTQIndexUpdater.h>
+#import <CDTQIndexCreator.h>
+#import <CDTQResultSet.h>
+#import <CDTQQueryExecutor.h>
+
+SpecBegin(CDTQQueryExecutorInvalidSyntax) describe(@"cloudant query using invalid syntax", ^{
+
+    __block NSString *factoryPath;
+    __block CDTDatastoreManager *factory;
+
+    beforeEach(^{
+        // Create a new CDTDatastoreFactory at a temp path
+
+        NSString *tempDirectoryTemplate = [NSTemporaryDirectory()
+            stringByAppendingPathComponent:@"cloudant_sync_ios_tests.XXXXXX"];
+        const char *tempDirectoryTemplateCString = [tempDirectoryTemplate fileSystemRepresentation];
+        char *tempDirectoryNameCString = (char *)malloc(strlen(tempDirectoryTemplateCString) + 1);
+        strcpy(tempDirectoryNameCString, tempDirectoryTemplateCString);
+
+        char *result = mkdtemp(tempDirectoryNameCString);
+        expect(result).to.beTruthy();
+
+        factoryPath = [[NSFileManager defaultManager]
+            stringWithFileSystemRepresentation:tempDirectoryNameCString
+                                        length:strlen(result)];
+        free(tempDirectoryNameCString);
+
+        NSError *error;
+        factory = [[CDTDatastoreManager alloc] initWithDirectory:factoryPath error:&error];
+    });
+
+    afterEach(^{
+        // Delete the databases we used
+
+        factory = nil;
+        NSError *error;
+        [[NSFileManager defaultManager] removeItemAtPath:factoryPath error:&error];
+    });
+
+    describe(@"When using query ", ^{
+
+        __block CDTDatastore *ds;
+        __block CDTQIndexManager *im;
+
+        beforeEach(^{
+            ds = [factory datastoreNamed:@"test" error:nil];
+            expect(ds).toNot.beNil();
+
+            CDTMutableDocumentRevision *rev = [CDTMutableDocumentRevision revision];
+
+            rev.docId = @"mike12";
+            rev.body = @{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" };
+            [ds createDocumentFromRevision:rev error:nil];
+
+            rev.docId = @"mike34";
+            rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"dog" };
+            [ds createDocumentFromRevision:rev error:nil];
+
+            rev.docId = @"mike72";
+            rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"cat" };
+            [ds createDocumentFromRevision:rev error:nil];
+
+            rev.docId = @"fred34";
+            rev.body = @{ @"name" : @"fred", @"age" : @34, @"pet" : @"cat" };
+            [ds createDocumentFromRevision:rev error:nil];
+
+            rev.docId = @"fred12";
+            rev.body = @{ @"name" : @"fred", @"age" : @12 };
+            [ds createDocumentFromRevision:rev error:nil];
+
+            im = [CDTQIndexManager managerUsingDatastore:ds error:nil];
+            expect(im).toNot.beNil();
+
+            expect([im ensureIndexed:@[ @"name", @"age" ] withName:@"basic"]).toNot.beNil();
+            expect([im ensureIndexed:@[ @"name", @"pet" ] withName:@"pet"]).toNot.beNil();
+        });
+
+        it(@"returns nil when arugment to $or is a string", ^{
+            NSDictionary *query = @{ @"$or" : @"I should be an array" };
+            CDTQResultSet *result = [im find:query];
+            expect(result).to.beNil();
+        });
+
+        it(@"returns nil when array passed to $or contains only a string", ^{
+            NSDictionary *query = @{ @"$or" : @[ @"I should be an array" ] };
+            CDTQResultSet *result = [im find:query];
+            expect(result).to.beNil();
+        });
+
+        it(@"returns nil when array passed to $or contains only one empty dict", ^{
+            NSDictionary *query = @{ @"$or" : @[ @{} ] };
+            CDTQResultSet *result = [im find:query];
+            expect(result).to.beNil();
+        });
+
+        it(@"returns nil when $or syntax is incorrect, using one correct dict and one empty "
+           @"dict",
+           ^{
+            NSDictionary *query = @{ @"$or" : @[ @{@"name" : @"mike"}, @{} ] };
+            CDTQResultSet *result = [im find:query];
+            expect(result).to.beNil();
+        });
+
+        it(@"returns nil when comparing attempting to use unsupported array comparison", ^{
+            NSDictionary *query = @{ @"friends" : @[] };
+            CDTQResultSet *result = [im find:query];
+            expect(result).to.beNil();
+        });
+
+        it(@"returns nil when $eq is top level element", ^{
+            NSDictionary *query = @{ @"$eq" : @"$eq should not be top level thing" };
+            CDTQResultSet *result = [im find:query];
+            expect(result).to.beNil();
+        });
+
+        it(@"returns nil when array passed to $eq contains only a string", ^{
+            NSDictionary *query = @{ @"name" : @[ @"I should be a dict" ] };
+            CDTQResultSet *result = [im find:query];
+            expect(result).to.beNil();
+        });
+
+        it(@"returns nil when compareing field value to empty dict", ^{
+            NSDictionary *query = @{ @"name" : @{} };
+            CDTQResultSet *result = [im find:query];
+            expect(result).to.beNil();
+        });
+
+        it(@"returns nil when using $or syntax for $eq", ^{
+            NSDictionary *query = @{ @"name" : @[ @{@"$eq" : @"mike"} ] };
+            CDTQResultSet *result = [im find:query];
+            expect(result).to.beNil();
+        });
+
+        it(@"returns nil when $eq syntax is incorrect, using an array of dictionaries", ^{
+            NSDictionary *query = @{ @"name" : @[ @{@"$eq" : @"mike"}, @{} ] };
+            CDTQResultSet *result = [im find:query];
+            expect(result).to.beNil();
+        });
+
+        it(@"returns nil when $exists has argument other than boolean", ^{
+            NSDictionary *query = @{ @"name" : @{@"$exists" : @{}} };
+            CDTQResultSet *result = [im find:query];
+            expect(result).to.beNil();
+        });
+    });
+});
+
+SpecEnd

--- a/Tests/Tests/CDTQPerformanceTests.m
+++ b/Tests/Tests/CDTQPerformanceTests.m
@@ -1,0 +1,171 @@
+//
+//  CloudantQueryObjcTests.m
+//  CloudantQueryObjcTests
+//
+//  Created by Michael Rhodes on 09/27/2014.
+//  Copyright (c) 2014 Michael Rhodes. All rights reserved.
+//
+
+#import <CloudantSync.h>
+#import <CDTQIndexManager.h>
+#import <CDTQIndexUpdater.h>
+#import <CDTQIndexCreator.h>
+#import <CDTQResultSet.h>
+#import <CDTQQueryExecutor.h>
+
+#import <CocoaLumberjack.h>
+
+SpecBegin(CDTQPerformance)
+
+    xdescribe(@"CDTQ Performance", ^{
+
+        __block NSString *factoryPath;
+        __block CDTDatastoreManager *factory;
+
+        beforeAll(^{
+
+            [DDLog addLogger:[DDTTYLogger sharedInstance]];
+
+            // Create a new CDTDatastoreFactory at a temp path
+
+            NSString *tempDirectoryTemplate = [NSTemporaryDirectory()
+                stringByAppendingPathComponent:@"cloudant_sync_ios_tests.XXXXXX"];
+            const char *tempDirectoryTemplateCString =
+                [tempDirectoryTemplate fileSystemRepresentation];
+            char *tempDirectoryNameCString =
+                (char *)malloc(strlen(tempDirectoryTemplateCString) + 1);
+            strcpy(tempDirectoryNameCString, tempDirectoryTemplateCString);
+
+            char *result = mkdtemp(tempDirectoryNameCString);
+            expect(result).to.beTruthy();
+
+            factoryPath = [[NSFileManager defaultManager]
+                stringWithFileSystemRepresentation:tempDirectoryNameCString
+                                            length:strlen(result)];
+            free(tempDirectoryNameCString);
+
+            NSError *error;
+            factory = [[CDTDatastoreManager alloc] initWithDirectory:factoryPath error:&error];
+
+            //
+            // Create databases with 1k, 10k, 50k, 100k docs for tests
+            //
+
+            CDTMutableDocumentRevision *rev = [CDTMutableDocumentRevision revision];
+
+            CDTDatastore *ds1k = [factory datastoreNamed:@"test1k" error:nil];
+            CDTDatastore *ds10k = [factory datastoreNamed:@"test10k" error:nil];
+            CDTDatastore *ds50k = [factory datastoreNamed:@"test50k" error:nil];
+            CDTDatastore *ds100k = [factory datastoreNamed:@"test100k" error:nil];
+            for (int i = 0; i < 100000; i++) {
+                
+                @autoreleasepool {
+                    
+                rev.docId = [NSString stringWithFormat:@"doc-%d", i];
+                rev.body = @{
+                    @"name" : @"mike",
+                    @"age" : @34,
+                    @"docNumber" : @(i),
+                    @"pet" : @"cat"
+                };
+
+                if (i < 1000) {
+                    [ds1k createDocumentFromRevision:rev error:nil];
+                }
+
+                if (i < 10000) {
+                    [ds10k createDocumentFromRevision:rev error:nil];
+                }
+
+                if (i < 50000) {
+                    [ds50k createDocumentFromRevision:rev error:nil];
+                }
+
+                [ds100k createDocumentFromRevision:rev error:nil];
+                    
+                }
+            }
+        });
+
+        afterAll(^{
+            // Delete the databases we used
+            factory = nil;
+            NSError *error;
+            [[NSFileManager defaultManager] removeItemAtPath:factoryPath error:&error];
+        });
+
+        it(@"create datastores", ^{// this test is just here to make beforeAll create
+                                   // its databases before starting the real tests.
+           });
+
+        context(@"1k docs", ^{
+            __block CDTQIndexManager *im;
+            beforeEach(^{
+                CDTDatastore *ds = [factory datastoreNamed:@"test1k" error:nil];
+                im = [CDTQIndexManager managerUsingDatastore:ds error:nil];
+                expect(im).toNot.beNil();
+            });
+
+            it(@"one field",
+               ^{ expect([im ensureIndexed:@[ @"name" ] withName:@"pet1"]).toNot.beNil(); });
+
+            it(@"three field", ^{
+                expect([im ensureIndexed:@[ @"name", @"age", @"pet" ] withName:@"pet2"])
+                    .toNot.beNil();
+            });
+        });
+
+        context(@"10k docs", ^{
+            __block CDTQIndexManager *im;
+            beforeEach(^{
+                CDTDatastore *ds = [factory datastoreNamed:@"test10k" error:nil];
+                im = [CDTQIndexManager managerUsingDatastore:ds error:nil];
+                expect(im).toNot.beNil();
+            });
+
+            it(@"one field",
+               ^{ expect([im ensureIndexed:@[ @"name" ] withName:@"pet1"]).toNot.beNil(); });
+
+            it(@"three field", ^{
+                expect([im ensureIndexed:@[ @"name", @"age", @"pet" ] withName:@"pet2"])
+                    .toNot.beNil();
+            });
+        });
+
+        context(@"50k docs", ^{
+            __block CDTQIndexManager *im;
+            beforeEach(^{
+                CDTDatastore *ds = [factory datastoreNamed:@"test50k" error:nil];
+                im = [CDTQIndexManager managerUsingDatastore:ds error:nil];
+                expect(im).toNot.beNil();
+            });
+
+            it(@"one field",
+               ^{ expect([im ensureIndexed:@[ @"name" ] withName:@"pet1"]).toNot.beNil(); });
+
+            it(@"three field", ^{
+                expect([im ensureIndexed:@[ @"name", @"age", @"pet" ] withName:@"pet2"])
+                    .toNot.beNil();
+            });
+        });
+
+        context(@"100k docs", ^{
+            __block CDTQIndexManager *im;
+            beforeEach(^{
+                CDTDatastore *ds = [factory datastoreNamed:@"test100k" error:nil];
+                im = [CDTQIndexManager managerUsingDatastore:ds error:nil];
+                expect(im).toNot.beNil();
+            });
+
+            it(@"one field",
+               ^{ expect([im ensureIndexed:@[ @"name" ] withName:@"pet1"]).toNot.beNil(); });
+
+            it(@"three field", ^{
+                expect([im ensureIndexed:@[ @"name", @"age", @"pet" ] withName:@"pet2"])
+                    .toNot.beNil();
+            });
+        });
+
+    });
+
+SpecEnd

--- a/Tests/Tests/CDTQQueryExecutorTests.m
+++ b/Tests/Tests/CDTQQueryExecutorTests.m
@@ -1,0 +1,1634 @@
+//
+//  CloudantQueryObjcTests.m
+//  CloudantQueryObjcTests
+//
+//  Created by Michael Rhodes on 09/27/2014.
+//  Copyright (c) 2014 Michael Rhodes. All rights reserved.
+//
+
+#import "CDTQMatcherIndexManager.h"
+#import "CDTQSQLOnlyIndexManager.h"
+
+#import <CloudantSync.h>
+#import <CDTQIndexManager.h>
+#import <CDTQIndexUpdater.h>
+#import <CDTQIndexCreator.h>
+#import <CDTQResultSet.h>
+#import <CDTQQueryExecutor.h>
+#import "Matchers/CDTQContainsAllElementsMatcher.h"
+#import "Matchers/CDTQEitherMatcher.h"
+
+SharedExamplesBegin(QueryExecution)
+
+    // The aim is to make sure that the post hoc matcher class behaves the
+    // same as the SQL query engine.
+    //
+    // For this, we test the entire pipeline using the usual CDTQQueryExectutor class. This does
+    // both SQL and post hoc matching. Then we have a sub-class of CDTQQueryExecutor which skips
+    // the SQL querying and just runs all documents through the CDTQUnindexedMatcher.
+    sharedExamplesFor(@"queries with covering indexes", ^(NSDictionary* data) {
+        // Pull the class to test out of the data object
+        Class imClass = data[@"index_manager_class"];
+
+        __block NSString* factoryPath;
+        __block CDTDatastoreManager* factory;
+
+        beforeEach(^{
+            // Create a new CDTDatastoreFactory at a temp path
+
+            NSString* tempDirectoryTemplate = [NSTemporaryDirectory()
+                stringByAppendingPathComponent:@"cloudant_sync_ios_tests.XXXXXX"];
+            const char* tempDirectoryTemplateCString =
+                [tempDirectoryTemplate fileSystemRepresentation];
+            char* tempDirectoryNameCString =
+                (char*)malloc(strlen(tempDirectoryTemplateCString) + 1);
+            strcpy(tempDirectoryNameCString, tempDirectoryTemplateCString);
+
+            char* result = mkdtemp(tempDirectoryNameCString);
+            expect(result).to.beTruthy();
+
+            factoryPath = [[NSFileManager defaultManager]
+                stringWithFileSystemRepresentation:tempDirectoryNameCString
+                                            length:strlen(result)];
+            free(tempDirectoryNameCString);
+
+            NSError* error;
+            factory = [[CDTDatastoreManager alloc] initWithDirectory:factoryPath error:&error];
+        });
+
+        afterEach(^{
+            // Delete the databases we used
+
+            factory = nil;
+            NSError* error;
+            [[NSFileManager defaultManager] removeItemAtPath:factoryPath error:&error];
+        });
+
+        describe(@"when executing queries", ^{
+
+            __block CDTDatastore* ds;
+            __block CDTQIndexManager* im;
+
+            beforeEach(^{
+                ds = [factory datastoreNamed:@"test" error:nil];
+                expect(ds).toNot.beNil();
+
+                CDTMutableDocumentRevision* rev = [CDTMutableDocumentRevision revision];
+
+                rev.docId = @"mike12";
+                rev.body = @{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" };
+                [ds createDocumentFromRevision:rev error:nil];
+
+                rev.docId = @"mike34";
+                rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"dog" };
+                [ds createDocumentFromRevision:rev error:nil];
+
+                rev.docId = @"mike72";
+                rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"cat" };
+                [ds createDocumentFromRevision:rev error:nil];
+
+                rev.docId = @"fred34";
+                rev.body = @{ @"name" : @"fred", @"age" : @34, @"pet" : @"cat" };
+                [ds createDocumentFromRevision:rev error:nil];
+
+                rev.docId = @"fred12";
+                rev.body = @{ @"name" : @"fred", @"age" : @12 };
+                [ds createDocumentFromRevision:rev error:nil];
+
+                im = [imClass managerUsingDatastore:ds error:nil];
+                expect(im).toNot.beNil();
+
+                expect([im ensureIndexed:@[ @"name", @"age" ] withName:@"basic"]).toNot.beNil();
+                expect([im ensureIndexed:@[ @"name", @"pet" ] withName:@"pet"]).toNot.beNil();
+            });
+
+            it(@"returns nil for no query", ^{
+                CDTQResultSet* result = [im find:nil];
+                expect(result).to.beNil();
+            });
+
+            it(@"returns all docs for empty query", ^{
+                NSDictionary* query = @{};
+                CDTQResultSet* result = [im find:query];
+                expect(result).toNot.beNil();
+                expect(result.documentIds.count).to.equal(5);
+            });
+
+            it(@"can query over one string field", ^{
+                NSDictionary* query = @{ @"name" : @{@"$eq" : @"mike"} };
+                CDTQResultSet* result = [im find:query];
+                expect(result).toNot.beNil();
+                expect(result.documentIds.count).to.equal(3);
+            });
+
+            it(@"can query over one number field", ^{
+                NSDictionary* query = @{ @"age" : @{@"$eq" : @12} };
+                CDTQResultSet* result = [im find:query];
+                expect(result).toNot.beNil();
+                expect(result.documentIds.count).to.equal(2);
+            });
+
+            it(@"can query over two string fields", ^{
+                NSDictionary* query = @{
+                    @"name" : @{@"$eq" : @"mike"},
+                    @"pet" : @{@"$eq" : @"cat"}
+                };
+                CDTQResultSet* result = [im find:query];
+                expect(result).toNot.beNil();
+                expect(result.documentIds.count).to.equal(2);
+            });
+
+            it(@"can query over two mixed fields", ^{
+                NSDictionary* query = @{ @"name" : @{@"$eq" : @"mike"}, @"age" : @{@"$eq" : @12} };
+                CDTQResultSet* result = [im find:query];
+                expect(result).toNot.beNil();
+                expect(result.documentIds.count).to.equal(1);
+            });
+
+            it(@"returns no results when query is for one predicate without match", ^{
+                NSDictionary* query = @{ @"name" : @{@"$eq" : @"bill"} };
+                CDTQResultSet* result = [im find:query];
+                expect(result).toNot.beNil();
+                expect(result.documentIds.count).to.equal(0);
+            });
+
+            it(@"returns no results when query is for two predicates, one without matches", ^{
+                NSDictionary* query = @{ @"name" : @{@"$eq" : @"bill"}, @"age" : @{@"$eq" : @12} };
+                CDTQResultSet* result = [im find:query];
+                expect(result).toNot.beNil();
+                expect(result.documentIds.count).to.equal(0);
+            });
+
+            it(@"returns no results when query is for two predicates, both without matches", ^{
+                NSDictionary* query = @{ @"name" : @{@"$eq" : @"bill"}, @"age" : @{@"$eq" : @17} };
+                CDTQResultSet* result = [im find:query];
+                expect(result).toNot.beNil();
+                expect(result.documentIds.count).to.equal(0);
+            });
+
+            context(@"when limiting and offsetting results", ^{
+
+                it(@"returns all for skip = limit = 0", ^{
+                    NSDictionary* query = @{ @"name" : @{@"$eq" : @"mike"} };
+                    CDTQResultSet* results = [im find:query skip:0 limit:0 fields:nil sort:nil];
+                    expect(results.documentIds.count).to.equal(3);
+                });
+
+                it(@"limits query results", ^{
+                    NSDictionary* query = @{ @"name" : @{@"$eq" : @"mike"} };
+                    CDTQResultSet* results = [im find:query skip:0 limit:1 fields:nil sort:nil];
+                    expect(results.documentIds.count).to.equal(1);
+                });
+
+                it(@"limits query and offsets starting point", ^{
+                    NSDictionary* query = @{ @"name" : @{@"$eq" : @"mike"} };
+                    CDTQResultSet* offsetResults =
+                        [im find:query skip:1 limit:1 fields:nil sort:nil];
+                    CDTQResultSet* results = [im find:query skip:0 limit:2 fields:nil sort:nil];
+
+                    expect(results.documentIds.count).to.equal(2);
+                    expect(results.documentIds[1]).to.equal(offsetResults.documentIds[0]);
+                });
+
+                it(@"disables limit for 0", ^{
+                    NSDictionary* query = @{ @"name" : @{@"$eq" : @"mike"} };
+                    CDTQResultSet* results = [im find:query skip:1 limit:0 fields:nil sort:nil];
+
+                    expect([results.documentIds count]).to.equal(2);
+                });
+
+                it(@"returns an array with results when limit is over array bounds", ^{
+                    NSDictionary* query = @{ @"name" : @{@"$eq" : @"mike"} };
+                    CDTQResultSet* results = [im find:query skip:0 limit:4 fields:nil sort:nil];
+
+                    expect([results.documentIds count]).to.equal(3);
+                });
+
+                it(@"returns all results with very large limit", ^{
+                    NSDictionary* query = @{ @"name" : @{@"$eq" : @"mike"} };
+                    CDTQResultSet* results = [im find:query skip:0 limit:1000 fields:nil sort:nil];
+
+                    expect([results.documentIds count]).to.equal(3);
+                });
+
+                it(@"returns an array with no results when range is out of bounds", ^{
+                    NSDictionary* query = @{ @"name" : @{@"$eq" : @"mike"} };
+                    CDTQResultSet* results = [im find:query skip:4 limit:4 fields:nil sort:nil];
+
+                    expect([results.documentIds count]).to.equal(0);
+
+                });
+
+                it(@"returns appropriate results skip and large limit used", ^{
+                    NSDictionary* query = @{ @"name" : @{@"$eq" : @"mike"} };
+                    CDTQResultSet* results =
+                        [im find:query skip:1000 limit:1000 fields:nil sort:nil];
+
+                    expect([results.documentIds count]).to.equal(0);
+                });
+            });
+
+            // TODO fill in when separate validation class written
+            xdescribe(@"when using unsupported operator", ^{
+                it(@"fails", ^{
+                    NSDictionary* query = @{ @"age" : @{@"$blah" : @12} };
+                    CDTQResultSet* result = [im find:query];
+                    expect(result).to.beNil();
+                });
+            });
+
+            describe(@"when using $gt operator", ^{
+                it(@"works used alone", ^{
+                    NSDictionary* query = @{ @"age" : @{@"$gt" : @12} };
+                    CDTQResultSet* result = [im find:query];
+                    expect(result.documentIds.count).to.equal(3);
+                });
+
+                it(@"works used with other predicates", ^{
+                    NSDictionary* query = @{
+                        @"name" : @{@"$eq" : @"mike"},
+                        @"age" : @{@"$gt" : @12}
+                    };
+                    CDTQResultSet* result = [im find:query];
+                    expect(result.documentIds.count).to.equal(2);
+                });
+
+                it(@"can compare string values", ^{
+                    NSDictionary* query = @{ @"name" : @{@"$gt" : @"fred"} };
+                    CDTQResultSet* result = [im find:query];
+                    expect(result).toNot.beNil();
+
+                    [result enumerateObjectsUsingBlock:^(CDTDocumentRevision* rev, NSUInteger i,
+                                                         BOOL* s) {
+                        expect([rev.body count]).to.beInTheRangeOf(@2, @3);
+                        expect(rev.body[@"name"]).to.equal(@"mike");
+                    }];
+                });
+
+                it(@"can compare string values as part of an $and query", ^{
+                    NSDictionary* query = @{ @"name" : @{@"$gt" : @"fred"}, @"age" : @34 };
+                    CDTQResultSet* result = [im find:query];
+                    expect(result).toNot.beNil();
+
+                    [result enumerateObjectsUsingBlock:^(CDTDocumentRevision* rev, NSUInteger i,
+                                                         BOOL* s) {
+                        expect([rev.body count]).to.beInTheRangeOf(@2, @3);
+                        expect(rev.body[@"name"]).to.equal(@"mike");
+                        expect(rev.body[@"age"]).to.equal(34);
+                    }];
+                });
+            });
+
+            describe(@"when using $gte operator", ^{
+                it(@"works used alone", ^{
+                    NSDictionary* query = @{ @"age" : @{@"$gte" : @12} };
+                    CDTQResultSet* result = [im find:query];
+                    expect(result.documentIds.count).to.equal(5);
+                });
+
+                it(@"works used with other predicates", ^{
+                    NSDictionary* query = @{
+                        @"name" : @{@"$eq" : @"mike"},
+                        @"age" : @{@"$gte" : @12}
+                    };
+                    CDTQResultSet* result = [im find:query];
+                    expect(result.documentIds.count).to.equal(3);
+                });
+            });
+
+            describe(@"when using $lt operator", ^{
+                it(@"works used alone", ^{
+                    NSDictionary* query = @{ @"age" : @{@"$lt" : @12} };
+                    CDTQResultSet* result = [im find:query];
+                    expect(result.documentIds.count).to.equal(0);
+                });
+
+                it(@"works used with other predicates", ^{
+                    NSDictionary* query = @{
+                        @"name" : @{@"$eq" : @"mike"},
+                        @"age" : @{@"$lt" : @12}
+                    };
+                    CDTQResultSet* result = [im find:query];
+                    expect(result.documentIds.count).to.equal(0);
+                });
+
+                it(@"can compare string values", ^{
+                    NSDictionary* query = @{ @"name" : @{@"$lt" : @"mike"} };
+                    CDTQResultSet* result = [im find:query];
+                    expect(result).toNot.beNil();
+
+                    [result enumerateObjectsUsingBlock:^(CDTDocumentRevision* rev, NSUInteger i,
+                                                         BOOL* s) {
+                        expect([rev.body count]).to.beInTheRangeOf(@2, @3);
+                        expect(rev.body[@"name"]).to.equal(@"fred");
+                    }];
+                });
+
+                it(@"can compare string values as part of an $and query", ^{
+                    NSDictionary* query = @{ @"name" : @{@"$lt" : @"mike"}, @"age" : @12 };
+                    CDTQResultSet* result = [im find:query];
+                    expect(result).toNot.beNil();
+
+                    [result enumerateObjectsUsingBlock:^(CDTDocumentRevision* rev, NSUInteger i,
+                                                         BOOL* s) {
+                        expect([rev.body count]).to.beInTheRangeOf(@2, @3);
+                        expect(rev.body[@"name"]).to.equal(@"fred");
+                        expect(rev.body[@"age"]).to.equal(12);
+                    }];
+                });
+            });
+
+            describe(@"when using $lte operator", ^{
+                it(@"works used alone", ^{
+                    NSDictionary* query = @{ @"age" : @{@"$lte" : @12} };
+                    CDTQResultSet* result = [im find:query];
+                    expect(result.documentIds.count).to.equal(2);
+                });
+
+                it(@"works used with other predicates", ^{
+                    NSDictionary* query = @{
+                        @"name" : @{@"$eq" : @"mike"},
+                        @"age" : @{@"$lte" : @12}
+                    };
+                    CDTQResultSet* result = [im find:query];
+                    expect(result.documentIds.count).to.equal(1);
+                });
+            });
+        });
+
+        describe(@"when using dotted notation", ^{
+
+            __block CDTDatastore* ds;
+            __block CDTQIndexManager* im;
+
+            beforeEach(^{
+                ds = [factory datastoreNamed:@"test" error:nil];
+                expect(ds).toNot.beNil();
+
+                CDTMutableDocumentRevision* rev = [CDTMutableDocumentRevision revision];
+
+                rev.docId = @"mike12";
+                rev.body = @{
+                    @"name" : @"mike",
+                    @"age" : @12,
+                    @"pet" : @{@"species" : @"cat", @"name" : @"mike"}
+                };
+                [ds createDocumentFromRevision:rev error:nil];
+
+                rev.docId = @"mike23";
+                rev.body = @{
+                    @"name" : @"mike",
+                    @"age" : @23,
+                    @"pet" : @{@"species" : @"cat", @"name" : @{@"first" : @"mike"}}
+                };
+                [ds createDocumentFromRevision:rev error:nil];
+
+                rev.docId = @"mike34";
+                rev.body = @{
+                    @"name" : @"mike",
+                    @"age" : @34,
+                    @"pet" : @{@"species" : @"cat", @"name" : @"mike"}
+                };
+                [ds createDocumentFromRevision:rev error:nil];
+
+                rev.docId = @"mike72";
+                rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"cat" };
+                [ds createDocumentFromRevision:rev error:nil];
+
+                rev.docId = @"fred34";
+                rev.body = @{ @"name" : @"fred", @"age" : @34, @"pet" : @"cat" };
+                [ds createDocumentFromRevision:rev error:nil];
+
+                rev.docId = @"fred12";
+                rev.body = @{ @"name" : @"fred", @"age" : @12 };
+                [ds createDocumentFromRevision:rev error:nil];
+
+                im = [imClass managerUsingDatastore:ds error:nil];
+                expect(im).toNot.beNil();
+
+                expect([im ensureIndexed:@[ @"age", @"pet.name", @"pet.species" ] withName:@"pet"])
+                    .toNot.beNil();
+                expect([im ensureIndexed:@[ @"age", @"pet.name.first" ] withName:@"firstname"])
+                    .toNot.beNil();
+            });
+
+            it(@"query with two level dotted no results", ^{
+                NSDictionary* query = @{
+                    @"pet.name" : @{@"$eq" : @"fred"},
+                    @"age" : @{@"$eq" : @12}
+                };
+                CDTQResultSet* result = [im find:query];
+                expect(result).toNot.beNil();
+                expect(result.documentIds).to.equal(@[]);
+            });
+
+            it(@"query with two level dotted one result", ^{
+                NSDictionary* query = @{
+                    @"pet.name" : @{@"$eq" : @"mike"},
+                    @"age" : @{@"$eq" : @12}
+                };
+                CDTQResultSet* result = [im find:query];
+                expect(result.documentIds).to.equal(@[ @"mike12" ]);
+            });
+
+            it(@"query with two level dotted multiple results", ^{
+                NSDictionary* query = @{ @"pet.species" : @{@"$eq" : @"cat"} };
+                CDTQResultSet* result = [im find:query];
+                expect(result.documentIds.count).to.equal(3);
+                expect(result.documentIds).to.beSupersetOf(@[ @"mike12", @"mike23", @"mike34" ]);
+            });
+
+            it(@"query with three level dotted", ^{
+                NSDictionary* query = @{ @"pet.name.first" : @{@"$eq" : @"mike"} };
+                CDTQResultSet* result = [im find:query];
+                expect(result.documentIds).to.equal(@[ @"mike23" ]);
+            });
+        });
+
+        describe(@"when using non-ascii text", ^{
+
+            __block CDTDatastore* ds;
+            __block CDTQIndexManager* im;
+
+            beforeEach(^{
+                ds = [factory datastoreNamed:@"test" error:nil];
+                expect(ds).toNot.beNil();
+
+                CDTMutableDocumentRevision* rev = [CDTMutableDocumentRevision revision];
+
+                rev.docId = @"mike12";
+                rev.body = @{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" };
+                [ds createDocumentFromRevision:rev error:nil];
+
+                rev.docId = @"mike34";
+                rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"dog" };
+                [ds createDocumentFromRevision:rev error:nil];
+
+                rev.docId = @"mike72";
+                rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"cat" };
+                [ds createDocumentFromRevision:rev error:nil];
+
+                rev.docId = @"اسم34";
+                rev.body = @{ @"name" : @"اسم", @"age" : @34, @"pet" : @"cat" };
+                [ds createDocumentFromRevision:rev error:nil];
+
+                rev.docId = @"fred12";
+                rev.body = @{ @"name" : @"fred", @"age" : @12 };
+                [ds createDocumentFromRevision:rev error:nil];
+
+                rev.docId = @"fredarabic";
+                rev.body = @{ @"اسم" : @"fred", @"age" : @12 };
+                [ds createDocumentFromRevision:rev error:nil];
+
+                rev.docId = @"freddatatype";
+                rev.body = @{ @"@datatype" : @"fred", @"age" : @12 };
+                [ds createDocumentFromRevision:rev error:nil];
+
+                im = [imClass managerUsingDatastore:ds error:nil];
+                expect(im).toNot.beNil();
+            });
+
+            it(@"can query for values non-ascii", ^{
+                expect([im ensureIndexed:@[ @"name" ] withName:@"nonascii"]).toNot.beNil();
+
+                NSDictionary* query = @{ @"name" : @{@"$eq" : @"اسم"} };
+                CDTQResultSet* result = [im find:query];
+                expect(result).toNot.beNil();
+                expect(result.documentIds.count).to.equal(1);
+            });
+
+            it(@"can use fields with odd names", ^{
+                expect([im ensureIndexed:@[ @"اسم", @"@datatype", @"age" ] withName:@"nonascii"])
+                    .toNot.beNil();
+
+                NSDictionary* query = @{ @"اسم" : @{@"$eq" : @"fred"}, @"age" : @{@"$eq" : @12} };
+                CDTQResultSet* result = [im find:query];
+                expect(result).toNot.beNil();
+                expect(result.documentIds.count).to.equal(1);
+
+                query = @{ @"@datatype" : @{@"$eq" : @"fred"}, @"age" : @{@"$eq" : @12} };
+                result = [im find:query];
+                expect(result).toNot.beNil();
+                expect(result.documentIds.count).to.equal(1);
+            });
+        });
+
+        describe(@"when using OR queries", ^{
+
+            __block CDTDatastore* ds;
+            __block CDTQIndexManager* im;
+
+            beforeEach(^{
+                ds = [factory datastoreNamed:@"test" error:nil];
+                expect(ds).toNot.beNil();
+
+                CDTMutableDocumentRevision* rev = [CDTMutableDocumentRevision revision];
+
+                rev.docId = @"mike12";
+                rev.body = @{
+                    @"name" : @"mike",
+                    @"age" : @12,
+                    @"pet" : @{@"species" : @"cat", @"name" : @"mike"}
+                };
+                [ds createDocumentFromRevision:rev error:nil];
+
+                rev.docId = @"mike23";
+                rev.body = @{
+                    @"name" : @"mike",
+                    @"age" : @23,
+                    @"pet" : @{@"species" : @"cat", @"name" : @{@"first" : @"mike"}}
+                };
+                [ds createDocumentFromRevision:rev error:nil];
+
+                rev.docId = @"mike34";
+                rev.body = @{
+                    @"name" : @"mike",
+                    @"age" : @34,
+                    @"pet" : @{@"species" : @"cat", @"name" : @"mike"}
+                };
+                [ds createDocumentFromRevision:rev error:nil];
+
+                rev.docId = @"mike72";
+                rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"cat" };
+                [ds createDocumentFromRevision:rev error:nil];
+
+                rev.docId = @"fred34";
+                rev.body = @{ @"name" : @"fred", @"age" : @34, @"pet" : @"cat" };
+                [ds createDocumentFromRevision:rev error:nil];
+
+                rev.docId = @"fred12";
+                rev.body = @{ @"name" : @"fred", @"age" : @12 };
+                [ds createDocumentFromRevision:rev error:nil];
+
+                im = [imClass managerUsingDatastore:ds error:nil];
+                expect(im).toNot.beNil();
+
+                expect([im ensureIndexed:@[ @"age", @"pet", @"name" ] withName:@"basic"])
+                    .toNot.beNil();
+                expect([im ensureIndexed:@[ @"age", @"pet.name", @"pet.species" ] withName:@"pet"])
+                    .toNot.beNil();
+                expect([im ensureIndexed:@[ @"age", @"pet.name.first" ] withName:@"firstname"])
+                    .toNot.beNil();
+            });
+
+            it(@"supports using OR", ^{
+                NSDictionary* query = @{ @"$or" : @[ @{@"name" : @"mike"}, @{@"pet" : @"cat"} ] };
+                CDTQResultSet* result = [im find:query];
+                expect(result).toNot.beNil();
+                expect(result.documentIds.count).to.equal(5);
+            });
+
+            it(@"supports using OR with specified operator", ^{
+                NSDictionary* query = @{
+                    @"$or" : @[
+                        @{@"name" : @"mike"},        // 4
+                        @{@"age" : @{@"$gt" : @30}}  // 1
+                    ]
+                };
+                CDTQResultSet* result = [im find:query];
+                expect(result).toNot.beNil();
+                expect(result.documentIds.count).to.equal(5);
+            });
+
+            it(@"supports using OR in sub trees", ^{
+                NSDictionary* query = @{
+                    @"$or" : @[
+                        @{@"name" : @"fred"},
+                        @{@"$or" : @[ @{@"age" : @12}, @{@"pet" : @"cat"} ]}
+                    ]
+                };
+                CDTQResultSet* result = [im find:query];
+                expect(result).toNot.beNil();
+                expect(result.documentIds.count).to.equal(4);
+            });
+
+            it(@"supports using OR with a single operand", ^{
+                NSDictionary* query = @{ @"$or" : @[ @{@"name" : @"mike"} ] };
+                CDTQResultSet* result = [im find:query];
+                expect(result).toNot.beNil();
+                expect([result.documentIds count]).to.equal(4);
+            });
+        });
+
+        describe(@"when using nested queries", ^{
+
+            __block CDTDatastore* ds;
+            __block CDTQIndexManager* im;
+
+            beforeEach(^{
+                ds = [factory datastoreNamed:@"test" error:nil];
+                expect(ds).toNot.beNil();
+
+                CDTMutableDocumentRevision* rev = [CDTMutableDocumentRevision revision];
+
+                rev.docId = @"mike12";
+                rev.body = @{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" };
+                [ds createDocumentFromRevision:rev error:nil];
+
+                rev.docId = @"mike23";
+                rev.body = @{ @"name" : @"mike", @"age" : @23, @"pet" : @"parrot" };
+                [ds createDocumentFromRevision:rev error:nil];
+
+                rev.docId = @"mike34";
+                rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"dog" };
+                [ds createDocumentFromRevision:rev error:nil];
+
+                rev.docId = @"john72";
+                rev.body = @{ @"name" : @"john", @"age" : @34, @"pet" : @"fish" };
+                [ds createDocumentFromRevision:rev error:nil];
+
+                rev.docId = @"fred34";
+                rev.body = @{ @"name" : @"fred", @"age" : @43, @"pet" : @"snake" };
+                [ds createDocumentFromRevision:rev error:nil];
+
+                rev.docId = @"fred12";
+                rev.body = @{ @"name" : @"fred", @"age" : @12 };
+                [ds createDocumentFromRevision:rev error:nil];
+
+                im = [imClass managerUsingDatastore:ds error:nil];
+                expect(im).toNot.beNil();
+
+                expect([im ensureIndexed:@[ @"age", @"pet", @"name" ] withName:@"basic"])
+                    .toNot.beNil();
+            });
+
+            it(@"query with two levels", ^{
+                NSDictionary* query = @{
+                    @"$or" : @[
+                        @{@"name" : @"mike"},  // 3
+                        @{@"age" : @34},       // 1
+                        @{
+                           @"$and" : @[
+                               @{@"name" : @"fred"},  // 1
+                               @{@"pet" : @"snake"}
+                           ]
+                        }
+                    ]
+                };
+                CDTQResultSet* result = [im find:query];
+                expect(result).toNot.beNil();
+                expect(result.documentIds.count).to.equal(5);
+            });
+
+            it(@"OR with sub OR", ^{
+                NSDictionary* query = @{
+                    @"$or" : @[
+                        @{@"name" : @"mike"},  // 3
+                        @{@"age" : @34},       // 1
+                        @{
+                           @"$or" : @[
+                               @{@"name" : @"fred"},   // 2
+                               @{@"pet" : @"hamster"}  // 0
+                           ]
+                        }
+                    ]
+                };
+                CDTQResultSet* result = [im find:query];
+                expect(result).toNot.beNil();
+                expect(result.documentIds.count).to.equal(6);
+            });
+
+            it(@"AND with sub AND", ^{
+                // No doc matches all these
+                NSDictionary* query = @{
+                    @"$and" : @[
+                        @{@"name" : @"mike"},
+                        @{@"age" : @34},
+                        @{@"$and" : @[ @{@"name" : @"fred"}, @{@"pet" : @"snake"} ]}
+                    ]
+                };
+                CDTQResultSet* result = [im find:query];
+                expect(result).toNot.beNil();
+                expect(result.documentIds.count).to.equal(0);
+            });
+
+            it(@"OR with sub AND", ^{
+                NSDictionary* query = @{
+                    @"$or" : @[
+                        @{@"name" : @"mike"},  // 3
+                        @{@"age" : @34},       // 1
+                        @{
+                           @"$and" : @[
+                               @{@"name" : @"fred"},  // 0
+                               @{@"pet" : @"cat"}
+                           ]
+                        }
+                    ]
+                };
+                CDTQResultSet* result = [im find:query];
+                expect(result).toNot.beNil();
+                expect(result.documentIds.count).to.equal(4);
+            });
+
+            it(@"AND with sub OR", ^{
+                NSDictionary* query = @{
+                    @"$and" : @[
+                        @{@"name" : @"mike"},
+                        @{@"age" : @34},
+                        @{@"$or" : @[ @{@"name" : @"fred"}, @{@"pet" : @"dog"} ]}
+                    ]
+                };
+                CDTQResultSet* result = [im find:query];
+                expect(result).toNot.beNil();
+                expect(result.documentIds.count).to.equal(1);
+            });
+
+            it(@"AND with sub AND with a sub AND", ^{
+                NSDictionary* query = @{
+                    @"$and" : @[
+                        @{@"name" : @"mike"},
+                        @{@"age" : @{@"$gt" : @10}},
+                        @{@"age" : @{@"$lt" : @30}},
+                        @{
+                           @"$and" : @[
+                               @{@"$and" : @[ @{@"pet" : @"cat"} ]},
+                               @{@"pet" : @{@"$gt" : @"ant"}}
+                           ]
+                        }
+                    ]
+                };
+                CDTQResultSet* result = [im find:query];
+                expect(result).toNot.beNil();
+                expect(result.documentIds.count).to.equal(1);
+            });
+
+            it(@"AND with sub AND with a sub AND", ^{
+                NSDictionary* query = @{
+                    @"$and" : @[
+                        @{@"name" : @"mike"},
+                        @{@"age" : @{@"$gt" : @10}},
+                        @{@"age" : @{@"$lt" : @12}},
+                        @{
+                           @"$and" : @[
+                               @{@"$and" : @[ @{@"pet" : @"cat"} ]},
+                               @{@"pet" : @{@"$gt" : @"ant"}}
+                           ]
+                        }
+                    ]
+                };
+                CDTQResultSet* result = [im find:query];
+                expect(result).toNot.beNil();
+                expect(result.documentIds.count).to.equal(0);
+            });
+
+            it(@"AND with sub OR and sub AND", ^{
+                NSDictionary* query = @{
+                    @"$or" : @[
+                        @{@"name" : @"mike"},  // 3
+                        @{@"pet" : @"cat"},    // 1, but named mike
+                        @{
+                           @"$or" : @[
+                               @{@"name" : @"mike"},  // 3
+                               @{@"pet" : @"snake"}   // 1
+                           ]
+                        },
+                        @{
+                           @"$and" : @[
+                               @{@"name" : @"mike"},  // 0
+                               @{@"pet" : @"snake"}
+                           ]
+                        }
+                    ]
+                };
+                CDTQResultSet* result = [im find:query];
+                expect(result).toNot.beNil();
+                expect(result.documentIds.count).to.equal(4);
+            });
+        });
+
+        describe(@"_id is queryable", ^{
+            __block CDTDatastore* ds;
+            __block CDTQIndexManager* im;
+
+            beforeEach(^{
+                ds = [factory datastoreNamed:@"test" error:nil];
+                expect(ds).toNot.beNil();
+
+                CDTMutableDocumentRevision* rev = [CDTMutableDocumentRevision revision];
+
+                rev.docId = @"mike12";
+                rev.body = @{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" };
+                [ds createDocumentFromRevision:rev error:nil];
+
+                rev.docId = @"mike23";
+                rev.body = @{ @"name" : @"mike", @"age" : @23, @"pet" : @"parrot" };
+                [ds createDocumentFromRevision:rev error:nil];
+
+                im = [imClass managerUsingDatastore:ds error:nil];
+                expect(im).toNot.beNil();
+
+                expect([im ensureIndexed:@[ @"age", @"pet", @"name" ] withName:@"basic"])
+                    .toNot.beNil();
+            });
+
+            it(@"works as single clause", ^{
+                NSDictionary* query = @{ @"_id" : @"mike12" };
+                CDTQResultSet* result = [im find:query];
+                expect(result).toNot.beNil();
+                expect(result.documentIds.count).to.equal(1);
+            });
+
+            it(@"works with other clauses", ^{
+                NSDictionary* query = @{ @"_id" : @"mike23", @"name" : @"mike" };
+                CDTQResultSet* result = [im find:query];
+                expect(result).toNot.beNil();
+                expect(result.documentIds.count).to.equal(1);
+            });
+        });
+
+        describe(@"_rev is queryable", ^{
+            __block CDTDatastore* ds;
+            __block CDTQIndexManager* im;
+            __block NSString* docRev;
+
+            beforeEach(^{
+                ds = [factory datastoreNamed:@"test" error:nil];
+                expect(ds).toNot.beNil();
+
+                CDTMutableDocumentRevision* rev = [CDTMutableDocumentRevision revision];
+
+                rev.docId = @"mike12";
+                rev.body = @{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" };
+                [ds createDocumentFromRevision:rev error:nil];
+
+                rev.docId = @"mike23";
+                rev.body = @{ @"name" : @"mike", @"age" : @23, @"pet" : @"parrot" };
+                CDTDocumentRevision* toRetrieve = [ds createDocumentFromRevision:rev error:nil];
+                docRev = toRetrieve.revId;
+
+                im = [imClass managerUsingDatastore:ds error:nil];
+                expect(im).toNot.beNil();
+
+                expect([im ensureIndexed:@[ @"age", @"pet", @"name" ] withName:@"basic"])
+                    .toNot.beNil();
+            });
+
+            it(@"works as single clause", ^{
+                NSDictionary* query = @{ @"_rev" : docRev };
+                CDTQResultSet* result = [im find:query];
+                expect(result).toNot.beNil();
+                expect(result.documentIds.count).to.equal(1);
+            });
+
+            it(@"works with other clauses", ^{
+                NSDictionary* query = @{ @"_rev" : docRev, @"name" : @"mike" };
+                CDTQResultSet* result = [im find:query];
+                expect(result).toNot.beNil();
+                expect(result.documentIds.count).to.equal(1);
+            });
+        });
+
+        describe(@"when using $not", ^{
+
+            __block CDTDatastore* ds;
+            __block CDTQIndexManager* im;
+
+            beforeEach(^{
+                ds = [factory datastoreNamed:@"test" error:nil];
+                expect(ds).toNot.beNil();
+
+                CDTMutableDocumentRevision* rev = [CDTMutableDocumentRevision revision];
+
+                rev.docId = @"mike12";
+                rev.body = @{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" };
+                [ds createDocumentFromRevision:rev error:nil];
+
+                rev.docId = @"mike34";
+                rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"dog" };
+                [ds createDocumentFromRevision:rev error:nil];
+
+                rev.docId = @"mike72";
+                rev.body = @{ @"name" : @"mike", @"age" : @67, @"pet" : @"cat" };
+                [ds createDocumentFromRevision:rev error:nil];
+
+                rev.docId = @"fred34";
+                rev.body = @{ @"name" : @"fred", @"age" : @34, @"pet" : @"parrot" };
+                [ds createDocumentFromRevision:rev error:nil];
+
+                rev.docId = @"fred12";
+                rev.body = @{ @"name" : @"fred", @"age" : @12 };
+                [ds createDocumentFromRevision:rev error:nil];
+
+                im = [imClass managerUsingDatastore:ds error:nil];
+                expect(im).toNot.beNil();
+
+                expect([im ensureIndexed:@[ @"name", @"pet", @"age" ] withName:@"pet"])
+                    .toNot.beNil();
+            });
+
+            it(@"can query over one string field", ^{
+                NSDictionary* query = @{ @"name" : @{@"$not" : @{@"$eq" : @"mike"}} };
+                CDTQResultSet* result = [im find:query];
+                expect(result).toNot.beNil();
+                expect(result.documentIds.count).to.equal(2);
+            });
+
+            it(@"can query over one int field", ^{
+                NSDictionary* query = @{ @"age" : @{@"$not" : @{@"$gt" : @34}} };
+                CDTQResultSet* result = [im find:query];
+                expect(result).toNot.beNil();
+                expect(result.documentIds.count).to.equal(4);
+            });
+
+            it(@"includes documents without field indexed", ^{
+                NSDictionary* query = @{ @"pet" : @{@"$not" : @{@"$eq" : @"cat"}} };
+                CDTQResultSet* result = [im find:query];
+                expect(result).toNot.beNil();
+                expect(result.documentIds.count).to.equal(3);
+            });
+
+            it(@"works with AND compound operator", ^{
+                NSDictionary* query = @{
+                    @"$and" : @[
+                        @{@"pet" : @{@"$not" : @{@"$eq" : @"cat"}}},
+                        @{@"pet" : @{@"$not" : @{@"$eq" : @"dog"}}}
+                    ]
+                };
+                CDTQResultSet* result = [im find:query];
+                expect(result).toNot.beNil();
+                expect(result.documentIds.count).to.equal(2);
+            });
+
+            it(@"works with AND compound operator, no results", ^{
+                NSDictionary* query = @{
+                    @"$and" : @[
+                        @{@"pet" : @{@"$not" : @{@"$eq" : @"cat"}}},
+                        @{@"pet" : @{@"$eq" : @"cat"}}
+                    ]
+                };
+                CDTQResultSet* result = [im find:query];
+                expect(result).toNot.beNil();
+                expect(result.documentIds.count).to.equal(0);
+            });
+
+            it(@"works with OR compond operator", ^{
+                NSDictionary* query = @{
+                    @"$or" : @[
+                        @{@"pet" : @{@"$not" : @{@"$eq" : @"cat"}}},
+                        @{@"pet" : @{@"$not" : @{@"$eq" : @"dog"}}}
+                    ]
+                };
+                CDTQResultSet* result = [im find:query];
+                expect(result).toNot.beNil();
+                expect(result.documentIds.count).to.equal(5);
+            });
+        });
+
+        describe(@"when indexing array fields", ^{
+
+            __block CDTDatastore* ds;
+            __block CDTQIndexManager* im;
+
+            beforeEach(^{
+                ds = [factory datastoreNamed:@"test" error:nil];
+                expect(ds).toNot.beNil();
+
+                CDTMutableDocumentRevision* rev = [CDTMutableDocumentRevision revision];
+
+                rev.docId = @"mike12";
+                rev.body = @{ @"name" : @"mike", @"age" : @12, @"pet" : @[ @"cat", @"dog" ] };
+                [ds createDocumentFromRevision:rev error:nil];
+
+                rev.docId = @"fred34";
+                rev.body = @{ @"name" : @"fred", @"age" : @34, @"pet" : @"parrot" };
+                [ds createDocumentFromRevision:rev error:nil];
+                
+                rev.docId = @"mike34";
+                rev.body = @{ @"name" : @"mike",
+                              @"age" : @34,
+                              @"pet" : @[ @"cat", @"dog", @"fish" ] };
+                [ds createDocumentFromRevision:rev error:nil];
+                
+                rev.docId = @"fred12";
+                rev.body = @{ @"name" : @"fred", @"age" : @12 };
+                [ds createDocumentFromRevision:rev error:nil];
+                
+                rev.docId = @"john44";
+                rev.body = @{ @"name" : @"john", @"age" : @44, @"pet" : @[ @"hamster", @"snake" ] };
+                [ds createDocumentFromRevision:rev error:nil];
+                
+                rev.docId = @"john22";
+                rev.body = @{ @"name" : @"john", @"age" : @22, @"pet" : @"cat" };
+                [ds createDocumentFromRevision:rev error:nil];
+
+                im = [imClass managerUsingDatastore:ds error:nil];
+                expect(im).toNot.beNil();
+
+                expect([im ensureIndexed:@[ @"name", @"pet", @"age" ] withName:@"pet"])
+                    .toNot.beNil();
+            });
+
+            it(@"finds documents with array", ^{
+                NSDictionary* query = @{ @"pet" : @{@"$eq" : @"dog"} };
+                CDTQResultSet* result = [im find:query];
+                expect(result).toNot.beNil();
+                expect(result.documentIds.count).to.equal(2);
+                expect(result.documentIds).to.containAllElements(@[ @"mike12", @"mike34" ]);
+            });
+
+            it(@"finds document without array", ^{
+                NSDictionary* query = @{ @"pet" : @{@"$eq" : @"parrot"} };
+                CDTQResultSet* result = [im find:query];
+                expect(result).toNot.beNil();
+                expect(result.documentIds.count).to.equal(1);
+                expect(result.documentIds).to.containAllElements(@[ @"fred34" ]);
+            });
+            
+            // Queries like { "pet" : "$eq" : "cat" } }
+            //     and      { "pet" : { "$not" : { "$ne" : "cat" } } }
+            // Should yield the same result set.  Evidenced in the next two tests.
+            
+            it(@"finds documents with and without array", ^{
+                NSDictionary* query = @{ @"pet" : @{@"$eq" : @"cat"} };
+                CDTQResultSet* result = [im find:query];
+                expect(result).toNot.beNil();
+                expect(result.documentIds.count).to.equal(3);
+                expect(result.documentIds).to.containAllElements(@[ @"mike12",
+                                                                    @"mike34",
+                                                                    @"john22" ]);
+            });
+            
+            it(@"finds documents with and without array while using $not..$ne", ^{
+                NSDictionary* query = @{ @"pet" : @{ @"$not" : @{@"$ne" : @"cat"} } };
+                CDTQResultSet* result = [im find:query];
+                expect(result).toNot.beNil();
+                expect(result.documentIds.count).to.equal(3);
+                expect(result.documentIds).to.containAllElements(@[ @"mike12",
+                                                                    @"mike34",
+                                                                    @"john22" ]);
+            });
+            
+            // Queries like { "pet" : { "$not" : { "$eq" : "dog" } } }
+            //     and      { "pet" : { "$ne" : "dog" } } }
+            // Should yield the same result set.  Evidenced in the next two tests.
+
+            it(@"works with $not", ^{
+                NSDictionary* query = @{ @"pet" : @{@"$not" : @{@"$eq" : @"dog"}} };
+                CDTQResultSet* result = [im find:query];
+                expect(result).toNot.beNil();
+                expect(result.documentIds.count).to.equal(4);
+                expect(result.documentIds).to.containAllElements(@[ @"fred34",
+                                                                    @"john44",
+                                                                    @"john22",
+                                                                    @"fred12" ]);
+            });
+            
+            it(@"works with $ne", ^{
+                NSDictionary* query = @{ @"pet" : @{@"$ne" : @"dog"} };
+                CDTQResultSet* result = [im find:query];
+                expect(result).toNot.beNil();
+                expect(result.documentIds.count).to.equal(4);
+                expect(result.documentIds).to.containAllElements(@[ @"fred34",
+                                                                    @"john44",
+                                                                    @"john22",
+                                                                    @"fred12" ]);
+            });
+            
+            // The $gt and $lte operators are logically opposite.  Consequently querying
+            // with those operators and for that matter $gte/$lt will yield result sets
+            // that are logically opposite.  Whereas using $not..$gt will yield a result
+            // set that consists of documents that do NOT satisfy the "greater than"
+            // condition.  This can be a result set that differs from the logical
+            // opposite as is evidenced in the following three tests.
+            
+            it(@"works with $gt", ^{
+                NSDictionary* query = @{ @"pet" : @{@"$gt" : @"dog"} };
+                CDTQResultSet* result = [im find:query];
+                expect(result).toNot.beNil();
+                expect(result.documentIds.count).to.equal(3);
+                expect(result.documentIds).to.containAllElements(@[ @"fred34",
+                                                                    @"john44",
+                                                                    @"mike34" ]);
+            });
+            
+            it(@"works with $lte", ^{
+                NSDictionary* query = @{ @"pet" : @{@"$lte" : @"dog"} };
+                CDTQResultSet* result = [im find:query];
+                expect(result).toNot.beNil();
+                expect(result.documentIds.count).to.equal(3);
+                expect(result.documentIds).to.containAllElements(@[ @"mike12",
+                                                                    @"john22",
+                                                                    @"mike34" ]);
+            });
+            
+            it(@"works with $not..$gt", ^{
+                NSDictionary* query = @{ @"pet" : @{ @"$not" : @{@"$gt" : @"dog"} } };
+                CDTQResultSet* result = [im find:query];
+                expect(result).toNot.beNil();
+                expect(result.documentIds.count).to.equal(3);
+                expect(result.documentIds).to.containAllElements(@[ @"fred12",
+                                                                    @"john22",
+                                                                    @"mike12" ]);
+            });
+            
+            it(@"can find documents with and without arrays using $not multiple times", ^{
+                NSDictionary* query = @{ @"$and" :
+                                             @[ @{ @"pet" : @{ @"$not" : @{@"$eq" : @"cat"} } },
+                                                @{ @"pet" : @{ @"$not" : @{@"$eq" : @"dog"} } }
+                                              ]
+                                       };
+                CDTQResultSet* result = [im find:query];
+                expect(result).toNot.beNil();
+                expect(result.documentIds.count).to.equal(3);
+                expect(result.documentIds).to.containAllElements(@[ @"fred34",
+                                                                    @"fred12",
+                                                                    @"john44" ]);
+            });
+            
+            // Arrays as part of the query is not yet supported.
+            
+            it(@"returns nil when using array in query", ^{
+                NSDictionary* query = @{ @"pet" : @{ @"$not" : @{@"$eq" : @[ @"dog" ] } } };
+                CDTQResultSet* result = [im find:query];
+                expect(result).to.beNil();
+            });
+            
+        });
+
+        describe(@"when using the $exists operator", ^{
+
+            __block CDTDatastore* ds;
+            __block CDTQIndexManager* im;
+
+            beforeEach(^{
+                ds = [factory datastoreNamed:@"test" error:nil];
+                expect(ds).toNot.beNil();
+
+                CDTMutableDocumentRevision* rev = [CDTMutableDocumentRevision revision];
+
+                rev.docId = @"mike12";
+                rev.body = @{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" };
+                [ds createDocumentFromRevision:rev error:nil];
+
+                rev.docId = @"mike34";
+                rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"dog" };
+                [ds createDocumentFromRevision:rev error:nil];
+
+                rev.docId = @"mike72";
+                rev.body = @{ @"name" : @"mike", @"age" : @67, @"pet" : @"cat" };
+                [ds createDocumentFromRevision:rev error:nil];
+
+                rev.docId = @"fred34";
+                rev.body = @{ @"name" : @"fred", @"age" : @34, @"pet" : @"parrot" };
+                [ds createDocumentFromRevision:rev error:nil];
+
+                rev.docId = @"fred12";
+                rev.body = @{ @"name" : @"fred", @"age" : @12 };
+                [ds createDocumentFromRevision:rev error:nil];
+
+                im = [CDTQIndexManager managerUsingDatastore:ds error:nil];
+                expect(im).toNot.beNil();
+
+                expect([im ensureIndexed:@[ @"name", @"pet", @"age" ] withName:@"pet"])
+                    .toNot.beNil();
+            });
+
+            it(@"returns records where the field does not exist", ^{
+                NSDictionary* query = @{ @"pet" : @{@"$exists" : @NO} };
+                CDTQResultSet* result = [im find:query];
+                expect(result).toNot.beNil();
+                expect([result.documentIds count]).to.equal(1);
+            });
+
+            it(@"returns records where the field does exist", ^{
+                NSDictionary* query = @{ @"pet" : @{@"$exists" : @YES} };
+                CDTQResultSet* result = [im find:query];
+                expect(result).toNot.beNil();
+                expect([result.documentIds count]).to.equal(4);
+            });
+
+            it(@"returns record where the field exists using $not clause", ^{
+                NSDictionary* query = @{ @"pet" : @{@"$not" : @{@"$exists" : @NO}} };
+                CDTQResultSet* result = [im find:query];
+                expect(result).toNot.beNil();
+                expect([result.documentIds count]).to.equal(4);
+            });
+
+            it(@"returns record where the field exists using $not clause", ^{
+                NSDictionary* query = @{ @"pet" : @{@"$not" : @{@"$exists" : @YES}} };
+                CDTQResultSet* result = [im find:query];
+                expect(result).toNot.beNil();
+                expect([result.documentIds count]).to.equal(1);
+            });
+        });
+        
+        describe(@"when using the $in operator", ^{
+            
+            __block CDTDatastore* ds;
+            __block CDTQIndexManager* im;
+            
+            beforeEach(^{
+                ds = [factory datastoreNamed:@"test" error:nil];
+                expect(ds).toNot.beNil();
+                
+                CDTMutableDocumentRevision* rev = [CDTMutableDocumentRevision revision];
+                
+                rev.docId = @"mike12";
+                rev.body = @{ @"name" : @"mike", @"age" : @12, @"pet" : @[ @"cat", @"dog" ] };
+                [ds createDocumentFromRevision:rev error:nil];
+                
+                rev.docId = @"fred34";
+                rev.body = @{ @"name" : @"fred", @"age" : @34, @"pet" : @"parrot" };
+                [ds createDocumentFromRevision:rev error:nil];
+                
+                rev.docId = @"mike34";
+                rev.body = @{ @"name" : @"mike",
+                              @"age" : @34,
+                              @"pet" : @[ @"cat", @"dog", @"fish" ] };
+                [ds createDocumentFromRevision:rev error:nil];
+                
+                rev.docId = @"fred12";
+                rev.body = @{ @"name" : @"fred", @"age" : @12 };
+                [ds createDocumentFromRevision:rev error:nil];
+                
+                rev.docId = @"john44";
+                rev.body = @{ @"name" : @"john", @"age" : @44, @"pet" : @[ @"hamster", @"snake" ] };
+                [ds createDocumentFromRevision:rev error:nil];
+                
+                rev.docId = @"john22";
+                rev.body = @{ @"name" : @"john", @"age" : @22, @"pet" : @"cat" };
+                [ds createDocumentFromRevision:rev error:nil];
+                
+                im = [imClass managerUsingDatastore:ds error:nil];
+                expect(im).toNot.beNil();
+                
+                expect([im ensureIndexed:@[ @"name", @"pet", @"age" ] withName:@"pet"])
+                .toNot.beNil();
+            });
+            
+            it(@"can find documents with arrays using $in", ^{
+                NSDictionary* query = @{ @"pet" : @{ @"$in" : @[ @"fish", @"hamster" ] } };
+                CDTQResultSet* result = [im find:query];
+                expect(result).toNot.beNil();
+                expect(result.documentIds.count).to.equal(2);
+                expect(result.documentIds).to.containAllElements(@[ @"mike34", @"john44" ]);
+            });
+            
+            it(@"can find documents without arrays using $in", ^{
+                NSDictionary* query = @{ @"pet" : @{ @"$in" : @[ @"parrot", @"turtle" ] } };
+                CDTQResultSet* result = [im find:query];
+                expect(result).toNot.beNil();
+                expect(result.documentIds.count).to.equal(1);
+                expect(result.documentIds).to.containAllElements(@[ @"fred34" ]);
+            });
+            
+            it(@"can find documents with and without arrays using $in", ^{
+                NSDictionary* query = @{ @"pet" : @{ @"$in" : @[ @"cat", @"dog" ] } };
+                CDTQResultSet* result = [im find:query];
+                expect(result).toNot.beNil();
+                expect(result.documentIds.count).to.equal(3);
+                expect(result.documentIds).to.containAllElements(@[ @"mike12",
+                                                                    @"mike34",
+                                                                    @"john22" ]);
+            });
+            
+            it(@"returns an empty result set when no matches found using $in", ^{
+                NSDictionary* query = @{ @"pet" : @{ @"$in" : @[ @"turtle", @"pig" ] } };
+                CDTQResultSet* result = [im find:query];
+                expect(result).toNot.beNil();
+                expect(result.documentIds.count).to.equal(0);
+            });
+            
+            it(@"can find documents using $not $in", ^{
+                NSDictionary* query = @{ @"pet" : @{ @"$not" : @{ @"$in" : @[ @"cat", @"dog" ] }}};
+                CDTQResultSet* result = [im find:query];
+                expect(result).toNot.beNil();
+                expect(result.documentIds.count).to.equal(3);
+                expect(result.documentIds).to.containAllElements(@[ @"fred12",
+                                                                    @"fred34",
+                                                                    @"john44" ]);
+            });
+        });
+
+        describe(@"stopping enumeration", ^{
+
+            __block CDTDatastore* ds;
+            __block CDTQIndexManager* im;
+
+            beforeEach(^{
+                ds = [factory datastoreNamed:@"test" error:nil];
+                expect(ds).toNot.beNil();
+
+                CDTMutableDocumentRevision* rev = [CDTMutableDocumentRevision revision];
+
+                rev.docId = @"mike12";
+                rev.body = @{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" };
+                [ds createDocumentFromRevision:rev error:nil];
+
+                rev.docId = @"mike34";
+                rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"dog" };
+                [ds createDocumentFromRevision:rev error:nil];
+
+                rev.docId = @"mike72";
+                rev.body = @{ @"name" : @"mike", @"age" : @67, @"pet" : @"cat" };
+                [ds createDocumentFromRevision:rev error:nil];
+
+                im = [CDTQIndexManager managerUsingDatastore:ds error:nil];
+                expect(im).toNot.beNil();
+
+                [im ensureIndexed:@[ @"_id" ] withName:@"id"];
+            });
+
+            it(@"enumerates all results when stop not set", ^{
+                NSDictionary* query = @{};
+                CDTQResultSet* result = [im find:query];
+                __block NSUInteger count = 0;
+
+                [result enumerateObjectsUsingBlock:^(CDTDocumentRevision* rev, NSUInteger i,
+                                                     BOOL* s) { count++; }];
+
+                expect(count).to.equal(3);
+            });
+
+            it(@"enumerates all results when set set to NO", ^{
+                NSDictionary* query = @{};
+                CDTQResultSet* result = [im find:query];
+                __block NSUInteger count = 0;
+
+                [result
+                    enumerateObjectsUsingBlock:^(CDTDocumentRevision* rev, NSUInteger i, BOOL* s) {
+                        count++;
+                        *s = NO;
+                    }];
+
+                expect(count).to.equal(3);
+            });
+
+            it(@"stops when stop is set to YES", ^{
+                NSDictionary* query = @{};
+                CDTQResultSet* result = [im find:query];
+                __block NSUInteger count = 0;
+
+                [result
+                    enumerateObjectsUsingBlock:^(CDTDocumentRevision* rev, NSUInteger i, BOOL* s) {
+                        count++;
+                        if (count == 2) {
+                            *s = NO;
+                        }
+                    }];
+
+                expect(count).to.equal(3);
+            });
+
+            it(@"stops when querying lots of docs", ^{
+
+                CDTMutableDocumentRevision* rev = [CDTMutableDocumentRevision revision];
+                [im ensureIndexed:@[ @"large_field" ] withName:@"large"];
+
+                for (int i = 0; i < 100; i++) {
+                    rev.body = @{ @"large_field" : @"cat" };
+                    [ds createDocumentFromRevision:rev error:nil];
+                }
+
+                NSDictionary* query = @{ @"large_field" : @{@"$eq" : @"cat"} };
+                CDTQResultSet* result = [im find:query skip:0 limit:0 fields:nil sort:nil];
+                __block NSUInteger count = 0;
+
+                [result
+                    enumerateObjectsUsingBlock:^(CDTDocumentRevision* rev, NSUInteger i, BOOL* s) {
+                        count++;
+                        if (count == 20) {
+                            *s = YES;
+                        }
+                    }];
+
+                expect(count).to.equal(20);
+            });
+
+            describe(@"large result set", ^{
+
+                it(@"limits correctly", ^{
+                    CDTMutableDocumentRevision* rev = [CDTMutableDocumentRevision revision];
+                    [im ensureIndexed:@[ @"large_field", @"idx" ] withName:@"large"];
+
+                    for (int i = 0; i < 100; i++) {
+                        rev.docId = [NSString stringWithFormat:@"d%d", i];
+                        rev.body = @{ @"large_field" : @"cat", @"idx" : @(i) };
+                        [ds createDocumentFromRevision:rev error:nil];
+                    }
+                    NSDictionary* query = @{ @"large_field" : @"cat" };
+                    CDTQResultSet* results = [im find:query skip:0 limit:20 fields:nil sort:nil];
+                    expect([results.documentIds count]).to.equal(20);
+                });
+
+                it(@"skips and limits across batch border", ^{
+                    CDTMutableDocumentRevision* rev = [CDTMutableDocumentRevision revision];
+                    [im ensureIndexed:@[ @"large_field", @"idx" ] withName:@"large"];
+
+                    for (int i = 0; i < 150; i++) {
+                        rev.docId = [NSString stringWithFormat:@"d%d", i];
+                        rev.body = @{ @"large_field" : @"cat", @"idx" : @(i) };
+                        [ds createDocumentFromRevision:rev error:nil];
+                    }
+
+                    NSDictionary* query = @{ @"large_field" : @"cat" };
+                    CDTQResultSet* results =
+                        [im find:query skip:90 limit:20 fields:nil sort:@[
+                            @{ @"idx" : @"asc" }
+                        ]];
+                    expect([results.documentIds count]).to.equal(20);
+                    expect(results.documentIds)
+                        .to.containAllElements(@[
+                            @"d90",
+                            @"d91",
+                            @"d92",
+                            @"d93",
+                            @"d94",
+                            @"d95",
+                            @"d96",
+                            @"d97",
+                            @"d98",
+                            @"d99",
+                            @"d100",
+                            @"d101",
+                            @"d102",
+                            @"d103",
+                            @"d104",
+                            @"d105",
+                            @"d106",
+                            @"d107",
+                            @"d108",
+                            @"d109"
+                        ]);
+                });
+            });
+
+        });
+    });
+
+// The aim is to make sure that the post hoc matcher class behaves the
+// same as the full version with SQL querying too.
+//
+// For this, we test the entire pipeline using the usual CDTQQueryExectutor class. This does
+// both SQL and post hoc matching. Then we have a sub-class of CDTQQueryExecutor which skips
+// the SQL querying and just runs all documents through the CDTQUnindexedMatcher.
+sharedExamplesFor(@"queries without covering indexes", ^(NSDictionary* data) {
+    // Pull the class to test out of the data object
+    Class imClass = data[@"index_manager_class"];
+
+    __block NSString* factoryPath;
+    __block CDTDatastoreManager* factory;
+
+    beforeEach(^{
+        // Create a new CDTDatastoreFactory at a temp path
+
+        NSString* tempDirectoryTemplate = [NSTemporaryDirectory()
+            stringByAppendingPathComponent:@"cloudant_sync_ios_tests.XXXXXX"];
+        const char* tempDirectoryTemplateCString = [tempDirectoryTemplate fileSystemRepresentation];
+        char* tempDirectoryNameCString = (char*)malloc(strlen(tempDirectoryTemplateCString) + 1);
+        strcpy(tempDirectoryNameCString, tempDirectoryTemplateCString);
+
+        char* result = mkdtemp(tempDirectoryNameCString);
+        expect(result).to.beTruthy();
+
+        factoryPath = [[NSFileManager defaultManager]
+            stringWithFileSystemRepresentation:tempDirectoryNameCString
+                                        length:strlen(result)];
+        free(tempDirectoryNameCString);
+
+        NSError* error;
+        factory = [[CDTDatastoreManager alloc] initWithDirectory:factoryPath error:&error];
+    });
+
+    afterEach(^{
+        // Delete the databases we used
+
+        factory = nil;
+        NSError* error;
+        [[NSFileManager defaultManager] removeItemAtPath:factoryPath error:&error];
+    });
+
+    describe(@"when executing queries", ^{
+
+        __block CDTDatastore* ds;
+        __block CDTQIndexManager* im;
+
+        beforeEach(^{
+            ds = [factory datastoreNamed:@"test" error:nil];
+            expect(ds).toNot.beNil();
+
+            CDTMutableDocumentRevision* rev = [CDTMutableDocumentRevision revision];
+
+            rev.docId = @"mike12";
+            rev.body = @{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" };
+            [ds createDocumentFromRevision:rev error:nil];
+
+            rev.docId = @"mike34";
+            rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"dog" };
+            [ds createDocumentFromRevision:rev error:nil];
+
+            rev.docId = @"mike72";
+            rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"cat", @"town" : @"bristol" };
+            [ds createDocumentFromRevision:rev error:nil];
+
+            rev.docId = @"fred34";
+            rev.body = @{ @"name" : @"fred", @"age" : @34, @"pet" : @"cat" };
+            [ds createDocumentFromRevision:rev error:nil];
+
+            rev.docId = @"fred12";
+            rev.body = @{ @"name" : @"fred", @"age" : @12, @"town" : @"bristol" };
+            [ds createDocumentFromRevision:rev error:nil];
+
+            im = [imClass managerUsingDatastore:ds error:nil];
+            expect(im).toNot.beNil();
+
+            expect([im ensureIndexed:@[ @"name", @"age" ] withName:@"basic"]).toNot.beNil();
+            expect([im ensureIndexed:@[ @"name", @"pet" ] withName:@"pet"]).toNot.beNil();
+        });
+
+        it(@"query without index", ^{
+            NSDictionary* query = @{ @"pet" : @{@"$eq" : @"cat"}, @"age" : @{@"$eq" : @12} };
+            CDTQResultSet* result = [im find:query];
+            expect(result).toNot.beNil();
+            expect(result.documentIds.count).to.equal(1);
+        });
+
+        it(@"query without index", ^{
+            NSDictionary* query = @{ @"town" : @"bristol" };
+            CDTQResultSet* result = [im find:query];
+            expect(result).toNot.beNil();
+            expect(result.documentIds.count).to.equal(2);
+            expect(result.documentIds).to.beSupersetOf(@[ @"mike72", @"fred12" ]);
+        });
+        
+        it(@"query using OR while missing a covering index", ^{
+            NSDictionary* query = @{ @"$or" : @[ @{ @"pet" : @{@"$eq" : @"cat"} },
+                                                 @{ @"town" : @{@"$eq" : @"bristol"} }
+                                               ]
+                                   };
+            CDTQResultSet* result = [im find:query];
+            expect(result).toNot.beNil();
+            expect(result.documentIds.count).to.equal(4);
+            expect(result.documentIds).to.beSupersetOf(@[ @"mike12",
+                                                          @"mike72",
+                                                          @"fred34",
+                                                          @"fred12" ]);
+        });
+        
+        it(@"query using OR without any covering indexes", ^{
+            expect([im deleteIndexNamed:@"pet"]).toNot.beNil();
+            NSDictionary *indexes = [im listIndexes];
+            expect(indexes.count).to.equal(1);
+            expect(indexes.allKeys).to.beSupersetOf(@[ @"basic" ]);
+            
+            NSDictionary* query = @{ @"$or" : @[ @{ @"pet" : @{@"$eq" : @"cat"} },
+                                                 @{ @"town" : @{@"$eq" : @"bristol"} }
+                                               ]
+                                   };
+            CDTQResultSet* result = [im find:query];
+            expect(result).toNot.beNil();
+            expect(result.documentIds.count).to.equal(4);
+            expect(result.documentIds).to.beSupersetOf(@[ @"mike12",
+                                                          @"mike72",
+                                                          @"fred34",
+                                                          @"fred12" ]);
+        });
+
+        it(@"post-hoc matches when projecting over non-queried fields", ^{
+            NSDictionary* query = @{ @"town" : @"bristol" };
+            CDTQResultSet* result = [im find:query skip:0 limit:0 fields:@[ @"name" ] sort:nil];
+            expect(result).toNot.beNil();
+            expect(result.documentIds.count).to.equal(2);
+            expect(result.documentIds).to.beSupersetOf(@[ @"mike72", @"fred12" ]);
+        });
+    });
+});
+
+SharedExamplesEnd
+
+    // This spec pushes the standard CDTQQueryExecutor through the shared behaviour tests.
+    SpecBegin(CDTQQueryExecutor) describe(@"full with covering", ^{
+        NSDictionary* data = @{ @"index_manager_class" : [CDTQIndexManager class] };
+        itShouldBehaveLike(@"queries with covering indexes", data);
+    });
+
+describe(@"full without covering", ^{
+    NSDictionary* data = @{ @"index_manager_class" : [CDTQIndexManager class] };
+    itShouldBehaveLike(@"queries without covering indexes", data);
+});
+
+SpecEnd
+
+    // This class skips the matcher to check that SQL only returns the same
+    SpecBegin(CDTQSQLOnlyQueryExecutor) describe(@"sql with covering", ^{
+        NSDictionary* data = @{ @"index_manager_class" : [CDTQSQLOnlyIndexManager class] };
+        itShouldBehaveLike(@"queries with covering indexes", data);
+    });
+
+// Don't run "queries without covering indexes" as they'll obviously not work
+
+SpecEnd
+
+    // This class skips SQL and just uses the matcher to ensure the matcher class returns
+    // the same as the SQL version.
+    SpecBegin(CDTQMatcherQueryExecutor) describe(@"matcher with covering", ^{
+        NSDictionary* data = @{ @"index_manager_class" : [CDTQMatcherIndexManager class] };
+        itShouldBehaveLike(@"queries with covering indexes", data);
+    });
+
+describe(@"matcher without covering", ^{
+    NSDictionary* data = @{ @"index_manager_class" : [CDTQMatcherIndexManager class] };
+    itShouldBehaveLike(@"queries without covering indexes", data);
+});
+
+SpecEnd

--- a/Tests/Tests/CDTQQuerySortTests.m
+++ b/Tests/Tests/CDTQQuerySortTests.m
@@ -1,0 +1,481 @@
+//
+//  CloudantQueryObjcTests.m
+//  CloudantQueryObjcTests
+//
+//  Created by Michael Rhodes on 09/27/2014.
+//  Copyright (c) 2014 Michael Rhodes. All rights reserved.
+//
+
+#import <CloudantSync.h>
+#import <CDTQIndexManager.h>
+#import <CDTQIndexUpdater.h>
+#import <CDTQIndexCreator.h>
+#import <CDTQResultSet.h>
+#import <CDTQQueryExecutor.h>
+
+SpecBegin(CDTQQueryExecutorSorting)
+
+    describe(@"cloudant query", ^{
+
+        __block NSString *factoryPath;
+        __block CDTDatastoreManager *factory;
+
+        beforeEach(^{
+            // Create a new CDTDatastoreFactory at a temp path
+
+            NSString *tempDirectoryTemplate = [NSTemporaryDirectory()
+                stringByAppendingPathComponent:@"cloudant_sync_ios_tests.XXXXXX"];
+            const char *tempDirectoryTemplateCString =
+                [tempDirectoryTemplate fileSystemRepresentation];
+            char *tempDirectoryNameCString =
+                (char *)malloc(strlen(tempDirectoryTemplateCString) + 1);
+            strcpy(tempDirectoryNameCString, tempDirectoryTemplateCString);
+
+            char *result = mkdtemp(tempDirectoryNameCString);
+            expect(result).to.beTruthy();
+
+            factoryPath = [[NSFileManager defaultManager]
+                stringWithFileSystemRepresentation:tempDirectoryNameCString
+                                            length:strlen(result)];
+            free(tempDirectoryNameCString);
+
+            NSError *error;
+            factory = [[CDTDatastoreManager alloc] initWithDirectory:factoryPath error:&error];
+        });
+
+        afterEach(^{
+            // Delete the databases we used
+
+            factory = nil;
+            NSError *error;
+            [[NSFileManager defaultManager] removeItemAtPath:factoryPath error:&error];
+        });
+
+        describe(@"when sorting", ^{
+
+            __block CDTDatastore *ds;
+            __block CDTQIndexManager *im;
+
+            beforeEach(^{
+                ds = [factory datastoreNamed:@"test" error:nil];
+                expect(ds).toNot.beNil();
+
+                CDTMutableDocumentRevision *rev = [CDTMutableDocumentRevision revision];
+
+                rev.docId = @"mike12";
+                rev.body = @{
+                    @"name" : @"mike",
+                    @"age" : @12,
+                    @"pet" : @[ @"cat", @"dog" ],
+                    @"same" : @"all"
+                };
+                [ds createDocumentFromRevision:rev error:nil];
+
+                rev.docId = @"fred34";
+                rev.body = @{
+                    @"name" : @"fred",
+                    @"age" : @34,
+                    @"pet" : @"parrot",
+                    @"same" : @"all"
+                };
+                [ds createDocumentFromRevision:rev error:nil];
+
+                rev.docId = @"fred11";
+                rev.body = @{ @"name" : @"fred", @"age" : @11, @"pet" : @"fish", @"same" : @"all" };
+                [ds createDocumentFromRevision:rev error:nil];
+
+                im = [CDTQIndexManager managerUsingDatastore:ds error:nil];
+                expect(im).toNot.beNil();
+
+                expect([im ensureIndexed:@[ @"name", @"pet", @"age", @"same" ] withName:@"pet"])
+                    .toNot.beNil();
+            });
+
+            it(@"sorts on name", ^{
+                NSDictionary *query = @{ @"same" : @"all" };
+                NSArray *order = @[ @{ @"name" : @"asc" } ];
+                CDTQResultSet *result =
+                    [im find:query skip:0 limit:NSUIntegerMax fields:nil sort:order];
+                expect(result.documentIds).to.equal(@[ @"fred11", @"fred34", @"mike12" ]);
+            });
+
+            it(@"sorts on name, age", ^{
+                NSDictionary *query = @{ @"same" : @"all" };
+                NSArray *order = @[ @{ @"name" : @"asc" }, @{ @"age" : @"desc" } ];
+                CDTQResultSet *result =
+                    [im find:query skip:0 limit:NSUIntegerMax fields:nil sort:order];
+                expect(result.documentIds).to.equal(@[ @"fred34", @"fred11", @"mike12" ]);
+            });
+
+            it(@"sorts on array field", ^{
+                NSDictionary *query = @{ @"same" : @"all" };
+                NSArray *order = @[ @{ @"pet" : @"asc" } ];
+                CDTQResultSet *result =
+                    [im find:query skip:0 limit:NSUIntegerMax fields:nil sort:order];
+                expect(result.documentIds).to.equal(@[ @"mike12", @"fred11", @"fred34" ]);
+            });
+
+            it(@"returns nil using not asc/desc", ^{
+                NSDictionary *query = @{ @"same" : @"all" };
+                NSArray *order = @[ @{ @"name" : @"blah" }, @{ @"age" : @"desc" } ];
+                CDTQResultSet *result =
+                    [im find:query skip:0 limit:NSUIntegerMax fields:nil sort:order];
+                expect(result).to.beNil();
+            });
+
+            it(@"returns nil using too many clauses", ^{
+                NSDictionary *query = @{ @"same" : @"all" };
+                NSArray *order = @[ @{ @"name" : @"asc", @"age" : @"desc" } ];
+                CDTQResultSet *result =
+                    [im find:query skip:0 limit:NSUIntegerMax fields:nil sort:order];
+                expect(result).to.beNil();
+            });
+
+        });
+
+        describe(@"when generating ordering SQL", ^{
+
+            __block NSDictionary *indexes = @{
+                @"a" :
+                    @{@"name" : @"a", @"type" : @"json", @"fields" : @[ @"name", @"age", @"pet" ]},
+                @"b" : @{@"name" : @"b", @"type" : @"json", @"fields" : @[ @"x", @"y", @"z" ]},
+            };
+
+            __block NSSet *smallDocIdSet = [NSSet setWithArray:@[ @"mike", @"john" ]];
+            __block NSMutableSet *largeDocIdSet;
+
+            beforeAll(^{
+                largeDocIdSet = [NSMutableSet set];
+                for (int i = 0; i < 501; i++) {  // 500 max id set for placeholders
+                    [largeDocIdSet addObject:[NSString stringWithFormat:@"doc-%d", i]];
+                }
+            });
+
+            context(@"two doc IDs", ^{
+
+                context(@"for single field", ^{
+
+                    it(@"asc", ^{
+                        NSArray *order = @[ @{ @"name" : @"asc" } ];
+                        CDTQSqlParts *parts = [CDTQQueryExecutor sqlToSortIds:smallDocIdSet
+                                                                   usingOrder:order
+                                                                      indexes:indexes];
+
+                        NSString *sql = @"SELECT DISTINCT _id FROM _t_cloudant_sync_query_index_a "
+                                        @"WHERE _id IN (?, ?) ORDER BY \"name\" ASC;";
+                        expect(parts.sqlWithPlaceholders).to.equal(sql);
+                        expect(parts.placeholderValues).to.equal([smallDocIdSet allObjects]);
+                    });
+
+                    it(@"desc", ^{
+                        NSArray *order = @[ @{ @"y" : @"desc" } ];
+                        CDTQSqlParts *parts = [CDTQQueryExecutor sqlToSortIds:smallDocIdSet
+                                                                   usingOrder:order
+                                                                      indexes:indexes];
+
+                        NSString *sql = @"SELECT DISTINCT _id FROM _t_cloudant_sync_query_index_b "
+                                        @"WHERE _id IN (?, ?) ORDER BY \"y\" DESC;";
+                        expect(parts.sqlWithPlaceholders).to.equal(sql);
+                        expect(parts.placeholderValues).to.equal([smallDocIdSet allObjects]);
+                    });
+
+                });
+
+                context(@"for multiple fields", ^{
+
+                    it(@"asc", ^{
+                        NSArray *order = @[ @{ @"y" : @"asc" }, @{ @"x" : @"asc" } ];
+                        CDTQSqlParts *parts = [CDTQQueryExecutor sqlToSortIds:smallDocIdSet
+                                                                   usingOrder:order
+                                                                      indexes:indexes];
+
+                        NSString *sql = @"SELECT DISTINCT _id FROM _t_cloudant_sync_query_index_b "
+                                        @"WHERE _id IN (?, ?) ORDER BY \"y\" ASC, \"x\" ASC;";
+                        expect(parts.sqlWithPlaceholders).to.equal(sql);
+                        expect(parts.placeholderValues).to.equal([smallDocIdSet allObjects]);
+                    });
+
+                    it(@"desc", ^{
+                        NSArray *order = @[ @{ @"y" : @"desc" }, @{ @"x" : @"desc" } ];
+                        CDTQSqlParts *parts = [CDTQQueryExecutor sqlToSortIds:smallDocIdSet
+                                                                   usingOrder:order
+                                                                      indexes:indexes];
+
+                        NSString *sql = @"SELECT DISTINCT _id FROM _t_cloudant_sync_query_index_b "
+                                        @"WHERE _id IN (?, ?) ORDER BY \"y\" DESC, \"x\" DESC;";
+                        expect(parts.sqlWithPlaceholders).to.equal(sql);
+                        expect(parts.placeholderValues).to.equal([smallDocIdSet allObjects]);
+                    });
+
+                    it(@"mixed", ^{
+                        NSArray *order = @[ @{ @"y" : @"desc" }, @{ @"x" : @"asc" } ];
+                        CDTQSqlParts *parts = [CDTQQueryExecutor sqlToSortIds:smallDocIdSet
+                                                                   usingOrder:order
+                                                                      indexes:indexes];
+
+                        NSString *sql = @"SELECT DISTINCT _id FROM _t_cloudant_sync_query_index_b "
+                                        @"WHERE _id IN (?, ?) ORDER BY \"y\" DESC, \"x\" ASC;";
+                        expect(parts.sqlWithPlaceholders).to.equal(sql);
+                        expect(parts.placeholderValues).to.equal([smallDocIdSet allObjects]);
+                    });
+
+                });
+
+            });
+
+            context(@"501 doc IDs", ^{
+
+                context(@"for single field", ^{
+
+                    it(@"asc", ^{
+                        NSArray *order = @[ @{ @"name" : @"asc" } ];
+                        CDTQSqlParts *parts = [CDTQQueryExecutor sqlToSortIds:largeDocIdSet
+                                                                   usingOrder:order
+                                                                      indexes:indexes];
+
+                        NSString *sql = @"SELECT DISTINCT _id FROM _t_cloudant_sync_query_index_a  "
+                                        @"ORDER BY \"name\" ASC;";
+                        expect(parts.sqlWithPlaceholders).to.equal(sql);
+                        expect(parts.placeholderValues).to.equal(@[]);
+                    });
+
+                    it(@"desc", ^{
+                        NSArray *order = @[ @{ @"y" : @"desc" } ];
+                        CDTQSqlParts *parts = [CDTQQueryExecutor sqlToSortIds:largeDocIdSet
+                                                                   usingOrder:order
+                                                                      indexes:indexes];
+
+                        NSString *sql = @"SELECT DISTINCT _id FROM _t_cloudant_sync_query_index_b  "
+                                        @"ORDER BY \"y\" DESC;";
+                        expect(parts.sqlWithPlaceholders).to.equal(sql);
+                        expect(parts.placeholderValues).to.equal(@[]);
+                    });
+
+                });
+
+                context(@"for multiple fields", ^{
+
+                    it(@"asc", ^{
+                        NSArray *order = @[ @{ @"y" : @"asc" }, @{ @"x" : @"asc" } ];
+                        CDTQSqlParts *parts = [CDTQQueryExecutor sqlToSortIds:largeDocIdSet
+                                                                   usingOrder:order
+                                                                      indexes:indexes];
+
+                        NSString *sql = @"SELECT DISTINCT _id FROM _t_cloudant_sync_query_index_b  "
+                                        @"ORDER BY \"y\" ASC, \"x\" ASC;";
+                        expect(parts.sqlWithPlaceholders).to.equal(sql);
+                        expect(parts.placeholderValues).to.equal(@[]);
+                    });
+
+                    it(@"desc", ^{
+                        NSArray *order = @[ @{ @"y" : @"desc" }, @{ @"x" : @"desc" } ];
+                        CDTQSqlParts *parts = [CDTQQueryExecutor sqlToSortIds:largeDocIdSet
+                                                                   usingOrder:order
+                                                                      indexes:indexes];
+
+                        NSString *sql = @"SELECT DISTINCT _id FROM _t_cloudant_sync_query_index_b  "
+                                        @"ORDER BY \"y\" DESC, \"x\" DESC;";
+                        expect(parts.sqlWithPlaceholders).to.equal(sql);
+                        expect(parts.placeholderValues).to.equal(@[]);
+                    });
+
+                    it(@"mixed", ^{
+                        NSArray *order = @[ @{ @"y" : @"desc" }, @{ @"x" : @"asc" } ];
+                        CDTQSqlParts *parts = [CDTQQueryExecutor sqlToSortIds:largeDocIdSet
+                                                                   usingOrder:order
+                                                                      indexes:indexes];
+
+                        NSString *sql = @"SELECT DISTINCT _id FROM _t_cloudant_sync_query_index_b  "
+                                        @"ORDER BY \"y\" DESC, \"x\" ASC;";
+                        expect(parts.sqlWithPlaceholders).to.equal(sql);
+                        expect(parts.placeholderValues).to.equal(@[]);
+                    });
+
+                });
+
+            });
+
+            it(@"fails when unindexed field", ^{
+                NSArray *order = @[ @{ @"apples" : @"asc" } ];
+                CDTQSqlParts *parts =
+                    [CDTQQueryExecutor sqlToSortIds:smallDocIdSet usingOrder:order indexes:indexes];
+                expect(parts).to.beNil();
+            });
+
+            it(@"fails when fields not in single index", ^{
+                NSArray *order = @[ @{ @"x" : @"asc" }, @{ @"age" : @"asc" } ];
+                CDTQSqlParts *parts =
+                    [CDTQQueryExecutor sqlToSortIds:smallDocIdSet usingOrder:order indexes:indexes];
+                expect(parts).to.beNil();
+            });
+
+            it(@"returns nil when no order", ^{
+                CDTQSqlParts *parts;
+                parts =
+                    [CDTQQueryExecutor sqlToSortIds:smallDocIdSet usingOrder:@[] indexes:indexes];
+                expect(parts).to.beNil();
+                parts =
+                    [CDTQQueryExecutor sqlToSortIds:smallDocIdSet usingOrder:nil indexes:indexes];
+                expect(parts).to.beNil();
+            });
+
+            it(@"returns nil when no indexes", ^{
+                CDTQSqlParts *parts;
+                NSArray *order = @[ @{ @"y" : @"desc" } ];
+                parts = [CDTQQueryExecutor sqlToSortIds:smallDocIdSet usingOrder:order indexes:@{}];
+                expect(parts).to.beNil();
+                parts = [CDTQQueryExecutor sqlToSortIds:smallDocIdSet usingOrder:order indexes:nil];
+                expect(parts).to.beNil();
+            });
+
+        });
+
+        /*
+         xdescribe(@"when generating ordering SQL for doc id set", ^{
+
+         __block NSDictionary *indexes = @{@"a": @{@"name": @"a",
+         @"type": @"json",
+         @"fields": @[@"name", @"age", @"pet"]},
+         @"b": @{@"name": @"b",
+         @"type": @"json",
+         @"fields": @[@"x", @"y", @"z"]},
+         };
+         __block NSArray *ids = @[@"a", @"b", @"c", @"d"];
+
+         context(@"for single field", ^{
+
+         it (@"asc", ^{
+         NSArray *order = @[ @{ @"name": @"asc" } ];
+         CDTQSqlParts *parts = [CDTQQueryExecutor sqlToSortIds:ids
+         usingOrder:order
+         usingIndexes:indexes];
+
+         NSString *sql = @"SELECT DISTINCT _id FROM _t_cloudant_sync_query_index_a ORDER BY \"name\"
+         ASC;";
+         expect(parts.sqlWithPlaceholders).to.equal(sql);
+         expect(parts.placeholderValues).to.equal(@[]);
+         });
+
+         it (@"desc", ^{
+         NSArray *order = @[ @{ @"y": @"desc" } ];
+         CDTQSqlParts *parts = [CDTQQueryExecutor sqlToSortIds:ids
+         usingOrder:order
+         usingIndexes:indexes];
+
+         NSString *sql = @"SELECT DISTINCT _id FROM _t_cloudant_sync_query_index_b ORDER BY \"y\"
+         DESC;";
+         expect(parts.sqlWithPlaceholders).to.equal(sql);
+         expect(parts.placeholderValues).to.equal(@[]);
+         });
+
+         });
+
+         context(@"for multiple fields", ^{
+
+
+         it (@"asc", ^{
+         NSArray *order = @[ @{ @"y": @"asc" }, @{ @"x": @"asc" } ];
+         CDTQSqlParts *parts = [CDTQQueryExecutor sqlToSortIds:ids
+         usingOrder:order
+         usingIndexes:indexes];
+
+         NSString *sql = @"SELECT DISTINCT _id FROM _t_cloudant_sync_query_index_b ORDER BY \"y\"
+         ASC, \"x\" ASC;";
+         expect(parts.sqlWithPlaceholders).to.equal(sql);
+         expect(parts.placeholderValues).to.equal(@[]);
+         });
+
+         it (@"desc", ^{
+         NSArray *order = @[ @{ @"y": @"desc" }, @{ @"x": @"desc" } ];
+         CDTQSqlParts *parts = [CDTQQueryExecutor sqlToSortIds:ids
+         usingOrder:order
+         usingIndexes:indexes];
+
+         NSString *sql = @"SELECT DISTINCT _id FROM _t_cloudant_sync_query_index_b ORDER BY \"y\"
+         DESC, \"x\" DESC;";
+         expect(parts.sqlWithPlaceholders).to.equal(sql);
+         expect(parts.placeholderValues).to.equal(@[]);
+         });
+
+         it (@"mixed", ^{
+         NSArray *order = @[ @{ @"y": @"desc" }, @{ @"x": @"asc" } ];
+         CDTQSqlParts *parts = [CDTQQueryExecutor sqlToSortIds:ids
+         usingOrder:order
+         usingIndexes:indexes];
+
+         NSString *sql = @"SELECT DISTINCT _id FROM _t_cloudant_sync_query_index_b ORDER BY \"y\"
+         DESC, \"x\" ASC;";
+         expect(parts.sqlWithPlaceholders).to.equal(sql);
+         expect(parts.placeholderValues).to.equal(@[]);
+         });
+
+         });
+
+         it(@"fails for invalid direction", ^{
+         NSArray *order = @[ @{ @"name": @"blah" } ];
+         CDTQSqlParts *parts = [CDTQQueryExecutor sqlToSortIds:ids
+         usingOrder:order
+         usingIndexes:indexes];
+         expect(parts).to.beNil();
+
+         });
+
+         it(@"fails when unindexed field", ^{
+         NSArray *order = @[ @{ @"apples": @"asc" } ];
+         CDTQSqlParts *parts = [CDTQQueryExecutor sqlToSortIds:ids
+         usingOrder:order
+         usingIndexes:indexes];
+         expect(parts).to.beNil();
+         });
+
+         it(@"fails when fields not in single index", ^{
+         NSArray *order = @[ @{ @"x": @"asc" }, @{ @"age": @"asc" } ];
+         CDTQSqlParts *parts = [CDTQQueryExecutor sqlToSortIds:ids
+         usingOrder:order
+         usingIndexes:indexes];
+         expect(parts).to.beNil();
+         });
+
+         it(@"returns nil when no doc ids", ^{
+         CDTQSqlParts *parts;
+         NSArray *order = @[ @{ @"y": @"desc" } ];
+         parts = [CDTQQueryExecutor sqlToSortIds:@[]
+         usingOrder:order
+         usingIndexes:indexes];
+         expect(parts).to.beNil();
+         parts = [CDTQQueryExecutor sqlToSortIds:nil
+         usingOrder:order
+         usingIndexes:indexes];
+         expect(parts).to.beNil();
+         });
+
+         it(@"returns nil when no order", ^{
+         CDTQSqlParts *parts;
+         parts = [CDTQQueryExecutor sqlToSortIds:ids
+         usingOrder:@[]
+         usingIndexes:indexes];
+         expect(parts).to.beNil();
+         parts = [CDTQQueryExecutor sqlToSortIds:ids
+         usingOrder:nil
+         usingIndexes:indexes];
+         expect(parts).to.beNil();
+         });
+
+         it(@"returns nil when no indexes", ^{
+         CDTQSqlParts *parts;
+         NSArray *order = @[ @{ @"y": @"desc" } ];
+         parts = [CDTQQueryExecutor sqlToSortIds:ids
+         usingOrder:order
+         usingIndexes:@{}];
+         expect(parts).to.beNil();
+         parts = [CDTQQueryExecutor sqlToSortIds:ids
+         usingOrder:order
+         usingIndexes:nil];
+         expect(parts).to.beNil();
+         });
+
+         });
+         */
+    });
+
+SpecEnd

--- a/Tests/Tests/CDTQQuerySqlTranslatorTests.m
+++ b/Tests/Tests/CDTQQuerySqlTranslatorTests.m
@@ -1,0 +1,1041 @@
+//
+//  CloudantQueryObjcTests.m
+//  CloudantQueryObjcTests
+//
+//  Created by Michael Rhodes on 09/27/2014.
+//  Copyright (c) 2014 Michael Rhodes. All rights reserved.
+//
+
+#import <CloudantSync.h>
+#import <CDTQIndexManager.h>
+#import <CDTQIndexUpdater.h>
+#import <CDTQIndexCreator.h>
+#import <CDTQResultSet.h>
+#import <CDTQQueryExecutor.h>
+#import <CDTQQuerySqlTranslator.h>
+#import <CDTQQueryValidator.h>
+#import <Specta.h>
+#import <Expecta.h>
+#import "Matchers/CDTQContainsAllElementsMatcher.h"
+#import "Matchers/CDTQQueryMatcher.h"
+#import "Matchers/CDTQEitherMatcher.h"
+
+SpecBegin(CDTQQuerySqlTranslator) describe(@"cdtq", ^{
+
+    __block NSString *factoryPath;
+    __block CDTDatastoreManager *factory;
+
+    beforeEach(^{
+        // Create a new CDTDatastoreFactory at a temp path
+
+        NSString *tempDirectoryTemplate = [NSTemporaryDirectory()
+            stringByAppendingPathComponent:@"cloudant_sync_ios_tests.XXXXXX"];
+        const char *tempDirectoryTemplateCString = [tempDirectoryTemplate fileSystemRepresentation];
+        char *tempDirectoryNameCString = (char *)malloc(strlen(tempDirectoryTemplateCString) + 1);
+        strcpy(tempDirectoryNameCString, tempDirectoryTemplateCString);
+
+        char *result = mkdtemp(tempDirectoryNameCString);
+        expect(result).to.beTruthy();
+
+        factoryPath = [[NSFileManager defaultManager]
+            stringWithFileSystemRepresentation:tempDirectoryNameCString
+                                        length:strlen(result)];
+        free(tempDirectoryNameCString);
+
+        NSError *error;
+        factory = [[CDTDatastoreManager alloc] initWithDirectory:factoryPath error:&error];
+    });
+
+    afterEach(^{
+        // Delete the databases we used
+
+        factory = nil;
+        NSError *error;
+        [[NSFileManager defaultManager] removeItemAtPath:factoryPath error:&error];
+    });
+
+    describe(@"when creating a tree", ^{
+
+        __block CDTDatastore *ds;
+        __block CDTQIndexManager *im;
+        __block NSDictionary *indexes;
+
+        beforeEach(^{
+            ds = [factory datastoreNamed:@"test" error:nil];
+            im = [CDTQIndexManager managerUsingDatastore:ds error:nil];
+
+            [im ensureIndexed:@[ @"name", @"age", @"pet" ] withName:@"basic"];
+
+            indexes = [im listIndexes];
+        });
+
+        it(@"can cope with single level ANDed query", ^{
+            BOOL indexesCoverQuery;
+            NSDictionary *query = [CDTQQueryValidator normaliseAndValidateQuery:@{ @"name" : @"mike" }];
+            CDTQQueryNode *node = [CDTQQuerySqlTranslator translateQuery:query
+                                                            toUseIndexes:indexes
+                                                       indexesCoverQuery:&indexesCoverQuery];
+            expect(node).to.beInstanceOf([CDTQAndQueryNode class]);
+            expect(indexesCoverQuery).to.beTruthy();
+
+            CDTQAndQueryNode *and = (CDTQAndQueryNode *)node;
+            expect(and.children.count).to.equal(1);
+
+            CDTQSqlQueryNode *sqlNode = and.children[0];
+            NSString *sql = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
+                             "WHERE \"name\" = ?;";
+            expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sql);
+            expect(sqlNode.sql.placeholderValues).to.equal(@[ @"mike" ]);
+        });
+
+        it(@"can cope with single level ANDed query", ^{
+            BOOL indexesCoverQuery;
+            NSDictionary *query = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                @"name" : @"mike",
+                @"pet" : @"cat"
+            }];
+            CDTQQueryNode *node = [CDTQQuerySqlTranslator translateQuery:query
+                                                            toUseIndexes:indexes
+                                                       indexesCoverQuery:&indexesCoverQuery];
+            expect(node).to.beInstanceOf([CDTQAndQueryNode class]);
+            expect(indexesCoverQuery).to.beTruthy();
+
+            CDTQAndQueryNode *and = (CDTQAndQueryNode *)node;
+            expect(and.children.count).to.equal(1);
+
+            CDTQSqlQueryNode *sqlNode = and.children[0];
+            NSString *sql = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
+                             "WHERE \"pet\" = ? AND \"name\" = ?;";
+            NSString *otherSql = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
+            "WHERE \"name\" = ? AND \"pet\" = ?;";
+            expect(sqlNode.sql.sqlWithPlaceholders).to.isEqualToEither(sql,otherSql);
+            expect(sqlNode.sql.placeholderValues).to.containsAllElements(@[ @"cat", @"mike" ]);
+        });
+
+        it(@"can cope with longhand single level ANDed query", ^{
+            BOOL indexesCoverQuery;
+            NSDictionary *query = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                @"$and" : @[ @{@"name" : @"mike"}, @{@"pet" : @"cat"} ]
+            }];
+            CDTQQueryNode *node = [CDTQQuerySqlTranslator translateQuery:query
+                                                            toUseIndexes:indexes
+                                                       indexesCoverQuery:&indexesCoverQuery];
+            expect(node).to.beInstanceOf([CDTQAndQueryNode class]);
+            expect(indexesCoverQuery).to.beTruthy();
+
+            CDTQAndQueryNode *and = (CDTQAndQueryNode *)node;
+            expect(and.children.count).to.equal(1);
+
+            CDTQSqlQueryNode *sqlNode = and.children[0];
+            NSString *sql = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
+                             "WHERE \"name\" = ? AND \"pet\" = ?;";
+            expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sql);
+            expect(sqlNode.sql.placeholderValues).to.equal(@[ @"mike", @"cat" ]);
+        });
+
+        it(@"can cope with longhand two level ANDed query", ^{
+            NSDictionary *query = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                @"$and" : @[
+                    @{@"name" : @"mike"},
+                    @{@"pet" : @"cat"},
+                    @{@"$and" : @[ @{@"name" : @"mike"}, @{@"pet" : @"cat"} ]}
+                ]
+            }];
+            BOOL indexesCoverQuery;
+            CDTQQueryNode *node = [CDTQQuerySqlTranslator translateQuery:query
+                                                            toUseIndexes:indexes
+                                                       indexesCoverQuery:&indexesCoverQuery];
+            expect(node).to.beInstanceOf([CDTQAndQueryNode class]);
+            expect(indexesCoverQuery).to.beTruthy();
+
+            //        AND
+            //       /   \
+            //      sql  AND
+            //             \
+            //             sql
+
+            CDTQAndQueryNode *and = (CDTQAndQueryNode *)node;
+            expect(and.children.count).to.equal(2);
+
+            NSString *sql = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
+                             "WHERE \"name\" = ? AND \"pet\" = ?;";
+
+            // As the embedded AND is the same as the top-level AND, both
+            // children should have the same embedded SQL.
+
+            CDTQSqlQueryNode *sqlNode = and.children[0];
+            expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sql);
+            expect(sqlNode.sql.placeholderValues).to.equal(@[ @"mike", @"cat" ]);
+
+            sqlNode = ((CDTQAndQueryNode *)and.children[1]).children[0];
+            expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sql);
+            expect(sqlNode.sql.placeholderValues).to.equal(@[ @"mike", @"cat" ]);
+        });
+
+        it(@"orders AND nodes last in trees", ^{
+            BOOL indexesCoverQuery;
+            NSDictionary *query = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                @"$and" : @[
+                    @{@"$and" : @[ @{@"name" : @"mike"}, @{@"pet" : @"cat"} ]},
+                    @{@"name" : @"mike"},
+                    @{@"pet" : @"cat"}
+                ]
+            }];
+            CDTQQueryNode *node = [CDTQQuerySqlTranslator translateQuery:query
+                                                            toUseIndexes:indexes
+                                                       indexesCoverQuery:&indexesCoverQuery];
+            expect(node).to.beInstanceOf([CDTQAndQueryNode class]);
+            expect(indexesCoverQuery).to.beTruthy();
+
+            //        AND
+            //       /   \
+            //      sql  AND
+            //             \
+            //             sql
+
+            CDTQAndQueryNode *and = (CDTQAndQueryNode *)node;
+            expect(and.children.count).to.equal(2);
+
+            NSString *sql = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
+                             "WHERE \"name\" = ? AND \"pet\" = ?;";
+
+            // As the embedded AND is the same as the top-level AND, both
+            // children should have the same embedded SQL.
+
+            CDTQSqlQueryNode *sqlNode = and.children[0];
+            expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sql);
+            expect(sqlNode.sql.placeholderValues).to.equal(@[ @"mike", @"cat" ]);
+
+            sqlNode = ((CDTQAndQueryNode *)and.children[1]).children[0];
+            expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sql);
+            expect(sqlNode.sql.placeholderValues).to.equal(@[ @"mike", @"cat" ]);
+        });
+
+        it(@"supports using OR", ^{
+            NSDictionary *query = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                @"$or" : @[ @{@"name" : @"mike"}, @{@"pet" : @"cat"} ]
+            }];
+            BOOL indexesCoverQuery;
+            CDTQQueryNode *node = [CDTQQuerySqlTranslator translateQuery:query
+                                                            toUseIndexes:indexes
+                                                       indexesCoverQuery:&indexesCoverQuery];
+            expect(node).to.beInstanceOf([CDTQOrQueryNode class]);
+            expect(indexesCoverQuery).to.beTruthy();
+
+            //        _OR_
+            //       /    \
+            //      sql   sql
+
+            CDTQOrQueryNode * or = (CDTQOrQueryNode *)node;
+            expect(or .children.count).to.equal(2);
+
+            NSString *sqlLeft = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
+                                 "WHERE \"name\" = ?;";
+
+            NSString *sqlRight = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
+                                  "WHERE \"pet\" = ?;";
+
+            CDTQSqlQueryNode *sqlNode;
+
+            sqlNode = or .children[0];
+            expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sqlLeft);
+            expect(sqlNode.sql.placeholderValues).to.equal(@[ @"mike" ]);
+
+            sqlNode = or .children[1];
+            expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sqlRight);
+            expect(sqlNode.sql.placeholderValues).to.equal(@[ @"cat" ]);
+        });
+
+        it(@"supports using OR in sub trees", ^{
+            NSDictionary *query = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                @"$or" : @[
+                    @{@"name" : @"mike"},
+                    @{@"pet" : @"cat"},
+                    @{@"$or" : @[ @{@"name" : @"mike"}, @{@"pet" : @"cat"} ]}
+                ]
+            }];
+            BOOL indexesCoverQuery;
+            CDTQQueryNode *node = [CDTQQuerySqlTranslator translateQuery:query
+                                                            toUseIndexes:indexes
+                                                       indexesCoverQuery:&indexesCoverQuery];
+            expect(node).to.beInstanceOf([CDTQOrQueryNode class]);
+            expect(indexesCoverQuery).to.beTruthy();
+
+            //        OR______
+            //       /   \    \
+            //      sql  sql  OR
+            //               /  \
+            //             sql  sql
+
+            CDTQOrQueryNode * or = (CDTQOrQueryNode *)node;
+            expect(or .children.count).to.equal(3);
+
+            NSString *sqlLeft = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
+                                 "WHERE \"name\" = ?;";
+
+            NSString *sqlRight = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
+                                  "WHERE \"pet\" = ?;";
+
+            CDTQSqlQueryNode *sqlNode;
+
+            sqlNode = or .children[0];
+            expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sqlLeft);
+            expect(sqlNode.sql.placeholderValues).to.equal(@[ @"mike" ]);
+
+            sqlNode = or .children[1];
+            expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sqlRight);
+            expect(sqlNode.sql.placeholderValues).to.equal(@[ @"cat" ]);
+
+            CDTQOrQueryNode *subOr = (CDTQOrQueryNode *) or .children[2];
+            expect(subOr).to.beInstanceOf([CDTQOrQueryNode class]);
+
+            sqlNode = subOr.children[0];
+            expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sqlLeft);
+            expect(sqlNode.sql.placeholderValues).to.equal(@[ @"mike" ]);
+
+            sqlNode = subOr.children[1];
+            expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sqlRight);
+            expect(sqlNode.sql.placeholderValues).to.equal(@[ @"cat" ]);
+        });
+
+        it(@"supports using AND and OR in sub trees", ^{
+            NSDictionary *query = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                @"$or" : @[
+                    @{@"name" : @"mike"},
+                    @{@"pet" : @"cat"},
+                    @{@"$or" : @[ @{@"name" : @"mike"}, @{@"pet" : @"cat"} ]},
+                    @{@"$and" : @[ @{@"name" : @"mike"}, @{@"pet" : @"cat"} ]}
+                ]
+            }];
+            BOOL indexesCoverQuery;
+            CDTQQueryNode *node = [CDTQQuerySqlTranslator translateQuery:query
+                                                            toUseIndexes:indexes
+                                                       indexesCoverQuery:&indexesCoverQuery];
+            expect(node).to.beInstanceOf([CDTQOrQueryNode class]);
+            expect(indexesCoverQuery).to.beTruthy();
+
+            //        OR____________
+            //       /   \    \     \
+            //      sql  sql  OR    AND
+            //               /  \     \
+            //             sql  sql   sql
+
+            CDTQOrQueryNode * or = (CDTQOrQueryNode *)node;
+            expect(or .children.count).to.equal(4);
+
+            NSString *sqlLeft = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
+                                 "WHERE \"name\" = ?;";
+
+            NSString *sqlRight = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
+                                  "WHERE \"pet\" = ?;";
+
+            NSString *sqlAnd = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
+                                "WHERE \"name\" = ? AND \"pet\" = ?;";
+
+            CDTQSqlQueryNode *sqlNode;
+
+            sqlNode = or .children[0];
+            expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sqlLeft);
+            expect(sqlNode.sql.placeholderValues).to.equal(@[ @"mike" ]);
+
+            sqlNode = or .children[1];
+            expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sqlRight);
+            expect(sqlNode.sql.placeholderValues).to.equal(@[ @"cat" ]);
+
+            CDTQOrQueryNode *subOr = (CDTQOrQueryNode *) or .children[2];
+            expect(subOr).to.beInstanceOf([CDTQOrQueryNode class]);
+            expect(subOr.children.count).to.equal(2);
+
+            sqlNode = subOr.children[0];
+            expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sqlLeft);
+            expect(sqlNode.sql.placeholderValues).to.equal(@[ @"mike" ]);
+
+            sqlNode = subOr.children[1];
+            expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sqlRight);
+            expect(sqlNode.sql.placeholderValues).to.equal(@[ @"cat" ]);
+
+            CDTQAndQueryNode *subAnd = (CDTQAndQueryNode *) or .children[3];
+            expect(subAnd).to.beInstanceOf([CDTQAndQueryNode class]);
+            expect(subAnd.children.count).to.equal(1);
+
+            sqlNode = subAnd.children[0];
+            expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sqlAnd);
+            expect(sqlNode.sql.placeholderValues).to.equal(@[ @"mike", @"cat" ]);
+        });
+
+        it(@"supports using AND and OR in sub trees", ^{
+            NSDictionary *query = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                @"$or" : @[
+                    @{@"name" : @"mike"},
+                    @{@"pet" : @"cat"},
+                    @{
+                       @"$or" : @[
+                           @{@"name" : @"mike"},
+                           @{@"pet" : @"cat"},
+                           @{@"$and" : @[ @{@"name" : @"mike"}, @{@"pet" : @"cat"} ]}
+                       ]
+                    }
+                ]
+            }];
+            BOOL indexesCoverQuery;
+            CDTQQueryNode *node = [CDTQQuerySqlTranslator translateQuery:query
+                                                            toUseIndexes:indexes
+                                                       indexesCoverQuery:&indexesCoverQuery];
+            expect(node).to.beInstanceOf([CDTQOrQueryNode class]);
+            expect(indexesCoverQuery).to.beTruthy();
+
+            //        OR______
+            //       /   \    \
+            //      sql  sql  OR______
+            //               /  \     \
+            //             sql  sql   AND
+            //                         |
+            //                        sql
+
+            CDTQOrQueryNode * or = (CDTQOrQueryNode *)node;
+            expect(or .children.count).to.equal(3);
+
+            NSString *sqlLeft = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
+                                 "WHERE \"name\" = ?;";
+
+            NSString *sqlRight = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
+                                  "WHERE \"pet\" = ?;";
+
+            NSString *sqlAnd = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
+                                "WHERE \"name\" = ? AND \"pet\" = ?;";
+
+            CDTQSqlQueryNode *sqlNode;
+
+            sqlNode = or .children[0];
+            expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sqlLeft);
+            expect(sqlNode.sql.placeholderValues).to.equal(@[ @"mike" ]);
+
+            sqlNode = or .children[1];
+            expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sqlRight);
+            expect(sqlNode.sql.placeholderValues).to.equal(@[ @"cat" ]);
+
+            CDTQOrQueryNode *subOr = (CDTQOrQueryNode *) or .children[2];
+            expect(subOr).to.beInstanceOf([CDTQOrQueryNode class]);
+            expect(subOr.children.count).to.equal(3);
+
+            sqlNode = subOr.children[0];
+            expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sqlLeft);
+            expect(sqlNode.sql.placeholderValues).to.equal(@[ @"mike" ]);
+
+            sqlNode = subOr.children[1];
+            expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sqlRight);
+            expect(sqlNode.sql.placeholderValues).to.equal(@[ @"cat" ]);
+
+            CDTQAndQueryNode *subAnd = (CDTQAndQueryNode *)subOr.children[2];
+            expect(subAnd).to.beInstanceOf([CDTQAndQueryNode class]);
+            expect(subAnd.children.count).to.equal(1);
+
+            sqlNode = subAnd.children[0];
+            expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sqlAnd);
+            expect(sqlNode.sql.placeholderValues).to.equal(@[ @"mike", @"cat" ]);
+        });
+    });
+
+    describe(@"when selecting an index to use", ^{
+
+        __block CDTDatastore *ds;
+        __block CDTQIndexManager *im;
+
+        beforeEach(^{
+            ds = [factory datastoreNamed:@"test" error:nil];
+            im = [CDTQIndexManager managerUsingDatastore:ds error:nil];
+        });
+
+        it(@"fails if no indexes available", ^{
+            expect([CDTQQuerySqlTranslator chooseIndexForAndClause:@[
+                                                                      @{ @"name" : @"mike" }
+                                                                   ]
+                                                       fromIndexes:@{}]).to.beNil();
+        });
+
+        it(@"fails if no keys in query", ^{
+            NSDictionary *indexes = @{ @"named" : @[ @"name", @"age", @"pet" ] };
+            expect([CDTQQuerySqlTranslator chooseIndexForAndClause:@[ @{} ] fromIndexes:indexes])
+                .to.beNil();
+        });
+
+        it(@"selects an index for single field queries", ^{
+            NSDictionary *indexes = @{
+                @"named" : @{@"name" : @"named", @"type" : @"json", @"fields" : @[ @"name" ]}
+            };
+            NSString *idx =
+                [CDTQQuerySqlTranslator chooseIndexForAndClause:@[
+                                                                   @{ @"name" : @"mike" }
+                                                                ]
+                                                    fromIndexes:indexes];
+            expect(idx).to.equal(@"named");
+        });
+
+        it(@"selects an index for multi-field queries", ^{
+            NSDictionary *indexes = @{
+                @"named" : @{
+                    @"name" : @"named",
+                    @"type" : @"json",
+                    @"fields" : @[ @"name", @"age", @"pet" ]
+                }
+            };
+            NSString *idx = [CDTQQuerySqlTranslator
+                chooseIndexForAndClause:@[ @{ @"name" : @"mike" }, @{
+                                            @"pet" : @"cat"
+                                        } ]
+                            fromIndexes:indexes];
+            expect(idx).to.equal(@"named");
+        });
+
+        it(@"selects an index from several indexes for multi-field queries", ^{
+            NSDictionary *indexes = @{
+                @"named" : @{
+                    @"name" : @"named",
+                    @"type" : @"json",
+                    @"fields" : @[ @"name", @"age", @"pet" ]
+                },
+                @"bopped" : @{
+                    @"name" : @"named",
+                    @"type" : @"json",
+                    @"fields" : @[ @"house_number", @"pet" ]
+                },
+                @"unsuitable" : @{@"name" : @"named", @"type" : @"json", @"fields" : @[ @"name" ]},
+            };
+            NSString *idx = [CDTQQuerySqlTranslator
+                chooseIndexForAndClause:@[ @{ @"name" : @"mike" }, @{
+                                            @"pet" : @"cat"
+                                        } ]
+                            fromIndexes:indexes];
+            expect(idx).to.equal(@"named");
+        });
+
+        it(@"selects an correct index when several match", ^{
+            NSDictionary *indexes = @{
+                @"named" : @{
+                    @"name" : @"named",
+                    @"type" : @"json",
+                    @"fields" : @[ @"name", @"age", @"pet" ]
+                },
+                @"bopped" : @{
+                    @"name" : @"named",
+                    @"type" : @"json",
+                    @"fields" : @[ @"name", @"age", @"pet" ]
+                },
+                @"many_field" : @{
+                    @"name" : @"named",
+                    @"type" : @"json",
+                    @"fields" : @[ @"name", @"age", @"pet", @"car", @"van" ]
+                },
+                @"unsuitable" : @{@"name" : @"named", @"type" : @"json", @"fields" : @[ @"name" ]},
+            };
+            NSString *idx = [CDTQQuerySqlTranslator
+                chooseIndexForAndClause:@[ @{ @"name" : @"mike" }, @{
+                                            @"pet" : @"cat"
+                                        } ]
+                            fromIndexes:indexes];
+            expect([@[ @"named", @"bopped" ] containsObject:idx]).to.beTruthy();
+        });
+
+        it(@"fails if no suitable index is available", ^{
+            NSDictionary *indexes = @{
+                @"named" :
+                    @{@"name" : @"named", @"type" : @"json", @"fields" : @[ @"name", @"age" ]},
+                @"unsuitable" : @{@"name" : @"named", @"type" : @"json", @"fields" : @[ @"name" ]},
+            };
+            expect([CDTQQuerySqlTranslator chooseIndexForAndClause:@[
+                                                                      @{ @"pet" : @"cat" }
+                                                                   ]
+                                                       fromIndexes:indexes]).to.beNil();
+        });
+    });
+
+    describe(@"when generating query WHERE clauses", ^{
+
+        it(@"returns nil when no query terms", ^{
+            CDTQSqlParts *parts = [CDTQQuerySqlTranslator wherePartsForAndClause:@[]
+                                                                      usingIndex:@"named"];
+            expect(parts).to.beNil();
+        });
+
+        describe(@"when using $eq operator", ^{
+
+            it(@"returns correctly for a single term", ^{
+                CDTQSqlParts *parts = [CDTQQuerySqlTranslator
+                    wherePartsForAndClause:@[
+                                              @{ @"name" : @{@"$eq" : @"mike"} }
+                                           ] usingIndex:@"named"];
+                expect(parts.sqlWithPlaceholders).to.equal(@"\"name\" = ?");
+                expect(parts.placeholderValues).to.equal(@[ @"mike" ]);
+            });
+
+            it(@"returns correctly for many query terms", ^{
+                NSArray *query = @[
+                    @{ @"name" : @{@"$eq" : @"mike"} },
+                    @{ @"age" : @{@"$eq" : @12} },
+                    @{ @"pet" : @{@"$eq" : @"cat"} }
+                ];
+                CDTQSqlParts *parts = [CDTQQuerySqlTranslator wherePartsForAndClause:query
+                                                                          usingIndex:@"named"];
+                expect(parts.sqlWithPlaceholders)
+                    .to.equal(@"\"name\" = ? AND \"age\" = ? AND \"pet\" = ?");
+                expect(parts.placeholderValues).to.equal(@[ @"mike", @12, @"cat" ]);
+            });
+        });
+
+        describe(@"when using $gt operator", ^{
+            it(@"uses correct SQL operator", ^{
+                CDTQSqlParts *parts = [CDTQQuerySqlTranslator
+                    wherePartsForAndClause:@[
+                                              @{ @"name" : @{@"$gt" : @"mike"} }
+                                           ] usingIndex:@"named"];
+                expect(parts.sqlWithPlaceholders).to.equal(@"\"name\" > ?");
+                expect(parts.placeholderValues).to.equal(@[ @"mike" ]);
+            });
+        });
+
+        describe(@"when using $gte operator", ^{
+            it(@"uses correct SQL operator", ^{
+                CDTQSqlParts *parts = [CDTQQuerySqlTranslator
+                    wherePartsForAndClause:@[
+                                              @{ @"name" : @{@"$gte" : @"mike"} }
+                                           ] usingIndex:@"named"];
+                expect(parts.sqlWithPlaceholders).to.equal(@"\"name\" >= ?");
+                expect(parts.placeholderValues).to.equal(@[ @"mike" ]);
+            });
+        });
+
+        describe(@"when using $lt operator", ^{
+            it(@"uses correct SQL operator", ^{
+                CDTQSqlParts *parts = [CDTQQuerySqlTranslator
+                    wherePartsForAndClause:@[
+                                              @{ @"name" : @{@"$lt" : @"mike"} }
+                                           ] usingIndex:@"named"];
+                expect(parts.sqlWithPlaceholders).to.equal(@"\"name\" < ?");
+                expect(parts.placeholderValues).to.equal(@[ @"mike" ]);
+            });
+        });
+
+        describe(@"when using $lte operator", ^{
+            it(@"uses correct SQL operator", ^{
+                CDTQSqlParts *parts = [CDTQQuerySqlTranslator
+                    wherePartsForAndClause:@[
+                                              @{ @"name" : @{@"$lte" : @"mike"} }
+                                           ] usingIndex:@"named"];
+                expect(parts.sqlWithPlaceholders).to.equal(@"\"name\" <= ?");
+                expect(parts.placeholderValues).to.equal(@[ @"mike" ]);
+            });
+        });
+
+        describe(@"when using the $exists operator", ^{
+            it(@"uses correct SQL operator for $exits : true", ^{
+                CDTQSqlParts *parts = [CDTQQuerySqlTranslator
+                    wherePartsForAndClause:@[
+                                              @{ @"name" : @{@"$exists" : @YES} }
+                                           ] usingIndex:@"named"];
+                expect(parts.sqlWithPlaceholders).to.equal(@"(\"name\" IS NOT NULL)");
+            });
+            it(@"uses correct SQL operator for $exits : false:", ^{
+                CDTQSqlParts *parts = [CDTQQuerySqlTranslator
+                    wherePartsForAndClause:@[
+                                              @{ @"name" : @{@"$exists" : @NO} }
+                                           ] usingIndex:@"named"];
+                expect(parts.sqlWithPlaceholders).to.equal(@"(\"name\" IS NULL)");
+            });
+            it(@"uses correct SQL operator for $not { $exits : false}", ^{
+                CDTQSqlParts *parts = [CDTQQuerySqlTranslator
+                    wherePartsForAndClause:@[
+                                              @{ @"name" : @{@"$not" : @{@"$exists" : @NO}} }
+                                           ] usingIndex:@"named"];
+                expect(parts.sqlWithPlaceholders).to.equal(@"(\"name\" IS NOT NULL)");
+            });
+            it(@"uses correct SQL operator for $not {$exits : true}", ^{
+                CDTQSqlParts *parts = [CDTQQuerySqlTranslator
+                    wherePartsForAndClause:@[
+                                              @{ @"name" : @{@"$not" : @{@"$exists" : @YES}} }
+                                           ] usingIndex:@"named"];
+                expect(parts.sqlWithPlaceholders).to.equal(@"(\"name\" IS NULL)");
+            });
+        });
+        
+        describe(@"when using the $in operator", ^{
+            it(@"constructs valid WHERE clause when using a single element in an array", ^{
+                CDTQSqlParts *parts = [CDTQQuerySqlTranslator
+                    wherePartsForAndClause:@[@{ @"name" : @{ @"$in" : @[ @"mike" ]} }]
+                                usingIndex:@"named"];
+                expect(parts.sqlWithPlaceholders).to.equal(@"\"name\" IN ( ? )");
+                expect(parts.placeholderValues).to.equal(@[ @"mike" ]);
+            });
+            it(@"constructs valid WHERE clause when using multiple elements in an array", ^{
+                CDTQSqlParts *parts = [CDTQQuerySqlTranslator
+                    wherePartsForAndClause:@[@{ @"name" : @{ @"$in" : @[ @"mike", @"fred" ]} }]
+                                usingIndex:@"named"];
+                expect(parts.sqlWithPlaceholders).to.equal(@"\"name\" IN ( ?, ? )");
+                expect(parts.placeholderValues).to.equal(@[ @"mike", @"fred" ]);
+            });
+        });
+    });
+
+    describe(@"when generating WHERE with $not", ^{
+
+        it(@"returns nil when no query terms", ^{
+            CDTQSqlParts *parts = [CDTQQuerySqlTranslator wherePartsForAndClause:@[]
+                                                                      usingIndex:@"named"];
+            expect(parts).to.beNil();
+        });
+
+        describe(@"when using $eq operator", ^{
+
+            it(@"returns correctly for a single term", ^{
+                CDTQSqlParts *parts = [CDTQQuerySqlTranslator
+                    wherePartsForAndClause:@[
+                                              @{ @"name" : @{@"$not" : @{@"$eq" : @"mike"}} }
+                                           ] usingIndex:@"named"];
+                NSString *expected = @"_id NOT IN (SELECT _id "
+                                                 @"FROM _t_cloudant_sync_query_index_named "
+                                                 @"WHERE \"name\" = ?)";
+                expect(parts.sqlWithPlaceholders).to.equal(expected);
+                expect(parts.placeholderValues).to.equal(@[ @"mike" ]);
+            });
+
+            it(@"returns correctly for many query terms", ^{
+                NSArray *query = @[
+                    @{ @"name" : @{@"$not" : @{@"$eq" : @"mike"}} },
+                    @{ @"age" : @{@"$eq" : @12} },
+                    @{ @"pet" : @{@"$not" : @{@"$eq" : @"cat"}} }
+                ];
+                CDTQSqlParts *parts = [CDTQQuerySqlTranslator wherePartsForAndClause:query
+                                                                          usingIndex:@"named"];
+                NSString *expected = @"_id NOT IN (SELECT _id "
+                                                 @"FROM _t_cloudant_sync_query_index_named "
+                                                 @"WHERE \"name\" = ?) "
+                                     @"AND "
+                                     @"\"age\" = ? "
+                                     @"AND "
+                                     @"_id NOT IN (SELECT _id "
+                                                 @"FROM _t_cloudant_sync_query_index_named "
+                                                 @"WHERE \"pet\" = ?)";
+                
+                expect(parts.sqlWithPlaceholders)
+                    .to.equal(expected);
+                expect(parts.placeholderValues).to.equal(@[ @"mike", @12, @"cat" ]);
+            });
+        });
+
+        describe(@"when using $gt operator", ^{
+            it(@"uses correct SQL operator", ^{
+                CDTQSqlParts *parts = [CDTQQuerySqlTranslator
+                    wherePartsForAndClause:@[
+                                              @{ @"name" : @{@"$not" : @{@"$gt" : @"mike"}} }
+                                           ] usingIndex:@"named"];
+                NSString *expected = @"_id NOT IN (SELECT _id "
+                                                 @"FROM _t_cloudant_sync_query_index_named "
+                                                 @"WHERE \"name\" > ?)";
+                expect(parts.sqlWithPlaceholders).to.equal(expected);
+                expect(parts.placeholderValues).to.equal(@[ @"mike" ]);
+            });
+        });
+
+        describe(@"when using $gte operator", ^{
+            it(@"uses correct SQL operator", ^{
+                CDTQSqlParts *parts = [CDTQQuerySqlTranslator
+                    wherePartsForAndClause:@[
+                                              @{ @"name" : @{@"$not" : @{@"$gte" : @"mike"}} }
+                                           ] usingIndex:@"named"];
+                NSString *expected = @"_id NOT IN (SELECT _id "
+                                                 @"FROM _t_cloudant_sync_query_index_named "
+                                                 @"WHERE \"name\" >= ?)";
+                expect(parts.sqlWithPlaceholders).to.equal(expected);
+                expect(parts.placeholderValues).to.equal(@[ @"mike" ]);
+            });
+        });
+
+        describe(@"when using $lt operator", ^{
+            it(@"uses correct SQL operator", ^{
+                CDTQSqlParts *parts = [CDTQQuerySqlTranslator
+                    wherePartsForAndClause:@[
+                                              @{ @"name" : @{@"$not" : @{@"$lt" : @"mike"}} }
+                                           ] usingIndex:@"named"];
+                NSString *expected = @"_id NOT IN (SELECT _id "
+                                                 @"FROM _t_cloudant_sync_query_index_named "
+                                                 @"WHERE \"name\" < ?)";
+                expect(parts.sqlWithPlaceholders).to.equal(expected);
+                expect(parts.placeholderValues).to.equal(@[ @"mike" ]);
+            });
+        });
+
+        describe(@"when using $lte operator", ^{
+            it(@"uses correct SQL operator", ^{
+                CDTQSqlParts *parts = [CDTQQuerySqlTranslator
+                    wherePartsForAndClause:@[
+                                              @{ @"name" : @{@"$not" : @{@"$lte" : @"mike"}} }
+                                           ] usingIndex:@"named"];
+                NSString *expected = @"_id NOT IN (SELECT _id "
+                                                 @"FROM _t_cloudant_sync_query_index_named "
+                                                 @"WHERE \"name\" <= ?)";
+                expect(parts.sqlWithPlaceholders).to.equal(expected);
+                expect(parts.placeholderValues).to.equal(@[ @"mike" ]);
+            });
+        });
+        
+        describe(@"when using the $in operator", ^{
+            it(@"uses correct SQL operator", ^{
+                CDTQSqlParts *parts = [CDTQQuerySqlTranslator
+                    wherePartsForAndClause:@[
+                                 @{ @"name" : @{ @"$not" : @{ @"$in" : @[ @"mike", @"fred" ]} } }
+                                            ] usingIndex:@"named"];
+                NSString *expected = @"_id NOT IN (SELECT _id "
+                                     @"FROM _t_cloudant_sync_query_index_named "
+                                     @"WHERE \"name\" IN ( ?, ? ))";
+                expect(parts.sqlWithPlaceholders).to.equal(expected);
+                expect(parts.placeholderValues).to.equal(@[ @"mike", @"fred" ]);
+            });
+        });
+    });
+
+    describe(@"when multiple conditions on one field", ^{
+
+        it(@"returns correctly for a two conditions", ^{
+            NSArray *clause = @[
+                @{ @"name" : @{@"$not" : @{@"$eq" : @"mike"}} },
+                @{ @"name" : @{@"$eq" : @"john"} }
+            ];
+            CDTQSqlParts *parts = [CDTQQuerySqlTranslator wherePartsForAndClause:clause
+                                                                      usingIndex:@"named"];
+            NSString *expected = @"_id NOT IN (SELECT _id "
+                                             @"FROM _t_cloudant_sync_query_index_named "
+                                             @"WHERE \"name\" = ?) "
+                                 @"AND \"name\" = ?";
+            expect(parts.sqlWithPlaceholders).to.equal(expected);
+            expect(parts.placeholderValues).to.equal(@[ @"mike", @"john" ]);
+        });
+
+        it(@"returns correctly for several conditions", ^{
+            NSArray *clause = @[
+                @{ @"age" : @{@"$gt" : @12} },
+                @{ @"age" : @{@"$lte" : @54} },
+                @{ @"name" : @{@"$eq" : @"mike"} },
+                @{ @"age" : @{ @"$not" : @{@"$eq" : @30} } },
+                @{ @"age" : @{@"$eq" : @42} },
+            ];
+            CDTQSqlParts *parts = [CDTQQuerySqlTranslator wherePartsForAndClause:clause
+                                                                      usingIndex:@"named"];
+            NSString *expected = @"\"age\" > ? "
+                                 @"AND \"age\" <= ? "
+                                 @"AND \"name\" = ? "
+                                 @"AND _id NOT IN (SELECT _id "
+                                                 @"FROM _t_cloudant_sync_query_index_named "
+                                                 @"WHERE \"age\" = ?) "
+                                 @"AND \"age\" = ?";
+            expect(parts.sqlWithPlaceholders).to.equal(expected);
+            expect(parts.placeholderValues).to.equal(@[ @12, @54, @"mike", @30, @42 ]);
+        });
+    });
+
+    describe(@"when generating query SELECT clauses", ^{
+
+        it(@"returns nil for no query terms", ^{
+            CDTQSqlParts *parts =
+                [CDTQQuerySqlTranslator selectStatementForAndClause:@[] usingIndex:@"named"];
+            expect(parts).to.beNil();
+        });
+
+        it(@"returns nil for no index name", ^{
+            CDTQSqlParts *parts = [CDTQQuerySqlTranslator
+                selectStatementForAndClause:@[
+                                               @{ @"name" : @{@"$eq" : @"mike"} }
+                                            ]
+                                 usingIndex:nil];
+            expect(parts).to.beNil();
+        });
+
+        it(@"returns correctly for single query term", ^{
+            CDTQSqlParts *parts = [CDTQQuerySqlTranslator
+                selectStatementForAndClause:@[
+                                               @{ @"name" : @{@"$eq" : @"mike"} }
+                                            ]
+                                 usingIndex:@"anIndex"];
+            NSString *sql = @"SELECT _id FROM _t_cloudant_sync_query_index_anIndex "
+                             "WHERE \"name\" = ?;";
+            expect(parts.sqlWithPlaceholders).to.equal(sql);
+            expect(parts.placeholderValues).to.equal(@[ @"mike" ]);
+        });
+
+        it(@"returns correctly for many query terms", ^{
+            NSArray *andClause = @[
+                @{ @"name" : @{@"$eq" : @"mike"} },
+                @{ @"age" : @{@"$eq" : @12} },
+                @{ @"pet" : @{@"$eq" : @"cat"} }
+            ];
+            CDTQSqlParts *parts = [CDTQQuerySqlTranslator selectStatementForAndClause:andClause
+                                                                           usingIndex:@"anIndex"];
+            NSString *sql = @"SELECT _id FROM _t_cloudant_sync_query_index_anIndex "
+                             "WHERE \"name\" = ? AND \"age\" = ? AND \"pet\" = ?;";
+            expect(parts.sqlWithPlaceholders).to.equal(sql);
+            expect(parts.placeholderValues).to.equal(@[ @"mike", @12, @"cat" ]);
+        });
+    });
+
+    describe(@"when normalising queries", ^{
+
+        it(@"expands top-level implicit $and single field", ^{
+            NSDictionary *actual = [CDTQQueryValidator normaliseAndValidateQuery:@{ @"name" : @"mike" }];
+            expect(actual).to.equal(@{ @"$and" : @[ @{@"name" : @{@"$eq" : @"mike"}} ] });
+        });
+
+        it(@"expands top-level implicit $and multi field", ^{
+            NSDictionary *actual = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                @"name" : @"mike",
+                @"pet" : @"cat",
+                @"age" : @12
+            }];
+            expect(actual).to.beTheSameQueryAs(@{
+                @"$and" : @[
+                    @{@"pet" : @{@"$eq" : @"cat"}},
+                    @{@"name" : @{@"$eq" : @"mike"}},
+                    @{@"age" : @{@"$eq" : @12}}
+                ]
+            });
+        });
+
+        it(@"doesn't change already normalised query", ^{
+            NSDictionary *actual = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                @"$and" : @[ @{@"name" : @"mike"}, @{@"pet" : @"cat"}, @{@"age" : @12} ]
+            }];
+            expect(actual).to.equal(@{
+                @"$and" : @[
+                    @{@"name" : @{@"$eq" : @"mike"}},
+                    @{@"pet" : @{@"$eq" : @"cat"}},
+                    @{@"age" : @{@"$eq" : @12}}
+                ]
+            });
+        });
+        
+        it(@"correctly normalizes query with an even number of NOT operators", ^{
+            NSDictionary *actual = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                @"pet" : @{ @"$not" : @{ @"$not" : @{ @"$eq" : @"cat" } } }
+                                                                                   }];
+            expect(actual).to.equal( @{ @"$and" : @[ @{ @"pet" : @{ @"$eq" : @"cat"} } ] } );
+        });
+        
+        it(@"correctly normalizes query with a single NE operator", ^{
+            NSDictionary *actual = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                @"pet" : @{ @"$ne" : @"cat" }
+                                                                                   }];
+            expect(actual).to.equal( @{
+                @"$and" : @[ @{ @"pet" : @{ @"$not" : @{ @"$eq" : @"cat"} } } ]
+                                      } );
+        });
+        
+        it(@"correctly normalizes query with multiple NOT operators and an NE operator", ^{
+            NSDictionary *actual = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                @"pet" : @{ @"$not" : @{ @"$not" : @{ @"$ne" : @"cat" } } }
+                                                                                   }];
+            expect(actual).to.equal( @{
+                @"$and" : @[ @{ @"pet" : @{ @"$not" : @{ @"$eq" : @"cat"} } } ]
+                                       } );
+        });
+        
+        it(@"correctly normalizes query with an odd number of NOT operators", ^{
+            NSDictionary *actual = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                @"pet" : @{ @"$not" : @{ @"$not" : @{ @"$not" : @{ @"$eq" : @"cat" } } } }
+                                                                                   }];
+            expect(actual).to.equal( @{
+                @"$and" : @[ @{ @"pet" : @{ @"$not" : @{ @"$eq" : @"cat"} } } ]
+                                       } );
+        });
+        
+        it(@"correctly normalizes multi-level query with multiple NOT operators", ^{
+            NSDictionary *actual = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                @"$or" : @[ @{ @"name": @{ @"$eq" : @"mike" } },
+                           @{ @"$and" : @[ @{ @"pet": @{ @"$not": @{ @"$not": @{ @"$not":
+                                                      @{ @"$eq": @"cat" } } } } },
+                                           @{ @"age": @{ @"$eq" : @12 } }
+                                        ]}
+                         ] } ];
+            expect(actual).to.equal( @{
+                @"$or" : @[ @{ @"name" : @{ @"$eq" : @"mike" } },
+                            @{ @"$and" : @[ @{ @"pet" : @{ @"$not" : @{ @"$eq" : @"cat" } } },
+                                            @{ @"age" : @{ @"$eq" : @12 } } ] } ] } );
+        });
+        
+        it(@"correctly normalizes query with IN", ^{
+            NSDictionary *actual = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                @"name" : @{ @"$in" : @[ @"mike", @"fred"] } } ];
+            expect(actual).to.equal( @{
+                @"$and" : @[ @{ @"name" : @{ @"$in" : @[ @"mike", @"fred"] } } ] } );
+        });
+        
+        it(@"correctly normalizes query with NIN", ^{
+            NSDictionary *actual = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                @"name" : @{ @"$nin" : @[ @"mike", @"fred"] } } ];
+            expect(actual).to.equal( @{
+                @"$and" : @[ @{ @"name" : @{ @"$not" : @{ @"$in" : @[ @"mike", @"fred"] } } } ] } );
+        });
+        
+        it(@"correctly normalizes query with NOT NIN", ^{
+            NSDictionary *actual = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                @"name" : @{ @"$not" : @{ @"$nin" : @[ @"mike", @"fred"] } } } ];
+            expect(actual).to.equal( @{
+                @"$and" : @[ @{ @"name" : @{ @"$in" : @[ @"mike", @"fred"] } } ] } );
+        });
+        
+        it(@"correctly normalizes query with mulitple NOT and a NIN", ^{
+            NSDictionary *actual = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                @"name" : @{ @"$not" : @{ @"$not" : @{ @"$nin" : @[ @"mike", @"fred"] } } } } ];
+            expect(actual).to.equal( @{
+                @"$and" : @[ @{ @"name" : @{ @"$not" : @{ @"$in" : @[ @"mike", @"fred"] } } } ] } );
+        });
+        
+        it(@"returns nil for query containing invalid operator", ^{
+            NSDictionary *actual = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                @"name" : @{ @"$blah" : @"mike" } } ];
+            expect(actual).to.beNil;
+        });
+        
+        it(@"returns nil for query containing invalid operator using $not", ^{
+            NSDictionary *actual = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                @"name" : @{ @"$not" : @{ @"$blah" : @"mike" } } } ];
+            expect(actual).to.beNil;
+        });
+        
+        it(@"returns nil for query using $not without additional operator", ^{
+            NSDictionary *actual = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                @"name" : @{ @"$not" : @"mike" } } ];
+            expect(actual).to.beNil;
+        });
+        
+        it(@"returns nil for query using $in without an array", ^{
+            NSDictionary *actual = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                @"name" : @{ @"$in" : @"mike" } } ];
+            expect(actual).to.beNil;
+        });
+        
+    });
+
+    describe(@"when extracting and clause field names", ^{
+
+        it(@"extracts a no field names", ^{
+            NSArray *fields = [CDTQQuerySqlTranslator fieldsForAndClause:@[]];
+            expect(fields).to.equal(@[]);
+        });
+
+        it(@"extracts a single field name", ^{
+            NSArray *fields =
+                [CDTQQuerySqlTranslator fieldsForAndClause:@[
+                                                              @{ @"name" : @"mike" }
+                                                           ]];
+            expect(fields).to.equal(@[ @"name" ]);
+        });
+
+        it(@"extracts a multiple field names", ^{
+            NSArray *fields = [CDTQQuerySqlTranslator fieldsForAndClause:@[
+                                                                            @{ @"name" : @"mike" },
+                                                                            @{ @"pet" : @"cat" },
+                                                                            @{ @"age" : @12 }
+                                                                         ]];
+            expect(fields).to.containAllElements(@[ @"name", @"pet", @"age" ]);
+        });
+    });
+});
+
+SpecEnd

--- a/Tests/Tests/CDTQUnindexedMatcherTests.m
+++ b/Tests/Tests/CDTQUnindexedMatcherTests.m
@@ -1,0 +1,639 @@
+//
+//  CloudantQueryObjcTests.m
+//  CloudantQueryObjcTests
+//
+//  Created by Michael Rhodes on 31/10/2014.
+//  Copyright (c) 2014 Cloudant. All rights reserved.
+//
+
+#import <CloudantSync.h>
+#import <CDTQIndexManager.h>
+#import <CDTQIndexUpdater.h>
+#import <CDTQIndexCreator.h>
+#import <CDTQResultSet.h>
+#import <CDTQQueryExecutor.h>
+#import <CDTQUnindexedMatcher.h>
+#import <CDTQQueryValidator.h>
+
+SpecBegin(CDTQUnindexedMatcher) describe(@"matcherWithSelector", ^{
+
+    it(@"returns initialised object", ^{
+        CDTQUnindexedMatcher *matcher =
+            [CDTQUnindexedMatcher matcherWithSelector:[CDTQQueryValidator normaliseAndValidateQuery:@{
+                                                          @"n" : @"m"
+                                                      }]];
+        expect(matcher).toNot.beNil();
+    });
+});
+
+describe(@"matches", ^{
+
+    __block CDTDocumentRevision *rev;
+
+    beforeAll(^{
+        NSDictionary *body = @{
+            @"name" : @"mike",
+            @"age" : @31,
+            @"pets" : @[ @"white_cat", @"black_cat" ],
+            @"address" : @{@"number" : @"1", @"road" : @"infinite loop"}
+        };
+        rev = [[CDTDocumentRevision alloc] initWithDocId:@"dsfsdfdfs"
+                                              revisionId:@"qweqeqwewqe"
+                                                    body:body
+                                             attachments:nil];
+    });
+
+    context(@"single", ^{
+
+        context(@"eq", ^{
+
+            it(@"matches", ^{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"name" : @{@"$eq" : @"mike"}
+                }];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beTruthy();
+            });
+
+            it(@"doesn't match", ^{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"name" : @{@"$eq" : @"fred"}
+                }];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beFalsy();
+            });
+
+            it(@"doesn't match bad field", ^{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"species" : @{@"$eq" : @"fred"}
+                }];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beFalsy();
+            });
+        });
+
+        context(@"implied eq", ^{
+
+            it(@"matches", ^{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{ @"name" : @"mike" }];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beTruthy();
+            });
+
+            it(@"doesn't match", ^{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{ @"name" : @"fred" }];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beFalsy();
+            });
+
+            it(@"doesn't match bad field", ^{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"species" : @"fred"
+                }];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beFalsy();
+            });
+        });
+
+        context(@"ne", ^{
+
+            it(@"matches", ^{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"name" : @{@"$ne" : @"fred"}
+                }];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beTruthy();
+            });
+
+            it(@"doesn't match", ^{
+                NSDictionary *selector = @{ @"name" : @{@"$ne" : @"mike"} };
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beFalsy();
+            });
+
+            it(@"matches bad field", ^{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"species" : @{@"$ne" : @"fred"}
+                }];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beTruthy();
+            });
+        });
+
+        context(@"gt", ^{
+
+            it(@"matches string", ^{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"name" : @{@"$gt" : @"andy"}
+                }];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beTruthy();
+            });
+
+            it(@"matches int", ^{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"age" : @{@"$gt" : @12}
+                }];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beTruthy();
+            });
+
+            it(@"doesn't match string", ^{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"name" : @{@"$gt" : @"robert"}
+                }];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beFalsy();
+            });
+
+            it(@"doesn't match int", ^{
+                NSDictionary *selector = @{ @"age" : @{@"$gt" : @45} };
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beFalsy();
+            });
+
+            it(@"doesn't match bad field", ^{
+                NSDictionary *selector = @{ @"species" : @{@"$gt" : @"fred"} };
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beFalsy();
+            });
+        });
+
+        context(@"gte", ^{
+
+            it(@"matches string", ^{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"name" : @{@"$gte" : @"andy"}
+                }];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beTruthy();
+            });
+
+            it(@"matches equal string", ^{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"name" : @{@"$gte" : @"mike"}
+                }];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beTruthy();
+            });
+
+            it(@"matches int", ^{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"age" : @{@"$gte" : @12}
+                }];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beTruthy();
+            });
+
+            it(@"matches equal int", ^{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"age" : @{@"$gte" : @31}
+                }];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beTruthy();
+            });
+
+            it(@"doesn't match string", ^{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"name" : @{@"$gte" : @"robert"}
+                }];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beFalsy();
+            });
+
+            it(@"doesn't match int", ^{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"age" : @{@"$gte" : @45}
+                }];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beFalsy();
+            });
+
+            it(@"doesn't match bad field", ^{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"species" : @{@"$gte" : @"fred"}
+                }];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beFalsy();
+            });
+        });
+
+        context(@"lt", ^{
+
+            it(@"matches string", ^{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"name" : @{@"$lt" : @"robert"}
+                }];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beTruthy();
+            });
+
+            it(@"matches int", ^{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"age" : @{@"$lt" : @45}
+                }];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beTruthy();
+            });
+
+            it(@"doesn't match string", ^{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"name" : @{@"$lt" : @"andy"}
+                }];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beFalsy();
+            });
+
+            it(@"doesn't match int", ^{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"age" : @{@"$lt" : @12}
+                }];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beFalsy();
+            });
+
+            it(@"doesn't match bad field", ^{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"species" : @{@"$lt" : @"fred"}
+                }];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beFalsy();
+            });
+        });
+        context(@"lte", ^{
+
+            it(@"matches string", ^{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"name" : @{@"$lte" : @"robert"}
+                }];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beTruthy();
+            });
+
+            it(@"matches equal string", ^{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"name" : @{@"$lte" : @"mike"}
+                }];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beTruthy();
+            });
+
+            it(@"matches int", ^{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"age" : @{@"$lte" : @45}
+                }];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beTruthy();
+            });
+
+            it(@"matches equal int", ^{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"age" : @{@"$lte" : @31}
+                }];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beTruthy();
+            });
+
+            it(@"doesn't match string", ^{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"name" : @{@"$lte" : @"andy"}
+                }];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beFalsy();
+            });
+
+            it(@"doesn't match int", ^{
+                NSDictionary *selector = @{ @"age" : @{@"$lte" : @12} };
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beFalsy();
+            });
+
+            it(@"doesn't match bad field", ^{
+                NSDictionary *selector = @{ @"species" : @{@"$lte" : @"fred"} };
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beFalsy();
+            });
+        });
+
+        context(@"exists", ^{
+
+            it(@"matches existing", ^{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"name" : @{@"$exists" : @YES}
+                }];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beTruthy();
+            });
+
+            it(@"doesn't match existing", ^{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"name" : @{@"$exists" : @NO}
+                }];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beFalsy();
+            });
+
+            it(@"matches missing", ^{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"species" : @{@"$exists" : @NO}
+                }];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beTruthy();
+            });
+
+            it(@"doesn't match missing", ^{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"species" : @{@"$exists" : @YES}
+                }];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beFalsy();
+            });
+        });
+    });
+
+    context(@"compound", ^{
+
+        context(@"and", ^{
+
+            it(@"matches all", ^{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"$and" : @[ @{@"name" : @{@"$eq" : @"mike"}}, @{@"age" : @{@"$eq" : @31}} ]
+                }];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beTruthy();
+            });
+
+            it(@"doesn't match some", ^{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"$and" : @[ @{@"name" : @{@"$eq" : @"mike"}}, @{@"age" : @{@"$eq" : @12}} ]
+                }];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beFalsy();
+            });
+
+            it(@"doesn't match any", ^{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"$and" : @[ @{@"name" : @{@"$eq" : @"fred"}}, @{@"age" : @{@"$eq" : @12}} ]
+                }];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beFalsy();
+            });
+        });
+
+        context(@"implicit and", ^{
+
+            it(@"matches", ^{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"name" : @{@"$eq" : @"mike"},
+                    @"age" : @{@"$eq" : @31}
+                }];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beTruthy();
+            });
+
+            it(@"doesn't match", ^{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"name" : @{@"$eq" : @"mike"},
+                    @"age" : @{@"$eq" : @12}
+                }];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beFalsy();
+            });
+        });
+
+        context(@"or", ^{
+
+            it(@"matches all okay", ^{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"$or" : @[ @{@"name" : @{@"$eq" : @"mike"}}, @{@"age" : @{@"$eq" : @31}} ]
+                }];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beTruthy();
+            });
+
+            it(@"matches one okay", ^{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"$or" : @[ @{@"name" : @{@"$eq" : @"mike"}}, @{@"age" : @{@"$eq" : @12}} ]
+                }];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beTruthy();
+            });
+
+            it(@"doesn't match", ^{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"$or" : @[ @{@"name" : @{@"$eq" : @"fred"}}, @{@"age" : @{@"$eq" : @12}} ]
+                }];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beFalsy();
+            });
+        });
+    });
+
+    context(@"not", ^{
+
+        //  We can be fairly simple here as we know that the internal is that $not just negates
+        //  and $ne is just translated to $not..$eq
+
+        context(@"eq", ^{
+
+            it(@"doesn't match", ^{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"name" : @{@"$not" : @{@"$eq" : @"mike"}}
+                }];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beFalsy();
+            });
+
+            it(@"matches", ^{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"name" : @{@"$not" : @{@"$eq" : @"fred"}}
+                }];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beTruthy();
+            });
+
+            it(@"matches bad field", ^{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"species" : @{@"$not" : @{@"$eq" : @"fred"}}
+                }];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beTruthy();
+            });
+        });
+        
+        context(@"ne", ^{
+            
+            it(@"doesn't match using $ne", ^{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"name" : @{@"$ne" : @"mike"}
+                }];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beFalsy();
+            });
+            it(@"doesn't match using $not..$ne", ^{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"name" : @{@"$not" : @{@"$ne" : @"fred"}}
+                }];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beFalsy();
+            });
+            it(@"matches using $ne", ^{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"name" : @{@"$ne" : @"fred"}
+                }];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beTruthy();
+            });
+            it(@"matches using $not..$ne", ^{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"name" : @{@"$not" : @{@"$ne" : @"mike"}}
+                }];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beTruthy();
+            });
+            it(@"matches bad field using $ne", ^{
+                NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                    @"species" : @{@"$ne" : @"fred"}
+                }];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beTruthy();
+            });
+        });
+    });
+
+    context(@"array fields", ^{
+
+        it(@"matches", ^{
+            NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                @"pets" : @"white_cat"
+            }];
+            CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+            expect([matcher matches:rev]).to.beTruthy();
+        });
+
+        it(@"doesn't match good item with $not", ^{
+            NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                @"pets" : @{@"$not" : @{@"$eq" : @"white_cat"}}
+            }];
+            CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+            expect([matcher matches:rev]).to.beFalsy();
+        });
+        
+        it(@"doesn't match good item with $ne", ^{
+            NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                @"pets" : @{@"$ne" : @"white_cat"}
+            }];
+            CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+            expect([matcher matches:rev]).to.beFalsy();
+        });
+
+        it(@"doesn't match bad item", ^{
+            NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                @"pets" : @"tabby_cat"
+            }];
+            CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+            expect([matcher matches:rev]).to.beFalsy();
+        });
+
+        it(@"matches bad item with $not", ^{
+            NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                @"pets" : @{@"$not" : @{@"$eq" : @"tabby_cat"}}
+            }];
+            CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+            expect([matcher matches:rev]).to.beTruthy();
+        });
+        
+        it(@"matches bad item with $ne", ^{
+            NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                @"pets" : @{@"$ne" : @"tabby_cat"}
+            }];
+            CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+            expect([matcher matches:rev]).to.beTruthy();
+        });
+        
+        it(@"matches on array using $in", ^{
+            NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                @"pets" : @{@"$in" : @[ @"white_cat", @"tabby_cat" ] }
+            }];
+            CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+            expect([matcher matches:rev]).to.beTruthy();
+        });
+        
+        it(@"doesn't match on array using $in with bad items", ^{
+            NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                @"pets" : @{@"$in" : @[ @"grey_cat", @"tabby_cat" ] }
+            }];
+            CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+            expect([matcher matches:rev]).to.beFalsy();
+        });
+        
+        it(@"matches on non-array field using $in", ^{
+            NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                @"name" : @{@"$in" : @[ @"mike", @"fred" ] }
+            }];
+            CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+            expect([matcher matches:rev]).to.beTruthy();
+        });
+        
+        it(@"doesn't match on non-array field using $in with bad items", ^{
+            NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                @"name" : @{@"$in" : @[ @"john", @"fred" ] }
+            }];
+            CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+            expect([matcher matches:rev]).to.beFalsy();
+        });
+        
+        it(@"matches on array using $not $in with bad items", ^{
+            NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                @"pets" : @{ @"$not" : @{@"$in" : @[ @"grey_cat", @"tabby_cat" ] } }
+            }];
+            CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+            expect([matcher matches:rev]).to.beTruthy();
+        });
+        
+        it(@"doesn't match on array using $not $in", ^{
+            NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                @"pets" : @{ @"$not" : @{@"$in" : @[ @"white_cat", @"tabby_cat" ] } }
+            }];
+            CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+            expect([matcher matches:rev]).to.beFalsy();
+        });
+        
+        it(@"matches on non-array field using $not $in with bad items", ^{
+            NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                @"name" : @{ @"$not" : @{@"$in" : @[ @"john", @"fred" ] } }
+            }];
+            CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+            expect([matcher matches:rev]).to.beTruthy();
+        });
+        
+        it(@"doesn't match on non-array field using $not $in", ^{
+            NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                @"name" : @{ @"$not" : @{@"$in" : @[ @"mike", @"fred" ] } }
+            }];
+            CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+            expect([matcher matches:rev]).to.beFalsy();
+        });
+    });
+
+    context(@"dotted fields", ^{
+
+        it(@"matches", ^{
+            NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                @"address.number" : @"1"
+            }];
+            CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+            expect([matcher matches:rev]).to.beTruthy();
+        });
+
+        it(@"doesn't match", ^{
+            NSDictionary *selector = [CDTQQueryValidator normaliseAndValidateQuery:@{
+                @"address.number" : @"2"
+            }];
+            CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+            expect([matcher matches:rev]).to.beFalsy();
+        });
+    });
+});
+
+SpecEnd

--- a/Tests/Tests/CDTQValueExtractorTests.m
+++ b/Tests/Tests/CDTQValueExtractorTests.m
@@ -1,0 +1,96 @@
+//
+//  CloudantQueryObjcTests.m
+//  CloudantQueryObjcTests
+//
+//  Created by Michael Rhodes on 09/27/2014.
+//  Copyright (c) 2014 Michael Rhodes. All rights reserved.
+//
+
+#import <CloudantSync.h>
+#import <CDTQValueExtractor.h>
+
+SpecBegin(CDTQValueExtractor)
+
+    describe(@"from revision", ^{
+
+        __block CDTDocumentRevision *rev;
+
+        beforeAll(^{
+            rev = [[CDTDocumentRevision alloc] initWithDocId:@"dsfsdfdfs"
+                                                  revisionId:@"qweqeqwewqe"
+                                                        body:@{
+                                                            @"name" : @"mike"
+                                                        }
+                                                 attachments:nil];
+        });
+
+        it(@"gets _id", ^{
+            NSObject *value = [CDTQValueExtractor extractValueForFieldName:@"_id" fromRevision:rev];
+            expect(value).to.equal(@"dsfsdfdfs");
+        });
+
+        it(@"gets _rev", ^{
+            NSObject *value =
+                [CDTQValueExtractor extractValueForFieldName:@"_rev" fromRevision:rev];
+            expect(value).to.equal(@"qweqeqwewqe");
+        });
+
+        it(@"gets name", ^{
+            NSObject *value =
+                [CDTQValueExtractor extractValueForFieldName:@"name" fromRevision:rev];
+            expect(value).to.equal(@"mike");
+        });
+
+    });
+
+describe(@"when extracting single fields", ^{
+
+    it(@"returns nil for empty field name", ^{
+        NSObject *v =
+            [CDTQValueExtractor extractValueForFieldName:@"" fromDictionary:@{
+                @"name" : @"mike"
+            }];
+        expect(v).to.beNil();
+    });
+
+    it(@"returns value for single field depth", ^{
+        NSObject *v = [CDTQValueExtractor extractValueForFieldName:@"name"
+                                                    fromDictionary:@{
+                                                        @"name" : @"mike"
+                                                    }];
+        expect(v).to.equal(@"mike");
+    });
+
+    it(@"returns value for two field depth", ^{
+        NSDictionary *d = @{ @"name" : @{@"first" : @"mike"} };
+        NSObject *v = [CDTQValueExtractor extractValueForFieldName:@"name.first" fromDictionary:d];
+        expect(v).to.equal(@"mike");
+    });
+
+    it(@"returns value for three field depth", ^{
+        NSDictionary *d = @{ @"aaa" : @{@"bbb" : @{@"ccc" : @"mike"}} };
+        NSObject *v = [CDTQValueExtractor extractValueForFieldName:@"aaa.bbb.ccc" fromDictionary:d];
+        expect(v).to.equal(@"mike");
+    });
+
+    it(@"copes when a prefix of the field name exists", ^{
+        NSObject *v = [CDTQValueExtractor extractValueForFieldName:@"name.first"
+                                                    fromDictionary:@{
+                                                        @"name" : @"mike"
+                                                    }];
+        expect(v).to.beNil();
+
+        NSDictionary *d = @{ @"name" : @{@"first" : @"mike"} };
+        v = [CDTQValueExtractor extractValueForFieldName:@"name.first.mike" fromDictionary:d];
+        expect(v).to.beNil();
+    });
+
+    it(@"returns the sub-document if the path doesn't terminate with a value", ^{
+        NSDictionary *d = @{ @"aaa" : @{@"bbb" : @{@"ccc" : @"mike"}} };
+        NSObject *v = [CDTQValueExtractor extractValueForFieldName:@"aaa.bbb" fromDictionary:d];
+        expect(v).to.equal(@{ @"ccc" : @"mike" });
+    });
+
+});
+
+SpecEnd

--- a/Tests/Tests/Matchers/CDTQContainsAllElementsMatcher.h
+++ b/Tests/Tests/Matchers/CDTQContainsAllElementsMatcher.h
@@ -1,0 +1,23 @@
+//
+//  CDTQContainsAllElementsMatcher.h
+//  CloudantQueryObjc
+//
+//  Created by Rhys Short on 21/01/2015.
+//  Copyright (c) 2015 IBM Corp. All rights reserved.
+//
+
+#ifndef CloudantQueryObjc_CDTQContainsAllElementsMatcher_h
+#define CloudantQueryObjc_CDTQContainsAllElementsMatcher_h
+
+#import "Expecta.h"
+
+/**
+ * Determines if an Array contains all the specified array,
+ * this does not take account of the ordering of elements.
+ *
+ */
+EXPMatcherInterface(containsAllElements, (NSArray * expected));
+
+#define containAllElements containsAllElements
+
+#endif

--- a/Tests/Tests/Matchers/CDTQContainsAllElementsMatcher.m
+++ b/Tests/Tests/Matchers/CDTQContainsAllElementsMatcher.m
@@ -1,0 +1,65 @@
+//
+//  CDTQContainsAllElementsMatcher.m
+//  CloudantQueryObjc
+//
+//  Created by Rhys Short on 21/01/2015.
+//  Copyright (c) 2015 IBM Corp.  All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "CDTQContainsAllElementsMatcher.h"
+
+EXPMatcherImplementationBegin(containsAllElements,(NSArray * expected))
+
+BOOL actualIsNil = (actual == nil);
+BOOL expectedIsNil = (expected == nil);
+
+prerequisite(^BOOL {
+    return !(actualIsNil || expectedIsNil);
+});
+
+
+match(^BOOL {
+
+    BOOL matches = YES;
+    
+    for(id element in expected){
+        if([actual containsObject:element]){
+            continue;
+        }
+        matches = NO;
+        break;
+    }
+    
+    return matches;
+    
+});
+
+failureMessageForTo(^NSString * {
+    if (actualIsNil) {
+        return @"the actual value is nil/null";
+    } else if (expectedIsNil) {
+        return @"the expected value is nil/null";
+    } else {
+        return [NSString stringWithFormat:@"expected values: %@, got values %@ some are missing",
+                expected,
+                actual];
+    }
+    
+    
+});
+
+failureMessageForNotTo(^NSString * {
+    if (actualIsNil) {
+        return @"the actual value is nil/null";
+    } else if (expectedIsNil) {
+        return @"the expected value is nil/null";
+    } else {
+        return [NSString stringWithFormat:@"expected values: %@, got values %@ some are not missing",
+                expected,
+                actual];
+    }
+    
+});
+
+EXPMatcherImplementationEnd

--- a/Tests/Tests/Matchers/CDTQEitherMatcher.h
+++ b/Tests/Tests/Matchers/CDTQEitherMatcher.h
@@ -1,0 +1,18 @@
+//
+//  CDTQEitherMatcher.h
+//  CloudantQueryObjc
+//
+//  Created by Rhys Short on 21/01/2015.
+//  Copyright (c) 2015 IBM Corp. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "Expecta.h"
+
+/**
+ * Determines if the value matches either values.
+ *
+ */
+EXPMatcherInterface(isEqualToEither, (id expected,id otherExpected))
+
+#define isEither

--- a/Tests/Tests/Matchers/CDTQEitherMatcher.m
+++ b/Tests/Tests/Matchers/CDTQEitherMatcher.m
@@ -1,0 +1,35 @@
+//
+//  CDTQEitherMatcher.m
+//  CloudantQueryObjc
+//
+//  Created by Rhys Short on 21/01/2015.
+//  Copyright (c) 2015 IBM Corp. All rights reserved.
+//
+
+#import "CDTQEitherMatcher.h"
+
+EXPMatcherImplementationBegin(isEqualToEither, (id expected,id otherExpected))
+
+match(^BOOL {
+    
+    return [actual isEqual:expected] || [actual isEqual:otherExpected];
+    
+});
+
+failureMessageForTo(^NSString * {
+    return [NSString stringWithFormat:@"expected: %@ or %@, got values %@ some are missing",
+            expected,
+            otherExpected,
+            actual];
+    
+});
+
+failureMessageForNotTo(^NSString * {
+    return [NSString stringWithFormat:@"expected neither: %@ or %@, got values %@",
+            expected,
+            otherExpected,
+            actual];
+    
+});
+
+EXPMatcherImplementationEnd

--- a/Tests/Tests/Matchers/CDTQQueryMatcher.h
+++ b/Tests/Tests/Matchers/CDTQQueryMatcher.h
@@ -1,0 +1,19 @@
+//
+//  CDTQQueryMatcher.h
+//  CloudantQueryObjc
+//
+//  Created by Rhys Short on 21/01/2015.
+//  Copyright (c) 2015 IBM Corp. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "Expecta.h"
+
+/**
+ *  Determines if two raw cloudant queries are the same
+ *
+ */
+EXPMatcherInterface(beTheSameQueryAs, (NSDictionary * expected));
+
+

--- a/Tests/Tests/Matchers/CDTQQueryMatcher.m
+++ b/Tests/Tests/Matchers/CDTQQueryMatcher.m
@@ -1,0 +1,81 @@
+//
+//  CDTQQueryMatcher.m
+//  CloudantQueryObjc
+//
+//  Created by Rhys Short on 21/01/2015.
+//  Copyright (c) 2015 IBM Corp. All rights reserved.
+//
+
+#import "CDTQQueryMatcher.h"
+
+EXPMatcherImplementationBegin(beTheSameQueryAs, (NSDictionary * expected))
+
+prerequisite(^BOOL {
+    
+    return [actual isKindOfClass:[NSDictionary class]];
+    
+});
+
+
+match(^BOOL {
+    
+    BOOL matches = YES;
+    NSDictionary * actualQuery = (NSDictionary*)actual;
+    
+    //first we check if dictionary has the same number of keys
+    if([actualQuery count] != [expected count]){
+        return NO;
+    }
+
+    for (id key in expected){
+        if([actualQuery objectForKey:key]){
+            //we have a key for that object
+            id object = [actualQuery objectForKey:key];
+            
+            if([object isKindOfClass:[NSArray class]] && [[expected objectForKey:key]isKindOfClass:[NSArray class]]){
+                
+                NSArray * expectedArray = (NSArray *)[expected objectForKey:key];
+                NSArray * actualArray = (NSArray *)[actualQuery objectForKey:key];
+                
+                if([expectedArray count] == [actualArray count]){
+                    for(id element in expectedArray){
+                        if(![actualArray containsObject:element]){
+                            matches = NO;
+                            break;
+                        }
+                    }
+                }
+                
+            } else {
+                if(![object isEqual:[expected objectForKey:key]]){
+                    matches = NO;
+                    break;
+                }
+            }
+        } else {
+            matches = NO;
+            break;
+        }
+    }
+    
+    
+    
+    return matches;
+    
+});
+
+failureMessageForTo(^NSString * {
+        return [NSString stringWithFormat:@"expected values: %@, got values %@ some are missing",
+                expected,
+                actual];
+    
+});
+
+failureMessageForNotTo(^NSString * {
+        return [NSString stringWithFormat:@"expected values: %@, got values %@",
+                expected,
+                actual];
+    
+});
+
+EXPMatcherImplementationEnd

--- a/Tests/Tests/Mocks/CDTQMatcherIndexManager.h
+++ b/Tests/Tests/Mocks/CDTQMatcherIndexManager.h
@@ -1,0 +1,15 @@
+//
+//  CDTQMatcherIndexManager.h
+//  CloudantQueryObjc
+//
+//  Created by Michael Rhodes on 01/11/2014.
+//  Copyright (c) 2014 Michael Rhodes. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#import <CDTQIndexManager.h>
+
+@interface CDTQMatcherIndexManager : CDTQIndexManager
+
+@end

--- a/Tests/Tests/Mocks/CDTQMatcherIndexManager.m
+++ b/Tests/Tests/Mocks/CDTQMatcherIndexManager.m
@@ -1,0 +1,45 @@
+//
+//  CDTQMatcherIndexManager.m
+//  CloudantQueryObjc
+//
+//  Created by Michael Rhodes on 01/11/2014.
+//  Copyright (c) 2014 Michael Rhodes. All rights reserved.
+//
+
+#import "CDTQMatcherIndexManager.h"
+
+#import "CDTQMatcherQueryExecutor.h"
+
+@implementation CDTQMatcherIndexManager
+
++ (CDTQIndexManager *)managerUsingDatastore:(CDTDatastore *)datastore
+                                      error:(NSError *__autoreleasing *)error
+{
+    return [[CDTQMatcherIndexManager alloc] initUsingDatastore:datastore error:error];
+}
+
+- (CDTQResultSet *)find:(NSDictionary *)query
+                   skip:(NSUInteger)skip
+                  limit:(NSUInteger)limit
+                 fields:(NSArray *)fields
+                   sort:(NSArray *)sortDocument
+{
+    if (!query) {
+        return nil;
+    }
+
+    if (![self updateAllIndexes]) {
+        return nil;
+    }
+
+    CDTQMatcherQueryExecutor *queryExecutor =
+        [[CDTQMatcherQueryExecutor alloc] initWithDatabase:self.database datastore:self.datastore];
+    return [queryExecutor find:query
+                  usingIndexes:[self listIndexes]
+                          skip:skip
+                         limit:limit
+                        fields:fields
+                          sort:sortDocument];
+}
+
+@end

--- a/Tests/Tests/Mocks/CDTQMatcherQueryExecutor.h
+++ b/Tests/Tests/Mocks/CDTQMatcherQueryExecutor.h
@@ -1,0 +1,13 @@
+//
+//  CDTQMatcherQueryExecutor.h
+//  CloudantQueryObjc
+//
+//  Created by Michael Rhodes on 01/11/2014.
+//  Copyright (c) 2014 Michael Rhodes. All rights reserved.
+//
+
+#import "CDTQQueryExecutor.h"
+
+@interface CDTQMatcherQueryExecutor : CDTQQueryExecutor
+
+@end

--- a/Tests/Tests/Mocks/CDTQMatcherQueryExecutor.m
+++ b/Tests/Tests/Mocks/CDTQMatcherQueryExecutor.m
@@ -1,0 +1,50 @@
+//
+//  CDTQMatcherQueryExecutor.m
+//  CloudantQueryObjc
+//
+//  Created by Michael Rhodes on 01/11/2014.
+//  Copyright (c) 2014 Michael Rhodes. All rights reserved.
+//
+
+#import "CDTQMatcherQueryExecutor.h"
+
+#import <CDTQQuerySqlTranslator.h>
+#import <CDTQIndexManager.h>
+
+#import <FMDB.h>
+
+@implementation CDTQMatcherQueryExecutor
+
+// MOD: indexesCoverQuery always false; return just a blank node (we don't execute it anyway).
+- (CDTQChildrenQueryNode *)translateQuery:(NSDictionary *)query 
+                                  indexes:(NSDictionary *)indexes 
+                        indexesCoverQuery:(BOOL *)indexesCoverQuery
+{
+    *indexesCoverQuery = NO;
+    return [[CDTQAndQueryNode alloc] init];
+}
+
+// MOD: just return all doc IDs rather than executing the query nodes
+- (NSSet*)executeQueryTree:(CDTQQueryNode*)node inDatabase:(FMDatabase*)db
+{
+    NSDictionary *indexes = [CDTQIndexManager listIndexesInDatabase:db];
+    
+    NSMutableSet *docIdSet = [NSMutableSet set];
+    NSSet *neededFields = [NSSet setWithObject:@"_id"];
+    NSString *allDocsIndex = [CDTQQuerySqlTranslator chooseIndexForFields:neededFields
+                                                              fromIndexes:indexes];
+    
+    NSString *tableName = [CDTQIndexManager tableNameForIndex:allDocsIndex];
+    NSString *sql = @"SELECT _id FROM %@;";
+    sql = [NSString stringWithFormat:sql, tableName];
+    FMResultSet *rs = [db executeQuery:sql];
+    while ([rs next]) {
+        [docIdSet addObject:[rs stringForColumn:@"_id"]];
+    }
+    [rs close];
+    
+    return docIdSet;
+}
+
+
+@end

--- a/Tests/Tests/Mocks/CDTQSQLOnlyIndexManager.h
+++ b/Tests/Tests/Mocks/CDTQSQLOnlyIndexManager.h
@@ -1,0 +1,13 @@
+//
+//  CDTQSQLOnlyIndexManager.h
+//  CloudantQueryObjc
+//
+//  Created by Michael Rhodes on 01/11/2014.
+//  Copyright (c) 2014 Michael Rhodes. All rights reserved.
+//
+
+#import "CDTQIndexManager.h"
+
+@interface CDTQSQLOnlyIndexManager : CDTQIndexManager
+
+@end

--- a/Tests/Tests/Mocks/CDTQSQLOnlyIndexManager.m
+++ b/Tests/Tests/Mocks/CDTQSQLOnlyIndexManager.m
@@ -1,0 +1,45 @@
+//
+//  CDTQSQLOnlyIndexManager.m
+//  CloudantQueryObjc
+//
+//  Created by Michael Rhodes on 01/11/2014.
+//  Copyright (c) 2014 Michael Rhodes. All rights reserved.
+//
+
+#import "CDTQSQLOnlyIndexManager.h"
+
+#import "CDTQSQLOnlyQueryExecutor.h"
+
+@implementation CDTQSQLOnlyIndexManager
+
++ (CDTQIndexManager *)managerUsingDatastore:(CDTDatastore *)datastore
+                                      error:(NSError *__autoreleasing *)error
+{
+    return [[CDTQSQLOnlyIndexManager alloc] initUsingDatastore:datastore error:error];
+}
+
+- (CDTQResultSet *)find:(NSDictionary *)query
+                   skip:(NSUInteger)skip
+                  limit:(NSUInteger)limit
+                 fields:(NSArray *)fields
+                   sort:(NSArray *)sortDocument
+{
+    if (!query) {
+        return nil;
+    }
+
+    if (![self updateAllIndexes]) {
+        return nil;
+    }
+
+    CDTQSQLOnlyQueryExecutor *queryExecutor =
+        [[CDTQSQLOnlyQueryExecutor alloc] initWithDatabase:self.database datastore:self.datastore];
+    return [queryExecutor find:query
+                  usingIndexes:[self listIndexes]
+                          skip:skip
+                         limit:limit
+                        fields:fields
+                          sort:sortDocument];
+}
+
+@end

--- a/Tests/Tests/Mocks/CDTQSQLOnlyQueryExecutor.h
+++ b/Tests/Tests/Mocks/CDTQSQLOnlyQueryExecutor.h
@@ -1,0 +1,13 @@
+//
+//  CDTQSQLOnlyQueryExecutor.h
+//  CloudantQueryObjc
+//
+//  Created by Michael Rhodes on 01/11/2014.
+//  Copyright (c) 2014 Michael Rhodes. All rights reserved.
+//
+
+#import "CDTQQueryExecutor.h"
+
+@interface CDTQSQLOnlyQueryExecutor : CDTQQueryExecutor
+
+@end

--- a/Tests/Tests/Mocks/CDTQSQLOnlyQueryExecutor.m
+++ b/Tests/Tests/Mocks/CDTQSQLOnlyQueryExecutor.m
@@ -1,0 +1,21 @@
+//
+//  CDTQSQLOnlyQueryExecutor.m
+//  CloudantQueryObjc
+//
+//  Created by Michael Rhodes on 01/11/2014.
+//  Copyright (c) 2014 Michael Rhodes. All rights reserved.
+//
+
+#import "CDTQSQLOnlyQueryExecutor.h"
+#import <CDTQUnindexedMatcher.h>
+
+@implementation CDTQSQLOnlyQueryExecutor
+
+// MOD: SQL only, so never run matcher
+- (CDTQUnindexedMatcher *)matcherForIndexCoverage:(BOOL)indexesCoverQuery
+                                         selector:(NSDictionary *)selector
+{
+    return nil;
+}
+
+@end

--- a/Tests/Tests/Tests-Prefix.pch
+++ b/Tests/Tests/Tests-Prefix.pch
@@ -7,4 +7,6 @@
 #ifdef __OBJC__
     #import <UIKit/UIKit.h>
     #import <Foundation/Foundation.h>
+    #import <Specta/Specta.h>
+    #import <Expecta/Expecta.h>
 #endif

--- a/Tests/Tests/Tests.m
+++ b/Tests/Tests/Tests.m
@@ -1,0 +1,57 @@
+//
+//  CloudantQueryObjcTests.m
+//  CloudantQueryObjcTests
+//
+//  Created by Michael Rhodes on 09/27/2014.
+//  Copyright (c) 2014 Michael Rhodes. All rights reserved.
+//
+
+#import <CloudantSync.h>
+#import <CDTQIndexManager.h>
+#import <CDTQIndexUpdater.h>
+#import <CDTQIndexCreator.h>
+#import <CDTQResultSet.h>
+#import <CDTQQueryExecutor.h>
+
+
+SpecBegin(CloudantQuery)
+
+
+describe(@"cloudant query", ^{
+    
+    __block NSString *factoryPath;
+    __block CDTDatastoreManager *factory;
+    
+    beforeEach(^{
+        // Create a new CDTDatastoreFactory at a temp path
+        
+        NSString *tempDirectoryTemplate =
+        [NSTemporaryDirectory() stringByAppendingPathComponent:@"cloudant_sync_ios_tests.XXXXXX"];
+        const char *tempDirectoryTemplateCString = [tempDirectoryTemplate fileSystemRepresentation];
+        char *tempDirectoryNameCString =  (char *)malloc(strlen(tempDirectoryTemplateCString) + 1);
+        strcpy(tempDirectoryNameCString, tempDirectoryTemplateCString);
+        
+        char *result = mkdtemp(tempDirectoryNameCString);
+        expect(result).to.beTruthy();
+        
+        factoryPath = [[NSFileManager defaultManager]
+                       stringWithFileSystemRepresentation:tempDirectoryNameCString
+                       length:strlen(result)];
+        free(tempDirectoryNameCString);
+        
+        NSError *error;
+        factory = [[CDTDatastoreManager alloc] initWithDirectory:factoryPath error:&error];
+    });
+    
+    afterEach(^{
+        // Delete the databases we used
+        
+        factory = nil;
+        NSError *error;
+        [[NSFileManager defaultManager] removeItemAtPath:factoryPath error:&error];
+    });
+    
+    
+});
+
+SpecEnd

--- a/doc/index-query.md
+++ b/doc/index-query.md
@@ -1,5 +1,9 @@
 ## Finding documents within Cloudant Sync
 
+_This functionality is now deprecated and will be removed from this repository shortly.  Please use the our new [query engine][1] instead when looking for an indexing/query solution._
+
+[1]: https://github.com/cloudant/CDTDatastore/blob/master/doc/query.md
+
 Cloudant Sync provides simple and powerful ways to index and query
 your documents, allowing your applications to make the most of the
 data they store.

--- a/doc/query.md
+++ b/doc/query.md
@@ -1,11 +1,11 @@
 # Finding documents with Cloudant Sync
 
-This query engine is inspired by MongoDB's query implementation, so users of MongoDB should feel
+Cloudant Query is inspired by MongoDB's query implementation, so users of MongoDB should feel
 at home using it in their mobile applications.
 
-The aim is that the query you use on our cloud-based database works for your mobile application.
+The aim is that the query you use on Cloudant works for your mobile application.
 
-This query engine is meant to replace our previous [indexing/query][1] solution which will be removed from this project repository shortly.  The functionality provided by this query engine already exceeds that of the previous solution.
+This query engine replaces our previous [indexing/query][1] solution which will be removed from this project repository shortly.  The functionality provided by this query engine already exceeds that of the previous solution.
   
 
 [1]: https://github.com/cloudant/CDTDatastore/blob/master/doc/index-query.md
@@ -499,7 +499,7 @@ The one-index was over the `name` field, the three-index over `name`, `age` and 
 
 ## Grammar
 
-To help, I've tried to write a grammar/schema for the Query language.
+To help, Below is a grammar/schema for the Query language.
 
 Here:
 

--- a/doc/query.md
+++ b/doc/query.md
@@ -1,0 +1,560 @@
+# Finding documents with Cloudant Sync
+
+This query engine is inspired by MongoDB's query implementation, so users of MongoDB should feel
+at home using it in their mobile applications.
+
+The aim is that the query you use on our cloud-based database works for your mobile application.
+
+This query engine is meant to replace our previous [indexing/query][1] solution which will be removed from this project repository shortly.  The functionality provided by this query engine already exceeds that of the previous solution.
+  
+
+[1]: https://github.com/cloudant/CDTDatastore/blob/master/doc/index-query.md
+
+## Usage
+
+
+This query engine uses indexes explicitly defined over the fields in the document. Multiple
+indexes can be created for use in different queries, the same field may end up indexed in
+more than one index.
+
+Querying is carried out by supplying a query in the form of a dictionary which describes the
+query.
+
+For the following examples, assume two things.
+
+Firstly, we set up a `CDTDatastore` object, `ds`, as follows:
+
+```objc
+#import <CloudantSync.h>
+
+NSError *outError = nil;
+NSString *path = /* a path within your app's file hierarchy */;
+
+CDTDatastoreManager *manager =
+[[CDTDatastoreManager alloc] initWithDirectory:path
+                                         error:&outError];
+
+CDTDatastore *ds = [manager datastoreNamed:@"my_datastore"
+                                     error:&outError];
+```
+
+Secondly, these documents are in the datastore:
+
+```objc
+@{ @"name": @"mike", 
+   @"age": @12, 
+   @"pet": @{@"species": @"cat"} };
+
+@{ @"name": @"mike", 
+   @"age": @34, 
+   @"pet": @{@"species": @"dog"} };
+
+@{ @"name": @"fred", 
+   @"age": @23, 
+   @"pet": @{@"species": @"cat"} };
+```
+
+### Headers
+
+You need to include `CDTDatastore+Query.h`:
+
+```objc
+#import "CDTDatastore+Query.h"
+```
+
+### The CDTDatastore+Query Category 
+
+The `CDTDatastore+Query` category adds the ability to manage query indexes and execute queries directly on the `CDTDatastore` object.
+
+### Creating indexes
+
+In order to query documents, indexes need to be created over
+the fields to be queried against.
+
+Use `-ensureIndexed:withName:` to create indexes. These indexes are persistent
+across application restarts as they are saved to disk. They are kept up to date
+documents change; there's no need to call `-ensureIndexed:withName:` each
+time your applications starts, though there is no harm in doing so.
+
+The first argument to `-ensureIndexed:withName:` is a list of fields to
+put into this index. The second argument is a name for the index. This is used
+to delete indexes at a later stage and appears when you list the indexes
+in the database.
+
+A field can appear in more than one index. The query engine will select an
+appropriate index to use for a given query. However, the more indexes you have,
+the more disk space they will use and the greater overhead in keeping them
+up to date.
+
+To index values in sub-documents, use _dotted notation_. This notation puts
+the field names in the path to a particular value into a single string,
+separated by dots. Therefore, to index the `species`
+field of the `pet` sub-document in the examples above, use `pet.species`.
+
+```objc
+// Create an index over the name and age fields.
+NSString *name = [ds ensureIndexed:@[@"name", @"age", @"pet.species"] 
+                          withName:@"basic"]
+if (!name) {
+    // there was an error creating the index
+}
+```
+
+`-ensureIndexed:withName:` returns the name of the index if it is successful,
+otherwise it returns `nil`.
+
+If an index needs to be changed, first delete the existing index, then call 
+`-ensureIndexed:withName:` with the new definition.
+
+#### Indexing document metadata (_id and _rev)
+
+The document ID and revision ID are automatically indexed under `_id` and `_rev` 
+respectively. If you need to query on document ID or document revision ID,
+use these field names.
+
+#### Indexing array fields
+
+Indexing of array fields is supported. See "Array fields" below for the indexing and
+querying semantics.
+
+### Querying syntax
+
+Query documents using `NSDictionary` objects. These use the [Cloudant Query `selector`][sel]
+syntax. Several features of Cloudant Query are not yet supported in this implementation.
+See below for more details.
+
+[sel]: https://docs.cloudant.com/api/cloudant-query.html#selector-syntax
+
+#### Equality and comparisons
+
+To query for all documents where `pet.species` is `cat`:
+
+```objc
+@{ @"pet.species": @"cat" };
+```
+
+If you don't specify a condition for the clause, equality (`$eq`) is used. To use
+other conditions, supply them explicitly in the clause.
+
+To query for documents where `age` is greater than twelve use the `$gt` condition:
+
+```objc
+@{ @"age": @{ @"$gt": @12 } };
+```
+
+See below for supported operators (Selections -> Conditions).
+
+#### Compound queries
+
+Compound queries allow selection of documents based on more than one criteria.
+If you specify several clauses, they are implicitly joined by AND.
+
+To find all people named `fred` with a `cat` use:
+
+```objc
+@{ @"name": @"fred", @"pet.species": @"cat" };
+```
+
+##### Using OR to join clauses
+
+Use `$or` to find documents where just one of the clauses match.
+
+To find all people with a `dog` who are under thirty:
+
+```objc
+@{ @"$or": @[ @{ @"pet.species": @{ @"$eq": @"dog" } }, 
+              @{ @"age": @{ @"$lt": @30 } }
+            ]};
+```
+
+#### Using AND and OR in queries
+
+Using a combination of AND and OR allows the specification of complex queries.
+
+This selects documents where _either_ the person has a pet `dog` _or_ they are
+both over thirty _and_ named `mike`:
+
+```objc
+@{ @"$or": @[ @{ @"pet.species": @{ @"$eq": @"dog" } }, 
+              @{ @"$and": @[ @{ @"age": @{ @"$gt": @30 } },
+                             @{ @"name": @{ @"$eq": @"mike" } }
+                          ] }
+            ]};
+```
+
+### Executing queries
+
+To find documents matching a query, use the `CDTQIndexManager` objects `-find:`
+function. Use the returned object's `-enumerateObjectsUsingBlock:` method to iterate
+over the results:
+
+```objc
+CDTQResultSet *result = [ds find:query];
+[result enumerateObjectsUsingBlock:^(CDTDocumentRevision *rev, NSUInteger idx, BOOL *stop) {
+    // The returned revision object contains all fields for
+    // the object. You cannot project certain fields in the
+    // current implementation.
+    //
+    // rev: the result revision.
+    // idx: the index of this result.
+    // stop: set to YES to stop the iteration.
+}];
+```
+
+There is an extended version of the `-find:` method which supports:
+
+- Sorting results.
+- Projecting fields from documents rather than returning whole documents.
+- Skipping results.
+- Limiting the number of results returned.
+
+For any of these, use 
+
+#### Sorting
+
+Provide a sort document to `-find:skip:limit:fields:sort:` to sort the results of a query. 
+
+The sort document is an array of fields to sort by. Each field is represented by a 
+dictionary specifying the name of the field to sort by and the direction to sort.
+
+The sort document must use fields from a single index.
+
+As yet, you can't leave out the sort direction. The sort direction can be `asc` (ascending)
+or `desc` (descending).
+
+```objc
+NSArray *sortDocument = @[ @{ @"name": @"asc" }, 
+                           @{ @"age": @"desc" } ];
+CDTQResultSet *result = [ds find:query
+                            skip:0
+                           limit:0
+                          fields:nil
+                            sort:sortDocument];
+```
+
+Pass `nil` as the `sort` argument to disable sorting.
+
+#### Projecting fields
+
+Projecting fields is useful when you have a large document and only need to use a
+subset of the fields for a given view.
+
+To project certain fields from the documents included in the results, pass an
+array of field names to the `fields` argument. These field names must:
+
+- Be top level fields in the document.
+- Cannot use dotted notation to access sub-documents.
+
+For example, in the following document the `name`, `age` and `pet` fields could
+be projected, but the `species` field inside `pet` cannot:
+
+```json
+{
+    "name": "mike",
+    "age": 12,
+    "pet": { "species": "cat" }
+}
+```
+
+To project the `name` and `age` fields of the above document:
+
+```objc
+NSArray *fields = @[ @"name", @"age" ];
+CDTQResultSet *result = [ds find:query
+                            skip:0
+                           limit:0
+                          fields:fields
+                            sort:nil];
+```
+
+Pass `nil` as the `fields` argument to disable projection.
+
+#### Skip and limit
+
+Skip and limit allow retrieving subsets of the results. Amongst other things, this is
+useful in pagination.
+
+* `skip` skips over a number of results from the result set.
+* `limit` defines the maximum number of results to return for the query.
+
+To display the twenty-first to thirtieth results:
+
+```objc
+CDTQResultSet *result = [ds find:query
+                            skip:20
+                           limit:10
+                          fields:fields
+                            sort:nil];
+```
+
+To disable:
+
+- `skip`, pass `0` as the `skip` argument.
+- `limit`, pass `0` as the `limit` argument.
+
+### Array fields
+
+Indexing and querying over array fields is supported by this query engine, with some
+caveats.
+
+Take this document as an example:
+
+```
+{
+  _id: mike32
+  pet: [ cat, dog, parrot ],
+  name: mike,
+  age: 32
+}
+```
+
+You can create an index over the `pet` field:
+
+```objc
+NSString *name = [ds ensureIndexed:@[@"name", @"age", @"pet"] 
+                          withName:@"basic"]
+```
+
+Each value of the array is treated as a separate entry in the index. This means that
+a query such as:
+
+```
+{ pet: { $eq: cat } }
+```
+
+Will return the document `mike32`. Negation such as:
+
+```
+{ pet: { $not: { $eq: cat } } }
+```
+
+Will not return `mike32` because negation returns the set of documents that are not in the set of documents returned by the non-negated query. In other words the negated query above will return all of the documents that are not in the set of documents returned by `{ pet: { $eq: cat } }`.
+
+#### Restrictions
+
+Only one field in a given index may be an array. This is because each entry in each array
+requires an entry in the index, causing a Cartesian explosion in index size. Taking the
+above example, this document wouldn't be indexed because the `name` and `pet` fields are
+both indexed in a single index:
+
+
+```
+{
+  _id: mike32
+  pet: [ cat, dog, parrot ],
+  name: [ mike, rhodes ],
+  age: 32
+}
+```
+
+If this happens, an error will be emitted into the log but the indexing process will be
+successful.
+
+However, if there was one index with `pet` in and another with `name` in, like this:
+
+```objc
+NSString *name = [ds ensureIndexed:@[@"name", @"age"] 
+                          withName:@"one_index"];
+NSString *name = [ds ensureIndexed:@[@"age", @"pet"] 
+                          withName:@"another_index"]
+```
+
+The document _would_ be indexed in both of these indexes: each index only contains one of
+the array fields.
+
+Also see "Unsupported features", below.
+
+
+### Errors
+
+Error reporting is terrible right now. The only indication something went wrong is a
+`nil` return value from `-find:` or `-ensureIndexed:withName:`. We're working on
+adding logging.
+
+## Supported features
+
+Right now the list of supported features is:
+
+- Create compound indexes using dotted notation that index JSON fields.
+- Delete index by name.
+- Execute nested queries.
+- Limiting returned results.
+- Skipping results.
+- Queries can include unindexed fields.
+      
+Selectors -> combination
+
+- `$and`
+- `$or`
+
+Selectors -> Conditions -> Equalities
+
+- `$lt`
+- `$lte`
+- `$eq`
+- `$gte`
+- `$gt`
+- `$ne`
+
+Selectors -> combination
+
+- `$not`
+
+Selectors -> Condition -> Objects
+
+- `$exists`
+
+Selectors -> Condition -> Array
+
+- `$in`
+- `$nin`
+
+Implicit operators
+
+- Implicit `$and`.
+- Implicit `$eq`.
+
+Arrays
+
+- Indexing individual values in an array.
+- Querying for individual values in an array.
+
+## Unsupported features
+
+Some features are not supported yet. We're actively working to support features -- check the commit log :)
+
+### Query
+
+Overall restrictions:
+
+- Cannot use covering indexes with projection (`fields`) to avoid loading 
+  documents from the datastore.
+
+#### Query syntax
+
+- Using non-dotted notation to query sub-documents.
+    - That is, `{"pet": { "species": {"$eq": "cat"} } }` is unsupported,
+      you must use `{"pet.species": {"$eq": "cat"}}`.
+- Cannot use multiple conditions in a single clause, `{ field: { $gt: 7, $lt: 14 } }`.
+
+Selectors -> combination
+
+- `$nor`
+- `$all`
+- `$elemMatch`
+
+Selectors -> Condition -> Objects
+
+- `$type`
+
+Selectors -> Condition -> Array
+
+- `$size`
+
+Selectors -> Condition -> Misc
+
+- `$mod`
+- `$regex`
+
+
+Arrays
+
+- Dotted notation to index or query sub-documents in arrays.
+- Querying for exact array match, `{ field: [ 1, 3, 7 ] }`.
+- Querying to match a specific array element using dotted notation, `{ field.0: 1 }`.
+- Querying using `$all`.
+- Querying using `$elemMatch`.
+
+
+## Performance
+
+### Indexing
+
+These were run on an iPhone 5 on commit c9bd52102fab8a8906b5fd8fe89f1f0f87568ef6, 2014-10-21.
+
+The documents were simple, of the form:
+
+```json
+{ 
+    "name": "mike", 
+    "age": 34, 
+    "docNumber": 0, 
+    "pet": "cat" 
+}
+```
+
+The one-index was over the `name` field, the three-index over `name`, `age` and `pet`.
+
+| Number of documents  | Number of fields  | Indexing time (seconds) |
+| ------------:|---------------:| -----:|
+| 1,000      | 1 | 0.8s |
+| 1,000      | 3 | 0.8s |
+| 10,000      | 1 | 6.9s |
+| 10,000      | 3 | 7.6s |
+| 50,000      | 1 | 56.2s |
+| 50,000      | 3 | 60.7s |
+| 100,000      | 1 | 169.2s |
+| 100,000      | 3 | 179.9s |
+
+
+## Grammar
+
+To help, I've tried to write a grammar/schema for the Query language.
+
+Here:
+
+* Bold is used for the JSON formatting (or to indicate use of NSDictionary, NSArray etc. in objc).
+* Italic is variables in the grammar-like thing.
+* Quotes enclose literal string values.
+
+<pre>
+<em>query</em> := 
+    <strong>{ }</strong>
+    <strong>{</strong> <em>many-expressions</em> <strong>}</strong>
+
+<em>many-expressions</em> := <em>expression</em> (&quot;,&quot; <em>expression</em>)*
+
+<em>expression</em> := 
+    <em>compound-expression</em>
+    <em>comparison-expression</em>
+
+<em>compound-expression</em> := 
+    <strong>{</strong> (&quot;$and&quot; | &quot;$nor&quot; | &quot;$or&quot;) <strong>:</strong> <strong>[</strong> <em>many-expressions</em> <strong>] }</strong>  // nor not implemented
+    
+<em>comparison-expression</em> :=
+    <strong>{</strong> <em>field</em> <strong>:</strong> <strong>{</strong> <em>operator-expression</em> <strong>} }</strong>
+
+<em>negation-expression</em> := 
+    <strong>{</strong> &quot;$not&quot; <strong>:</strong> <strong>{</strong> <em>operator-expression</em> <strong>} }</strong>
+
+<em>operator-expression</em> := 
+    <em>negation-expression</em>
+    <strong>{</strong> <em>operator</em> <strong>:</strong> <em>simple-value</em> <strong>}</strong>
+    <strong>{</strong> &quot;$regex&quot; <strong>:</strong> <em>NSRegularExpression</em> <strong>}</strong>  // not implemented
+    <strong>{</strong> &quot;$mod&quot; <strong>:</strong> <strong>[</strong> <em>divisor, remainder</em> <strong>] }</strong>  // not implemented
+    <strong>{</strong> &quot;$elemMatch&quot; <strong>: {</strong> <em>many-expressions</em> <strong>} }</strong>  // not implemented
+    <strong>{</strong> &quot;$size&quot; <strong>:</strong> <em>positive-integer</em> <strong>}</strong>  // not implemented
+    <strong>{</strong> &quot;$all&quot; <strong>:</strong> <em>array-value</em> <strong>}</strong>  // not implemented
+    <strong>{</strong> &quot;$in&quot; <strong>:</strong> <em>array-value</em> <strong>}</strong>
+    <strong>{</strong> &quot;$nin&quot; <strong>:</strong> <em>array-value</em> <strong>}</strong>
+    <strong>{</strong> &quot;$exists&quot; <strong>:</strong> <em>boolean</em> <strong>}</strong>
+    <strong>{</strong> &quot;$type&quot; <strong>:</strong> <em>type</em> <strong>}</strong>  // not implemented
+
+<em>operator</em> := &quot;$gt&quot; | &quot;$gte&quot; | &quot;$lt&quot; | &quot;$lte&quot; | &quot;$eq&quot; | &quot;$ne&quot;
+
+// Obviously NSArray, but easier to express like this
+<em>array-value</em> := <strong>[</strong> simple-value (&quot;,&quot; simple-value)+ <strong>]</strong>
+
+// Objective-C mappings of basic types
+
+<em>field</em> := <em>NSString</em>  // a field name
+
+<em>simple-value</em> := <em>NSString</em> | <em>NSNumber</em>
+
+<em>positive-integer</em> := <em>NSNumber</em>
+
+<em>boolean</em> := <em>NSNumber (boxed BOOL)</em>
+
+<em>type</em> := <em>Class</em>
+</pre>
+


### PR DESCRIPTION
This PR adds the query code and tests from CloudantQueryObjC into the CDTDatastore repo.  The majority of the changes within this branch are additions of the Query .h and .m files.  Actual file modifications within this branch are detailed below:

- contents.xcworkspacedata: Adds query classes to Query group in workspace (done by Xcode)
- CloudantSync.h: Adds CDTDatastore+Query.h and CDTQResults.h to CloudantSync.h
- readme.md: Updates the old indexing/query reference to now match the new query syntax.
- Podfile: Add Specta, Expecta library reference.
- Tests OSX-Prefix.pch: Add Specta, Expecta library reference.
- project.pbxproj: Updated by Xcode
- Tests-Prefix.pch: Add Specta, Expecta library reference.
- index-query.md:  Update old indexing/query documentation to alert readers that the code will be removed and to reference the new query.md doc.
- query.md: This file was added and it includes the new query docs.  Worth a review.