### PR TITLE
46367 support frameworks

### DIFF
--- a/Classes/common/Attachments/CDTDatastore+Attachments.m
+++ b/Classes/common/Attachments/CDTDatastore+Attachments.m
@@ -16,9 +16,9 @@
 
 #import "CDTDatastore+Attachments.h"
 
-#import "FMDatabase.h"
-#import "FMDatabaseAdditions.h"
-#import "FMDatabaseQueue.h"
+#import <FMDB/FMDatabase.h>
+#import <FMDB/FMDatabaseAdditions.h>
+#import <FMDB/FMDatabaseQueue.h>
 
 #import "TD_Database.h"
 #import "TD_Database+Attachments.h"

--- a/Classes/common/CDTDatastore+Conflicts.m
+++ b/Classes/common/CDTDatastore+Conflicts.m
@@ -27,7 +27,7 @@
 #import "TDStatus.h"
 #import "CDTMutableDocumentRevision.h"
 #import "TDInternal.h"
-#import "fmdb.h"
+#import <FMDB/FMDB.h>
 #import "TD_Body.h"
 #import "CDTLogging.h"
 

--- a/Classes/common/CDTDatastore.m
+++ b/Classes/common/CDTDatastore.m
@@ -29,9 +29,9 @@
 #import "TDInternal.h"
 #import "TDMisc.h"
 
-#import "FMDatabase.h"
-#import "FMDatabaseAdditions.h"
-#import "FMDatabaseQueue.h"
+#import <FMDB/FMDatabase.h>
+#import <FMDB/FMDatabaseAdditions.h>
+#import <FMDB/FMDatabaseQueue.h>
 
 #import "Version.h"
 

--- a/Classes/common/CDTLogging.h
+++ b/Classes/common/CDTLogging.h
@@ -1,10 +1,19 @@
 //
 //  CDTLogging.h
+//  CloudantSync
 //
 //
 //  Created by Rhys Short on 01/10/2014.
+//  Copyright (c) 2014 Cloudant. All rights reserved.
 //
 //
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
 
 #import "CocoaLumberjack.h"
 

--- a/Classes/common/CDTLogging.h
+++ b/Classes/common/CDTLogging.h
@@ -15,7 +15,7 @@
 //  either express or implied. See the License for the specific language governing permissions
 //  and limitations under the License.
 
-#import "CocoaLumberjack.h"
+#import <CocoaLumberjack/CocoaLumberjack.h>
 
 #ifndef _CDTLogging_h
 #define _CDTLogging_h

--- a/Classes/common/fmdb/FMDatabase+LongLong.h
+++ b/Classes/common/fmdb/FMDatabase+LongLong.h
@@ -9,9 +9,11 @@
 // LongLong feature added by Jens Alfke
 // https://github.com/couchbaselabs/fmdb/commit/1a3cf0f872b9d017eb1eb977df85cfeedce45156
 //
+//
+// Modified for distribution by IBM Cloudant, (c) copyright IBM Cloudant 2015
 
 #import <Foundation/Foundation.h>
-#import "FMDatabase.h"
+#import <FMDB/FMDatabase.h>
 
 @interface FMDatabase (LongLong)
 

--- a/Classes/common/fmdb/FMDatabase+LongLong.m
+++ b/Classes/common/fmdb/FMDatabase+LongLong.m
@@ -9,11 +9,13 @@
 // LongLong feature added by Jens Alfke
 // https://github.com/couchbaselabs/fmdb/commit/1a3cf0f872b9d017eb1eb977df85cfeedce45156
 //
+//
+// Modified for distribution by IBM Cloudant, (c) copyright IBM Cloudant 2015
 
 #import "FMDatabase+LongLong.h"
 
-#import "FMDatabase.h"
-#import "FMDatabaseAdditions.h"
+#import <FMDB/FMDatabase.h>
+#import <FMDB/FMDatabaseAdditions.h>
 
 @interface FMDatabase (PrivateStuff)
 - (FMResultSet *)executeQuery:(NSString *)sql withArgumentsInArray:(NSArray*)arrayArgs orDictionary:(NSDictionary *)dictionaryArgs orVAList:(va_list)args;

--- a/Classes/common/query/CDTQIndexCreator.m
+++ b/Classes/common/query/CDTQIndexCreator.m
@@ -19,7 +19,7 @@
 #import "CDTQLogging.h"
 
 #import "CloudantSync.h"
-#import "FMDB.h"
+#import <FMDB/FMDB.h>
 
 @interface CDTQIndexCreator ()
 

--- a/Classes/common/query/CDTQIndexManager.m
+++ b/Classes/common/query/CDTQIndexManager.m
@@ -49,7 +49,7 @@
 #import "TD_Body.h"
 
 #import <CloudantSync.h>
-#import <FMDB.h>
+#import <FMDB/FMDB.h>
 
 NSString *const CDTQIndexManagerErrorDomain = @"CDTIndexManagerErrorDomain";
 

--- a/Classes/common/query/CDTQIndexUpdater.m
+++ b/Classes/common/query/CDTQIndexUpdater.m
@@ -23,7 +23,7 @@
 
 #import "CloudantSync.h"
 
-#import "FMDB.h"
+#import <FMDB/FMDB.h>
 
 @interface CDTQIndexUpdater ()
 

--- a/Classes/common/query/CDTQLogging.h
+++ b/Classes/common/query/CDTQLogging.h
@@ -15,7 +15,7 @@
 #ifndef Pods_CDTQueryLogging_h
 #define Pods_CDTQueryLogging_h
 
-#import "CocoaLumberjack.h"
+#import <CocoaLumberjack/CocoaLumberjack.h>
 
 #define CDTQ_LOGGING_CONTEXT 17  // one level higher than CDT logger myabe should be 20?
 static DDLogLevel CDTQLogLevel = DDLogLevelWarning;

--- a/Classes/common/query/CDTQQueryExecutor.m
+++ b/Classes/common/query/CDTQQueryExecutor.m
@@ -23,7 +23,7 @@
 #import "CDTDocumentRevision.h"
 #import "CDTQQueryValidator.h"
 
-#import "FMDB.h"
+#import <FMDB/FMDB.h>
 
 const NSUInteger kSmallResultSetSizeThreshold = 500;
 

--- a/Classes/common/touchdb/TD_Database+Attachments.m
+++ b/Classes/common/touchdb/TD_Database+Attachments.m
@@ -37,10 +37,10 @@
 #import "TDInternal.h"
 
 #import "CollectionUtils.h"
-#import "FMDatabase.h"
-#import "FMDatabaseQueue.h"
-#import "FMDatabaseAdditions.h"
-#import "FMResultSet.h"
+#import <FMDB/FMDatabase.h>
+#import <FMDB/FMDatabaseQueue.h>
+#import <FMDB/FMDatabaseAdditions.h>
+#import <FMDB/FMResultSet.h>
 #import "GTMNSData+zlib.h"
 
 #import "CDTLogging.h"

--- a/Classes/common/touchdb/TD_Database+Conflicts.m
+++ b/Classes/common/touchdb/TD_Database+Conflicts.m
@@ -14,9 +14,9 @@
 //  and limitations under the License.
 
 #import "TD_Database+Conflicts.h"
-#import "FMDatabase.h"
-#import "FMResultSet.h"
-#import "FMDatabaseQueue.h"
+#import <FMDB/FMDatabase.h>
+#import <FMDB/FMResultSet.h>
+#import <FMDB/FMDatabaseQueue.h>
 
 @implementation TD_Database (Conflicts)
 

--- a/Classes/common/touchdb/TD_Database+Insertion.m
+++ b/Classes/common/touchdb/TD_Database+Insertion.m
@@ -26,9 +26,9 @@
 #import "TDMisc.h"
 #import "Test.h"
 
-#import "FMDatabase.h"
-#import "FMDatabaseAdditions.h"
-#import "FMDatabaseQueue.h"
+#import <FMDB/FMDatabase.h>
+#import <FMDB/FMDatabaseAdditions.h>
+#import <FMDB/FMDatabaseQueue.h>
 
 #import "CDTLogging.h"
 

--- a/Classes/common/touchdb/TD_Database+LocalDocs.m
+++ b/Classes/common/touchdb/TD_Database+LocalDocs.m
@@ -21,8 +21,8 @@
 #import "TDInternal.h"
 #import "TDJSON.h"
 
-#import "FMDatabase.h"
-#import "FMDatabaseQueue.h"
+#import <FMDB/FMDatabase.h>
+#import <FMDB/FMDatabaseQueue.h>
 
 @implementation TD_Database (LocalDocs)
 

--- a/Classes/common/touchdb/TD_Database+Replication.m
+++ b/Classes/common/touchdb/TD_Database+Replication.m
@@ -21,9 +21,9 @@
 #import "TDJSON.h"
 #import "MYBlockUtils.h"
 
-#import "FMDatabase.h"
-#import "FMDatabaseAdditions.h"
-#import "FMDatabaseQueue.h"
+#import <FMDB/FMDatabase.h>
+#import <FMDB/FMDatabaseAdditions.h>
+#import <FMDB/FMDatabaseQueue.h>
 
 #define kActiveReplicatorCleanupDelay 10.0
 

--- a/Classes/common/touchdb/TD_Database.m
+++ b/Classes/common/touchdb/TD_Database.m
@@ -27,10 +27,10 @@
 #import "TDMisc.h"
 #import "TDJSON.h"
 
-#import "FMDatabase.h"
-#import "FMDatabaseAdditions.h"
+#import <FMDB/FMDatabase.h>
+#import <FMDB/FMDatabaseAdditions.h>
 #import "FMDatabase+LongLong.h"
-#import "FMDatabaseQueue.h"
+#import <FMDB/FMDatabaseQueue.h>
 #import "CDTLogging.h"
 
 NSString* const TD_DatabaseWillCloseNotification = @"TD_DatabaseWillClose";

--- a/Classes/common/touchdb/TD_View.m
+++ b/Classes/common/touchdb/TD_View.m
@@ -22,10 +22,10 @@
 #import "TDMisc.h"
 #import "TDJSON.h"
 
-#import "FMDatabase.h"
-#import "FMDatabaseAdditions.h"
-#import "FMDatabaseQueue.h"
-#import "FMResultSet.h"
+#import <FMDB/FMDatabase.h>
+#import <FMDB/FMDatabaseAdditions.h>
+#import <FMDB/FMDatabaseQueue.h>
+#import <FMDB/FMResultSet.h>
 
 #import "FMDatabase+LongLong.h"
 


### PR DESCRIPTION
When compiling CDTDatastore with the `use_frameworks!` cocoapods
directive depedancies are built as frameworks. The header import
statements for frameworks need to be in the form
<framework/header.h> and are updated to follow said form.

Note: CDTDatastore will not compile under the `user_frameworks!`
cocoapods directive until FMDB supports being built as a framework.

BugzID: 46367

reviewer @mikerhodes 
reviewer @tomblench 