### PR TITLE
Index documents with long deleted branches correctly [45667]

### DIFF
--- a/Tests/Podfile
+++ b/Tests/Podfile
@@ -6,7 +6,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 def import_pods
     pod "CDTDatastore", :path => "../"
     pod "MRDatabaseContentChecker"
-    pod 'Specta', :git => 'https://github.com/specta/specta.git', :tag => 'v0.3.0.beta1'
+    pod 'Specta'
     pod 'Expecta'
 end
 


### PR DESCRIPTION
Previously the index updating code used the revision provided by the
changes feed from the local database. However, this feed always provides
the revision with the highest revID, regardless of whether it's the
winning revision or not.

An incorrect revision might occur when there is a document with two
branches, and the longer branch is tombstoned. The tombstone revision
has a higher revID so is returned by the changes feed. However, we
actually want to index the non-deleted revision -- i.e., the current
winner.

```
            winner (returned by getDocumentWithId:...)
              |
       /---- 2-4f
1-97 --
       \---- 2-33 ---- 3-bc
                        |
                      deleted (returned by changes feed)
```

This fix uses a brute force approach. It simply uses
`[CDTDatastore -getDocumentsWithIds:]` to get the real winning revision
for every entry in the changes feed. The winning revision is used to
update the index. The list from changes is still needed to cover any
deleted items and to get the sequence number the index is up to date
with.

reviewer @tomblench 
reviewer @rhyshort 