### PR TITLE
Support cancelling of CDTFetchChanges

### DIFF
--- a/Classes/common/CDTFetchChanges.h
+++ b/Classes/common/CDTFetchChanges.h
@@ -38,10 +38,9 @@
  The sequence value should be treated as an opaque value, but can be saved and used across
  application sessions.
 
- The blocks you assign to process the fetched documents are executed serially on an
- internal queue managed by the operation. Your blocks must be capable of executing
- on a background thread, so any tasks that require access to the main thread must
- be redirected accordingly.
+ The blocks you assign to process the fetched documents are executed serially. Your blocks must
+ be capable of executing on a background thread, so any tasks that require access to the main
+ thread must be redirected accordingly.
  */
 @interface CDTFetchChanges : NSOperation
 

--- a/Classes/common/CDTFetchChanges.h
+++ b/Classes/common/CDTFetchChanges.h
@@ -31,7 +31,7 @@
  documentWithIDWasDeletedBlock is just passed the id of the deleted document.
 
  In addition, CDTFetchChanges is able to report on changes since a given point. The completion
- block provides a sequence value which can be passed to future requests to have only changes
+ block provides a sequence value which can be passed to future operations to have only changes
  from that point reported. This allows your application to make incremental updates
  in response to changes in a database.
 
@@ -56,9 +56,9 @@
 /**
  The sequence value identifying the starting point for reading changes.
 
- The value to use for this is returned by the completion block for a fetch request. This sequence
- value can be used to
- receive changes that have occured since the previous request.
+ The value to use for this is returned by the completion block for a fetch operation. This
+ sequence value can be used to receive changes that have occured since the previous operation.
+
  Treat the sequence value as an opaque string; different implementations may provide
  differently formatted values. A given sequence value should only be used with the
  database that it was received from.
@@ -80,7 +80,7 @@
  </dl>
 
  The operation object executes this block once for each document in the database that changed
- since the previous fetch request. Each time the block is executed, it is executed
+ since the previous fetch operation. Each time the block is executed, it is executed
  serially with respect to the other progress blocks of the operation. If no documents
  changed, the block is not executed.
 
@@ -89,24 +89,23 @@
  */
 @property (nonatomic, copy) void (^documentChangedBlock)(CDTDocumentRevision *revision);
 
-
 /**
  The block to execute for each deleted document.
- 
+
  The block returns no value and takes the following parameters:
- 
+
  <dl>
  <dt>docId</dt>
  <dd>The document id for the deleted document.</dd>
  </dl>
- 
+
  The operation object executes this block once for each document in the database that
- was deleted since the previous fetch request. Each time the block is executed, it 
- is executed serially with respect to the other progress blocks of the operation. 
+ was deleted since the previous fetch operation. Each time the block is executed, it
+ is executed serially with respect to the other progress blocks of the operation.
  If no documents were deleted, the block is not executed.
- 
- If you intend to use this block to process results, set it before executing the 
- operation or submitting it to a queue. 
+
+ If you intend to use this block to process results, set it before executing the
+ operation or submitting it to a queue.
  */
 @property (nonatomic, copy) void (^documentWithIDWasDeletedBlock)(NSString *docId);
 
@@ -144,19 +143,19 @@
 
 /**
  Initializes and returns an object configured to fetch changes in the specified database.
- 
- When initializing the fetch object, use the sequence value from a previous fetch request if 
+
+ When initializing the fetch object, use the sequence value from a previous fetch operation if
  you have one. You can archive sequence values and write them to disk for later use if needed.
- 
- After initializing the operation, associate at least one progress block with the operation 
- object (excluding the completion block) to process the results. 
- 
+
+ After initializing the operation, associate at least one progress block with the operation
+ object (excluding the completion block) to process the results.
+
  @param datastore The datastore containing the changes that should be fetched.
- @param previousServerChangeToken The sequence value from a previous fetch. This is the value
-            passed to the completionHandler for this object. This value limits the changes
-            retrieved to those occuring after this sequence value. Pass `nil` to receive
-            all changes.
- 
+ @param previousServerChangeToken The sequence value from a previous fetch operation. This
+            is the value passed to the completionHandler for this object. This value limits
+            the changes retrieved to those occuring after this sequence value. Pass `nil` to
+            receive all changes.
+
  @return An initialised fetch object.
  */
 - (instancetype)initWithDatastore:(CDTDatastore *)datastore

--- a/Classes/common/CDTFetchChanges.h
+++ b/Classes/common/CDTFetchChanges.h
@@ -144,7 +144,7 @@
 /**
  Initializes and returns an object configured to fetch changes in the specified database.
 
- When initializing the fetch object, use the sequence value from a previous fetch operation if
+ When initializing the fetch operation, use the sequence value from a previous fetch operation if
  you have one. You can archive sequence values and write them to disk for later use if needed.
 
  After initializing the operation, associate at least one progress block with the operation
@@ -156,7 +156,7 @@
             the changes retrieved to those occuring after this sequence value. Pass `nil` to
             receive all changes.
 
- @return An initialised fetch object.
+ @return An initialised fetch operation.
  */
 - (instancetype)initWithDatastore:(CDTDatastore *)datastore
                startSequenceValue:(NSString *)startSequenceValue;

--- a/Classes/common/CDTFetchChanges.m
+++ b/Classes/common/CDTFetchChanges.m
@@ -20,6 +20,21 @@
 
 #import "TD_Database.h"
 
+@interface CDTFetchChanges ()
+
+@property (nonatomic, copy) void (^mDocumentChangedBlock)(CDTDocumentRevision *revision);
+
+@property (nonatomic, copy) void (^mDocumentWithIDWasDeletedBlock)(NSString *docId);
+
+@property (nonatomic, copy) void (^mFetchRecordChangesCompletionBlock)
+    (NSString *newSequenceValue, NSString *startSequenceValue, NSError *fetchError);
+
+@property (nonatomic, strong) CDTDatastore *mDatastore;
+
+@property (nonatomic, copy) NSString *mStartSequenceValue;
+
+@end
+
 @implementation CDTFetchChanges
 
 #pragma mark Initialisers
@@ -39,6 +54,14 @@
 
 - (void)main
 {
+    // Ensure our settings are not changed during execution
+    self.mDocumentChangedBlock = [self.documentChangedBlock copy];
+    self.mDocumentWithIDWasDeletedBlock = [self.documentWithIDWasDeletedBlock copy];
+    self.mFetchRecordChangesCompletionBlock = [self.fetchRecordChangesCompletionBlock copy];
+
+    self.mDatastore = self.datastore;
+    self.mStartSequenceValue = self.startSequenceValue;
+
     TDChangesOptions options = {.limit = 500,
         .contentOptions = 0,                                
         .includeDocs = NO,  // we only need the docIDs and sequences, body is retrieved separately
@@ -46,27 +69,28 @@
         .sortBySequence = TRUE};
     
     TD_RevisionList *changes;
-    SequenceNumber lastSequence = [_startSequenceValue longLongValue];
+    SequenceNumber lastSequence = [self.mStartSequenceValue longLongValue];
 
     do {
         if (self.cancelled) {
             return;  // Bail early, don't call completion block
         }
 
-        changes = [[_datastore database] changesSinceSequence:lastSequence
-                                                      options:&options
-                                                       filter:nil
-                                                       params:nil];
+        changes = [[self.mDatastore database] changesSinceSequence:lastSequence
+                                                           options:&options
+                                                            filter:nil
+                                                            params:nil];
         lastSequence = [self notifyChanges:changes startingSequence:lastSequence];
     } while (changes.count > 0);
 
-    void (^f)(NSString *nsv, NSString *ssv, NSError *fe) = self.fetchRecordChangesCompletionBlock;
+    void (^f)(NSString *nsv, NSString *ssv, NSError *fe) = self.mFetchRecordChangesCompletionBlock;
     if (f) {
         // Try our best to avoid calling the completion block if cancelled is set:
         //  - after the check in the loop above 
         //  - where there are no remaining changes, so we fall through to here
         if (!self.cancelled) {
-            f([[NSNumber numberWithLongLong:lastSequence] stringValue], _startSequenceValue, nil);
+            f([[NSNumber numberWithLongLong:lastSequence] stringValue], self.mStartSequenceValue,
+              nil);
         }
     }
 }
@@ -97,7 +121,7 @@
     // that are updated rather than deleted, we need to be sure we index the
     // winning revision. This loop gets those revisions.
     NSMutableDictionary *updatedRevisions = [NSMutableDictionary dictionary];
-    for (CDTDocumentRevision *rev in [_datastore getDocumentsWithIds:[changes allDocIDs]]) {
+    for (CDTDocumentRevision *rev in [self.mDatastore getDocumentsWithIds:[changes allDocIDs]]) {
         if (rev != nil && !rev.deleted) {
             updatedRevisions[rev.docId] = rev;
         }
@@ -110,14 +134,12 @@
 
         CDTDocumentRevision *updatedRevision;
         if ((updatedRevision = updatedRevisions[change.docID]) != nil) {
-            void (^dcb)(CDTDocumentRevision *r) = self.documentChangedBlock;
-            if (dcb) {
-                dcb(updatedRevision);
+            if (self.mDocumentChangedBlock) {
+                self.mDocumentChangedBlock(updatedRevision);
             }
         } else {
-            void (^ddb)(NSString *docId) = self.documentWithIDWasDeletedBlock;
-            if (ddb) {
-                ddb(change.docID);
+            if (self.mDocumentWithIDWasDeletedBlock) {
+                self.mDocumentWithIDWasDeletedBlock(change.docID);
             }
         }
         

--- a/Classes/common/CDTFetchChanges.m
+++ b/Classes/common/CDTFetchChanges.m
@@ -62,7 +62,12 @@
 
     void (^f)(NSString *nsv, NSString *ssv, NSError *fe) = self.fetchRecordChangesCompletionBlock;
     if (f) {
-        f([[NSNumber numberWithLongLong:lastSequence] stringValue], _startSequenceValue, nil);
+        // Try our best to avoid calling the completion block if cancelled is set:
+        //  - after the check in the loop above 
+        //  - where there are no remaining changes, so we fall through to here
+        if (!self.cancelled) {
+            f([[NSNumber numberWithLongLong:lastSequence] stringValue], _startSequenceValue, nil);
+        }
     }
 }
 

--- a/Classes/common/CDTFetchChanges.m
+++ b/Classes/common/CDTFetchChanges.m
@@ -55,10 +55,9 @@
 - (void)main
 {
     // Ensure our settings are not changed during execution
-    self.mDocumentChangedBlock = [self.documentChangedBlock copy];
-    self.mDocumentWithIDWasDeletedBlock = [self.documentWithIDWasDeletedBlock copy];
-    self.mFetchRecordChangesCompletionBlock = [self.fetchRecordChangesCompletionBlock copy];
-
+    self.mDocumentChangedBlock = self.documentChangedBlock;
+    self.mDocumentWithIDWasDeletedBlock = self.documentWithIDWasDeletedBlock;
+    self.mFetchRecordChangesCompletionBlock = self.fetchRecordChangesCompletionBlock;
     self.mDatastore = self.datastore;
     self.mStartSequenceValue = self.startSequenceValue;
 
@@ -83,14 +82,14 @@
         lastSequence = [self notifyChanges:changes startingSequence:lastSequence];
     } while (changes.count > 0);
 
-    void (^f)(NSString *nsv, NSString *ssv, NSError *fe) = self.mFetchRecordChangesCompletionBlock;
-    if (f) {
+    if (self.mFetchRecordChangesCompletionBlock) {
         // Try our best to avoid calling the completion block if cancelled is set:
         //  - after the check in the loop above 
         //  - where there are no remaining changes, so we fall through to here
         if (!self.cancelled) {
-            f([[NSNumber numberWithLongLong:lastSequence] stringValue], self.mStartSequenceValue,
-              nil);
+            self.mFetchRecordChangesCompletionBlock(
+                [[NSNumber numberWithLongLong:lastSequence] stringValue], self.mStartSequenceValue,
+                nil);
         }
     }
 }

--- a/Classes/common/CDTFetchChanges.m
+++ b/Classes/common/CDTFetchChanges.m
@@ -86,6 +86,10 @@
 - (SequenceNumber)notifyChanges:(TD_RevisionList *)changes
                startingSequence:(SequenceNumber)startingSequence
 {
+    if (self.cancelled) {
+        return startingSequence;  // processed no changes
+    }
+
     SequenceNumber lastSequence = startingSequence;
     
     // _changes provides the revs with highest rev ID, which might not be the

--- a/Classes/common/CDTFetchChanges.m
+++ b/Classes/common/CDTFetchChanges.m
@@ -49,6 +49,10 @@
     SequenceNumber lastSequence = [_startSequenceValue longLongValue];
 
     do {
+        if (self.cancelled) {
+            return;  // Bail early, don't call completion block
+        }
+
         changes = [[_datastore database] changesSinceSequence:lastSequence
                                                       options:&options
                                                        filter:nil
@@ -91,7 +95,10 @@
     }
     
     for (TD_Revision *change in changes) {
-        
+        if (self.cancelled) {
+            return lastSequence;  // We processed changes up to this sequence
+        }
+
         CDTDocumentRevision *updatedRevision;
         if ((updatedRevision = updatedRevisions[change.docID]) != nil) {
             void (^dcb)(CDTDocumentRevision *r) = self.documentChangedBlock;


### PR DESCRIPTION
_What_

We now periodically check for the NSOperation's cancelled
property and bail early rather than always running the whole
changes fetch process.

_How_

Returning early from methods if the cancel state is set.

reviewer: @indisoluble 
reviewer: @gadamc

BugId: 46038