### PR TITLE
Enable Replication Acceptance Tests to run against a specified CouchDB Instance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,6 +136,34 @@ Xcodebuild references:
 
 Miss out the `| xcpretty` if you didn't install that.
 
+### Configuring ReplicationAcceptance Tests
+
+ReplicationAcceptance are a set of tests which tests the replication function of CDTDatastore, the tests are found in the ReplicationAcceptance.xcworkspace in the ReplicationAcceptance directory in CDTDatastore. 
+
+The tests can be configured by using a series of environment variables. The environment variables are as follows:
+
+Environment Variable | Purpose | Default
+------------ | ------------- | ------------- | -------------
+`TEST_COUCH_HOST` | CouchDB hostname | `localhost`
+`TEST_COUCH_PORT` | Port couchdb is listening on | `5984`
+`TEST_COUCH_HTTP` | http protocol to use, either http or https | `http`
+`TEST_COUCH_USERNAME` | CouchDB account username | 
+`TEST_COUCH_PASSWROD` | CouchDB account Password | 
+
+
+Example
+
+```bash
+
+$ export TEST_COUCH_HOST=couchdbhost
+$ export TEST_COUCH_PORT=8080
+$ export TEST_COUCH_HTTP=http
+$ export TEST_COUCH_USERNAME=auser
+$ export TEST_COUCH_PASSWORD=apassword
+$ xcodebuild -workspace ReplicationAcceptance.xcworkspace -scheme RA_Tests_OSX -destination 'platform=OS X' test | xcpretty
+
+```
+
 ## Contributing your changes
 
 We follow a fairly standard proceedure:

--- a/ReplicationAcceptance/ReplicationAcceptance.xcodeproj/project.pbxproj
+++ b/ReplicationAcceptance/ReplicationAcceptance.xcodeproj/project.pbxproj
@@ -41,6 +41,10 @@
 		4510BA04F5FB481E882AF5EE /* libPods-ios.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C61CF9A9D4564F53BC1F7321 /* libPods-ios.a */; };
 		86A30343408047EEBBF8EC4C /* libPods-ios.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C61CF9A9D4564F53BC1F7321 /* libPods-ios.a */; };
 		8E89B680A5F347559033D1B3 /* libPods-osx.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 97F72706FFD44D88B6E5E667 /* libPods-osx.a */; };
+		984775051AB886790024B64C /* ReplicationSettings.m in Sources */ = {isa = PBXBuildFile; fileRef = 984775041AB886790024B64C /* ReplicationSettings.m */; };
+		984775061AB886790024B64C /* ReplicationSettings.m in Sources */ = {isa = PBXBuildFile; fileRef = 984775041AB886790024B64C /* ReplicationSettings.m */; };
+		984775081AB888F40024B64C /* ReplicationSettings.plist in Resources */ = {isa = PBXBuildFile; fileRef = 984775071AB888F40024B64C /* ReplicationSettings.plist */; };
+		984775091AB888F40024B64C /* ReplicationSettings.plist in Resources */ = {isa = PBXBuildFile; fileRef = 984775071AB888F40024B64C /* ReplicationSettings.plist */; };
 		9F8CA2C71A639AB000A0E91C /* ChangeTrackerNSURLProtocolTimedOut.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F8CA2C61A639AB000A0E91C /* ChangeTrackerNSURLProtocolTimedOut.m */; };
 		9F8CA2C81A639AB000A0E91C /* ChangeTrackerNSURLProtocolTimedOut.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F8CA2C61A639AB000A0E91C /* ChangeTrackerNSURLProtocolTimedOut.m */; };
 		9F8CA2C91A639AB000A0E91C /* ChangeTrackerNSURLProtocolTimedOut.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F8CA2C61A639AB000A0E91C /* ChangeTrackerNSURLProtocolTimedOut.m */; };
@@ -107,6 +111,9 @@
 		5E90CA923A123284AF6B8CE0 /* Pods-osx.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-osx.release.xcconfig"; path = "Pods/Target Support Files/Pods-osx/Pods-osx.release.xcconfig"; sourceTree = "<group>"; };
 		6A9AF7E2659CCF39B5454D35 /* Pods-ios.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ios.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ios/Pods-ios.debug.xcconfig"; sourceTree = "<group>"; };
 		97F72706FFD44D88B6E5E667 /* libPods-osx.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-osx.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		984775031AB886790024B64C /* ReplicationSettings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ReplicationSettings.h; sourceTree = "<group>"; };
+		984775041AB886790024B64C /* ReplicationSettings.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ReplicationSettings.m; sourceTree = "<group>"; };
+		984775071AB888F40024B64C /* ReplicationSettings.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = ReplicationSettings.plist; sourceTree = "<group>"; };
 		9F8CA2C51A639AB000A0E91C /* ChangeTrackerNSURLProtocolTimedOut.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ChangeTrackerNSURLProtocolTimedOut.h; sourceTree = "<group>"; };
 		9F8CA2C61A639AB000A0E91C /* ChangeTrackerNSURLProtocolTimedOut.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ChangeTrackerNSURLProtocolTimedOut.m; sourceTree = "<group>"; };
 		9F8CA2CA1A64E63F00A0E91C /* CDTRunBlocksForReplicatorDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDTRunBlocksForReplicatorDelegate.h; sourceTree = "<group>"; };
@@ -236,6 +243,8 @@
 				9F8CA2C61A639AB000A0E91C /* ChangeTrackerNSURLProtocolTimedOut.m */,
 				9FC2F12F19F72B710032A074 /* ReplicatorURLProtocolTester.h */,
 				9FC2F13019F72B710032A074 /* ReplicatorURLProtocolTester.m */,
+				984775031AB886790024B64C /* ReplicationSettings.h */,
+				984775041AB886790024B64C /* ReplicationSettings.m */,
 			);
 			path = ReplicationAcceptance;
 			sourceTree = "<group>";
@@ -246,6 +255,7 @@
 				27A7E67B189973EE007FAF1C /* ReplicationAcceptance-Info.plist */,
 				27A7E67C189973EE007FAF1C /* InfoPlist.strings */,
 				27A7E681189973EE007FAF1C /* ReplicationAcceptance-Prefix.pch */,
+				984775071AB888F40024B64C /* ReplicationSettings.plist */,
 			);
 			name = "Supporting Files";
 			sourceTree = "<group>";
@@ -445,6 +455,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				984775081AB888F40024B64C /* ReplicationSettings.plist in Resources */,
 				277992BB18A2503C00BAB6ED /* ReplicationAcceptance.h in Resources */,
 				27A7E69218997412007FAF1C /* InfoPlist.strings in Resources */,
 			);
@@ -454,6 +465,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				984775091AB888F40024B64C /* ReplicationSettings.plist in Resources */,
 				277992BC18A2503C00BAB6ED /* ReplicationAcceptance.h in Resources */,
 				27A7E6A41899741C007FAF1C /* InfoPlist.strings in Resources */,
 			);
@@ -586,6 +598,7 @@
 				27A7E6AF189975B2007FAF1C /* CloudantReplicationBase.m in Sources */,
 				9F8CA2C71A639AB000A0E91C /* ChangeTrackerNSURLProtocolTimedOut.m in Sources */,
 				27DFEEB718DB4A0D0052D487 /* Attachments.m in Sources */,
+				984775051AB886790024B64C /* ReplicationSettings.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -603,6 +616,7 @@
 				27A7E6B0189975B2007FAF1C /* CloudantReplicationBase.m in Sources */,
 				9F8CA2C81A639AB000A0E91C /* ChangeTrackerNSURLProtocolTimedOut.m in Sources */,
 				27DFEEB818DB4A0D0052D487 /* Attachments.m in Sources */,
+				984775061AB886790024B64C /* ReplicationSettings.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ReplicationAcceptance/ReplicationAcceptance.xcodeproj/project.pbxproj
+++ b/ReplicationAcceptance/ReplicationAcceptance.xcodeproj/project.pbxproj
@@ -364,8 +364,9 @@
 				86D70F8BECFE48389B7B243B /* Check Pods Manifest.lock */,
 				27A7E6991899741C007FAF1C /* Sources */,
 				27A7E69A1899741C007FAF1C /* Frameworks */,
-				27A7E69B1899741C007FAF1C /* Resources */,
 				BB7BC6BD2CC743AAAAC21269 /* Copy Pods Resources */,
+				27A7E69B1899741C007FAF1C /* Resources */,
+				9847750B1AB9CDE50024B64C /* Set replication settings */,
 			);
 			buildRules = (
 			);
@@ -550,6 +551,21 @@
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
+		};
+		9847750B1AB9CDE50024B64C /* Set replication settings */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"",
+			);
+			name = "Set replication settings";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/buildplist.sh\"";
 		};
 		BB7BC6BD2CC743AAAAC21269 /* Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/ReplicationAcceptance/ReplicationAcceptance/CloudantReplicationBase.m
+++ b/ReplicationAcceptance/ReplicationAcceptance/CloudantReplicationBase.m
@@ -10,6 +10,7 @@
 
 #import "CDTDatastoreManager.h"
 #import "CDTDatastore.h"
+#import "ReplicationSettings.h"
 
 #import <UNIRest.h>
 
@@ -28,7 +29,7 @@
     XCTAssertNil(error, @"CDTDatastoreManager had error");
     XCTAssertNotNil(self.factory, @"Factory is nil");
 
-    self.remoteRootURL = [NSURL URLWithString:@"http://localhost:5984"];
+    self.remoteRootURL = [NSURL URLWithString:[[ReplicationSettings alloc] init].serverURI];
     self.remoteDbPrefix = @"replication-acceptance";
 }
 

--- a/ReplicationAcceptance/ReplicationAcceptance/ReplicationSettings.h
+++ b/ReplicationAcceptance/ReplicationAcceptance/ReplicationSettings.h
@@ -1,0 +1,15 @@
+//
+//  ReplicationSettings.h
+//  ReplicationAcceptance
+//
+//  Created by Rhys Short on 17/03/2015.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+@interface ReplicationSettings : NSObject
+
+@property (readonly) NSString* serverURI;
+
+@end

--- a/ReplicationAcceptance/ReplicationAcceptance/ReplicationSettings.m
+++ b/ReplicationAcceptance/ReplicationAcceptance/ReplicationSettings.m
@@ -1,0 +1,75 @@
+//
+//  ReplicationSettings.m
+//  ReplicationAcceptance
+//
+//  Created by Rhys Short on 17/03/2015.
+//
+//
+
+#import "ReplicationSettings.h"
+
+@interface ReplicationSettings ()
+
+
+@property NSDictionary * replicationSettings;
+
+@end
+
+@implementation ReplicationSettings
+
+
+-(instancetype)init
+{
+    self = [super init];
+
+    if(self){
+        NSString *replicationSettingsPath = [[NSBundle bundleForClass:[ReplicationSettings class]]
+            pathForResource:@"ReplicationSettings"
+                     ofType:@"plist"];
+
+        _replicationSettings = [NSDictionary dictionaryWithContentsOfFile:replicationSettingsPath];
+    }
+    return self;
+}
+
+
+-(NSString *) host{
+
+    return self.replicationSettings[@"TEST_COUCH_HOST"];
+}
+
+- (NSString *) http {
+    return self.replicationSettings[@"TEST_COUCH_HTTP"];
+}
+
+-(NSString *) port{
+    return self.replicationSettings[@"TEST_COUCH_PORT"];
+}
+
+-(NSString *) username{
+    return self.replicationSettings[@"TEST_COUCH_USERNAME"];
+}
+
+-(NSString *)password {
+    return self.replicationSettings[@"TEST_COUCH_PASSWORD"];
+}
+
+-(NSString *) serverURI {
+
+    NSString * server;
+
+    if (self.username == nil || [self.username isEqualToString:@""] ){
+        server = [NSString stringWithFormat:@"%@://%@:%@", self.http,self.host,self.port ];
+    } else {
+         server = [NSString stringWithFormat:@"%@://%@:%@@%@:%@",
+                   self.http,
+                   self.username,
+                   self.password,
+                   self.host,
+                   self.port ];
+    }
+    
+    return server;
+}
+
+@end

--- a/ReplicationAcceptance/ReplicationAcceptance/ReplicationSettings.plist
+++ b/ReplicationAcceptance/ReplicationAcceptance/ReplicationSettings.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>TEST_COUCH_USERNAME</key>
+	<string></string>
+	<key>TEST_COUCH_PASSWORD</key>
+	<string></string>
+	<key>TEST_COUCH_HOST</key>
+	<string>localhost</string>
+	<key>TEST_COUCH_PORT</key>
+	<string>5984</string>
+	<key>TEST_COUCH_HTTP</key>
+	<string>http</string>
+</dict>
+</plist>

--- a/ReplicationAcceptance/buildplist.sh
+++ b/ReplicationAcceptance/buildplist.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+#We modify this plist file so as not to affect files under revision control
+info_plist="${BUILT_PRODUCTS_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ReplicationSettings.plist"
+
+echo $info_plist
+
+if [ "$TEST_COUCH_USERNAME" ]; then
+	echo "Setting couch username"
+    /usr/libexec/PlistBuddy -c "Set :TEST_COUCH_USERNAME '${TEST_COUCH_USERNAME}'" "${info_plist}"
+fi
+
+if [ "$TEST_COUCH_PASSWORD" ]; then
+		echo "Setting couch password"
+/usr/libexec/PlistBuddy -c "Set :TEST_COUCH_PASSWORD '${TEST_COUCH_PASSWORD}'" "${info_plist}"
+fi
+
+if [ "$TEST_COUCH_HOST" ]; then
+		echo "Setting couch host"
+/usr/libexec/PlistBuddy -c "Set :TEST_COUCH_HOST '${TEST_COUCH_HOST}'" "${info_plist}"
+fi
+
+if [ "$TEST_COUCH_PORT" ]; then
+		echo "Setting couch port"
+    /usr/libexec/PlistBuddy -c "Set :TEST_COUCH_PORT '${TEST_COUCH_PORT}'" "${info_plist}";
+fi
+
+if [ "$TEST_COUCH_HTTP" ]; then
+		echo "Setting couch http"
+    /usr/libexec/PlistBuddy -c "Set :TEST_COUCH_HTTP '${TEST_COUCH_HTTP}'" "${info_plist}";
+fi

--- a/build.rb
+++ b/build.rb
@@ -1,0 +1,102 @@
+#!/usr/bin/ruby 
+#
+#  -couch <type> couchdb1.6, couchdb2.0, cloudantSAAS, cloudantlocal - default is couchdb1.6
+
+#  -platform <platfrom> OSX | iOS default is OSX
+#  -platform-version iOS version to test agasint (only supported for iOS)
+#  -hardware the simultated hardware to test against eg iPhone 4S (only supported for iOS)
+#  -D* gets passed into build.
+#  
+#
+
+params = {}
+arg_is_value = false 
+prev_arg = nil
+
+
+ARGV.each do |arg|
+
+	 #process arguments into a hash
+	 unless arg_is_value 
+	 	params[arg[1,arg.length] ] = nil
+	 	$prev_arg = arg[1,arg.length] 
+	 	arg_is_value = true
+	 else
+	 	params[$prev_arg] = arg
+	 	arg_is_value = false 
+	 end
+
+end
+
+
+#apply defaults
+params["platform"] = "OSX" unless params["platform"] 
+params["couch"] = "couchdb1.6" unless params["couch"]
+params["platform-version"] = "latest" unless params["platform-version"]
+params["hardware"] = "iPhone 4S" unless params["hardware"]
+
+
+#launch docker
+puts "Starting docker container #{$couch}"
+
+#cloudant local current runs in a Vagrant box, rather than docker, this box is *always* running on cloudantsync001
+#so we skip the docker set up commands and change the options to enable connection to cloudant local
+if params["couch"] == "cloudantlocal" 
+
+	#Set evn variables to cloudant local settings
+
+	ENV["TEST_COUCH_USERNAME"] = "admin"
+	ENV["TEST_COUCH_PASSWORD"] = "pass"
+	ENV["TEST_COUCH_HOST"] = "127.0.0.1"
+	ENV["TEST_COUCH_PORT"] = "8081"
+	ENV["TEST_COUCH_HTTP"] = "http"
+else
+
+	docker_port = 5984 
+	#special case for couchdb2.0 it runs on port 15984 in the docker container rather than 5984
+	docker_port = 15984 if params["couch"] == "couchdb2.0"
+
+	unless system("docker run -p 5984:#{docker_port} -d -h db1.dockertest --name 'couchdb' #{params["couch"]}")
+		#we need to stop, we failed to run the docker container, just in case we will delete
+		system("docker rm couchdb")
+		exit 1
+
+	end
+end
+
+puts "Performing build"
+
+system("rake podupdate")
+
+#handle the differences in the platform
+
+replication_options = Array.new
+
+
+ENV.each do |key,value|
+
+	next unless key.start_with?("TEST_COUCH")
+
+
+	replication_options.push(key+"="+value)
+
+end
+
+if params["platform"] == "OSX"
+	system("xcodebuild -workspace ./ReplicationAcceptance/ReplicationAcceptance.xcworkspace -scheme 'RA_Tests_OSX' -destination 'platform=OS X' #{replication_options.join(" ")} test | xcpretty -r junit; exit ${PIPESTATUS[0]}")
+elsif params["platform"] == "iOS"
+	system("xcodebuild -workspace ./ReplicationAcceptance/ReplicationAcceptance.xcworkspace -scheme 'RA_Tests' -destination 'platform=iOS Simulator,OS=#{params["platform-version"]},name=#{params["hardware"]}' #{replication_options.join(" ")}  test | xcpretty -r junit; exit ${PIPESTATUS[0]}")
+end
+
+#get the build exit code, will exit with this after tearing down the docker container
+exitcode = $?
+
+
+unless params["couch"] == "cloudantlocal"
+	puts "Tearing down docker container" 
+	system("docker stop couchdb")
+
+	system("docker rm couchdb")
+end
+
+exit exitcode.to_i


### PR DESCRIPTION
The aim of this PR is to create a build script for the CI server to use to build the replication acceptance tests in a controlled manor. In a similar vein to the build script for sync-android.

1. Modified `CloudantReplicationTestBase` to get the URI for the test server from a new ReplicationSettings, which reads the configuration from a plist file, `ReplicationSettings.plist`.

2.  `ReplicationSettings.plist` file is modified based on environment variables by `buildplist.sh` during the 
xcode build process. 

3. `build.rb` manages the lifecycle of docker containers which run an instance of CouchDB, at the version specified by the command line argument. The script exits with the same exit code provided by  the xcodebuild command.


reviewer @mikerhodes 
reviewer @emlaver 