### PR TITLE
45570 Generate, retrieve & store a key: Data & storage classes to save a key

### DIFF
--- a/CDTDatastore.xcworkspace/contents.xcworkspacedata
+++ b/CDTDatastore.xcworkspace/contents.xcworkspacedata
@@ -30,6 +30,18 @@
                location = "group:Keychain"
                name = "Keychain">
                <FileRef
+                  location = "group:CDTEncryptionKeychainData.h">
+               </FileRef>
+               <FileRef
+                  location = "group:CDTEncryptionKeychainData.m">
+               </FileRef>
+               <FileRef
+                  location = "group:CDTEncryptionKeychainStorage.h">
+               </FileRef>
+               <FileRef
+                  location = "group:CDTEncryptionKeychainStorage.m">
+               </FileRef>
+               <FileRef
                   location = "group:CDTEncryptionKeychainUtils.h">
                </FileRef>
                <FileRef

--- a/Classes/common/Encryption/Keychain/CDTEncryptionKeychainData.h
+++ b/Classes/common/Encryption/Keychain/CDTEncryptionKeychainData.h
@@ -1,0 +1,50 @@
+//
+//  CDTEncryptionKeychainData.h
+//  CloudantSync
+//
+//  Created by Enrique de la Torre Fernandez on 12/04/2015.
+//  Copyright (c) 2015 IBM Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+
+/**
+ NSSecureCoding compliant class for data needed to store and retrieve a DPK (Data Protection Key)
+ from the keychain.
+ 
+ In general it is not safe storing a DPK, it is a better idea to store an encrypted version of it.
+ However the next time we want to use it, we have to decrypt it; therefore it has to saved with
+ enough data to inverse the process but without exposing too much information. This class defines
+ all the values required to store an encrypted DPK and decipher it later on.
+
+ @see CDTEncryptionKeychainStorage
+ */
+@interface CDTEncryptionKeychainData : NSObject <NSSecureCoding>
+
+@property (strong, nonatomic, readonly) NSData *encryptedDPK;
+@property (strong, nonatomic, readonly) NSData *salt;
+@property (strong, nonatomic, readonly) NSData *iv;
+@property (assign, nonatomic, readonly) NSInteger iterations;
+@property (strong, nonatomic, readonly) NSString *version;
+
+- (instancetype)initWithEncryptedDPK:(NSData *)encryptedDPK
+                                salt:(NSData *)salt
+                                  iv:(NSData *)iv
+                          iterations:(NSInteger)iterations
+                             version:(NSString *)version;
+
++ (instancetype)dataWithEncryptedDPK:(NSData *)encryptedDPK
+                                salt:(NSData *)salt
+                                  iv:(NSData *)iv
+                          iterations:(NSInteger)iterations
+                             version:(NSString *)version;
+
+@end

--- a/Classes/common/Encryption/Keychain/CDTEncryptionKeychainData.m
+++ b/Classes/common/Encryption/Keychain/CDTEncryptionKeychainData.m
@@ -1,0 +1,111 @@
+//
+//  CDTEncryptionKeychainData.m
+//  CloudantSync
+//
+//  Created by Enrique de la Torre Fernandez on 12/04/2015.
+//  Copyright (c) 2015 IBM Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#import "CDTEncryptionKeychainData.h"
+
+#import "CDTLogging.h"
+
+#define CDTENCRYPTION_KEYCHAINDATA_KEY_DPK @"dpk"
+#define CDTENCRYPTION_KEYCHAINDATA_KEY_SALT @"salt"
+#define CDTENCRYPTION_KEYCHAINDATA_KEY_IV @"iv"
+#define CDTENCRYPTION_KEYCHAINDATA_KEY_ITERATIONS @"iterations"
+#define CDTENCRYPTION_KEYCHAINDATA_KEY_VERSION @"version"
+
+@interface CDTEncryptionKeychainData ()
+
+@end
+
+@implementation CDTEncryptionKeychainData
+
+#pragma mark - Init object
+- (instancetype)init
+{
+    return [self initWithEncryptedDPK:nil salt:nil iv:nil iterations:NSIntegerMin version:nil];
+}
+
+- (id)initWithCoder:(NSCoder *)aDecoder
+{
+    NSData *encryptedDPK =
+        [aDecoder decodeObjectOfClass:[NSData class] forKey:CDTENCRYPTION_KEYCHAINDATA_KEY_DPK];
+    NSData *salt =
+        [aDecoder decodeObjectOfClass:[NSData class] forKey:CDTENCRYPTION_KEYCHAINDATA_KEY_SALT];
+    NSData *iv =
+        [aDecoder decodeObjectOfClass:[NSData class] forKey:CDTENCRYPTION_KEYCHAINDATA_KEY_IV];
+    NSNumber *iterations = [aDecoder decodeObjectOfClass:[NSNumber class]
+                                                  forKey:CDTENCRYPTION_KEYCHAINDATA_KEY_ITERATIONS];
+    NSString *version = [aDecoder decodeObjectOfClass:[NSString class]
+                                               forKey:CDTENCRYPTION_KEYCHAINDATA_KEY_VERSION];
+
+    return [self initWithEncryptedDPK:encryptedDPK
+                                 salt:salt
+                                   iv:iv
+                           iterations:[iterations integerValue]
+                              version:version];
+}
+
+- (instancetype)initWithEncryptedDPK:(NSData *)encryptedDPK
+                                salt:(NSData *)salt
+                                  iv:(NSData *)iv
+                          iterations:(NSInteger)iterations
+                             version:(NSString *)version
+{
+    self = [super init];
+    if (self) {
+        if (encryptedDPK && salt && iv && (iterations >= 0) && version) {
+            _encryptedDPK = encryptedDPK;
+            _salt = salt;
+            _iv = iv;
+            _iterations = iterations;
+            _version = version;
+        } else {
+            CDTLogError(
+                CDTDATASTORE_LOG_CONTEXT,
+                @"All params are mandatory (and iterations value has to be positive or zero)");
+
+            self = nil;
+        }
+    }
+
+    return self;
+}
+
+#pragma mark - NSCoding methods
++ (BOOL)supportsSecureCoding { return YES; }
+
+- (void)encodeWithCoder:(NSCoder *)aCoder
+{
+    [aCoder encodeObject:self.encryptedDPK forKey:CDTENCRYPTION_KEYCHAINDATA_KEY_DPK];
+    [aCoder encodeObject:self.salt forKey:CDTENCRYPTION_KEYCHAINDATA_KEY_SALT];
+    [aCoder encodeObject:self.iv forKey:CDTENCRYPTION_KEYCHAINDATA_KEY_IV];
+    [aCoder encodeInteger:self.iterations forKey:CDTENCRYPTION_KEYCHAINDATA_KEY_ITERATIONS];
+    [aCoder encodeObject:self.version forKey:CDTENCRYPTION_KEYCHAINDATA_KEY_VERSION];
+}
+
+#pragma mark - Public class methods
++ (instancetype)dataWithEncryptedDPK:(NSData *)encryptedDPK
+                                salt:(NSData *)salt
+                                  iv:(NSData *)iv
+                          iterations:(NSInteger)iterations
+                             version:(NSString *)version
+{
+    return [[[self class] alloc] initWithEncryptedDPK:encryptedDPK
+                                                 salt:salt
+                                                   iv:iv
+                                           iterations:iterations
+                                              version:version];
+}
+
+@end

--- a/Classes/common/Encryption/Keychain/CDTEncryptionKeychainStorage.h
+++ b/Classes/common/Encryption/Keychain/CDTEncryptionKeychainStorage.h
@@ -1,0 +1,85 @@
+//
+//  CDTEncryptionKeychainStorage.h
+//  CloudantSync
+//
+//  Created by Enrique de la Torre Fernandez on 12/04/2015.
+//  Copyright (c) 2015 IBM Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "CDTEncryptionKeychainData.h"
+
+/**
+ Use this class to store a CDTEncryptionKeychainData instance in the keychain associated to an
+ identifier. To say in another way, it is possible to store multiple CDTEncryptionKeychainData
+ instances as long as you use a CDTEncryptionKeychainStorage with a different identifier for each
+ one.
+
+ Each CDTEncryptionKeychainData is bound to a specific identifier and all of them are grouped in
+ the keychain by service (service name defined with CDTENCRYPTION_KEYCHAINSTORAGE_SERVICE_VALUE).
+ This means that if you use the same identifier to store other data in the keychain it will not
+ conflict with these values.
+ 
+ @warning Data is saved in the keychain with kSecAttrAccessible equal to
+ kSecAttrAccessibleAfterFirstUnlock, so the data can only be accessed once the device has been
+ unlocked after a restart.
+
+ @see CDTEncryptionKeychainData
+ */
+@interface CDTEncryptionKeychainStorage : NSObject
+
+/**
+ Initialise a storage with an identifier. A CDTEncryptionKeychainData saved to the keychain using
+ this storage will be bound to the identifier specified here.
+
+ @param identifier A string
+ */
+- (instancetype)initWithIdentifier:(NSString *)identifier;
+
+/**
+ A CDTEncryptionKeychainData previously saved with this storage (or other storage created before
+ with the same identifier).
+
+ @return A CDTEncryptionKeychainData saved before or nil
+ */
+- (CDTEncryptionKeychainData *)encryptionKeyData;
+
+/*
+ Save to the keychain a CDTEncryptionKeychainData.
+
+ Notice that if there is already data in the keychain bound to the same identifier used to create
+ this storage, the operation will fail.
+
+ @param data Data to save to the keychain
+
+ @return YES (success) or NO (fail)
+ */
+- (BOOL)saveEncryptionKeyData:(CDTEncryptionKeychainData *)data;
+
+/**
+ Remove from the keychain a CDTEncryptionKeychainData associated to the same identifier used to
+ create this storage.
+
+ It will succeed if the data is deleted or if there is no data at all.
+
+ @return YES (success) or NO (fail)
+ */
+- (BOOL)clearEncryptionKeyData;
+
+/**
+ Look for data saved in the keychain with the same identifier used to create this storage instance.
+
+ @return YES (data found) or NO (data not found)
+ */
+- (BOOL)encryptionKeyDataExists;
+
+@end

--- a/Classes/common/Encryption/Keychain/CDTEncryptionKeychainStorage.m
+++ b/Classes/common/Encryption/Keychain/CDTEncryptionKeychainStorage.m
@@ -1,0 +1,206 @@
+//
+//  CDTEncryptionKeychainStorage.m
+//  CloudantSync
+//
+//  Created by Enrique de la Torre Fernandez on 12/04/2015.
+//  Copyright (c) 2015 IBM Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#import "CDTEncryptionKeychainStorage.h"
+
+#import "CDTLogging.h"
+
+#define CDTENCRYPTION_KEYCHAINSTORAGE_SERVICE_VALUE \
+    @"com.cloudant.sync.CDTEncryptionKeychainStorage.keychain.service"
+
+#define CDTENCRYPTION_KEYCHAINSTORAGE_ARCHIVE_KEY \
+    @"com.cloudant.sync.CDTEncryptionKeychainStorage.archive.key"
+
+@interface CDTEncryptionKeychainStorage ()
+
+@property (strong, nonatomic, readonly) NSString *service;
+@property (strong, nonatomic, readonly) NSString *account;
+
+@end
+
+@implementation CDTEncryptionKeychainStorage
+
+#pragma mark - Init object
+- (instancetype)init
+{
+    return [self initWithIdentifier:nil];
+}
+
+- (instancetype)initWithIdentifier:(NSString *)identifier
+{
+    self = [super init];
+    if (self) {
+        if (identifier) {
+            _service = CDTENCRYPTION_KEYCHAINSTORAGE_SERVICE_VALUE;
+            _account = identifier;
+        } else {
+            self = nil;
+            
+            CDTLogError(CDTDATASTORE_LOG_CONTEXT, @"identifier is mandatory");
+        }
+    }
+    
+    return self;
+}
+
+#pragma mark - Public methods
+- (CDTEncryptionKeychainData *)encryptionKeyData
+{
+    CDTEncryptionKeychainData *encryptionData = nil;
+
+    NSData *data = nil;
+    NSMutableDictionary *query =
+        [CDTEncryptionKeychainStorage genericPwLookupDictWithService:self.service
+                                                             account:self.account];
+
+    OSStatus err = SecItemCopyMatching((__bridge CFDictionaryRef)query, (void *)&data);
+    if (err == noErr) {
+        NSKeyedUnarchiver *unarchiver = [[NSKeyedUnarchiver alloc] initForReadingWithData:data];
+        [unarchiver setRequiresSecureCoding:YES];
+
+        encryptionData = [unarchiver decodeObjectOfClass:[CDTEncryptionKeychainData class]
+                                                  forKey:CDTENCRYPTION_KEYCHAINSTORAGE_ARCHIVE_KEY];
+
+        [unarchiver finishDecoding];
+    } else {
+        CDTLogWarn(CDTDATASTORE_LOG_CONTEXT,
+                   @"Error getting DPK doc from keychain, SecItemCopyMatching returned: %d", err);
+    }
+
+    return encryptionData;
+}
+
+- (BOOL)saveEncryptionKeyData:(CDTEncryptionKeychainData *)data
+{
+    BOOL success = NO;
+
+    NSMutableData *archivedData = [NSMutableData data];
+    NSKeyedArchiver *archiver = [[NSKeyedArchiver alloc] initForWritingWithMutableData:archivedData];
+    [archiver setRequiresSecureCoding:YES];
+    [archiver encodeObject:data forKey:CDTENCRYPTION_KEYCHAINSTORAGE_ARCHIVE_KEY];
+    [archiver finishEncoding];
+    
+    NSMutableDictionary *dataStoreDict =
+        [CDTEncryptionKeychainStorage genericPwStoreDictWithService:self.service
+                                                            account:self.account
+                                                               data:archivedData];
+
+    OSStatus err = SecItemAdd((__bridge CFDictionaryRef)dataStoreDict, nil);
+    if (err == noErr) {
+        success = YES;
+    } else if (err == errSecDuplicateItem) {
+        CDTLogWarn(CDTDATASTORE_LOG_CONTEXT, @"Doc already exists in keychain");
+        success = NO;
+    } else {
+        CDTLogWarn(CDTDATASTORE_LOG_CONTEXT,
+                   @"Unable to store Doc in keychain, SecItemAdd returned: %d", err);
+        success = NO;
+    }
+
+    return success;
+}
+
+- (BOOL)clearEncryptionKeyData
+{
+    BOOL success = NO;
+
+    NSMutableDictionary *dict =
+        [CDTEncryptionKeychainStorage genericPwLookupDictWithService:self.service
+                                                             account:self.account];
+    [dict removeObjectForKey:(__bridge id)(kSecMatchLimit)];
+    [dict removeObjectForKey:(__bridge id)(kSecReturnAttributes)];
+    [dict removeObjectForKey:(__bridge id)(kSecReturnData)];
+
+    OSStatus err = SecItemDelete((__bridge CFDictionaryRef)dict);
+
+    if (err == noErr || err == errSecItemNotFound) {
+        success = YES;
+    } else {
+        CDTLogWarn(CDTDATASTORE_LOG_CONTEXT,
+                   @"Error getting DPK doc from keychain, SecItemDelete returned: %d", err);
+    }
+
+    return success;
+}
+
+- (BOOL)encryptionKeyDataExists
+{
+    BOOL result = NO;
+
+    NSData *data = nil;
+    NSMutableDictionary *query =
+        [CDTEncryptionKeychainStorage genericPwLookupDictWithService:self.service
+                                                             account:self.account];
+
+    OSStatus err = SecItemCopyMatching((__bridge CFDictionaryRef)query, (void *)&data);
+    if (err == noErr) {
+        result = ((data != nil) && (data.length > 0));
+
+        if (!result) {
+            CDTLogWarn(CDTDATASTORE_LOG_CONTEXT, @"Found a match in keychain, but it was empty");
+        }
+    } else if (err == errSecItemNotFound) {
+        CDTLogWarn(CDTDATASTORE_LOG_CONTEXT, @"DPK doc not found in keychain");
+    } else {
+        CDTLogWarn(CDTDATASTORE_LOG_CONTEXT,
+                   @"Error getting DPK doc from keychain, SecItemCopyMatching returned: %d", err);
+    }
+
+    return result;
+}
+
+#pragma mark - Private class methods
++ (NSMutableDictionary *)genericPwLookupDictWithService:(NSString *)service
+                                                account:(NSString *)account
+{
+    NSMutableDictionary *genericPasswordQuery = [[NSMutableDictionary alloc] init];
+    
+    [genericPasswordQuery setObject:(__bridge id)kSecClassGenericPassword
+                             forKey:(__bridge id)kSecClass];
+    [genericPasswordQuery setObject:service forKey:(__bridge id<NSCopying>)(kSecAttrService)];
+    [genericPasswordQuery setObject:account forKey:(__bridge id<NSCopying>)(kSecAttrAccount)];
+
+    // Use the proper search constants, return only the attributes of the first match.
+    [genericPasswordQuery setObject:(__bridge id)kSecMatchLimitOne
+                             forKey:(__bridge id<NSCopying>)(kSecMatchLimit)];
+    [genericPasswordQuery setObject:(__bridge id)kCFBooleanFalse
+                             forKey:(__bridge id<NSCopying>)(kSecReturnAttributes)];
+    [genericPasswordQuery setObject:(__bridge id)kCFBooleanTrue
+                             forKey:(__bridge id<NSCopying>)(kSecReturnData)];
+    
+    return genericPasswordQuery;
+}
+
++ (NSMutableDictionary *)genericPwStoreDictWithService:(NSString *)service
+                                               account:(NSString *)account
+                                                  data:(NSData *)data
+{
+    NSMutableDictionary *genericPasswordQuery = [[NSMutableDictionary alloc] init];
+    
+    [genericPasswordQuery setObject:(__bridge id)kSecClassGenericPassword
+                             forKey:(__bridge id)kSecClass];
+    [genericPasswordQuery setObject:service forKey:(__bridge id<NSCopying>)(kSecAttrService)];
+    [genericPasswordQuery setObject:account forKey:(__bridge id<NSCopying>)(kSecAttrAccount)];
+
+    [genericPasswordQuery setObject:data forKey:(__bridge id<NSCopying>)(kSecValueData)];
+
+    [genericPasswordQuery setObject:(__bridge id)(kSecAttrAccessibleAfterFirstUnlock)
+                             forKey:(__bridge id<NSCopying>)(kSecAttrAccessible)];
+
+    return genericPasswordQuery;
+}
+
+@end

--- a/Tests/Tests.xcodeproj/project.pbxproj
+++ b/Tests/Tests.xcodeproj/project.pbxproj
@@ -90,6 +90,8 @@
 		CD2188E41AE571410036F59F /* CDTEncryptionKeychainUtilsAESTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD2188E11AE571410036F59F /* CDTEncryptionKeychainUtilsAESTests.m */; };
 		CD2188E51AE571410036F59F /* CDTEncryptionKeychainUtilsPBKDF2Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD2188E21AE571410036F59F /* CDTEncryptionKeychainUtilsPBKDF2Tests.m */; };
 		CD2188E61AE571410036F59F /* CDTEncryptionKeychainUtilsPBKDF2Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD2188E21AE571410036F59F /* CDTEncryptionKeychainUtilsPBKDF2Tests.m */; };
+		CD2188E81AE574A20036F59F /* CDTEncryptionKeychainDataTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD2188E71AE574A20036F59F /* CDTEncryptionKeychainDataTests.m */; };
+		CD2188E91AE574A20036F59F /* CDTEncryptionKeychainDataTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD2188E71AE574A20036F59F /* CDTEncryptionKeychainDataTests.m */; };
 		CD3FBCA61AB05A170032376E /* CDTHelperFixedKeyProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = CD3FBCA31AB05A170032376E /* CDTHelperFixedKeyProvider.m */; };
 		CD3FBCA71AB05A170032376E /* CDTHelperFixedKeyProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = CD3FBCA31AB05A170032376E /* CDTHelperFixedKeyProvider.m */; };
 		CD3FBCA81AB05A170032376E /* CDTHelperOneUseKeyProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = CD3FBCA51AB05A170032376E /* CDTHelperOneUseKeyProvider.m */; };
@@ -202,6 +204,7 @@
 		CD2188D51AE5711A0036F59F /* TD_DatabaseEncryptionTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TD_DatabaseEncryptionTests.m; sourceTree = "<group>"; };
 		CD2188E11AE571410036F59F /* CDTEncryptionKeychainUtilsAESTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTEncryptionKeychainUtilsAESTests.m; sourceTree = "<group>"; };
 		CD2188E21AE571410036F59F /* CDTEncryptionKeychainUtilsPBKDF2Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTEncryptionKeychainUtilsPBKDF2Tests.m; sourceTree = "<group>"; };
+		CD2188E71AE574A20036F59F /* CDTEncryptionKeychainDataTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTEncryptionKeychainDataTests.m; sourceTree = "<group>"; };
 		CD3FBCA21AB05A170032376E /* CDTHelperFixedKeyProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDTHelperFixedKeyProvider.h; sourceTree = "<group>"; };
 		CD3FBCA31AB05A170032376E /* CDTHelperFixedKeyProvider.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTHelperFixedKeyProvider.m; sourceTree = "<group>"; };
 		CD3FBCA41AB05A170032376E /* CDTHelperOneUseKeyProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDTHelperOneUseKeyProvider.h; sourceTree = "<group>"; };
@@ -443,6 +446,7 @@
 		CD2188E01AE571250036F59F /* Keychain */ = {
 			isa = PBXGroup;
 			children = (
+				CD2188E71AE574A20036F59F /* CDTEncryptionKeychainDataTests.m */,
 				CD2188E11AE571410036F59F /* CDTEncryptionKeychainUtilsAESTests.m */,
 				CD2188E21AE571410036F59F /* CDTEncryptionKeychainUtilsPBKDF2Tests.m */,
 			);
@@ -704,6 +708,7 @@
 				EC0C834E1AB217290051042F /* CDTQQuerySqlTranslatorTests.m in Sources */,
 				EC0C835A1AB217290051042F /* CDTQMatcherIndexManager.m in Sources */,
 				EC0C83581AB217290051042F /* CDTQQueryMatcher.m in Sources */,
+				CD2188E81AE574A20036F59F /* CDTEncryptionKeychainDataTests.m in Sources */,
 				EC0C83561AB217290051042F /* CDTQEitherMatcher.m in Sources */,
 				EC0C83401AB217290051042F /* CDTQIndexCreatorTests.m in Sources */,
 				9F95D61018CF6A580006D349 /* DBQueryUtils.m in Sources */,
@@ -767,6 +772,7 @@
 				EC0C835B1AB217290051042F /* CDTQMatcherIndexManager.m in Sources */,
 				EC0C83591AB217290051042F /* CDTQQueryMatcher.m in Sources */,
 				EC0C83571AB217290051042F /* CDTQEitherMatcher.m in Sources */,
+				CD2188E91AE574A20036F59F /* CDTEncryptionKeychainDataTests.m in Sources */,
 				9F95D61118CF6A580006D349 /* DBQueryUtils.m in Sources */,
 				EC0C83411AB217290051042F /* CDTQIndexCreatorTests.m in Sources */,
 				27CCEDD6187AD70C006F3C66 /* CloudantSyncTests.m in Sources */,

--- a/Tests/Tests/Encryption/Keychain/CDTEncryptionKeychainDataTests.m
+++ b/Tests/Tests/Encryption/Keychain/CDTEncryptionKeychainDataTests.m
@@ -1,0 +1,134 @@
+//
+//  CDTEncryptionKeychainDataTests.m
+//  Tests
+//
+//  Created by Enrique de la Torre Fernandez on 14/04/2015.
+//  Copyright (c) 2015 IBM Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#import <XCTest/XCTest.h>
+
+#import "CDTEncryptionKeychainData.h"
+
+@interface CDTEncryptionKeychainDataTests : XCTestCase
+
+@property (strong, nonatomic) NSData *defaultEncryptedDPK;
+@property (strong, nonatomic) NSData *defaultSalt;
+@property (strong, nonatomic) NSData *defaultIv;
+@property (assign, nonatomic) NSInteger defaultIterations;
+@property (strong, nonatomic) NSString *defaultVersion;
+
+@end
+
+@implementation CDTEncryptionKeychainDataTests
+
+- (void)setUp
+{
+    [super setUp];
+
+    // Put setup code here. This method is called before the invocation of each test method in the
+    // class.
+    self.defaultEncryptedDPK = [@"encryptedDPK" dataUsingEncoding:NSUnicodeStringEncoding];
+    self.defaultSalt = [@"salt" dataUsingEncoding:NSUnicodeStringEncoding];
+    self.defaultIv = [@"iv" dataUsingEncoding:NSUnicodeStringEncoding];
+    self.defaultIterations = 0;
+    self.defaultVersion = @"x.x";
+}
+
+- (void)tearDown
+{
+    // Put teardown code here. This method is called after the invocation of each test method in the
+    // class.
+    self.defaultEncryptedDPK = nil;
+    self.defaultSalt = nil;
+    self.defaultIv = nil;
+    self.defaultVersion = nil;
+
+    [super tearDown];
+}
+
+- (void)testSimpleInitFails
+{
+    XCTAssertNil([[CDTEncryptionKeychainData alloc] init], @"All properties are mandatory");
+}
+
+- (void)testInitFailsIfEncryptedDPKIsNil
+{
+    XCTAssertNil([[CDTEncryptionKeychainData alloc] initWithEncryptedDPK:nil
+                                                                    salt:self.defaultSalt
+                                                                      iv:self.defaultIv
+                                                              iterations:self.defaultIterations
+                                                                 version:self.defaultVersion],
+                 @"Encrypted DPK is mandatory");
+}
+
+- (void)testInitFailsIfSaltIsNil
+{
+    XCTAssertNil([[CDTEncryptionKeychainData alloc] initWithEncryptedDPK:self.defaultEncryptedDPK
+                                                                    salt:nil
+                                                                      iv:self.defaultIv
+                                                              iterations:self.defaultIterations
+                                                                 version:self.defaultVersion],
+                 @"Salt is mandatory");
+}
+
+- (void)testInitFailsIfIVIsNil
+{
+    XCTAssertNil([[CDTEncryptionKeychainData alloc] initWithEncryptedDPK:self.defaultEncryptedDPK
+                                                                    salt:self.defaultSalt
+                                                                      iv:nil
+                                                              iterations:self.defaultIterations
+                                                                 version:self.defaultVersion],
+                 @"IV is mandatory");
+}
+
+- (void)testInitFailsIfVersionIsNil
+{
+    XCTAssertNil([[CDTEncryptionKeychainData alloc] initWithEncryptedDPK:self.defaultEncryptedDPK
+                                                                    salt:self.defaultSalt
+                                                                      iv:self.defaultIv
+                                                              iterations:self.defaultIterations
+                                                                 version:nil],
+                 @"IV is mandatory");
+}
+
+- (void)testInitFailsIfIterationsValueIsNotPositiveOrZero
+{
+    XCTAssertNil([[CDTEncryptionKeychainData alloc] initWithEncryptedDPK:self.defaultEncryptedDPK
+                                                                    salt:self.defaultSalt
+                                                                      iv:self.defaultIv
+                                                              iterations:-1
+                                                                 version:self.defaultVersion],
+                 @"Iterations value has to be positive or zero");
+}
+
+- (void)testArchiveUnarchiveData
+{
+    CDTEncryptionKeychainData *keychainData =
+        [[CDTEncryptionKeychainData alloc] initWithEncryptedDPK:self.defaultEncryptedDPK
+                                                           salt:self.defaultSalt
+                                                             iv:self.defaultIv
+                                                     iterations:self.defaultIterations
+                                                        version:self.defaultVersion];
+
+    NSData *archivedData = [NSKeyedArchiver archivedDataWithRootObject:keychainData];
+    CDTEncryptionKeychainData *keychainUnarchivedData =
+        [NSKeyedUnarchiver unarchiveObjectWithData:archivedData];
+    
+    XCTAssertTrue([keychainData.encryptedDPK isEqualToData:keychainUnarchivedData.encryptedDPK] &&
+                  [keychainData.salt isEqualToData:keychainUnarchivedData.salt] &&
+                  [keychainData.iv isEqualToData:keychainUnarchivedData.iv] &&
+                  (keychainData.iterations == keychainUnarchivedData.iterations) &&
+                  [keychainData.version isEqualToString:keychainUnarchivedData.version],
+                  @"An unarchived data must be equal to the original");
+}
+
+@end


### PR DESCRIPTION
*What:*
Add classes to safely store a DPK (Data Protection Key) in the keychain.

*Why:*
This PR is part of a bigger development to provide a mechanism to generate a key and safely store it.

*How:*
Instead of saving the DPK, we save enough data to recreate the DPK after the user provides the correct password.

*Tests:*
* A data class can only be created if all properties are provided
* A data class can archive and unarchive.

reviewer @mikerhodes 
reviewer @rhyshort 

**NOTE:** Wait to review this PR until PR #126 is closed. This branch will be rebased and there will be only one commit to review.
