### PR TITLE
45570 Generate, retrieve & store a key: Manager to generate & retrieve a key

### DIFF
--- a/CDTDatastore.xcworkspace/contents.xcworkspacedata
+++ b/CDTDatastore.xcworkspace/contents.xcworkspacedata
@@ -30,10 +30,22 @@
                location = "group:Keychain"
                name = "Keychain">
                <FileRef
+                  location = "group:CDTEncryptionKeychainConstants.h">
+               </FileRef>
+               <FileRef
                   location = "group:CDTEncryptionKeychainData.h">
                </FileRef>
                <FileRef
                   location = "group:CDTEncryptionKeychainData.m">
+               </FileRef>
+               <FileRef
+                  location = "group:CDTEncryptionKeychainManager.h">
+               </FileRef>
+               <FileRef
+                  location = "group:CDTEncryptionKeychainManager.m">
+               </FileRef>
+               <FileRef
+                  location = "group:CDTEncryptionKeychainManager+Internal.h">
                </FileRef>
                <FileRef
                   location = "group:CDTEncryptionKeychainStorage.h">

--- a/Classes/common/Encryption/Keychain/CDTEncryptionKeychainConstants.h
+++ b/Classes/common/Encryption/Keychain/CDTEncryptionKeychainConstants.h
@@ -1,0 +1,37 @@
+//
+//  CDTEncryptionKeychainConstants.h
+//  CloudantSync
+//
+//  Created by Enrique de la Torre Fernandez on 09/04/2015.
+//  Copyright (c) 2015 IBM Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#ifndef _CDTEncryptionKeychainConstants_h
+#define _CDTEncryptionKeychainConstants_h
+
+#import <CommonCrypto/CommonCryptor.h>
+
+// Define the version of the implementation used to cipher/decipher DPKs
+#define CDTENCRYPTION_KEYCHAIN_VERSION @"1.0"
+
+// Size (bytes) of the DPK (Data Protection Key)
+#define CDTENCRYPTION_KEYCHAIN_ENCRYPTIONKEY_SIZE 32
+
+// PBKDF2: Size (bytes) of the salt value used to derive a user-provided password
+#define CDTENCRYPTION_KEYCHAIN_PBKDF2_SALT_SIZE 32
+
+// PBKDF2: Number of times the derivation process is applied to a user-provided password
+#define CDTENCRYPTION_KEYCHAIN_PBKDF2_ITERATIONS (NSInteger)10000
+
+// AES: Size (bytes) of the key used to encrypt/decrypt a DPK
+#define CDTENCRYPTION_KEYCHAIN_AES_KEY_SIZE kCCKeySizeAES256
+
+#endif

--- a/Classes/common/Encryption/Keychain/CDTEncryptionKeychainManager+Internal.h
+++ b/Classes/common/Encryption/Keychain/CDTEncryptionKeychainManager+Internal.h
@@ -1,0 +1,43 @@
+//
+//  CDTEncryptionKeychainManager+Internal.h
+//  CloudantSync
+//
+//  Created by Enrique de la Torre Fernandez on 15/04/2015.
+//  Copyright (c) 2015 IBM Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#import "CDTEncryptionKeychainManager.h"
+
+/**
+ This category is only for testing purposes. It presents some of the private methods used by
+ CDTEncryptionKeychainManager to complete its job.
+ */
+@interface CDTEncryptionKeychainManager (Internal)
+
+- (BOOL)validateEncryptionKeyData:(CDTEncryptionKeychainData *)data;
+
+- (NSData *)generateDpk;
+
+- (CDTEncryptionKeychainData *)keychainDataToStoreDpk:(NSData *)dpk
+                                encryptedWithPassword:(NSString *)password;
+
+- (NSData *)generatePBKDF2Salt;
+- (NSData *)pbkdf2DerivedKeyForPassword:(NSString *)pass
+                                   salt:(NSData *)salt
+                             iterations:(NSInteger)iterations
+                                 length:(NSUInteger)length;
+
+- (NSData *)generateAESIv;
+
+- (NSData *)encryptDpk:(NSData *)dpk usingAESWithKey:(NSData *)key iv:(NSData *)iv;
+- (NSData *)decryptDpk:(NSData *)cipheredDpk usingAESWithKey:(NSData *)key iv:(NSData *)iv;
+
+@end

--- a/Classes/common/Encryption/Keychain/CDTEncryptionKeychainManager.h
+++ b/Classes/common/Encryption/Keychain/CDTEncryptionKeychainManager.h
@@ -1,0 +1,85 @@
+//
+//  CDTEncryptionKeychainManager.h
+//  CloudantSync
+//
+//  Created by Enrique de la Torre Fernandez on 09/04/2015.
+//  Copyright (c) 2015 IBM Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "CDTEncryptionKeychainStorage.h"
+
+/**
+ Use this class to generate a Data Protection Key (DPK), i.e. a strong password that can be used
+ later on for other purposes like encrypting a database.
+ 
+ The generated DPK is automatically encrypted and saved to the keychain, for this reason, it is
+ neccesary to provide a password to generate and retrieve the DPK. On a high level, this is done as
+ follow:
+ - Generate a DPK as a 32 bytes buffer with secure random values.
+ - Generate a salt as a 32 bytes buffer with secure random values.
+ - Use PBKDF2 to derive a key based on the user-provided password and the salt.
+ - Generate an initialization vector (IV) as a 16 bytes buffer with secure random values.
+ - Use AES to cipher the DPK with the key and the IV.
+ - Return the DPK and save the encrypted version to the keychain.
+ */
+@interface CDTEncryptionKeychainManager : NSObject
+
+- (instancetype)init UNAVAILABLE_ATTRIBUTE;
+
+/**
+ Initialise a manager with a CDTEncryptionKeychainStorage instance.
+ 
+ A CDTEncryptionKeychainStorage binds an entry in the keychain to an identifier. The data
+ protection key (DPK) saved to the keychain by this class will therefore be bound to the storage's
+ identifier. To save different DPKs (say for different users of your application), create multiple
+ managers using storages initialised with different identifiers.
+ 
+ @param storage Storage instance to save DPKs to the keychain
+ 
+ @see CDTEncryptionKeychainStorage
+ */
+- (instancetype)initWithStorage:(CDTEncryptionKeychainStorage *)storage;
+
+/**
+ Returns the decrypted Data Protection Key (DPK) from the keychain.
+ 
+ @param password Password used to decrypt the DPK
+ 
+ @return The DPK
+ */
+- (NSData *)loadKeyUsingPassword:(NSString *)password;
+
+/**
+ Generates a Data Protection Key (DPK), encrypts it, and stores it inside the keychain.
+ 
+ @param password Password used to encrypt the DPK
+ 
+ @return The DPK
+ */
+- (NSData *)generateAndSaveKeyProtectedByPassword:(NSString *)password;
+
+/**
+ Checks if the encrypted Data Protection Key (DPK) is inside the keychain.
+ 
+ @return YES if the encrypted DPK is inside the keychain, NO otherwise
+ */
+- (BOOL)keyExists;
+
+/**
+ Clears security metadata from the keychain.
+ 
+ @return Success (true) or failure (false)
+ */
+- (BOOL)clearKey;
+
+@end

--- a/Classes/common/Encryption/Keychain/CDTEncryptionKeychainManager.m
+++ b/Classes/common/Encryption/Keychain/CDTEncryptionKeychainManager.m
@@ -1,0 +1,184 @@
+//
+//  CDTEncryptionKeychainManager.m
+//  CloudantSync
+//
+//  Created by Enrique de la Torre Fernandez on 09/04/2015.
+//  Copyright (c) 2015 IBM Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#import <CommonCrypto/CommonCryptor.h>
+
+#import "CDTEncryptionKeychainManager.h"
+
+#import "CDTEncryptionKeychainUtils.h"
+#import "CDTEncryptionKeychainConstants.h"
+
+#import "CDTLogging.h"
+
+#define CDTENCRYPTIONKEYCHAINMANAGER_AES_IV_SIZE kCCBlockSizeAES128
+
+@interface CDTEncryptionKeychainManager ()
+
+@property (strong, nonatomic, readonly) CDTEncryptionKeychainStorage *storage;
+
+@end
+
+@implementation CDTEncryptionKeychainManager
+
+#pragma mark - Init object
+- (instancetype)init { return [self initWithStorage:nil]; }
+
+- (instancetype)initWithStorage:(CDTEncryptionKeychainStorage *)storage
+{
+    self = [super init];
+    if (self) {
+        if (storage) {
+            _storage = storage;
+        } else {
+            CDTLogError(CDTDATASTORE_LOG_CONTEXT, @"Storage is mandatory");
+
+            self = nil;
+        }
+    }
+
+    return self;
+}
+
+#pragma mark - Public methods
+- (NSData *)loadKeyUsingPassword:(NSString *)password
+{
+    CDTEncryptionKeychainData *data = [self.storage encryptionKeyData];
+    if (!data || ![self validateEncryptionKeyData:data]) {
+        return nil;
+    }
+
+    NSData *aesKey = [self pbkdf2DerivedKeyForPassword:password
+                                                  salt:data.salt
+                                            iterations:data.iterations
+                                                length:CDTENCRYPTION_KEYCHAIN_AES_KEY_SIZE];
+
+    NSData *dpk = [self decryptDpk:data.encryptedDPK usingAESWithKey:aesKey iv:data.iv];
+
+    return dpk;
+}
+
+- (NSData *)generateAndSaveKeyProtectedByPassword:(NSString *)password
+{
+    NSData *dpk = nil;
+
+    if (![self keyExists]) {
+        dpk = [self generateDpk];
+
+        CDTEncryptionKeychainData *keychainData =
+            [self keychainDataToStoreDpk:dpk encryptedWithPassword:password];
+
+        if (![self.storage saveEncryptionKeyData:keychainData]) {
+            dpk = nil;
+        }
+    }
+
+    return dpk;
+}
+
+- (BOOL)keyExists { return [self.storage encryptionKeyDataExists]; }
+
+- (BOOL)clearKey { return [self.storage clearEncryptionKeyData]; }
+
+#pragma mark - CDTEncryptionKeychainManager+Internal methods
+- (BOOL)validateEncryptionKeyData:(CDTEncryptionKeychainData *)data
+{
+    // Ensure IV has the correct length
+    if (data.iv.length != CDTENCRYPTIONKEYCHAINMANAGER_AES_IV_SIZE) {
+        CDTLogWarn(CDTDATASTORE_LOG_CONTEXT, @"IV does not have the expected size: %i bytes",
+                   CDTENCRYPTIONKEYCHAINMANAGER_AES_IV_SIZE);
+
+        return NO;
+    }
+
+    return YES;
+}
+
+- (NSData *)generateDpk
+{
+    NSData *dpk = [CDTEncryptionKeychainUtils
+        generateSecureRandomBytesWithLength:CDTENCRYPTION_KEYCHAIN_ENCRYPTIONKEY_SIZE];
+
+    return dpk;
+}
+
+- (CDTEncryptionKeychainData *)keychainDataToStoreDpk:(NSData *)dpk
+                                encryptedWithPassword:(NSString *)password
+{
+    NSData *salt = [self generatePBKDF2Salt];
+
+    NSData *key = [self pbkdf2DerivedKeyForPassword:password
+                                               salt:salt
+                                         iterations:CDTENCRYPTION_KEYCHAIN_PBKDF2_ITERATIONS
+                                             length:CDTENCRYPTION_KEYCHAIN_AES_KEY_SIZE];
+
+    NSData *iv = [self generateAESIv];
+
+    NSData *encryptedDpk = [self encryptDpk:dpk usingAESWithKey:key iv:iv];
+
+    CDTEncryptionKeychainData *keychainData =
+        [CDTEncryptionKeychainData dataWithEncryptedDPK:encryptedDpk
+                                                   salt:salt
+                                                     iv:iv
+                                             iterations:CDTENCRYPTION_KEYCHAIN_PBKDF2_ITERATIONS
+                                                version:CDTENCRYPTION_KEYCHAIN_VERSION];
+
+    return keychainData;
+}
+
+- (NSData *)generatePBKDF2Salt
+{
+    NSData *salt = [CDTEncryptionKeychainUtils
+        generateSecureRandomBytesWithLength:CDTENCRYPTION_KEYCHAIN_PBKDF2_SALT_SIZE];
+
+    return salt;
+}
+
+- (NSData *)pbkdf2DerivedKeyForPassword:(NSString *)pass
+                                   salt:(NSData *)salt
+                             iterations:(NSInteger)iterations
+                                 length:(NSUInteger)length
+{
+    NSData *key = [CDTEncryptionKeychainUtils pbkdf2DerivedKeyForPassword:pass
+                                                                     salt:salt
+                                                               iterations:iterations
+                                                                   length:length];
+
+    return key;
+}
+
+- (NSData *)generateAESIv
+{
+    NSData *iv = [CDTEncryptionKeychainUtils
+        generateSecureRandomBytesWithLength:CDTENCRYPTIONKEYCHAINMANAGER_AES_IV_SIZE];
+
+    return iv;
+}
+
+- (NSData *)encryptDpk:(NSData *)dpk usingAESWithKey:(NSData *)key iv:(NSData *)iv
+{
+    NSData *encyptedDpk = [CDTEncryptionKeychainUtils aesEncryptedDataForData:dpk key:key iv:iv];
+
+    return encyptedDpk;
+}
+
+- (NSData *)decryptDpk:(NSData *)cipheredDpk usingAESWithKey:(NSData *)key iv:(NSData *)iv
+{
+    NSData *dpk = [CDTEncryptionKeychainUtils dataForAESEncryptedData:cipheredDpk key:key iv:iv];
+
+    return dpk;
+}
+
+@end

--- a/Classes/common/Encryption/Keychain/CDTEncryptionKeychainUtils+PBKDF2.h
+++ b/Classes/common/Encryption/Keychain/CDTEncryptionKeychainUtils+PBKDF2.h
@@ -28,7 +28,7 @@
 /**
  Generates a key by using the PBKDF2 algorithm.
 
- @param length Size of the key
+ @param length Size of the key in bytes
  @param password The password that is used to generate the key
  @param salt The salt that is used to generate the key
  @param iterations The number of iterations that is passed to the key generation algorithm

--- a/Classes/common/Encryption/Keychain/CDTEncryptionKeychainUtils.h
+++ b/Classes/common/Encryption/Keychain/CDTEncryptionKeychainUtils.h
@@ -34,10 +34,11 @@ extern NSString *const CDTENCRYPTION_KEYCHAIN_UTILS_ERROR_LABEL_DECRYPT;
 
  @return The buffer, nil if the operation fails
  */
-+ (NSData *)generateRandomBytesInBufferWithLength:(NSUInteger)length;
++ (NSData *)generateSecureRandomBytesWithLength:(NSUInteger)length;
 
 /**
- Encrypts a buffer by using a key and an Initialization Vector (IV).
+ Generates a new buffer by applying AES to the buffer passed as a parameter with the key and
+ Initialization Vector (IV) also supplied as parameters.
 
  This method asummes correct inputs:
  - The key length must be kCCKeySizeAES128(16), kCCKeySizeAES192(24) or kCCKeySizeAES256(32)
@@ -50,10 +51,11 @@ extern NSString *const CDTENCRYPTION_KEYCHAIN_UTILS_ERROR_LABEL_DECRYPT;
 
  @return The encrypted data
  */
-+ (NSData *)encryptData:(NSData *)data withKey:(NSData *)key iv:(NSData *)iv;
++ (NSData *)aesEncryptedDataForData:(NSData *)data key:(NSData *)key iv:(NSData *)iv;
 
 /**
- Decrypts a buffer by using a key and an Initialization Vector (IV).
+ Generates a new buffer using AES to decrypt the buffer passed as a parameter with the key and
+ Initialization Vector (IV) also supplied as parameters.
 
  This method asummes correct inputs:
  - The key length must be kCCKeySizeAES128(16), kCCKeySizeAES192(24) or kCCKeySizeAES256(32)
@@ -66,21 +68,21 @@ extern NSString *const CDTENCRYPTION_KEYCHAIN_UTILS_ERROR_LABEL_DECRYPT;
 
  @return The decrypted data
  */
-+ (NSData *)decryptData:(NSData *)data withKey:(NSData *)key iv:(NSData *)iv;
++ (NSData *)dataForAESEncryptedData:(NSData *)data key:(NSData *)key iv:(NSData *)iv;
 
 /**
  Generates a key by using the PBKDF2 algorithm.
 
- @param length Size of the key
  @param pass The password that is used to generate the key
  @param salt The salt that is used to generate the key
  @param iterations The number of iterations that is passed to the key generation algorithm
+ @param length Size of the key in bytes
 
  @return The generated key
  */
-+ (NSData *)generateKeyOfLength:(NSUInteger)length
-                  usingPassword:(NSString *)pass
-                       withSalt:(NSData *)salt
-                     iterations:(NSInteger)iterations;
++ (NSData *)pbkdf2DerivedKeyForPassword:(NSString *)pass
+                                   salt:(NSData *)salt
+                             iterations:(NSInteger)iterations
+                                 length:(NSUInteger)length;
 
 @end

--- a/Classes/common/Encryption/Keychain/CDTEncryptionKeychainUtils.m
+++ b/Classes/common/Encryption/Keychain/CDTEncryptionKeychainUtils.m
@@ -53,7 +53,7 @@ NSString *const CDTENCRYPTION_KEYCHAIN_UTILS_ERROR_DECRYPT_MSG_EMPTY_IV =
 @implementation CDTEncryptionKeychainUtils
 
 #pragma mark - Public class methods
-+ (NSData *)generateRandomBytesInBufferWithLength:(NSUInteger)length
++ (NSData *)generateSecureRandomBytesWithLength:(NSUInteger)length
 {
     NSAssert((size_t)length <= SIZE_T_MAX, @"length %lu out of bound", (unsigned long)length);
     
@@ -69,7 +69,7 @@ NSString *const CDTENCRYPTION_KEYCHAIN_UTILS_ERROR_DECRYPT_MSG_EMPTY_IV =
     return data;
 }
 
-+ (NSData *)encryptData:(NSData *)data withKey:(NSData *)key iv:(NSData *)iv
++ (NSData *)aesEncryptedDataForData:(NSData *)data key:(NSData *)key iv:(NSData *)iv
 {
     if (![data isKindOfClass:[NSData class]] || (data.length < 1)) {
         [NSException raise:CDTENCRYPTION_KEYCHAIN_UTILS_ERROR_ENCRYPT_LABEL
@@ -91,7 +91,7 @@ NSString *const CDTENCRYPTION_KEYCHAIN_UTILS_ERROR_DECRYPT_MSG_EMPTY_IV =
     return cipherDat;
 }
 
-+ (NSData *)decryptData:(NSData *)data withKey:(NSData *)key iv:(NSData *)iv
++ (NSData *)dataForAESEncryptedData:(NSData *)data key:(NSData *)key iv:(NSData *)iv
 {
     if (![data isKindOfClass:[NSData class]] || (data.length < 1)) {
         [NSException raise:CDTENCRYPTION_KEYCHAIN_UTILS_ERROR_DECRYPT_LABEL
@@ -113,10 +113,10 @@ NSString *const CDTENCRYPTION_KEYCHAIN_UTILS_ERROR_DECRYPT_MSG_EMPTY_IV =
     return decodedCipher;
 }
 
-+ (NSData *)generateKeyOfLength:(NSUInteger)length
-                  usingPassword:(NSString *)pass
-                       withSalt:(NSData *)salt
-                     iterations:(NSInteger)iterations
++ (NSData *)pbkdf2DerivedKeyForPassword:(NSString *)pass
+                                   salt:(NSData *)salt
+                             iterations:(NSInteger)iterations
+                                 length:(NSUInteger)length
 {
     if (length < 1) {
         [NSException raise:CDTENCRYPTION_KEYCHAIN_UTILS_ERROR_KEYGEN_LABEL

--- a/Tests/Tests.xcodeproj/project.pbxproj
+++ b/Tests/Tests.xcodeproj/project.pbxproj
@@ -92,6 +92,10 @@
 		CD2188E61AE571410036F59F /* CDTEncryptionKeychainUtilsPBKDF2Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD2188E21AE571410036F59F /* CDTEncryptionKeychainUtilsPBKDF2Tests.m */; };
 		CD2188E81AE574A20036F59F /* CDTEncryptionKeychainDataTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD2188E71AE574A20036F59F /* CDTEncryptionKeychainDataTests.m */; };
 		CD2188E91AE574A20036F59F /* CDTEncryptionKeychainDataTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD2188E71AE574A20036F59F /* CDTEncryptionKeychainDataTests.m */; };
+		CD2188EB1AE5764B0036F59F /* CDTEncryptionKeychainManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD2188EA1AE5764B0036F59F /* CDTEncryptionKeychainManagerTests.m */; };
+		CD2188EC1AE5764B0036F59F /* CDTEncryptionKeychainManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD2188EA1AE5764B0036F59F /* CDTEncryptionKeychainManagerTests.m */; };
+		CD2188F01AE576740036F59F /* CDTMockEncryptionKeychainStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = CD2188EF1AE576740036F59F /* CDTMockEncryptionKeychainStorage.m */; };
+		CD2188F11AE576740036F59F /* CDTMockEncryptionKeychainStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = CD2188EF1AE576740036F59F /* CDTMockEncryptionKeychainStorage.m */; };
 		CD3FBCA61AB05A170032376E /* CDTHelperFixedKeyProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = CD3FBCA31AB05A170032376E /* CDTHelperFixedKeyProvider.m */; };
 		CD3FBCA71AB05A170032376E /* CDTHelperFixedKeyProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = CD3FBCA31AB05A170032376E /* CDTHelperFixedKeyProvider.m */; };
 		CD3FBCA81AB05A170032376E /* CDTHelperOneUseKeyProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = CD3FBCA51AB05A170032376E /* CDTHelperOneUseKeyProvider.m */; };
@@ -205,6 +209,9 @@
 		CD2188E11AE571410036F59F /* CDTEncryptionKeychainUtilsAESTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTEncryptionKeychainUtilsAESTests.m; sourceTree = "<group>"; };
 		CD2188E21AE571410036F59F /* CDTEncryptionKeychainUtilsPBKDF2Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTEncryptionKeychainUtilsPBKDF2Tests.m; sourceTree = "<group>"; };
 		CD2188E71AE574A20036F59F /* CDTEncryptionKeychainDataTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTEncryptionKeychainDataTests.m; sourceTree = "<group>"; };
+		CD2188EA1AE5764B0036F59F /* CDTEncryptionKeychainManagerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTEncryptionKeychainManagerTests.m; sourceTree = "<group>"; };
+		CD2188EE1AE576740036F59F /* CDTMockEncryptionKeychainStorage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDTMockEncryptionKeychainStorage.h; sourceTree = "<group>"; };
+		CD2188EF1AE576740036F59F /* CDTMockEncryptionKeychainStorage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTMockEncryptionKeychainStorage.m; sourceTree = "<group>"; };
 		CD3FBCA21AB05A170032376E /* CDTHelperFixedKeyProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDTHelperFixedKeyProvider.h; sourceTree = "<group>"; };
 		CD3FBCA31AB05A170032376E /* CDTHelperFixedKeyProvider.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTHelperFixedKeyProvider.m; sourceTree = "<group>"; };
 		CD3FBCA41AB05A170032376E /* CDTHelperOneUseKeyProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDTHelperOneUseKeyProvider.h; sourceTree = "<group>"; };
@@ -446,11 +453,22 @@
 		CD2188E01AE571250036F59F /* Keychain */ = {
 			isa = PBXGroup;
 			children = (
+				CD2188ED1AE576680036F59F /* Mock */,
 				CD2188E71AE574A20036F59F /* CDTEncryptionKeychainDataTests.m */,
+				CD2188EA1AE5764B0036F59F /* CDTEncryptionKeychainManagerTests.m */,
 				CD2188E11AE571410036F59F /* CDTEncryptionKeychainUtilsAESTests.m */,
 				CD2188E21AE571410036F59F /* CDTEncryptionKeychainUtilsPBKDF2Tests.m */,
 			);
 			path = Keychain;
+			sourceTree = "<group>";
+		};
+		CD2188ED1AE576680036F59F /* Mock */ = {
+			isa = PBXGroup;
+			children = (
+				CD2188EE1AE576740036F59F /* CDTMockEncryptionKeychainStorage.h */,
+				CD2188EF1AE576740036F59F /* CDTMockEncryptionKeychainStorage.m */,
+			);
+			path = Mock;
 			sourceTree = "<group>";
 		};
 		CD3FBCA11AB05A170032376E /* Helpers */ = {
@@ -680,6 +698,7 @@
 				9F0D24111890AD0C00D3D04E /* TDMultipartDownloaderTests.m in Sources */,
 				27F43D4918E99C31003E8422 /* AmazonMD5Util.m in Sources */,
 				EC0C83501AB217290051042F /* CDTQUnindexedMatcherTests.m in Sources */,
+				CD2188F01AE576740036F59F /* CDTMockEncryptionKeychainStorage.m in Sources */,
 				CD2188E31AE571410036F59F /* CDTEncryptionKeychainUtilsAESTests.m in Sources */,
 				EC0C83481AB217290051042F /* CDTQPerformanceTests.m in Sources */,
 				EC0C835C1AB217290051042F /* CDTQMatcherQueryExecutor.m in Sources */,
@@ -704,6 +723,7 @@
 				EC0C83601AB217290051042F /* CDTQSQLOnlyQueryExecutor.m in Sources */,
 				CD3FBCA81AB05A170032376E /* CDTHelperOneUseKeyProvider.m in Sources */,
 				CD2188D61AE5711A0036F59F /* CDTQIndexManagerEncryptionTests.m in Sources */,
+				CD2188EB1AE5764B0036F59F /* CDTEncryptionKeychainManagerTests.m in Sources */,
 				9F0D24171893161000D3D04E /* TDReachabilityTests.m in Sources */,
 				EC0C834E1AB217290051042F /* CDTQQuerySqlTranslatorTests.m in Sources */,
 				EC0C835A1AB217290051042F /* CDTQMatcherIndexManager.m in Sources */,
@@ -744,6 +764,7 @@
 				9F0D24121890AD0C00D3D04E /* TDMultipartDownloaderTests.m in Sources */,
 				27F43D4A18E99C31003E8422 /* AmazonMD5Util.m in Sources */,
 				EC0C83511AB217290051042F /* CDTQUnindexedMatcherTests.m in Sources */,
+				CD2188F11AE576740036F59F /* CDTMockEncryptionKeychainStorage.m in Sources */,
 				CD2188E41AE571410036F59F /* CDTEncryptionKeychainUtilsAESTests.m in Sources */,
 				EC0C83491AB217290051042F /* CDTQPerformanceTests.m in Sources */,
 				EC0C835D1AB217290051042F /* CDTQMatcherQueryExecutor.m in Sources */,
@@ -768,6 +789,7 @@
 				EC0C83611AB217290051042F /* CDTQSQLOnlyQueryExecutor.m in Sources */,
 				CD3FBCA91AB05A170032376E /* CDTHelperOneUseKeyProvider.m in Sources */,
 				CD2188D71AE5711A0036F59F /* CDTQIndexManagerEncryptionTests.m in Sources */,
+				CD2188EC1AE5764B0036F59F /* CDTEncryptionKeychainManagerTests.m in Sources */,
 				EC0C834F1AB217290051042F /* CDTQQuerySqlTranslatorTests.m in Sources */,
 				EC0C835B1AB217290051042F /* CDTQMatcherIndexManager.m in Sources */,
 				EC0C83591AB217290051042F /* CDTQQueryMatcher.m in Sources */,

--- a/Tests/Tests/Encryption/Keychain/CDTEncryptionKeychainManagerTests.m
+++ b/Tests/Tests/Encryption/Keychain/CDTEncryptionKeychainManagerTests.m
@@ -1,0 +1,352 @@
+//
+//  CDTEncryptionKeychainManagerTests.m
+//  Tests
+//
+//  Created by Enrique de la Torre Fernandez on 15/04/2015.
+//  Copyright (c) 2015 IBM Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#import <XCTest/XCTest.h>
+
+#import "CDTEncryptionKeychainManager+Internal.h"
+
+#import "CDTEncryptionKeychainUtils.h"
+#import "CDTEncryptionKeychainConstants.h"
+
+#import "CDTMockEncryptionKeychainStorage.h"
+
+// NOTE: There is no need for a stronger password given that the following tests check the
+// behaviour of CDTEncryptionKeychainManager, not its encryption capabilities (which is tested in
+// 'CDTEncryptionKeychainUtilsAESTests.m' and 'CDTEncryptionKeychainUtilsPBKDF2Tests.m')
+#define CDTENCRYPTIONKEYCHAINMANAGERTESTS_PASSWORD_DEFAULT @"password"
+
+// Constant for 'CDTEncryptionKeychainManager:validateEncryptionKeyData:'
+NSString *const kCDTEncryptionKeychainManagerTestsValidateEncryptionKeyData =
+    @"kCDTEncryptionKeychainManagerTestsValidateEncryptionKeyData";
+// Constant for 'CDTEncryptionKeychainManager:keyExists'
+NSString *const kCDTEncryptionKeychainManagerTestsKeyExists =
+    @"kCDTEncryptionKeychainManagerTestsKeyExists";
+// Constant for 'CDTEncryptionKeychainManager:generateDpk'
+NSString *const kCDTEncryptionKeychainManagerTestsGenerateDpk =
+    @"kCDTEncryptionKeychainManagerTestsGenerateDpk";
+// Constant for 'CDTEncryptionKeychainManager:keychainDataToStoreDpk:encryptedWithPassword:'
+NSString *const kCDTEncryptionKeychainManagerTestsKeychainDataToStoreDpk =
+    @"kCDTEncryptionKeychainManagerTestsKeychainDataToStoreDpk";
+// Constant for 'CDTEncryptionKeychainManager:generatePBKDF2Salt'
+NSString *const kCDTEncryptionKeychainManagerTestsGeneratePBKDF2Salt =
+    @"kCDTEncryptionKeychainManagerTestsGeneratePBKDF2Salt";
+// Constant for 'CDTEncryptionKeychainManager:pbkdf2DerivedKeyForPassword:salt:iterations:length:'
+NSString *const kCDTEncryptionKeychainManagerTestsPBKDF2DerivedKey =
+    @"kCDTEncryptionKeychainManagerTestsPBKDF2DerivedKey";
+// Constant for 'CDTEncryptionKeychainManager:generateAESIv'
+NSString *const kCDTEncryptionKeychainManagerTestsGenerateAESIv =
+    @"kCDTEncryptionKeychainManagerTestsGenerateAESIv";
+// Constant for 'CDTEncryptionKeychainManager:encryptDpk:usingAESWithKey:iv:'
+NSString *const kCDTEncryptionKeychainManagerTestsEncryptDpk =
+    @"kCDTEncryptionKeychainManagerTestsEncryptDpk";
+// Constant for 'CDTEncryptionKeychainManager:decryptDpk:usingAESWithKey:iv:'
+NSString *const kCDTEncryptionKeychainManagerTestsDecryptDpk =
+    @"kCDTEncryptionKeychainManagerTestsDecryptDpk";
+
+/**
+ CDTEncryptionCustomKeychainManager is a mock class for CDTEncryptionKeychainManager. 
+ 
+ It does not add or modify the functionality of its parent class, instead it overrides the methods
+ declared in CDTEncryptionKeychainManager+Internal this way:
+ - Add to 'lastSteps' the constant related to the current method (check above).
+ - Use 'super' to execute the implementation of the method in the parent class.
+ 
+ This allows us to track the behaviour of the parent class when we execute its methods under
+ different circunstances.
+ */
+@interface CDTEncryptionCustomKeychainManager : CDTEncryptionKeychainManager
+
+@property (strong, nonatomic) NSMutableArray *lastSteps;
+
+@end
+
+@interface CDTEncryptionKeychainManagerTests : XCTestCase
+
+@property (strong, nonatomic) CDTEncryptionCustomKeychainManager *manager;
+
+@property (strong, nonatomic) NSString *password;
+@property (strong, nonatomic) CDTEncryptionKeychainData *keychainData;
+@property (strong, nonatomic) CDTMockEncryptionKeychainStorage *mockStorage;
+
+@end
+
+@implementation CDTEncryptionKeychainManagerTests
+
+- (void)setUp
+{
+    [super setUp];
+
+    // Put setup code here. This method is called before the invocation of each test method in the
+    // class.
+    CDTMockEncryptionKeychainStorage *oneStorage = [[CDTMockEncryptionKeychainStorage alloc] init];
+    CDTEncryptionKeychainManager *oneManager = [[CDTEncryptionKeychainManager alloc]
+        initWithStorage:(CDTEncryptionKeychainStorage *)oneStorage];
+    NSData *oneDpk = [oneManager generateDpk];
+
+    self.password = CDTENCRYPTIONKEYCHAINMANAGERTESTS_PASSWORD_DEFAULT;
+    self.keychainData =
+        [oneManager keychainDataToStoreDpk:oneDpk encryptedWithPassword:self.password];
+
+    self.mockStorage = [[CDTMockEncryptionKeychainStorage alloc] init];
+    self.manager = [[CDTEncryptionCustomKeychainManager alloc]
+        initWithStorage:(CDTEncryptionKeychainStorage *)self.mockStorage];
+}
+
+- (void)tearDown
+{
+    // Put teardown code here. This method is called after the invocation of each test method in the
+    // class.
+    self.password = nil;
+    self.keychainData = nil;
+    self.mockStorage = nil;
+    self.manager = nil;
+
+    [super tearDown];
+}
+
+- (void)testInitWithStorageNilFails
+{
+    XCTAssertNil([[CDTEncryptionKeychainManager alloc] initWithStorage:nil],
+                 @"A storage is mandatory");
+}
+
+- (void)testClearKeyDelegatesToStorage
+{
+    [self.manager clearKey];
+
+    XCTAssertTrue(self.mockStorage.clearEncryptionKeyDataExecuted,
+                  @"Data is read or written with the storage instance, therefore it is its "
+                  @"responsability clearing the info");
+}
+
+- (void)testKeyExistsDelegatesToStorage
+{
+    [self.manager keyExists];
+
+    XCTAssertTrue(self.mockStorage.encryptionKeyDataExistsExecuted,
+                  @"Data is read or written with the storage instance, therefore it is its "
+                  @"responsability veritying if there is a key");
+}
+
+- (void)testLoadKeyUsingPasswordFailsIfThereIsNotData
+{
+    XCTAssertNil([self.manager loadKeyUsingPassword:self.password],
+                 @"No key to return if there is no data in the keychain");
+}
+
+- (void)testLoadKeyUsingPasswordDoesNotFailIfNumberOfIterationsIsNotAsExpected
+{
+    CDTEncryptionKeychainData *otherData =
+        [CDTEncryptionKeychainData dataWithEncryptedDPK:self.keychainData.encryptedDPK
+                                                   salt:self.keychainData.salt
+                                                     iv:self.keychainData.iv
+                                             iterations:1
+                                                version:self.keychainData.version];
+
+    self.mockStorage.encryptionKeyDataResult = otherData;
+    self.mockStorage.encryptionKeyDataExistsResult = YES;
+
+    XCTAssertNotNil([self.manager loadKeyUsingPassword:self.password],
+                    @"Iterations does not have to be equal to %li",
+                    (long)CDTENCRYPTION_KEYCHAIN_PBKDF2_ITERATIONS);
+}
+
+- (void)testLoadKeyUsingPasswordFailsIfIVDoesNotHaveTheRightSize
+{
+    CDTEncryptionKeychainData *otherData = [CDTEncryptionKeychainData
+        dataWithEncryptedDPK:self.keychainData.encryptedDPK
+                        salt:self.keychainData.salt
+                          iv:[CDTEncryptionKeychainUtils
+                                 generateSecureRandomBytesWithLength:(kCCBlockSizeAES128 + 1)]
+                  iterations:self.keychainData.iterations
+                     version:self.keychainData.version];
+
+    self.mockStorage.encryptionKeyDataResult = otherData;
+    self.mockStorage.encryptionKeyDataExistsResult = YES;
+
+    XCTAssertNil([self.manager loadKeyUsingPassword:self.password], @"IV size must be equalt to %i",
+                 kCCBlockSizeAES128);
+}
+
+- (void)testLoadKeyUsingPasswordRaisesExceptionIfNoPassIsProvided
+{
+    self.mockStorage.encryptionKeyDataResult = self.keychainData;
+    self.mockStorage.encryptionKeyDataExistsResult = YES;
+
+    XCTAssertThrows([self.manager loadKeyUsingPassword:nil],
+                    @"A password is neccesary to decipher the key");
+}
+
+- (void)testLoadKeyUsingPasswordPerformsTheExpectedSteps
+{
+    self.mockStorage.encryptionKeyDataResult = self.keychainData;
+    self.mockStorage.encryptionKeyDataExistsResult = YES;
+
+    [self.manager loadKeyUsingPassword:self.password];
+
+    NSArray *expectedSteps = @[
+        kCDTEncryptionKeychainManagerTestsValidateEncryptionKeyData,
+        kCDTEncryptionKeychainManagerTestsPBKDF2DerivedKey,
+        kCDTEncryptionKeychainManagerTestsDecryptDpk
+    ];
+
+    XCTAssertEqualObjects(expectedSteps, self.manager.lastSteps,
+                          @"Method did not behave as expected");
+}
+
+- (void)testGenerateAndSaveKeyProtectedByPasswordRaisesExceptionIfNoPassIsProvided
+{
+    XCTAssertThrows([self.manager generateAndSaveKeyProtectedByPassword:nil],
+                    @"A password is neccesary to cipher the key");
+}
+
+- (void)testGenerateAndSaveKeyProtectedByPasswordFailsIfEncryptionDataWasAlreadyGenerated
+{
+    self.mockStorage.encryptionKeyDataResult = self.keychainData;
+    self.mockStorage.encryptionKeyDataExistsResult = YES;
+
+    XCTAssertNil([self.manager generateAndSaveKeyProtectedByPassword:self.password],
+                 @"No key should be generated if there is one already");
+}
+
+- (void)testGenerateAndSaveKeyProtectedByPasswordFailsIfKeyIsNotSaved
+{
+    self.mockStorage.saveEncryptionKeyDataResult = NO;
+
+    XCTAssertNil([self.manager generateAndSaveKeyProtectedByPassword:self.password],
+                 @"No key must be returned if it is not saved to the keychain");
+}
+
+- (void)testGenerateAndSaveKeyProtectedByPasswordPerformsExpectedHighlevelSteps
+{
+    [self.manager generateAndSaveKeyProtectedByPassword:self.password];
+
+    NSArray *expectedSteps = @[
+        kCDTEncryptionKeychainManagerTestsKeyExists,
+        kCDTEncryptionKeychainManagerTestsGenerateDpk,
+        kCDTEncryptionKeychainManagerTestsKeychainDataToStoreDpk
+    ];
+    NSArray *highlevelSteps =
+        [self.manager.lastSteps subarrayWithRange:NSMakeRange(0, [expectedSteps count])];
+    BOOL asExpected = [expectedSteps isEqualToArray:highlevelSteps];
+
+    XCTAssertTrue(asExpected && self.mockStorage.saveEncryptionKeyDataExecuted,
+                  @"Method did not behave as expected. Expected: %@. Performed: %@ (didSave: %i)",
+                  expectedSteps, highlevelSteps, self.mockStorage.saveEncryptionKeyDataExecuted);
+}
+
+- (void)testKeychainDataToStoreDpkPerformsExpectedHighlevelSteps
+{
+    NSData *dpk = [CDTEncryptionKeychainUtils
+        generateSecureRandomBytesWithLength:CDTENCRYPTION_KEYCHAIN_ENCRYPTIONKEY_SIZE];
+    [self.manager keychainDataToStoreDpk:dpk encryptedWithPassword:self.password];
+
+    NSSet *expectedSteps =
+        [NSSet setWithObjects:kCDTEncryptionKeychainManagerTestsKeychainDataToStoreDpk,
+                              kCDTEncryptionKeychainManagerTestsGeneratePBKDF2Salt,
+                              kCDTEncryptionKeychainManagerTestsPBKDF2DerivedKey,
+                              kCDTEncryptionKeychainManagerTestsGenerateAESIv,
+                              kCDTEncryptionKeychainManagerTestsEncryptDpk, nil];
+    NSSet *highlevelSteps = [NSSet setWithArray:self.manager.lastSteps];
+
+    XCTAssertEqualObjects(expectedSteps, highlevelSteps, @"Method did not behave as expected");
+}
+
+@end
+
+@implementation CDTEncryptionCustomKeychainManager
+
+#pragma mark - Init object
+- (instancetype)initWithStorage:(CDTEncryptionKeychainStorage *)storage
+{
+    self = [super initWithStorage:storage];
+    if (self) {
+        _lastSteps = [NSMutableArray array];
+    }
+
+    return self;
+}
+
+#pragma mark - CDTEncryptionKeychainManager methods
+- (BOOL)keyExists
+{
+    [self.lastSteps addObject:kCDTEncryptionKeychainManagerTestsKeyExists];
+
+    return [super keyExists];
+}
+
+#pragma mark - CDTEncryptionKeychainManager+Internal methods
+- (BOOL)validateEncryptionKeyData:(CDTEncryptionKeychainData *)data
+{
+    [self.lastSteps addObject:kCDTEncryptionKeychainManagerTestsValidateEncryptionKeyData];
+
+    return [super validateEncryptionKeyData:data];
+}
+
+- (NSData *)generateDpk
+{
+    [self.lastSteps addObject:kCDTEncryptionKeychainManagerTestsGenerateDpk];
+
+    return [super generateDpk];
+}
+
+- (CDTEncryptionKeychainData *)keychainDataToStoreDpk:(NSData *)dpk
+                                encryptedWithPassword:(NSString *)password
+{
+    [self.lastSteps addObject:kCDTEncryptionKeychainManagerTestsKeychainDataToStoreDpk];
+
+    return [super keychainDataToStoreDpk:dpk encryptedWithPassword:password];
+}
+
+- (NSData *)generatePBKDF2Salt
+{
+    [self.lastSteps addObject:kCDTEncryptionKeychainManagerTestsGeneratePBKDF2Salt];
+
+    return [super generatePBKDF2Salt];
+}
+
+- (NSData *)pbkdf2DerivedKeyForPassword:(NSString *)pass
+                                   salt:(NSData *)salt
+                             iterations:(NSInteger)iterations
+                                 length:(NSUInteger)length
+{
+    [self.lastSteps addObject:kCDTEncryptionKeychainManagerTestsPBKDF2DerivedKey];
+
+    return [super pbkdf2DerivedKeyForPassword:pass salt:salt iterations:iterations length:length];
+}
+
+- (NSData *)generateAESIv
+{
+    [self.lastSteps addObject:kCDTEncryptionKeychainManagerTestsGenerateAESIv];
+
+    return [super generateAESIv];
+}
+
+- (NSData *)encryptDpk:(NSData *)dpk usingAESWithKey:(NSData *)key iv:(NSData *)iv
+{
+    [self.lastSteps addObject:kCDTEncryptionKeychainManagerTestsEncryptDpk];
+
+    return [super encryptDpk:dpk usingAESWithKey:key iv:iv];
+}
+
+- (NSData *)decryptDpk:(NSData *)cipheredDpk usingAESWithKey:(NSData *)key iv:(NSData *)iv
+{
+    [self.lastSteps addObject:kCDTEncryptionKeychainManagerTestsDecryptDpk];
+
+    return [super decryptDpk:cipheredDpk usingAESWithKey:key iv:iv];
+}
+
+@end

--- a/Tests/Tests/Encryption/Keychain/Mock/CDTMockEncryptionKeychainStorage.h
+++ b/Tests/Tests/Encryption/Keychain/Mock/CDTMockEncryptionKeychainStorage.h
@@ -1,0 +1,45 @@
+//
+//  CDTMockEncryptionKeychainStorage.h
+//  Tests
+//
+//  Created by Enrique de la Torre Fernandez on 15/04/2015.
+//  Copyright (c) 2015 IBM Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "CDTEncryptionKeychainData.h"
+
+#define CDTMOCKENCRYPTIONKEYCHAINSTORAGE_DEFAULT_DATA nil
+#define CDTMOCKENCRYPTIONKEYCHAINSTORAGE_DEFAULT_SAVE YES
+#define CDTMOCKENCRYPTIONKEYCHAINSTORAGE_DEFAULT_CLEAR YES
+#define CDTMOCKENCRYPTIONKEYCHAINSTORAGE_DEFAULT_ARETHEREDATA NO
+
+@interface CDTMockEncryptionKeychainStorage : NSObject
+
+@property (assign, nonatomic) BOOL encryptionKeyDataExecuted;
+@property (strong, nonatomic) CDTEncryptionKeychainData *encryptionKeyDataResult;
+
+@property (assign, nonatomic) BOOL saveEncryptionKeyDataExecuted;
+@property (assign, nonatomic) BOOL saveEncryptionKeyDataResult;
+
+@property (assign, nonatomic) BOOL clearEncryptionKeyDataExecuted;
+@property (assign, nonatomic) BOOL clearEncryptionKeyDataResult;
+
+@property (assign, nonatomic) BOOL encryptionKeyDataExistsExecuted;
+@property (assign, nonatomic) BOOL encryptionKeyDataExistsResult;
+
+- (CDTEncryptionKeychainData *)encryptionKeyData;
+- (BOOL)saveEncryptionKeyData:(CDTEncryptionKeychainData *)data;
+- (BOOL)clearEncryptionKeyData;
+- (BOOL)encryptionKeyDataExists;
+
+@end

--- a/Tests/Tests/Encryption/Keychain/Mock/CDTMockEncryptionKeychainStorage.m
+++ b/Tests/Tests/Encryption/Keychain/Mock/CDTMockEncryptionKeychainStorage.m
@@ -1,0 +1,75 @@
+//
+//  CDTMockEncryptionKeychainStorage.m
+//  Tests
+//
+//  Created by Enrique de la Torre Fernandez on 15/04/2015.
+//  Copyright (c) 2015 IBM Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#import "CDTMockEncryptionKeychainStorage.h"
+
+@interface CDTMockEncryptionKeychainStorage ()
+
+@end
+
+@implementation CDTMockEncryptionKeychainStorage
+
+#pragma mark - Init object
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        _encryptionKeyDataExecuted = NO;
+        _encryptionKeyDataResult = CDTMOCKENCRYPTIONKEYCHAINSTORAGE_DEFAULT_DATA;
+        
+        _saveEncryptionKeyDataExecuted = NO;
+        _saveEncryptionKeyDataResult = CDTMOCKENCRYPTIONKEYCHAINSTORAGE_DEFAULT_SAVE;
+        
+        _clearEncryptionKeyDataExecuted = NO;
+        _clearEncryptionKeyDataResult = CDTMOCKENCRYPTIONKEYCHAINSTORAGE_DEFAULT_CLEAR;
+        
+        _encryptionKeyDataExistsExecuted = NO;
+        _encryptionKeyDataExistsResult = CDTMOCKENCRYPTIONKEYCHAINSTORAGE_DEFAULT_ARETHEREDATA;
+    }
+    
+    return self;
+}
+
+#pragma mark - Public methods
+- (CDTEncryptionKeychainData *)encryptionKeyData
+{
+    self.encryptionKeyDataExecuted = YES;
+    
+    return self.encryptionKeyDataResult;
+}
+
+- (BOOL)saveEncryptionKeyData:(CDTEncryptionKeychainData *)data
+{
+    self.saveEncryptionKeyDataExecuted = YES;
+    
+    return self.saveEncryptionKeyDataResult;
+}
+
+- (BOOL)clearEncryptionKeyData
+{
+    self.clearEncryptionKeyDataExecuted = YES;
+    
+    return self.clearEncryptionKeyDataResult;
+}
+
+- (BOOL)encryptionKeyDataExists
+{
+    self.encryptionKeyDataExistsExecuted = YES;
+    
+    return self.encryptionKeyDataExistsResult;
+}
+
+@end


### PR DESCRIPTION
*What:*
Define a manager able to create a DPK (Data Protection Key) and store and retrieve this DPK from keychain.

*Why:*
This PR is the last one in a bigger development to provide a mechanism to generate a key and safely store it.

*How:*
The manager will be based on the classes implemented before to apply AES, PBKDF2 and read from/write to the keychain.

*Tests:*
* Clear the data stored in the keychain
* Check there is data in the keychain
* Get data from the keychain
* Check that the number of iterations stored in the keychain is right
* Check that the IV in the keychain has the correct size
* Validate the steps followed to retrieve a key
* Check that is not possible to generate the key twice
* Validate the steps followed to generate a key

reviewer @mikerhodes 
reviewer @rhyshort 

**NOTE:** Wait to review this PR until PR #134  is closed. This branch will be rebased and there will be only one commit to review.