### PR TITLE
Add CloudKit-inspired changes fetcher

### DIFF
--- a/CDTDatastore.xcworkspace/contents.xcworkspacedata
+++ b/CDTDatastore.xcworkspace/contents.xcworkspacedata
@@ -467,6 +467,12 @@
          <FileRef
             location = "group:CDTLogging.m">
          </FileRef>
+         <FileRef
+            location = "group:CDTFetchChanges.h">
+         </FileRef>
+         <FileRef
+            location = "group:CDTFetchChanges.m">
+         </FileRef>
       </Group>
       <Group
          location = "group:Classes/ios"

--- a/Classes/common/CDTFetchChanges.h
+++ b/Classes/common/CDTFetchChanges.h
@@ -1,0 +1,167 @@
+//
+//  CDTFetchChanges.h
+//  CloudantSync
+//
+//  Created by Michael Rhodes on 31/03/2015.
+//  Copyright (c) 2015 IBM Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+@class CDTDatastore;
+@class CDTDocumentRevision;
+
+/**
+ CDTFetchChanges objects report changes to a database. The changes include documents which
+ have been created, updated or deleted. Use this class to update your user interface efficiently
+ when notified a replication is complete, for example, by updating elements for only those
+ documents that have changed.
+
+ CDTFetchChanges provides callbacks for updated and created documents (documentChangedBlock)
+ and deleted documents (documentWithIDWasDeletedBlock). It also provides a completion block
+ for when all changes have been received and processed (fetchRecordChangesCompletionBlock).
+ The documentChangedBlock is passed the current revision of each document, the
+ documentWithIDWasDeletedBlock is just passed the id of the deleted document.
+
+ In addition, CDTFetchChanges is able to report on changes since a given point. The completion
+ block provides a sequence value which can be passed to future requests to have only changes
+ from that point reported. This allows your application to make incremental updates
+ in response to changes in a database.
+
+ The sequence value should be treated as an opaque value, but can be saved and used across
+ application sessions.
+
+ The blocks you assign to process the fetched documents are executed serially on an
+ internal queue managed by the operation. Your blocks must be capable of executing
+ on a background thread, so any tasks that require access to the main thread must
+ be redirected accordingly.
+ */
+@interface CDTFetchChanges : NSOperation
+
+#pragma mark Properties
+
+/**
+ The datastore whose changes should be reported.
+
+ Typically this is set with the initialiser.
+ */
+@property (nonatomic, strong) CDTDatastore *datastore;
+
+/**
+ The sequence value identifying the starting point for reading changes.
+
+ The value to use for this is returned by the completion block for a fetch request. This sequence
+ value can be used to
+ receive changes that have occured since the previous request.
+ Treat the sequence value as an opaque string; different implementations may provide
+ differently formatted values. A given sequence value should only be used with the
+ database that it was received from.
+
+ Typically this is set with the initialiser.
+ */
+@property (nonatomic, copy) NSString *startSequenceValue;
+
+#pragma mark Callbacks
+
+/**
+ The block to execute for each changed document.
+
+ The block returns no value and takes the following parameter:
+
+ <dl>
+ <dt>revision</dt>
+ <dd>The winning revision for the document that changed.</dd>
+ </dl>
+
+ The operation object executes this block once for each document in the database that changed
+ since the previous fetch request. Each time the block is executed, it is executed
+ serially with respect to the other progress blocks of the operation. If no documents
+ changed, the block is not executed.
+
+ If you intend to use this block to process results, set it before executing the
+ operation or submitting it to a queue.
+ */
+@property (nonatomic, copy) void (^documentChangedBlock)(CDTDocumentRevision *revision);
+
+
+/**
+ The block to execute for each deleted document.
+ 
+ The block returns no value and takes the following parameters:
+ 
+ <dl>
+ <dt>docId</dt>
+ <dd>The document id for the deleted document.</dd>
+ </dl>
+ 
+ The operation object executes this block once for each document in the database that
+ was deleted since the previous fetch request. Each time the block is executed, it 
+ is executed serially with respect to the other progress blocks of the operation. 
+ If no documents were deleted, the block is not executed.
+ 
+ If you intend to use this block to process results, set it before executing the 
+ operation or submitting it to a queue. 
+ */
+@property (nonatomic, copy) void (^documentWithIDWasDeletedBlock)(NSString *docId);
+
+/**
+ The block to execute when all changes have been reported.
+
+ The block returns no value and takes the following parameters:
+
+ <dl>
+ <dt>newSequenceValue</dt>
+ <dd>The new sequence value from the database. You can store this value locally and use it
+ during subsequent fetch operations to limit the results to documents that changed since
+ this operation executed. A sequence value is only valid for the database it was
+ originally retrieved from.</dd>
+
+ <dt>startSequenceValue</dt>
+ <dd>The sequence value you specified when you initialized the operation object.</dd>
+
+ <dt>fetchError</dt>
+ <dd>An error object containing information about a problem, or nil if the changes are
+ retrieved successfully.</dd>
+ </dl>
+
+ The operation object executes this block only once, at the conclusion of the operation. It
+ is executed after all individual change blocks.
+ The block is executed serially with respect to the other progress blocks of the operation.
+
+ If you intend to use this block to process results, set it before executing the operation or
+ submitting the operation object to a queue.
+ */
+@property (nonatomic, copy) void (^fetchRecordChangesCompletionBlock)
+    (NSString *newSequenceValue, NSString *startSequenceValue, NSError *fetchError);
+
+#pragma mark Initialisers
+
+/**
+ Initializes and returns an object configured to fetch changes in the specified database.
+ 
+ When initializing the fetch object, use the sequence value from a previous fetch request if 
+ you have one. You can archive sequence values and write them to disk for later use if needed.
+ 
+ After initializing the operation, associate at least one progress block with the operation 
+ object (excluding the completion block) to process the results. 
+ 
+ @param datastore The datastore containing the changes that should be fetched.
+ @param previousServerChangeToken The sequence value from a previous fetch. This is the value
+            passed to the completionHandler for this object. This value limits the changes
+            retrieved to those occuring after this sequence value. Pass `nil` to receive
+            all changes.
+ 
+ @return An initialised fetch object.
+ */
+- (instancetype)initWithDatastore:(CDTDatastore *)datastore
+               startSequenceValue:(NSString *)startSequenceValue;
+
+
+@end

--- a/Classes/common/CDTFetchChanges.m
+++ b/Classes/common/CDTFetchChanges.m
@@ -1,0 +1,115 @@
+//
+//  CDTFetchChanges.m
+//  CloudantSync
+//
+//  Created by Michael Rhodes on 31/03/2015.
+//  Copyright (c) 2015 IBM Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+#import "CDTFetchChanges.h"
+
+#import "CDTDatastore.h"
+#import "CDTDocumentRevision.h"
+
+#import "TD_Database.h"
+
+@implementation CDTFetchChanges
+
+#pragma mark Initialisers
+
+- (instancetype)initWithDatastore:(CDTDatastore *)datastore
+               startSequenceValue:(NSString *)startSequenceValue
+{
+    self = [super init];
+    if (self) {
+        _datastore = datastore;
+        _startSequenceValue = [startSequenceValue copy];
+    }
+    return self;
+}
+
+#pragma mark Instance methods
+
+- (void)main
+{
+    TDChangesOptions options = {.limit = 500,
+        .contentOptions = 0,                                
+        .includeDocs = NO,  // we only need the docIDs and sequences, body is retrieved separately
+        .includeConflicts = FALSE,
+        .sortBySequence = TRUE};
+    
+    TD_RevisionList *changes;
+    SequenceNumber lastSequence = [_startSequenceValue longLongValue];
+
+    do {
+        changes = [[_datastore database] changesSinceSequence:lastSequence
+                                                      options:&options
+                                                       filter:nil
+                                                       params:nil];
+        lastSequence = [self notifyChanges:changes startingSequence:lastSequence];
+    } while (changes.count > 0);
+
+    void (^f)(NSString *nsv, NSString *ssv, NSError *fe) = self.fetchRecordChangesCompletionBlock;
+    if (f) {
+        f([[NSNumber numberWithLongLong:lastSequence] stringValue], _startSequenceValue, nil);
+    }
+}
+
+/*
+ Process a batch of changes and return the last sequence value in the changes.
+ 
+ This method works out whether each change is an update/create or a delete, and calls
+ the user-provided callback for each.
+ 
+ @param changes changes come from the from the -changesSinceSequence:options:filter:params: call
+ @param startingSequence the sequence value used for the list passed in `changes`.
+            This is returned if no changes are processed.
+ 
+ @return Last sequence number in the changes processed, used for the next _changes call.
+ */
+- (SequenceNumber)notifyChanges:(TD_RevisionList *)changes
+               startingSequence:(SequenceNumber)startingSequence
+{
+    SequenceNumber lastSequence = startingSequence;
+    
+    // _changes provides the revs with highest rev ID, which might not be the
+    // winning revision (e.g., tombstone on long doc branch). For all docs
+    // that are updated rather than deleted, we need to be sure we index the
+    // winning revision. This loop gets those revisions.
+    NSMutableDictionary *updatedRevisions = [NSMutableDictionary dictionary];
+    for (CDTDocumentRevision *rev in [_datastore getDocumentsWithIds:[changes allDocIDs]]) {
+        if (rev != nil && !rev.deleted) {
+            updatedRevisions[rev.docId] = rev;
+        }
+    }
+    
+    for (TD_Revision *change in changes) {
+        
+        CDTDocumentRevision *updatedRevision;
+        if ((updatedRevision = updatedRevisions[change.docID]) != nil) {
+            void (^dcb)(CDTDocumentRevision *r) = self.documentChangedBlock;
+            if (dcb) {
+                dcb(updatedRevision);
+            }
+        } else {
+            void (^ddb)(NSString *docId) = self.documentWithIDWasDeletedBlock;
+            if (ddb) {
+                ddb(change.docID);
+            }
+        }
+        
+        lastSequence = change.sequence;
+    }
+    
+    return lastSequence;
+}
+
+
+@end

--- a/Classes/common/CloudantSync.h
+++ b/Classes/common/CloudantSync.h
@@ -22,6 +22,7 @@
 #import "CDTMutableDocumentRevision.h"
 #import "CDTDocumentBody.h"
 #import "CDTAttachment.h"
+#import "CDTFetchChanges.h"
 
 #import "CDTReplicator.h"
 #import "CDTPushReplication.h"


### PR DESCRIPTION
CDTFetchChanges can be thought a more useful changes feed for
the outside world. It returns either the winning revision for
changes or new documents, or the IDs for deleted documents,
sparing callers from the plumbing required to work this out.

The CDTFetchChanges class allows users to find out what has
changed in a database. Inspired by CloudKit's fetch operations,
it uses a block-based method for notifying of the changes to
a database. The class uses sequence values, as one would expect,
to do this.

The class was build in response to our own issues reading
changes for our indexing code.

BugId: 45845

reviewer: @indisoluble 
reviewer: @gadamc 