### PR TITLE
Port index encryption code to Query

### DIFF
--- a/Classes/common/query/CDTQIndexManager.h
+++ b/Classes/common/query/CDTQIndexManager.h
@@ -49,7 +49,11 @@ typedef NS_ENUM(NSInteger, CDTQQueryError) {
     /**
      * No index with this name was found.
      */
-    CDTQIndexErrorIndexDoesNotExist = 3
+    CDTQIndexErrorIndexDoesNotExist = 3,
+    /**
+     * Key provided could not be used to initialize index manager
+     */
+    CDTQIndexErrorEncryptionKeyError = 4
 };
 
 /**

--- a/EncryptionTests/Encryption Tests/CDTQIndexManagerEncryptionTests.m
+++ b/EncryptionTests/Encryption Tests/CDTQIndexManagerEncryptionTests.m
@@ -1,0 +1,216 @@
+//
+//  CDTQIndexManagerEncryptionTests.m
+//  EncryptionTests
+//
+//  Created by Enrique de la Torre Fernandez on 08/04/2015.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#import <XCTest/XCTest.h>
+
+#import "CloudantSyncTests.h"
+#import "CloudantTests+EncryptionTests.h"
+#import "CDTDatastoreManager+EncryptionKey.h"
+#import "CDTEncryptionKeyNilProvider.h"
+#import "CDTHelperFixedKeyProvider.h"
+#import "FMDatabase+SQLCipher.h"
+
+#import "CDTQIndexManager.h"
+
+@interface CDTQIndexManagerEncryptionTests : CloudantSyncTests
+
+@end
+
+@implementation CDTQIndexManagerEncryptionTests
+
+- (void)setUp
+{
+    [super setUp];
+
+    // Put setup code here. This method is called before the invocation of each test method in the
+    // class.
+}
+
+- (void)tearDown
+{
+    // Put teardown code here. This method is called after the invocation of each test method in the
+    // class.
+
+    [super tearDown];
+}
+
+- (void)testCreateQueryIndexManagerWithEncryptionKeyNilProvider
+{
+    CDTEncryptionKeyNilProvider *provider = [CDTEncryptionKeyNilProvider provider];
+    CDTDatastore *datastore = [self.factory datastoreNamed:@"create_query_index_tests_nilprovider"
+                                 withEncryptionKeyProvider:provider
+                                                     error:nil];
+
+    NSError *err = nil;
+    CDTQIndexManager *im = [[CDTQIndexManager alloc] initUsingDatastore:datastore error:&err];
+
+    XCTAssertNotNil(im, @"indexManager is not nil");
+    XCTAssertNil(err, @"error has to be nil");
+}
+
+- (void)testCreateQueryIndexManagerWithEncryptionKeyNilProviderDoesNotCipherIndex
+{
+    // Create index
+    CDTEncryptionKeyNilProvider *provider = [CDTEncryptionKeyNilProvider provider];
+    CDTDatastore *datastore =
+        [self.factory datastoreNamed:@"create_query_index_tests_nilprovider_notcipher"
+            withEncryptionKeyProvider:provider
+                                error:nil];
+
+    __unused CDTQIndexManager *im = [[CDTQIndexManager alloc] initUsingDatastore:datastore error:nil];
+
+    // Check
+    NSString *path = [CloudantSyncTests pathForQueryIndexInDatastore:datastore];
+
+    XCTAssertEqual([FMDatabase isDatabaseUnencryptedAtPath:path],
+                   kFMDatabaseUnencryptedIsUnencrypted,
+                   @"If no key is provided, index should not be encrypted");
+}
+
+- (void)testCreateQueryIndexManagerWithFixedKeyProvider
+{
+    CDTHelperFixedKeyProvider *provider = [[CDTHelperFixedKeyProvider alloc] init];
+    CDTDatastore *datastore = [self.factory datastoreNamed:@"create_query_index_tests_fixedprovider"
+                                 withEncryptionKeyProvider:provider
+                                                     error:nil];
+
+    NSError *err = nil;
+    CDTQIndexManager *im = [[CDTQIndexManager alloc] initUsingDatastore:datastore error:&err];
+
+    XCTAssertNotNil(im, @"indexManager is not nil");
+    XCTAssertNil(err, @"error has to be nil");
+}
+
+- (void)testCreateQueryIndexManagerWithFixedKeyProviderCiphersIndex
+{
+    // Create index
+    CDTHelperFixedKeyProvider *provider = [[CDTHelperFixedKeyProvider alloc] init];
+    CDTDatastore *datastore =
+        [self.factory datastoreNamed:@"create_query_index_textests_fixedprovider_cipher"
+            withEncryptionKeyProvider:provider
+                                error:nil];
+
+    __unused CDTQIndexManager *im = [[CDTQIndexManager alloc] initUsingDatastore:datastore error:nil];
+
+    // Check
+    NSString *path = [CloudantSyncTests pathForQueryIndexInDatastore:datastore];
+
+    XCTAssertEqual([FMDatabase isDatabaseUnencryptedAtPath:path], kFMDatabaseUnencryptedIsEncrypted,
+                   @"If a key is provided, index has to be encrypted");
+}
+
+- (void)testCreateQueryIndexManagerWithEncryptionKeyNilProviderFailsIfDBExistsAndItIsEncrypted
+{
+    // Create datastore
+    CDTEncryptionKeyNilProvider *provider = [CDTEncryptionKeyNilProvider provider];
+    CDTDatastore *datastore =
+        [self.factory datastoreNamed:@"create_query_index_tests_nilprovider_fails_with_cipher_db"
+            withEncryptionKeyProvider:provider
+                                error:nil];
+
+    // Copy encrypted db to index folder
+    NSFileManager *defaultManager = [NSFileManager defaultManager];
+    NSString *indexDBPath = [CloudantTests pathForQueryIndexInDatastore:datastore];
+    NSString *indexDirectoryPath = [indexDBPath stringByDeletingLastPathComponent];
+
+    [defaultManager createDirectoryAtPath:indexDirectoryPath
+              withIntermediateDirectories:YES
+                               attributes:nil
+                                    error:nil];
+
+    NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+    NSString *assetPath = [bundle pathForResource:@"emptyencryptedindex" ofType:@"sqlite"];
+
+    [defaultManager copyItemAtPath:assetPath toPath:indexDBPath error:nil];
+
+    // Test
+    NSError *err = nil;
+    CDTQIndexManager *im = [[CDTQIndexManager alloc] initUsingDatastore:datastore error:&err];
+
+    XCTAssertNil(im, @"indexManager is nil");
+    XCTAssertNotNil(err, @"There is an error");
+}
+
+- (void)testCreateQueryIndexManagerWithFixedKeyProviderFailsIfDBExistsAndItIsNotEncrypted
+{
+    // Create datastore
+    CDTHelperFixedKeyProvider *provider = [[CDTHelperFixedKeyProvider alloc] init];
+    CDTDatastore *datastore =
+        [self.factory datastoreNamed:
+                          @"create_query_index_textests_fixedprovider_fails_with_noncipher_db"
+            withEncryptionKeyProvider:provider
+                                error:nil];
+
+    // Copy non-encrypted db to index folder
+    NSFileManager *defaultManager = [NSFileManager defaultManager];
+    NSString *indexDBPath = [CloudantTests pathForQueryIndexInDatastore:datastore];
+    NSString *indexDirectoryPath = [indexDBPath stringByDeletingLastPathComponent];
+
+    [defaultManager createDirectoryAtPath:indexDirectoryPath
+              withIntermediateDirectories:YES
+                               attributes:nil
+                                    error:nil];
+
+    NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+    NSString *assetPath = [bundle pathForResource:@"emptynonencryptedindex" ofType:@"sqlite"];
+
+    [defaultManager copyItemAtPath:assetPath toPath:indexDBPath error:nil];
+
+    // Test
+    NSError *err = nil;
+    CDTQIndexManager *im = [[CDTQIndexManager alloc] initUsingDatastore:datastore error:&err];
+
+    XCTAssertNil(im, @"indexManager is nil");
+    XCTAssertNotNil(err, @"There is an error");
+}
+
+- (void)testCreateQueryIndexManagerWithFixedKeyProviderFailsIfDBIsEncryptedButKeyIsWrong
+{
+    // Create datastore
+    CDTHelperFixedKeyProvider *provider = [[CDTHelperFixedKeyProvider alloc] init];
+
+    NSString *otherKey =
+        [[provider encryptionKey] stringByAppendingString:[provider encryptionKey]];
+    provider = [[CDTHelperFixedKeyProvider alloc] initWithKey:otherKey];
+
+    CDTDatastore *datastore = [self.factory
+                   datastoreNamed:@"create_query_index_textests_fixedprovider_fails_with_wrong_key"
+        withEncryptionKeyProvider:provider
+                            error:nil];
+
+    // Copy encrypted db to index folder
+    NSFileManager *defaultManager = [NSFileManager defaultManager];
+    NSString *indexDBPath = [CloudantTests pathForQueryIndexInDatastore:datastore];
+    NSString *indexDirectoryPath = [indexDBPath stringByDeletingLastPathComponent];
+    
+    [defaultManager createDirectoryAtPath:indexDirectoryPath
+              withIntermediateDirectories:YES
+                               attributes:nil
+                                    error:nil];
+    
+    NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+    NSString *assetPath = [bundle pathForResource:@"emptyencryptedindex" ofType:@"sqlite"];
+    
+    [defaultManager copyItemAtPath:assetPath toPath:indexDBPath error:nil];
+    
+    // Test
+    NSError *err = nil;
+    CDTQIndexManager *im = [[CDTQIndexManager alloc] initUsingDatastore:datastore error:&err];
+
+    XCTAssertNil(im, @"indexManager is nil");
+    XCTAssertNotNil(err, @"There is an error");
+}
+
+@end

--- a/EncryptionTests/EncryptionTests.xcodeproj/project.pbxproj
+++ b/EncryptionTests/EncryptionTests.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 		CD48786F1A9BA6C80070EB63 /* CloudantSyncTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD48786B1A9BA6C80070EB63 /* CloudantSyncTests.m */; };
 		CD4878701A9BA6C80070EB63 /* CloudantTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD48786D1A9BA6C80070EB63 /* CloudantTests.m */; };
 		CD4878711A9BA6C80070EB63 /* CloudantTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD48786D1A9BA6C80070EB63 /* CloudantTests.m */; };
+		CD55A19B1AD56F2300A52281 /* CDTQIndexManagerEncryptionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD55A19A1AD56F2300A52281 /* CDTQIndexManagerEncryptionTests.m */; };
+		CD55A19C1AD56F2300A52281 /* CDTQIndexManagerEncryptionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD55A19A1AD56F2300A52281 /* CDTQIndexManagerEncryptionTests.m */; };
 		CD5D68311AB347D700F0BF8A /* DatastoreEncryptionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD5D68301AB347D700F0BF8A /* DatastoreEncryptionTests.m */; };
 		CD5D68321AB347D700F0BF8A /* DatastoreEncryptionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD5D68301AB347D700F0BF8A /* DatastoreEncryptionTests.m */; };
 		CDCB7A331AB3AB51000D8FFC /* DatastoreManagerEncryptionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CDCB7A321AB3AB51000D8FFC /* DatastoreManagerEncryptionTests.m */; };
@@ -52,6 +54,7 @@
 		CD48786B1A9BA6C80070EB63 /* CloudantSyncTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CloudantSyncTests.m; path = ../../Tests/Tests/CloudantSyncTests.m; sourceTree = "<group>"; };
 		CD48786C1A9BA6C80070EB63 /* CloudantTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CloudantTests.h; path = ../../Tests/Tests/CloudantTests.h; sourceTree = "<group>"; };
 		CD48786D1A9BA6C80070EB63 /* CloudantTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CloudantTests.m; path = ../../Tests/Tests/CloudantTests.m; sourceTree = "<group>"; };
+		CD55A19A1AD56F2300A52281 /* CDTQIndexManagerEncryptionTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTQIndexManagerEncryptionTests.m; sourceTree = "<group>"; };
 		CD5D68301AB347D700F0BF8A /* DatastoreEncryptionTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DatastoreEncryptionTests.m; sourceTree = "<group>"; };
 		CDCB7A321AB3AB51000D8FFC /* DatastoreManagerEncryptionTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DatastoreManagerEncryptionTests.m; sourceTree = "<group>"; };
 		CDEE6ECB1AAF3BD0002C96C0 /* CloudantTests+EncryptionTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "CloudantTests+EncryptionTests.h"; path = "../../Tests/Tests/CloudantTests+EncryptionTests.h"; sourceTree = "<group>"; };
@@ -121,6 +124,7 @@
 			children = (
 				CD00CBC01AC7705200C3F2D5 /* Assets */,
 				CD3FBCAA1AB05C080032376E /* Helpers */,
+				CD55A19A1AD56F2300A52281 /* CDTQIndexManagerEncryptionTests.m */,
 				CD48786C1A9BA6C80070EB63 /* CloudantTests.h */,
 				CD48786D1A9BA6C80070EB63 /* CloudantTests.m */,
 				CDEE6ECB1AAF3BD0002C96C0 /* CloudantTests+EncryptionTests.h */,
@@ -345,6 +349,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CD55A19B1AD56F2300A52281 /* CDTQIndexManagerEncryptionTests.m in Sources */,
 				CDEE6ECD1AAF3BD0002C96C0 /* CloudantTests+EncryptionTests.m in Sources */,
 				CD3FBCAD1AB05CAB0032376E /* CDTHelperFixedKeyProvider.m in Sources */,
 				CD48786E1A9BA6C80070EB63 /* CloudantSyncTests.m in Sources */,
@@ -360,6 +365,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CD55A19C1AD56F2300A52281 /* CDTQIndexManagerEncryptionTests.m in Sources */,
 				CDEE6ECE1AAF3BD0002C96C0 /* CloudantTests+EncryptionTests.m in Sources */,
 				CD3FBCAE1AB05CAB0032376E /* CDTHelperFixedKeyProvider.m in Sources */,
 				CD48786F1A9BA6C80070EB63 /* CloudantSyncTests.m in Sources */,

--- a/Tests/Tests.xcodeproj/project.pbxproj
+++ b/Tests/Tests.xcodeproj/project.pbxproj
@@ -76,6 +76,28 @@
 		9F95D61118CF6A580006D349 /* DBQueryUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F95D60F18CF6A580006D349 /* DBQueryUtils.m */; };
 		9FC082981913378F0024EA1E /* DatastoreConflictResolvers.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FC082971913378F0024EA1E /* DatastoreConflictResolvers.m */; };
 		9FC082991913378F0024EA1E /* DatastoreConflictResolvers.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FC082971913378F0024EA1E /* DatastoreConflictResolvers.m */; };
+		CD00CBBE1AC7703800C3F2D5 /* emptyencryptedindex.sqlite in Resources */ = {isa = PBXBuildFile; fileRef = CD00CBBD1AC7703800C3F2D5 /* emptyencryptedindex.sqlite */; };
+		CD00CBBF1AC7703800C3F2D5 /* emptyencryptedindex.sqlite in Resources */ = {isa = PBXBuildFile; fileRef = CD00CBBD1AC7703800C3F2D5 /* emptyencryptedindex.sqlite */; };
+		CD0D10EC1AB09CE8003315B5 /* TD_DatabaseDeletionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD0D10EB1AB09CE8003315B5 /* TD_DatabaseDeletionTests.m */; };
+		CD0D10ED1AB09CE8003315B5 /* TD_DatabaseDeletionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD0D10EB1AB09CE8003315B5 /* TD_DatabaseDeletionTests.m */; };
+		CD3FBCA61AB05A170032376E /* CDTHelperFixedKeyProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = CD3FBCA31AB05A170032376E /* CDTHelperFixedKeyProvider.m */; };
+		CD3FBCA71AB05A170032376E /* CDTHelperFixedKeyProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = CD3FBCA31AB05A170032376E /* CDTHelperFixedKeyProvider.m */; };
+		CD3FBCA81AB05A170032376E /* CDTHelperOneUseKeyProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = CD3FBCA51AB05A170032376E /* CDTHelperOneUseKeyProvider.m */; };
+		CD3FBCA91AB05A170032376E /* CDTHelperOneUseKeyProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = CD3FBCA51AB05A170032376E /* CDTHelperOneUseKeyProvider.m */; };
+		CD55A1981AD56B3600A52281 /* CDTQIndexManagerEncryptionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD55A1971AD56B3600A52281 /* CDTQIndexManagerEncryptionTests.m */; };
+		CD55A1991AD56B3600A52281 /* CDTQIndexManagerEncryptionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD55A1971AD56B3600A52281 /* CDTQIndexManagerEncryptionTests.m */; };
+		CD7110421AB6282500558645 /* DatastoreEncryptionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD7110401AB6282500558645 /* DatastoreEncryptionTests.m */; };
+		CD7110431AB6282500558645 /* DatastoreEncryptionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD7110401AB6282500558645 /* DatastoreEncryptionTests.m */; };
+		CD7110441AB6282500558645 /* DatastoreManagerEncryptionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD7110411AB6282500558645 /* DatastoreManagerEncryptionTests.m */; };
+		CD7110451AB6282500558645 /* DatastoreManagerEncryptionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD7110411AB6282500558645 /* DatastoreManagerEncryptionTests.m */; };
+		CD79FFE11A9B40FA00F5B5C5 /* IndexManagerEncryptionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD79FFDF1A9B3E0F00F5B5C5 /* IndexManagerEncryptionTests.m */; };
+		CD79FFE71A9B478A00F5B5C5 /* IndexManagerEncryptionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD79FFDF1A9B3E0F00F5B5C5 /* IndexManagerEncryptionTests.m */; };
+		CD94A6FE1AB8A24C006C8343 /* emptyencrypteddb.touchdb in Resources */ = {isa = PBXBuildFile; fileRef = CD94A6FD1AB8A24C006C8343 /* emptyencrypteddb.touchdb */; };
+		CD94A6FF1AB8A24C006C8343 /* emptyencrypteddb.touchdb in Resources */ = {isa = PBXBuildFile; fileRef = CD94A6FD1AB8A24C006C8343 /* emptyencrypteddb.touchdb */; };
+		CDE860371A97AF2B00828AC4 /* TD_DatabaseEncryptionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CDE860361A97AF2B00828AC4 /* TD_DatabaseEncryptionTests.m */; };
+		CDE860381A97AF2B00828AC4 /* TD_DatabaseEncryptionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CDE860361A97AF2B00828AC4 /* TD_DatabaseEncryptionTests.m */; };
+		CDEE6ED11AAF3C17002C96C0 /* CloudantTests+EncryptionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CDEE6ED01AAF3C17002C96C0 /* CloudantTests+EncryptionTests.m */; };
+		CDEE6ED21AAF3C17002C96C0 /* CloudantTests+EncryptionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CDEE6ED01AAF3C17002C96C0 /* CloudantTests+EncryptionTests.m */; };
 		EC0C833C1AB217290051042F /* CDTDatastoreQueryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C831F1AB217290051042F /* CDTDatastoreQueryTests.m */; };
 		EC0C833D1AB217290051042F /* CDTDatastoreQueryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C831F1AB217290051042F /* CDTDatastoreQueryTests.m */; };
 		EC0C833E1AB217290051042F /* CDTQFilterFieldsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C83201AB217290051042F /* CDTQFilterFieldsTest.m */; };
@@ -116,26 +138,6 @@
 		EC0C83611AB217290051042F /* CDTQSQLOnlyQueryExecutor.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C833A1AB217290051042F /* CDTQSQLOnlyQueryExecutor.m */; };
 		EC0C83621AB217290051042F /* Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C833B1AB217290051042F /* Tests.m */; };
 		EC0C83631AB217290051042F /* Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C833B1AB217290051042F /* Tests.m */; };
-		CD00CBBE1AC7703800C3F2D5 /* emptyencryptedindex.sqlite in Resources */ = {isa = PBXBuildFile; fileRef = CD00CBBD1AC7703800C3F2D5 /* emptyencryptedindex.sqlite */; };
-		CD00CBBF1AC7703800C3F2D5 /* emptyencryptedindex.sqlite in Resources */ = {isa = PBXBuildFile; fileRef = CD00CBBD1AC7703800C3F2D5 /* emptyencryptedindex.sqlite */; };
-		CD0D10EC1AB09CE8003315B5 /* TD_DatabaseDeletionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD0D10EB1AB09CE8003315B5 /* TD_DatabaseDeletionTests.m */; };
-		CD0D10ED1AB09CE8003315B5 /* TD_DatabaseDeletionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD0D10EB1AB09CE8003315B5 /* TD_DatabaseDeletionTests.m */; };
-		CD3FBCA61AB05A170032376E /* CDTHelperFixedKeyProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = CD3FBCA31AB05A170032376E /* CDTHelperFixedKeyProvider.m */; };
-		CD3FBCA71AB05A170032376E /* CDTHelperFixedKeyProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = CD3FBCA31AB05A170032376E /* CDTHelperFixedKeyProvider.m */; };
-		CD3FBCA81AB05A170032376E /* CDTHelperOneUseKeyProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = CD3FBCA51AB05A170032376E /* CDTHelperOneUseKeyProvider.m */; };
-		CD3FBCA91AB05A170032376E /* CDTHelperOneUseKeyProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = CD3FBCA51AB05A170032376E /* CDTHelperOneUseKeyProvider.m */; };
-		CD7110421AB6282500558645 /* DatastoreEncryptionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD7110401AB6282500558645 /* DatastoreEncryptionTests.m */; };
-		CD7110431AB6282500558645 /* DatastoreEncryptionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD7110401AB6282500558645 /* DatastoreEncryptionTests.m */; };
-		CD7110441AB6282500558645 /* DatastoreManagerEncryptionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD7110411AB6282500558645 /* DatastoreManagerEncryptionTests.m */; };
-		CD7110451AB6282500558645 /* DatastoreManagerEncryptionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD7110411AB6282500558645 /* DatastoreManagerEncryptionTests.m */; };
-		CD79FFE11A9B40FA00F5B5C5 /* IndexManagerEncryptionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD79FFDF1A9B3E0F00F5B5C5 /* IndexManagerEncryptionTests.m */; };
-		CD79FFE71A9B478A00F5B5C5 /* IndexManagerEncryptionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD79FFDF1A9B3E0F00F5B5C5 /* IndexManagerEncryptionTests.m */; };
-		CD94A6FE1AB8A24C006C8343 /* emptyencrypteddb.touchdb in Resources */ = {isa = PBXBuildFile; fileRef = CD94A6FD1AB8A24C006C8343 /* emptyencrypteddb.touchdb */; };
-		CD94A6FF1AB8A24C006C8343 /* emptyencrypteddb.touchdb in Resources */ = {isa = PBXBuildFile; fileRef = CD94A6FD1AB8A24C006C8343 /* emptyencrypteddb.touchdb */; };
-		CDE860371A97AF2B00828AC4 /* TD_DatabaseEncryptionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CDE860361A97AF2B00828AC4 /* TD_DatabaseEncryptionTests.m */; };
-		CDE860381A97AF2B00828AC4 /* TD_DatabaseEncryptionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CDE860361A97AF2B00828AC4 /* TD_DatabaseEncryptionTests.m */; };
-		CDEE6ED11AAF3C17002C96C0 /* CloudantTests+EncryptionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CDEE6ED01AAF3C17002C96C0 /* CloudantTests+EncryptionTests.m */; };
-		CDEE6ED21AAF3C17002C96C0 /* CloudantTests+EncryptionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CDEE6ED01AAF3C17002C96C0 /* CloudantTests+EncryptionTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -195,6 +197,20 @@
 		9FC082971913378F0024EA1E /* DatastoreConflictResolvers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DatastoreConflictResolvers.m; sourceTree = "<group>"; };
 		BBD8D50209E84CD981F3FA7A /* libPods-osx.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-osx.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C0D0295E40984E2788387EEE /* libPods-ios.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ios.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		CD00CBBD1AC7703800C3F2D5 /* emptyencryptedindex.sqlite */ = {isa = PBXFileReference; lastKnownFileType = file; name = emptyencryptedindex.sqlite; path = Assets/emptyencryptedindex.sqlite; sourceTree = "<group>"; };
+		CD0D10EB1AB09CE8003315B5 /* TD_DatabaseDeletionTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TD_DatabaseDeletionTests.m; sourceTree = "<group>"; };
+		CD3FBCA21AB05A170032376E /* CDTHelperFixedKeyProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDTHelperFixedKeyProvider.h; sourceTree = "<group>"; };
+		CD3FBCA31AB05A170032376E /* CDTHelperFixedKeyProvider.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTHelperFixedKeyProvider.m; sourceTree = "<group>"; };
+		CD3FBCA41AB05A170032376E /* CDTHelperOneUseKeyProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDTHelperOneUseKeyProvider.h; sourceTree = "<group>"; };
+		CD3FBCA51AB05A170032376E /* CDTHelperOneUseKeyProvider.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTHelperOneUseKeyProvider.m; sourceTree = "<group>"; };
+		CD55A1971AD56B3600A52281 /* CDTQIndexManagerEncryptionTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTQIndexManagerEncryptionTests.m; sourceTree = "<group>"; };
+		CD7110401AB6282500558645 /* DatastoreEncryptionTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DatastoreEncryptionTests.m; sourceTree = "<group>"; };
+		CD7110411AB6282500558645 /* DatastoreManagerEncryptionTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DatastoreManagerEncryptionTests.m; sourceTree = "<group>"; };
+		CD79FFDF1A9B3E0F00F5B5C5 /* IndexManagerEncryptionTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IndexManagerEncryptionTests.m; sourceTree = "<group>"; };
+		CD94A6FD1AB8A24C006C8343 /* emptyencrypteddb.touchdb */ = {isa = PBXFileReference; lastKnownFileType = file; name = emptyencrypteddb.touchdb; path = Assets/emptyencrypteddb.touchdb; sourceTree = "<group>"; };
+		CDE860361A97AF2B00828AC4 /* TD_DatabaseEncryptionTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TD_DatabaseEncryptionTests.m; sourceTree = "<group>"; };
+		CDEE6ECF1AAF3C17002C96C0 /* CloudantTests+EncryptionTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "CloudantTests+EncryptionTests.h"; sourceTree = "<group>"; };
+		CDEE6ED01AAF3C17002C96C0 /* CloudantTests+EncryptionTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "CloudantTests+EncryptionTests.m"; sourceTree = "<group>"; };
 		EC0C831F1AB217290051042F /* CDTDatastoreQueryTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTDatastoreQueryTests.m; sourceTree = "<group>"; };
 		EC0C83201AB217290051042F /* CDTQFilterFieldsTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTQFilterFieldsTest.m; sourceTree = "<group>"; };
 		EC0C83211AB217290051042F /* CDTQIndexCreatorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTQIndexCreatorTests.m; sourceTree = "<group>"; };
@@ -222,19 +238,6 @@
 		EC0C83391AB217290051042F /* CDTQSQLOnlyQueryExecutor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDTQSQLOnlyQueryExecutor.h; sourceTree = "<group>"; };
 		EC0C833A1AB217290051042F /* CDTQSQLOnlyQueryExecutor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTQSQLOnlyQueryExecutor.m; sourceTree = "<group>"; };
 		EC0C833B1AB217290051042F /* Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Tests.m; sourceTree = "<group>"; };
-		CD00CBBD1AC7703800C3F2D5 /* emptyencryptedindex.sqlite */ = {isa = PBXFileReference; lastKnownFileType = file; name = emptyencryptedindex.sqlite; path = Assets/emptyencryptedindex.sqlite; sourceTree = "<group>"; };
-		CD0D10EB1AB09CE8003315B5 /* TD_DatabaseDeletionTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TD_DatabaseDeletionTests.m; sourceTree = "<group>"; };
-		CD3FBCA21AB05A170032376E /* CDTHelperFixedKeyProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDTHelperFixedKeyProvider.h; sourceTree = "<group>"; };
-		CD3FBCA31AB05A170032376E /* CDTHelperFixedKeyProvider.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTHelperFixedKeyProvider.m; sourceTree = "<group>"; };
-		CD3FBCA41AB05A170032376E /* CDTHelperOneUseKeyProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDTHelperOneUseKeyProvider.h; sourceTree = "<group>"; };
-		CD3FBCA51AB05A170032376E /* CDTHelperOneUseKeyProvider.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTHelperOneUseKeyProvider.m; sourceTree = "<group>"; };
-		CD7110401AB6282500558645 /* DatastoreEncryptionTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DatastoreEncryptionTests.m; sourceTree = "<group>"; };
-		CD7110411AB6282500558645 /* DatastoreManagerEncryptionTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DatastoreManagerEncryptionTests.m; sourceTree = "<group>"; };
-		CD79FFDF1A9B3E0F00F5B5C5 /* IndexManagerEncryptionTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IndexManagerEncryptionTests.m; sourceTree = "<group>"; };
-		CD94A6FD1AB8A24C006C8343 /* emptyencrypteddb.touchdb */ = {isa = PBXFileReference; lastKnownFileType = file; name = emptyencrypteddb.touchdb; path = Assets/emptyencrypteddb.touchdb; sourceTree = "<group>"; };
-		CDE860361A97AF2B00828AC4 /* TD_DatabaseEncryptionTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TD_DatabaseEncryptionTests.m; sourceTree = "<group>"; };
-		CDEE6ECF1AAF3C17002C96C0 /* CloudantTests+EncryptionTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "CloudantTests+EncryptionTests.h"; sourceTree = "<group>"; };
-		CDEE6ED01AAF3C17002C96C0 /* CloudantTests+EncryptionTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "CloudantTests+EncryptionTests.m"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -301,6 +304,7 @@
 				EC0C831F1AB217290051042F /* CDTDatastoreQueryTests.m */,
 				EC0C83201AB217290051042F /* CDTQFilterFieldsTest.m */,
 				EC0C83211AB217290051042F /* CDTQIndexCreatorTests.m */,
+				CD55A1971AD56B3600A52281 /* CDTQIndexManagerEncryptionTests.m */,
 				EC0C83221AB217290051042F /* CDTQIndexManagerTests.m */,
 				EC0C83231AB217290051042F /* CDTQIndexUpdaterTests.m */,
 				EC0C83241AB217290051042F /* CDTQInvalidQuerySyntax.m */,
@@ -665,6 +669,7 @@
 				989E6E22198799AE00FB8510 /* DatastoreCRUD.m in Sources */,
 				CDEE6ED11AAF3C17002C96C0 /* CloudantTests+EncryptionTests.m in Sources */,
 				9F0D241A18932DA700D3D04E /* TDSequenceMapTests.m in Sources */,
+				CD55A1981AD56B3600A52281 /* CDTQIndexManagerEncryptionTests.m in Sources */,
 				9FC082981913378F0024EA1E /* DatastoreConflictResolvers.m in Sources */,
 				EC0C83621AB217290051042F /* Tests.m in Sources */,
 				9F0D23FA188DF36800D3D04E /* TD_DatabaseTests.m in Sources */,
@@ -728,6 +733,7 @@
 				EC0C835D1AB217290051042F /* CDTQMatcherQueryExecutor.m in Sources */,
 				CDEE6ED21AAF3C17002C96C0 /* CloudantTests+EncryptionTests.m in Sources */,
 				989E6E23198799AE00FB8510 /* DatastoreCRUD.m in Sources */,
+				CD55A1991AD56B3600A52281 /* CDTQIndexManagerEncryptionTests.m in Sources */,
 				9F0D241B18932DA700D3D04E /* TDSequenceMapTests.m in Sources */,
 				9FC082991913378F0024EA1E /* DatastoreConflictResolvers.m in Sources */,
 				EC0C83631AB217290051042F /* Tests.m in Sources */,

--- a/Tests/Tests/CDTQIndexManagerEncryptionTests.m
+++ b/Tests/Tests/CDTQIndexManagerEncryptionTests.m
@@ -1,0 +1,112 @@
+//
+//  CDTQIndexManagerEncryptionTests.m
+//  Tests
+//
+//  Created by Enrique de la Torre Fernandez on 08/04/2015.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#import <XCTest/XCTest.h>
+
+#import "CloudantSyncTests.h"
+#import "CloudantTests+EncryptionTests.h"
+#import "CDTDatastoreManager+EncryptionKey.h"
+#import "CDTEncryptionKeyNilProvider.h"
+#import "FMDatabase+SQLCipher.h"
+
+#import "CDTQIndexManager.h"
+
+@interface CDTQIndexManagerEncryptionTests : CloudantSyncTests
+
+@end
+
+@implementation CDTQIndexManagerEncryptionTests
+
+- (void)setUp
+{
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the
+    // class.
+}
+
+- (void)tearDown
+{
+    // Put teardown code here. This method is called after the invocation of each test method in the
+    // class.
+    [super tearDown];
+}
+
+- (void)testCreateQueryIndexManagerWithEncryptionKeyNilProvider
+{
+    CDTEncryptionKeyNilProvider *provider = [CDTEncryptionKeyNilProvider provider];
+    CDTDatastore *datastore = [self.factory datastoreNamed:@"create_query_index_tests_nilprovider"
+                                 withEncryptionKeyProvider:provider
+                                                     error:nil];
+
+    NSError *err = nil;
+    CDTQIndexManager *im = [[CDTQIndexManager alloc] initUsingDatastore:datastore error:&err];
+
+    XCTAssertNotNil(im, @"indexManager is not nil");
+    XCTAssertNil(err, @"error has to be nil");
+}
+
+- (void)testCreateQueryIndexManagerWithEncryptionKeyNilProviderDoesNotCipherIndex
+{
+    // Create index
+    CDTEncryptionKeyNilProvider *provider = [CDTEncryptionKeyNilProvider provider];
+    CDTDatastore *datastore =
+        [self.factory datastoreNamed:@"create_query_index_tests_nilprovider_notcipher"
+            withEncryptionKeyProvider:provider
+                                error:nil];
+
+    __unused CDTQIndexManager *im =
+        [[CDTQIndexManager alloc] initUsingDatastore:datastore error:nil];
+
+    // Check
+    NSString *path = [CloudantSyncTests pathForQueryIndexInDatastore:datastore];
+
+    XCTAssertEqual([FMDatabase isDatabaseUnencryptedAtPath:path],
+                   kFMDatabaseUnencryptedIsUnencrypted,
+                   @"No encryption library available, database can not be encrypted");
+}
+
+- (void)testCreateQueryIndexManagerWithEncryptionKeyNilProviderFailsIfDBExistsAndItIsEncrypted
+{
+    // Create datastore
+    CDTEncryptionKeyNilProvider *provider = [CDTEncryptionKeyNilProvider provider];
+    CDTDatastore *datastore =
+        [self.factory datastoreNamed:@"create_query_index_tests_nilprovider_fails_with_cipher_db"
+            withEncryptionKeyProvider:provider
+                                error:nil];
+
+    // Copy encrypted db to index folder
+    NSFileManager *defaultManager = [NSFileManager defaultManager];
+    NSString *indexDBPath = [CloudantTests pathForQueryIndexInDatastore:datastore];
+    NSString *indexDirectoryPath = [indexDBPath stringByDeletingLastPathComponent];
+    
+    [defaultManager createDirectoryAtPath:indexDirectoryPath
+              withIntermediateDirectories:YES
+                               attributes:nil
+                                    error:nil];
+    
+    NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+    NSString *assetPath = [bundle pathForResource:@"emptyencryptedindex" ofType:@"sqlite"];
+    
+    [defaultManager copyItemAtPath:assetPath toPath:indexDBPath error:nil];
+    
+    // Test
+    NSError *err = nil;
+    CDTQIndexManager *im = [[CDTQIndexManager alloc] initUsingDatastore:datastore error:&err];
+
+    XCTAssertNil(im, @"indexManager is nil");
+    XCTAssertNotNil(err, @"There is an error");
+}
+
+@end

--- a/Tests/Tests/CloudantTests+EncryptionTests.h
+++ b/Tests/Tests/CloudantTests+EncryptionTests.h
@@ -18,10 +18,13 @@
 
 @class CDTDatastore;
 
-#define kCDTIndexFolder     @"com.cloudant.indexing"    //in CDTIndexManager.m. Move it into .h?
-#define kCDTIndexFilename   @"indexes.sqlite"
+#define kCDTIndexFolder @"com.cloudant.indexing"  // in CDTIndexManager.m. Move it into .h?
+#define kCDTIndexFilename @"indexes.sqlite"
 
-#define kCDTSQLiteStandardHeader    @"SQLite format 3"
+#define kCDTQueryIndexFolder @"com.cloudant.sync.query"  // in CDTQIndexManager.m. Move it into .h?
+#define kCDTQueryIndexFilename @"indexes.sqlite"
+
+#define kCDTSQLiteStandardHeader @"SQLite format 3"
 
 @interface CloudantTests (EncryptionTests)
 
@@ -35,5 +38,16 @@
  * @return Path to a SQLite database
  */
 + (NSString *)pathForIndexInDatastore:(CDTDatastore *)datastore;
+
+/**
+ * Returns the path to the database in the query index manager for the provided datastore.
+ * It does not check if the query index manager was created before and it does not create it if
+ * it does not exist
+ *
+ * @param datastore a datastore (not nil)
+ *
+ * @return Path to a SQLite database
+ */
++ (NSString *)pathForQueryIndexInDatastore:(CDTDatastore *)datastore;
 
 @end

--- a/Tests/Tests/CloudantTests+EncryptionTests.m
+++ b/Tests/Tests/CloudantTests+EncryptionTests.m
@@ -29,4 +29,12 @@
     return path;
 }
 
++ (NSString *)pathForQueryIndexInDatastore:(CDTDatastore *)datastore
+{
+    NSString *dir = [datastore extensionDataFolder:kCDTQueryIndexFolder];
+    NSString *path = [NSString pathWithComponents:@[dir, kCDTQueryIndexFilename]];
+    
+    return path;
+}
+
 @end


### PR DESCRIPTION
*What*
Encrypt the SQLite database used in a query index

*Why*
As the rest of the databases in the library, this one has to be encrypted too.

*How*
Use the same mechanism that we use for the other databases, i.e. we provide a encryption key to FMDB through a CDTEncryptionKeyProvider.

*Tests*
* Query index + SQLCipher
  1. Create an non-encrypted db with a non-encrypted datastore
  2. Create an encrypted db with an encrypted datastore
  3. Do not open an encrypted db with a non-encrypted datastore
  4. Do not open a non-encrypted db with an encrypted datastore
  5. Do not open an encrypted db with an encrypted datastore if they do not share the same key

* Query index + SQLite
  1. Create an non-encrypted db with a non-encrypted datastore
  2. Do not open an encrypted db with a non-encrypted datastore

reviewer @mikerhodes
reviewer @alfinkel 