### PR TITLE
Add Index class to manage index attribute validation for Query

### DIFF
--- a/CDTDatastore.xcworkspace/contents.xcworkspacedata
+++ b/CDTDatastore.xcworkspace/contents.xcworkspacedata
@@ -27,6 +27,12 @@
             location = "container:"
             name = "Query">
             <FileRef
+               location = "group:Classes/common/query/CDTQIndex.h">
+            </FileRef>
+            <FileRef
+               location = "group:Classes/common/query/CDTQIndex.m">
+            </FileRef>
+            <FileRef
                location = "group:Classes/common/query/CDTDatastore+Query.h">
             </FileRef>
             <FileRef

--- a/Classes/common/query/CDTQIndex.h
+++ b/Classes/common/query/CDTQIndex.h
@@ -1,0 +1,75 @@
+//
+//  CDTQIndex.h
+//
+//  Created by Al Finkelstein on 2015-04-20
+//  Copyright (c) 2015 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+extern NSString *const kCDTQJsonType;
+extern NSString *const kCDTQTextType;
+
+/**
+ * This class provides functionality to manage an index
+ */
+@interface CDTQIndex : NSObject
+
+@property (nonatomic, strong) NSArray *fieldNames;
+@property (nonatomic, strong) NSString *indexName;
+@property (nonatomic, strong) NSString *indexType;
+@property (nonatomic, strong) NSDictionary *indexSettings;
+
+/**
+ * This function sets the index type to the default setting of "json"
+ *
+ * @param indexName the index name
+ * @param fieldNames the field names in the index
+ * @return the Index object or nil if arguments passed in were invalid.
+ */
++ (instancetype)index:(NSString *)indexName withFields:(NSArray *)fieldNames;
+
++ (instancetype)index:(NSString *)indexName
+           withFields:(NSArray *)fieldNames
+               ofType:(NSString *)indexType;
+
+/**
+ * This function handles index specific validation and ensures that the constructed
+ * Index object is valid.
+ *
+ * @param indexName the index name
+ * @param fieldNames the field names in the index
+ * @param indexType the index type (json or text)
+ * @param indexSettings the optional settings used to configure the index.
+ *                      Only supported parameter is 'tokenize' for text indexes only.
+ * @return the Index object or nil if arguments passed in were invalid.
+ */
++ (instancetype)index:(NSString *)indexName
+           withFields:(NSArray *)fieldNames
+               ofType:(NSString *)indexType
+         withSettings:(NSDictionary *)indexSettings;
+
+/**
+ * Compares the index type and accompanying settings with the passed in arguments.
+ *
+ * @param indexType the index type to compare to
+ * @param indexSettings the indexSettings to compare to as an NSString
+ * @return YES/NO - whether there is a match
+ */
+- (BOOL)compareIndexTypeTo:(NSString *)indexType withIndexSettings:(NSString *)indexSettings;
+
+/**
+ * Converts the index settings to a JSON string
+ *
+ * @return the JSON representation of the index settings
+ */
+- (NSString *)settingsAsJSON;
+
+@end

--- a/Classes/common/query/CDTQIndex.m
+++ b/Classes/common/query/CDTQIndex.m
@@ -1,0 +1,171 @@
+//
+//  CDTQIndex.m
+//
+//  Created by Al Finkelstein on 2015-04-20
+//  Copyright (c) 2015 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+#import "CDTQIndex.h"
+
+#import "CDTQLogging.h"
+
+NSString *const kCDTQJsonType = @"json";
+NSString *const kCDTQTextType = @"text";
+
+static NSString *const kCDTQTextTokenize = @"tokenize";
+static NSString *const kCDTQTextDefaultTokenizer = @"simple";
+
+@interface CDTQIndex ()
+
+@end
+
+@implementation CDTQIndex
+
+// Static array of supported index types
++ (NSArray *)validTypes
+{
+    static NSArray *validTypesArray = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        validTypesArray = @[ kCDTQJsonType, kCDTQTextType ];
+    });
+    return validTypesArray;
+}
+
+// Static array of supported index settings
++ (NSArray *)validSettings
+{
+    static NSArray *validSettingsArray = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        validSettingsArray = @[ kCDTQTextTokenize ];
+    });
+    return validSettingsArray;
+}
+
+- (instancetype)initWithFields:(NSArray *)fieldNames
+                     indexName:(NSString *)indexName
+                     indexType:(NSString *)indexType
+                 indexSettings:(NSDictionary *)indexSettings
+{
+    self = [super init];
+    if (self) {
+        _fieldNames = fieldNames;
+        _indexName = indexName;
+        _indexType = indexType;
+        _indexSettings = indexSettings;
+    }
+    return self;
+}
+
++ (instancetype)index:(NSString *)indexName withFields:(NSArray *)fieldNames
+{
+    return [[self class] index:indexName withFields:fieldNames ofType:kCDTQJsonType];
+}
+
++ (instancetype)index:(NSString *)indexName
+           withFields:(NSArray *)fieldNames
+               ofType:(NSString *)indexType
+{
+    return [[self class] index:indexName withFields:fieldNames ofType:indexType withSettings:nil];
+}
+
++ (instancetype)index:(NSString *)indexName
+           withFields:(NSArray *)fieldNames
+               ofType:(NSString *)indexType
+         withSettings:(NSDictionary *)indexSettings
+{
+    if (fieldNames.count == 0) {
+        LogError(@"No field names provided.");
+        return nil;
+    }
+    
+    if (indexName.length == 0) {
+        LogError(@"No index name provided.");
+        return nil;
+    }
+    
+    if (indexType.length == 0) {
+        LogError(@"No index type provided.");
+        return nil;
+    }
+    
+    if (![[CDTQIndex validTypes] containsObject:indexType.lowercaseString]) {
+        LogError(@"Invalid index type %@.", indexType);
+        return nil;
+    }
+    
+    if ([indexType.lowercaseString isEqualToString:kCDTQJsonType] && indexSettings) {
+        LogWarn(@"Index type is %@, index settings %@ ignored.", indexType, indexSettings);
+        indexSettings = nil;
+    } else if ([indexType.lowercaseString isEqualToString:kCDTQTextType]) {
+        if (!indexSettings) {
+            indexSettings = @{ kCDTQTextTokenize: kCDTQTextDefaultTokenizer };
+            LogDebug(@"Index type is %@, defaulting settings to %@.", indexType, indexSettings);
+        } else {
+            for (NSString *parameter in [indexSettings allKeys]) {
+                if (![[CDTQIndex validSettings] containsObject:parameter.lowercaseString]) {
+                    LogError(@"Invalid parameter %@ in index settings %@.", parameter,
+                                                                            indexSettings);
+                    return nil;
+                }
+            }
+        }
+    }
+    
+    return [[[self class] alloc] initWithFields:fieldNames
+                                      indexName:indexName
+                                      indexType:indexType
+                                  indexSettings:indexSettings];
+}
+
+-(BOOL) compareIndexTypeTo:(NSString *)indexType withIndexSettings:(NSString *)indexSettings
+{
+    if (![self.indexType.lowercaseString isEqualToString:indexType.lowercaseString]) {
+        return NO;
+    }
+    
+    if (!self.indexSettings && !indexSettings) {
+        return YES;
+    } else if (!self.indexSettings || !indexSettings) {
+        return NO;
+    }
+    
+    NSError *error;
+    NSData *settingsData = [indexSettings dataUsingEncoding:NSUTF8StringEncoding];
+    NSDictionary *settingsDict = [NSJSONSerialization JSONObjectWithData:settingsData
+                                                                 options:kNilOptions
+                                                                   error:&error];
+    if (!settingsDict) {
+        LogError(@"Error processing index settings %@", indexSettings);
+        return NO;
+    }
+    
+    return [self.indexSettings isEqualToDictionary:settingsDict];
+}
+
+-(NSString *) settingsAsJSON {
+    if (!self.indexSettings) {
+        LogWarn(@"Index settings are nil.  Nothing to return.");
+        return nil;
+    }
+    NSError *error;
+    NSData *settingsData = [NSJSONSerialization dataWithJSONObject:self.indexSettings
+                                                           options:kNilOptions
+                                                             error:&error];
+    if (!settingsData) {
+        LogError(@"Error processing index settings %@", self.indexSettings);
+        return nil;
+    }
+    
+    return [[NSString alloc] initWithData:settingsData encoding:NSUTF8StringEncoding];
+}
+
+@end

--- a/Tests/Tests.xcodeproj/project.pbxproj
+++ b/Tests/Tests.xcodeproj/project.pbxproj
@@ -112,6 +112,8 @@
 		EC0C83611AB217290051042F /* CDTQSQLOnlyQueryExecutor.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C833A1AB217290051042F /* CDTQSQLOnlyQueryExecutor.m */; };
 		EC0C83621AB217290051042F /* Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C833B1AB217290051042F /* Tests.m */; };
 		EC0C83631AB217290051042F /* Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C833B1AB217290051042F /* Tests.m */; };
+		EC578D8A1AE67D60003D6006 /* CDTQIndexTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EC578D891AE67D60003D6006 /* CDTQIndexTests.m */; };
+		EC578D8B1AE67D60003D6006 /* CDTQIndexTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EC578D891AE67D60003D6006 /* CDTQIndexTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -195,6 +197,7 @@
 		EC0C83391AB217290051042F /* CDTQSQLOnlyQueryExecutor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDTQSQLOnlyQueryExecutor.h; sourceTree = "<group>"; };
 		EC0C833A1AB217290051042F /* CDTQSQLOnlyQueryExecutor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTQSQLOnlyQueryExecutor.m; sourceTree = "<group>"; };
 		EC0C833B1AB217290051042F /* Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Tests.m; sourceTree = "<group>"; };
+		EC578D891AE67D60003D6006 /* CDTQIndexTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTQIndexTests.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -257,6 +260,7 @@
 		27389E15185345FD0027A404 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				EC578D891AE67D60003D6006 /* CDTQIndexTests.m */,
 				EC0C831F1AB217290051042F /* CDTDatastoreQueryTests.m */,
 				EC0C83201AB217290051042F /* CDTQFilterFieldsTest.m */,
 				EC0C83211AB217290051042F /* CDTQIndexCreatorTests.m */,
@@ -622,6 +626,7 @@
 				EC0C83441AB217290051042F /* CDTQIndexUpdaterTests.m in Sources */,
 				9F0D23F4188B4FFF00D3D04E /* TDMultipartWriterTests.m in Sources */,
 				9F0D24141892E9B800D3D04E /* TDPusherTests.m in Sources */,
+				EC578D8A1AE67D60003D6006 /* CDTQIndexTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -675,6 +680,7 @@
 				EC0C83451AB217290051042F /* CDTQIndexUpdaterTests.m in Sources */,
 				9F0D23F5188B4FFF00D3D04E /* TDMultipartWriterTests.m in Sources */,
 				9F0D24151892E9B800D3D04E /* TDPusherTests.m in Sources */,
+				EC578D8B1AE67D60003D6006 /* CDTQIndexTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Tests/Tests/CDTQIndexTests.m
+++ b/Tests/Tests/CDTQIndexTests.m
@@ -1,0 +1,174 @@
+//
+//  CDTQIndexTests.m
+//  CDTQIndexTests
+//
+//  Created by Al Finkelstein on 04/21/2015.
+//  Copyright (c) 2015 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+#import <CloudantSync.h>
+#import <CDTQIndex.h>
+#import "Matchers/CDTQContainsAllElementsMatcher.h"
+
+SpecBegin(CDTQIndex)
+
+describe(@"When creating an instance of index", ^{
+
+    __block NSArray *fieldNames;
+    __block NSString *indexName;
+    
+    beforeAll(^{
+        fieldNames = @[ @"name", @"age" ];
+        indexName = @"basic";
+    });
+    
+    it(@"constructs an index instance with the default index type", ^{
+        CDTQIndex *index = [CDTQIndex index:indexName withFields:fieldNames];
+        
+        expect(index.indexName).to.equal(@"basic");
+        expect(index.fieldNames).to.containsAllElements(@[ @"name", @"age" ]);
+        expect(index.indexType).to.equal(@"json");
+        expect(index.indexSettings).to.beNil();
+    });
+    
+    it(@"constructs an index instance with the TEXT index type and default index settings", ^{
+        CDTQIndex *index = [CDTQIndex index:indexName withFields:fieldNames ofType:@"text"];
+
+        expect(index.indexName).to.equal(@"basic");
+        expect(index.fieldNames).to.containsAllElements(@[ @"name", @"age" ]);
+        expect(index.indexType).to.equal(@"text");
+        expect(index.indexSettings.count).to.equal(1);
+        expect(index.indexSettings[ @"tokenize" ]).to.equal(@"simple");
+    });
+    
+    it(@"returns nil when no fields are provided", ^{
+        expect([CDTQIndex index:indexName withFields:nil]).to.beNil();
+        
+        expect([CDTQIndex index:indexName withFields:@[]]).to.beNil();
+    });
+    
+    it(@"returns nil when no index name is provided", ^{
+        expect([CDTQIndex index:nil withFields:fieldNames]).to.beNil();
+        
+        expect([CDTQIndex index:@"" withFields:fieldNames]).to.beNil();
+    });
+    
+    it(@"returns nil when index type is specifically nil or blank", ^{
+        expect([CDTQIndex index:indexName withFields:fieldNames ofType:nil]).to.beNil();
+        
+        expect([CDTQIndex index:indexName withFields:fieldNames ofType:@""]).to.beNil();
+    });
+    
+    it(@"returns nil when index type is invalid", ^{
+        expect([CDTQIndex index:indexName withFields:fieldNames ofType:@"blah"]).to.beNil();
+    });
+    
+    it(@"returns nil when index settings are invalid", ^{
+        expect([CDTQIndex index:indexName
+                     withFields:fieldNames
+                         ofType:@"text"
+                   withSettings:@{ @"foo": @"bar" }]).to.beNil();
+    });
+    
+    it(@"constructs index instance but ignores index settings when appropriate", ^{
+        // json indexes do not support index settings.  Index settings will be ignored.
+        CDTQIndex *index = [CDTQIndex index:indexName
+                                 withFields:fieldNames
+                                     ofType:@"json"
+                               withSettings:@{ @"tokenize": @"porter" }];
+
+        expect(index.indexName).to.equal(@"basic");
+        expect(index.fieldNames).to.containsAllElements(@[ @"name", @"age" ]);
+        expect(index.indexType).to.equal(@"json");
+        expect(index.indexSettings).to.beNil();
+    });
+    
+    it(@"constructs index instance and sets index settings when appropriate", ^{
+        // text indexes support the tokenize setting.
+        CDTQIndex *index = [CDTQIndex index:indexName
+                                 withFields:fieldNames
+                                     ofType:@"text"
+                               withSettings:@{ @"tokenize": @"porter" }];
+
+        expect(index.indexName).to.equal(@"basic");
+        expect(index.fieldNames).to.containsAllElements(@[ @"name", @"age" ]);
+        expect(index.indexType).to.equal(@"text");
+        expect(index.indexSettings[ @"tokenize" ]).to.equal(@"porter");
+    });
+    
+});
+
+describe(@"When comparing index content", ^{
+    
+    __block NSArray *fieldNames;
+    __block NSString *indexName;
+    
+    beforeAll(^{
+        fieldNames = @[ @"name", @"age" ];
+        indexName = @"basic";
+    });
+    
+    it(@"correctly compares index type inequality", ^{
+        // Construct an index instance of default index type "json"
+        CDTQIndex *index = [CDTQIndex index:indexName withFields:fieldNames];
+        
+        expect([index compareIndexTypeTo:@"text" withIndexSettings:nil]).to.equal(NO);
+    });
+    
+    it(@"correctly compares index type equality", ^{
+        // Construct an index instance of default index type "json"
+        CDTQIndex *index = [CDTQIndex index:indexName withFields:fieldNames];
+        
+        expect([index compareIndexTypeTo:@"json" withIndexSettings:nil]).to.equal(YES);
+    });
+    
+    it(@"correctly compares index setting inequality", ^{
+        // Construct a "text" index instance with default index settings of { "tokenize": "simple" }
+        CDTQIndex *index = [CDTQIndex index:indexName withFields:fieldNames ofType:@"text"];
+        
+        expect([index compareIndexTypeTo:@"text"
+                       withIndexSettings:@"{\"tokenize\":\"porter\"}"]).to.equal(NO);
+    });
+    
+    it(@"correctly compares index setting equality", ^{
+        // Construct a "text" index instance with default index settings of { "tokenize": "simple" }
+        CDTQIndex *index = [CDTQIndex index:indexName withFields:fieldNames ofType:@"text"];
+        
+        expect([index compareIndexTypeTo:@"text"
+                       withIndexSettings:@"{\"tokenize\":\"simple\"}"]).to.equal(YES);
+    });
+    
+});
+
+describe(@"When retrieving index settings as a String", ^{
+    
+    __block NSArray *fieldNames;
+    __block NSString *indexName;
+    
+    beforeAll(^{
+        fieldNames = @[ @"name", @"age" ];
+        indexName = @"basic";
+    });
+    
+    it(@"returns a String representation of the index settings", ^{
+        CDTQIndex *index = [CDTQIndex index:indexName withFields:fieldNames ofType:@"text"];
+        
+        expect([index settingsAsJSON]).to.equal(@"{\"tokenize\":\"simple\"}");
+    });
+    
+    it(@"returns nil when appropriate", ^{
+        CDTQIndex *index = [CDTQIndex index:indexName withFields:fieldNames];
+        
+        expect([index settingsAsJSON]).to.beNil();
+    });
+    
+});
+
+SpecEnd


### PR DESCRIPTION
_What_

Establish a new index class to house all index related validation and any utility functions related to index processing for use in Query.

_Why_

In an effort to add support for query full text search we are starting the process of migrating index related functionality to this new index class.  It allows us to better compartmentalize index related functionality and pass index data around the various change agents in Query - mobile (such as manager, creator, updater, etc...) in a cleaner manner.

_How_

In this PR we are focused on moving validation currently performed in the index manager and the index creator to the new index class.  Likewise, we added some utility functions that supports index creator functionality such as retrieving the index settings as a String and comparing index types and settings as they relate to index types.

_Notes_

- This implementation is a port of the work done in sync-android.  Specifically https://github.com/cloudant/sync-android/pull/109.  As such, the comments and issues found with the Android implementation have already been applied to this implementation and FB cases have been opened for both platforms whenever appropriate.
- The integration of the index class with the current index management framework will be done in a follow up PR.
- Likewise, query search work will also happen in follow up PRs.
- Finally it is worth noting that the index class in this PR is an initial cut of the class and only meant to provide functionality that will allow us to complete the query full text search work.  A separate FB case (https://cloudant.fogbugz.com/f/cases/46029) is already open to complete additional work on the index class at a future date.

reviewer @mikerhodes 
reviewer @rhyshort 

BugId: 46368