### PR TITLE
45597 Provide a key to SQLCipher (key provider based on keychain encryption classes)

### DIFF
--- a/CDTDatastore.xcworkspace/contents.xcworkspacedata
+++ b/CDTDatastore.xcworkspace/contents.xcworkspacedata
@@ -48,6 +48,15 @@
                   location = "group:CDTEncryptionKeychainManager+Internal.h">
                </FileRef>
                <FileRef
+                  location = "group:CDTEncryptionKeychainProvider.h">
+               </FileRef>
+               <FileRef
+                  location = "group:CDTEncryptionKeychainProvider.m">
+               </FileRef>
+               <FileRef
+                  location = "group:CDTEncryptionKeychainProvider+Internal.h">
+               </FileRef>
+               <FileRef
                   location = "group:CDTEncryptionKeychainStorage.h">
                </FileRef>
                <FileRef

--- a/Classes/common/CloudantSync.h
+++ b/Classes/common/CloudantSync.h
@@ -20,6 +20,7 @@
 // only if ENCRYPT_DATABASE exists, i.e. unless you want this functionality, the methods and classes
 // will not be available and Xcode will not autocomplete the code with them.
 #ifdef ENCRYPT_DATABASE
+#import "CDTEncryptionKeychainProvider.h"
 #import "CDTDatastoreManager+EncryptionKey.h"
 #else
 #import "CDTDatastoreManager.h"

--- a/Classes/common/Encryption/Keychain/CDTEncryptionKeychainProvider+Internal.h
+++ b/Classes/common/Encryption/Keychain/CDTEncryptionKeychainProvider+Internal.h
@@ -1,0 +1,40 @@
+//
+//  CDTEncryptionKeychainProvider+Internal.h
+//  CloudantSync
+//
+//  Created by Enrique de la Torre Fernandez on 15/05/2015.
+//  Copyright (c) 2015 IBM Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#import "CDTEncryptionKeychainProvider.h"
+
+#import "CDTEncryptionKeychainManager.h"
+
+/**
+ This category is only for testing purposes.
+ */
+@interface CDTEncryptionKeychainProvider (Internal)
+
+/**
+ Initialise a provider with a password and a CDTEncryptionKeychainManager instance.
+ 
+ The returned provider will pass the password to the manager to generate the key or get it from the
+ keychain if it already exists.
+ 
+ @param password An user-provided password
+ @param manager A manager to generate and store the resulting key
+ 
+ @see CDTEncryptionKeychainManager
+ */
+- (instancetype)initWithPassword:(NSString *)password
+                      forManager:(CDTEncryptionKeychainManager *)manager;
+
+@end

--- a/Classes/common/Encryption/Keychain/CDTEncryptionKeychainProvider.h
+++ b/Classes/common/Encryption/Keychain/CDTEncryptionKeychainProvider.h
@@ -1,0 +1,54 @@
+//
+//  CDTEncryptionKeychainProvider.h
+//  CloudantSync
+//
+//  Created by Enrique de la Torre Fernandez on 21/04/2015.
+//  Copyright (c) 2015 IBM Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "CDTEncryptionKeyProvider.h"
+
+/**
+ This class conforms to protocol CDTEncryptionKeyProvider and it can be used to create an
+ encrypted datastore.
+ 
+ Given an user-provided password and an identifier, it generates a strong key and store it safely
+ in the keychain, so the same key can be retrieved later provided that the user supplies the same
+ password and id.
+ 
+ The password is used to protect the key before saving it to the keychain. The identifier is an
+ easy way to have more than one encryption key in the same app, the only condition is to provide
+ different ids for each of them.
+ 
+ @see CDTEncryptionKeyProvider
+ @see CDTEncryptionKeychainManager
+ @see CDTEncryptionKeychainStorage
+ */
+@interface CDTEncryptionKeychainProvider : NSObject <CDTEncryptionKeyProvider>
+
+- (instancetype)init UNAVAILABLE_ATTRIBUTE;
+
+/**
+ This is a convenience method that creates a CDTEncryptionKeychainManager with the provided
+ identifier before calling the init method to create a provider.
+ 
+ @param password An user-provided password
+ @param identifier The data saved in the keychain will be accessed with this identifier
+ 
+ @return A key provider
+ 
+ @see CDTEncryptionKeychainManager
+ */
++ (instancetype)providerWithPassword:(NSString *)password forIdentifier:(NSString *)identifier;
+
+@end

--- a/Classes/common/Encryption/Keychain/CDTEncryptionKeychainProvider.m
+++ b/Classes/common/Encryption/Keychain/CDTEncryptionKeychainProvider.m
@@ -1,0 +1,80 @@
+//
+//  CDTEncryptionKeychainProvider.m
+//  CloudantSync
+//
+//  Created by Enrique de la Torre Fernandez on 21/04/2015.
+//  Copyright (c) 2015 IBM Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#import "CDTEncryptionKeychainProvider.h"
+
+#import "CDTEncryptionKeychainManager.h"
+
+#import "TDMisc.h"
+#import "CDTLogging.h"
+
+@interface CDTEncryptionKeychainProvider ()
+
+@property (strong, nonatomic) NSString *password;
+@property (strong, nonatomic) CDTEncryptionKeychainManager *manager;
+
+@end
+
+@implementation CDTEncryptionKeychainProvider
+
+#pragma mark - Init method
+- (instancetype)init { return [self initWithPassword:nil forManager:nil]; }
+
+- (instancetype)initWithPassword:(NSString *)password
+                      forManager:(CDTEncryptionKeychainManager *)manager
+{
+    self = [super init];
+    if (self) {
+        if (password && manager) {
+            _password = password;
+            _manager = manager;
+        } else {
+            CDTLogError(CDTDATASTORE_LOG_CONTEXT, @"All parameters are mandatory");
+
+            self = nil;
+        }
+    }
+
+    return self;
+}
+
+#pragma mark - CDTEncryptionKeyProvider methods
+- (NSString *)encryptionKey
+{
+    NSData *data = nil;
+    if ([self.manager keyExists]) {
+        data = [self.manager loadKeyUsingPassword:self.password];
+    } else {
+        data = [self.manager generateAndSaveKeyProtectedByPassword:self.password];
+    }
+    
+    NSString *hexStr = (data ? TDHexFromBytes(data.bytes, data.length) : nil);
+    
+    return hexStr;
+}
+
+#pragma mark - Public class methods
++ (instancetype)providerWithPassword:(NSString *)password forIdentifier:(NSString *)identifier
+{
+    CDTEncryptionKeychainStorage *storage =
+        [[CDTEncryptionKeychainStorage alloc] initWithIdentifier:identifier];
+    CDTEncryptionKeychainManager *manager =
+        [[CDTEncryptionKeychainManager alloc] initWithStorage:storage];
+
+    return [[[self class] alloc] initWithPassword:password forManager:manager];
+}
+
+@end

--- a/Tests/Tests.xcodeproj/project.pbxproj
+++ b/Tests/Tests.xcodeproj/project.pbxproj
@@ -102,6 +102,10 @@
 		CD3FBCA91AB05A170032376E /* CDTHelperOneUseKeyProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = CD3FBCA51AB05A170032376E /* CDTHelperOneUseKeyProvider.m */; };
 		CD94A6FE1AB8A24C006C8343 /* emptyencrypteddb.touchdb in Resources */ = {isa = PBXBuildFile; fileRef = CD94A6FD1AB8A24C006C8343 /* emptyencrypteddb.touchdb */; };
 		CD94A6FF1AB8A24C006C8343 /* emptyencrypteddb.touchdb in Resources */ = {isa = PBXBuildFile; fileRef = CD94A6FD1AB8A24C006C8343 /* emptyencrypteddb.touchdb */; };
+		CDBC57361AE66CD700CF9E6B /* CDTEncryptionKeychainProviderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CDBC57351AE66CD700CF9E6B /* CDTEncryptionKeychainProviderTests.m */; };
+		CDBC57371AE66CD700CF9E6B /* CDTEncryptionKeychainProviderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CDBC57351AE66CD700CF9E6B /* CDTEncryptionKeychainProviderTests.m */; };
+		CDBC573A1AE6A06C00CF9E6B /* CDTMockEncryptionKeychainManager.m in Sources */ = {isa = PBXBuildFile; fileRef = CDBC57391AE6A06C00CF9E6B /* CDTMockEncryptionKeychainManager.m */; };
+		CDBC573B1AE6A06C00CF9E6B /* CDTMockEncryptionKeychainManager.m in Sources */ = {isa = PBXBuildFile; fileRef = CDBC57391AE6A06C00CF9E6B /* CDTMockEncryptionKeychainManager.m */; };
 		EC0C833C1AB217290051042F /* CDTDatastoreQueryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C831F1AB217290051042F /* CDTDatastoreQueryTests.m */; };
 		EC0C833D1AB217290051042F /* CDTDatastoreQueryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C831F1AB217290051042F /* CDTDatastoreQueryTests.m */; };
 		EC0C833E1AB217290051042F /* CDTQFilterFieldsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C83201AB217290051042F /* CDTQFilterFieldsTest.m */; };
@@ -219,6 +223,9 @@
 		CD3FBCA41AB05A170032376E /* CDTHelperOneUseKeyProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDTHelperOneUseKeyProvider.h; sourceTree = "<group>"; };
 		CD3FBCA51AB05A170032376E /* CDTHelperOneUseKeyProvider.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTHelperOneUseKeyProvider.m; sourceTree = "<group>"; };
 		CD94A6FD1AB8A24C006C8343 /* emptyencrypteddb.touchdb */ = {isa = PBXFileReference; lastKnownFileType = file; name = emptyencrypteddb.touchdb; path = Assets/emptyencrypteddb.touchdb; sourceTree = "<group>"; };
+		CDBC57351AE66CD700CF9E6B /* CDTEncryptionKeychainProviderTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTEncryptionKeychainProviderTests.m; sourceTree = "<group>"; };
+		CDBC57381AE6A06C00CF9E6B /* CDTMockEncryptionKeychainManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDTMockEncryptionKeychainManager.h; sourceTree = "<group>"; };
+		CDBC57391AE6A06C00CF9E6B /* CDTMockEncryptionKeychainManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTMockEncryptionKeychainManager.m; sourceTree = "<group>"; };
 		EC0C831F1AB217290051042F /* CDTDatastoreQueryTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTDatastoreQueryTests.m; sourceTree = "<group>"; };
 		EC0C83201AB217290051042F /* CDTQFilterFieldsTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTQFilterFieldsTest.m; sourceTree = "<group>"; };
 		EC0C83211AB217290051042F /* CDTQIndexCreatorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTQIndexCreatorTests.m; sourceTree = "<group>"; };
@@ -460,6 +467,7 @@
 				CD2188ED1AE576680036F59F /* Mock */,
 				CD2188E71AE574A20036F59F /* CDTEncryptionKeychainDataTests.m */,
 				CD2188EA1AE5764B0036F59F /* CDTEncryptionKeychainManagerTests.m */,
+				CDBC57351AE66CD700CF9E6B /* CDTEncryptionKeychainProviderTests.m */,
 				CD2188E11AE571410036F59F /* CDTEncryptionKeychainUtilsAESTests.m */,
 				CD2188E21AE571410036F59F /* CDTEncryptionKeychainUtilsPBKDF2Tests.m */,
 			);
@@ -469,6 +477,8 @@
 		CD2188ED1AE576680036F59F /* Mock */ = {
 			isa = PBXGroup;
 			children = (
+				CDBC57381AE6A06C00CF9E6B /* CDTMockEncryptionKeychainManager.h */,
+				CDBC57391AE6A06C00CF9E6B /* CDTMockEncryptionKeychainManager.m */,
 				CD2188EE1AE576740036F59F /* CDTMockEncryptionKeychainStorage.h */,
 				CD2188EF1AE576740036F59F /* CDTMockEncryptionKeychainStorage.m */,
 			);
@@ -729,12 +739,14 @@
 				CD2188D61AE5711A0036F59F /* CDTQIndexManagerEncryptionTests.m in Sources */,
 				CD2188EB1AE5764B0036F59F /* CDTEncryptionKeychainManagerTests.m in Sources */,
 				9F0D24171893161000D3D04E /* TDReachabilityTests.m in Sources */,
+				CDBC573A1AE6A06C00CF9E6B /* CDTMockEncryptionKeychainManager.m in Sources */,
 				EC0C834E1AB217290051042F /* CDTQQuerySqlTranslatorTests.m in Sources */,
 				EC0C835A1AB217290051042F /* CDTQMatcherIndexManager.m in Sources */,
 				EC0C83581AB217290051042F /* CDTQQueryMatcher.m in Sources */,
 				CD2188E81AE574A20036F59F /* CDTEncryptionKeychainDataTests.m in Sources */,
 				EC0C83561AB217290051042F /* CDTQEitherMatcher.m in Sources */,
 				EC0C83401AB217290051042F /* CDTQIndexCreatorTests.m in Sources */,
+				CDBC57361AE66CD700CF9E6B /* CDTEncryptionKeychainProviderTests.m in Sources */,
 				9F95D61018CF6A580006D349 /* DBQueryUtils.m in Sources */,
 				EC0C83441AB217290051042F /* CDTQIndexUpdaterTests.m in Sources */,
 				9F0D23F4188B4FFF00D3D04E /* TDMultipartWriterTests.m in Sources */,
@@ -796,12 +808,14 @@
 				CD2188D71AE5711A0036F59F /* CDTQIndexManagerEncryptionTests.m in Sources */,
 				CD2188EC1AE5764B0036F59F /* CDTEncryptionKeychainManagerTests.m in Sources */,
 				EC0C834F1AB217290051042F /* CDTQQuerySqlTranslatorTests.m in Sources */,
+				CDBC573B1AE6A06C00CF9E6B /* CDTMockEncryptionKeychainManager.m in Sources */,
 				EC0C835B1AB217290051042F /* CDTQMatcherIndexManager.m in Sources */,
 				EC0C83591AB217290051042F /* CDTQQueryMatcher.m in Sources */,
 				EC0C83571AB217290051042F /* CDTQEitherMatcher.m in Sources */,
 				CD2188E91AE574A20036F59F /* CDTEncryptionKeychainDataTests.m in Sources */,
 				9F95D61118CF6A580006D349 /* DBQueryUtils.m in Sources */,
 				EC0C83411AB217290051042F /* CDTQIndexCreatorTests.m in Sources */,
+				CDBC57371AE66CD700CF9E6B /* CDTEncryptionKeychainProviderTests.m in Sources */,
 				27CCEDD6187AD70C006F3C66 /* CloudantSyncTests.m in Sources */,
 				EC0C83451AB217290051042F /* CDTQIndexUpdaterTests.m in Sources */,
 				9F0D23F5188B4FFF00D3D04E /* TDMultipartWriterTests.m in Sources */,

--- a/Tests/Tests/Encryption/Keychain/CDTEncryptionKeychainProviderTests.m
+++ b/Tests/Tests/Encryption/Keychain/CDTEncryptionKeychainProviderTests.m
@@ -1,0 +1,152 @@
+//
+//  CDTEncryptionKeychainProviderTests.m
+//  Tests
+//
+//  Created by Enrique de la Torre Fernandez on 21/04/2015.
+//  Copyright (c) 2015 IBM Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#import <XCTest/XCTest.h>
+
+#import "CDTEncryptionKeychainProvider+Internal.h"
+
+#import "CDTMockEncryptionKeychainManager.h"
+
+@interface CDTEncryptionKeychainProviderTests : XCTestCase
+
+@property (strong, nonatomic) CDTEncryptionKeychainProvider *provider;
+
+@property (strong, nonatomic) NSString *password;
+@property (strong, nonatomic) NSData *encryptionKeyData;
+@property (strong, nonatomic) CDTMockEncryptionKeychainManager *mockManager;
+
+@end
+
+@implementation CDTEncryptionKeychainProviderTests
+
+- (void)setUp
+{
+    [super setUp];
+
+    // Put setup code here. This method is called before the invocation of each test method in the
+    // class.
+    self.password = @"password";
+    self.encryptionKeyData = [@"encryptionKeyData" dataUsingEncoding:NSUnicodeStringEncoding];
+    self.mockManager = [[CDTMockEncryptionKeychainManager alloc] init];
+
+    self.provider = [[CDTEncryptionKeychainProvider alloc]
+        initWithPassword:self.password
+              forManager:(CDTEncryptionKeychainManager *)self.mockManager];
+}
+
+- (void)tearDown
+{
+    // Put teardown code here. This method is called after the invocation of each test method in the
+    // class.
+    self.mockManager = nil;
+    self.encryptionKeyData = nil;
+    self.password = nil;
+
+    [super tearDown];
+}
+
+- (void)testInitWithoutPasswordFails
+{
+    XCTAssertNil([[CDTEncryptionKeychainProvider alloc]
+                     initWithPassword:nil
+                           forManager:(CDTEncryptionKeychainManager *)self.mockManager],
+                 @"All parameters in the designated initialiser are mandatory");
+}
+
+- (void)testInitWithoutManagerFails
+{
+    XCTAssertNil(
+        [[CDTEncryptionKeychainProvider alloc] initWithPassword:self.password forManager:nil],
+        @"All parameters in the designated initialiser are mandatory");
+}
+
+- (void)testEncryptionKeyGenerateEncryptionKeyDataIfDataWasNotGeneratedBefore
+{
+    self.mockManager.keyExistsResult = NO;
+
+    [self.provider encryptionKey];
+
+    XCTAssertTrue(self.mockManager.keyExistsExecuted &&
+                      self.mockManager.generateAndSaveKeyProtectedByPasswordExecuted,
+                  @"Generate the key if it was not created before");
+}
+
+- (void)testEncryptionKeyReturnNilIfGenerateEncryptionKeyDataReturnsNil
+{
+    self.mockManager.keyExistsResult = NO;
+    self.mockManager.generateAndSaveKeyProtectedByPasswordResult = nil;
+
+    XCTAssertNil([self.provider encryptionKey],
+                 @"If no data is generated, there is not key to return");
+}
+
+- (void)testEncryptionKeyReturnHexStringIfGenerateEncryptionKeyDataReturnsData
+{
+    self.mockManager.keyExistsResult = NO;
+    self.mockManager.generateAndSaveKeyProtectedByPasswordResult = self.encryptionKeyData;
+
+    NSString *key = [self.provider encryptionKey];
+
+    XCTAssertTrue([CDTEncryptionKeychainProviderTests isHexadecimalString:key],
+                  @"The key has to be a hexadecimal string");
+}
+
+- (void)testEncryptionKeyRetrieveEncryptionKeyDataIfDataWasGeneratedBefore
+{
+    self.mockManager.keyExistsResult = YES;
+
+    [self.provider encryptionKey];
+
+    XCTAssertTrue(self.mockManager.keyExistsExecuted && self.mockManager.loadKeyUsingPasswordExecuted,
+                  @"Get the key from keychain if it was generated before");
+}
+
+- (void)testEncryptionKeyReturnsNilIfRetrieveEncryptionKeyDataReturnsNil
+{
+    self.mockManager.keyExistsResult = YES;
+    self.mockManager.loadKeyUsingPasswordResult = nil;
+
+    XCTAssertNil([self.provider encryptionKey],
+                 @"If no data is retrieved, there is not key to return");
+}
+
+- (void)testEncryptionKeyReturnHexStringIfRetrieveEncryptionKeyDataReturnsData
+{
+    self.mockManager.keyExistsResult = YES;
+    self.mockManager.loadKeyUsingPasswordResult = self.encryptionKeyData;
+
+    NSString *key = [self.provider encryptionKey];
+
+    XCTAssertTrue([CDTEncryptionKeychainProviderTests isHexadecimalString:key],
+                  @"The key has to be a hexadecimal string");
+}
+
+#pragma mark - Private class methods
++ (BOOL)isHexadecimalString:(NSString *)str
+{
+    if (!str) {
+        return NO;
+    }
+
+    NSCharacterSet *noHexCharSet =
+        [[NSCharacterSet characterSetWithCharactersInString:@"0123456789ABCDEFabcdef"] invertedSet];
+    NSRange noHexRange = [str rangeOfCharacterFromSet:noHexCharSet];
+    BOOL isHex = (noHexRange.location == NSNotFound);
+
+    return isHex;
+}
+
+@end

--- a/Tests/Tests/Encryption/Keychain/CDTEncryptionKeychainUtilsPBKDF2Tests.m
+++ b/Tests/Tests/Encryption/Keychain/CDTEncryptionKeychainUtilsPBKDF2Tests.m
@@ -19,8 +19,9 @@
 #import <CommonCrypto/CommonCryptor.h>
 #import <CommonCrypto/CommonKeyDerivation.h>
 
-
 #import "CDTEncryptionKeychainUtils+PBKDF2.h"
+
+#import "TDMisc.h"
 
 @interface CDTEncryptionKeychainUtilsPBKDF2Tests : XCTestCase
 
@@ -101,15 +102,9 @@
 #pragma mark - Private class methods
 + (NSString *)hexadecimalRepresentationForData:(NSData *)data
 {
-    NSUInteger dataLength = data.length;
-    const unsigned char *dataBytes = data.bytes;
-
-    NSMutableString *hexString = [NSMutableString stringWithCapacity:(dataLength * 2)];
-    for (NSUInteger idx = 0; idx < dataLength; idx++) {
-        [hexString appendFormat:@"%02x", dataBytes[idx]];
-    }
-
-    return [NSString stringWithString:hexString];
+    NSString *hexStr = TDHexFromBytes(data.bytes, data.length);
+    
+    return hexStr;
 }
 
 @end

--- a/Tests/Tests/Encryption/Keychain/Mock/CDTMockEncryptionKeychainManager.h
+++ b/Tests/Tests/Encryption/Keychain/Mock/CDTMockEncryptionKeychainManager.h
@@ -1,0 +1,43 @@
+//
+//  CDTMockEncryptionKeychainManager.h
+//  Tests
+//
+//  Created by Enrique de la Torre Fernandez on 21/04/2015.
+//  Copyright (c) 2015 IBM Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+
+#define CDTMOCKENCRYPTIONKEYCHAINMANAGER_DEFAULT_LOADKEY nil
+#define CDTMOCKENCRYPTIONKEYCHAINMANAGER_DEFAULT_GENERATEANDSAVEKEY nil
+#define CDTMOCKENCRYPTIONKEYCHAINMANAGER_DEFAULT_KEYEXISTS NO
+#define CDTMOCKENCRYPTIONKEYCHAINMANAGER_DEFAULT_CLEARKEY YES
+
+@interface CDTMockEncryptionKeychainManager : NSObject
+
+@property (assign, nonatomic) BOOL loadKeyUsingPasswordExecuted;
+@property (strong, nonatomic) NSData *loadKeyUsingPasswordResult;
+
+@property (assign, nonatomic) BOOL generateAndSaveKeyProtectedByPasswordExecuted;
+@property (strong, nonatomic) NSData *generateAndSaveKeyProtectedByPasswordResult;
+
+@property (assign, nonatomic) BOOL keyExistsExecuted;
+@property (assign, nonatomic) BOOL keyExistsResult;
+
+@property (assign, nonatomic) BOOL clearKeyExecuted;
+@property (assign, nonatomic) BOOL clearKeyResult;
+
+- (NSData *)loadKeyUsingPassword:(NSString *)password;
+- (NSData *)generateAndSaveKeyProtectedByPassword:(NSString *)password;
+- (BOOL)keyExists;
+- (BOOL)clearKey;
+
+@end

--- a/Tests/Tests/Encryption/Keychain/Mock/CDTMockEncryptionKeychainManager.m
+++ b/Tests/Tests/Encryption/Keychain/Mock/CDTMockEncryptionKeychainManager.m
@@ -1,0 +1,76 @@
+//
+//  CDTMockEncryptionKeychainManager.m
+//  Tests
+//
+//  Created by Enrique de la Torre Fernandez on 21/04/2015.
+//  Copyright (c) 2015 IBM Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#import "CDTMockEncryptionKeychainManager.h"
+
+@interface CDTMockEncryptionKeychainManager ()
+
+@end
+
+@implementation CDTMockEncryptionKeychainManager
+
+#pragma mark - Init object
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        _loadKeyUsingPasswordExecuted = NO;
+        _loadKeyUsingPasswordResult = CDTMOCKENCRYPTIONKEYCHAINMANAGER_DEFAULT_LOADKEY;
+
+        _generateAndSaveKeyProtectedByPasswordExecuted = NO;
+        _generateAndSaveKeyProtectedByPasswordResult =
+            CDTMOCKENCRYPTIONKEYCHAINMANAGER_DEFAULT_GENERATEANDSAVEKEY;
+
+        _keyExistsExecuted = NO;
+        _keyExistsResult = CDTMOCKENCRYPTIONKEYCHAINMANAGER_DEFAULT_KEYEXISTS;
+
+        _clearKeyExecuted = NO;
+        _clearKeyResult = CDTMOCKENCRYPTIONKEYCHAINMANAGER_DEFAULT_CLEARKEY;
+    }
+
+    return self;
+}
+
+#pragma mark - Public methods
+- (NSData *)loadKeyUsingPassword:(NSString *)password
+{
+    self.loadKeyUsingPasswordExecuted = YES;
+
+    return self.loadKeyUsingPasswordResult;
+}
+
+- (NSData *)generateAndSaveKeyProtectedByPassword:(NSString *)password
+{
+    self.generateAndSaveKeyProtectedByPasswordExecuted = YES;
+
+    return self.generateAndSaveKeyProtectedByPasswordResult;
+}
+
+- (BOOL)keyExists
+{
+    self.keyExistsExecuted = YES;
+
+    return self.keyExistsResult;
+}
+
+- (BOOL)clearKey
+{
+    self.clearKeyExecuted = YES;
+
+    return self.clearKeyResult;
+}
+
+@end

--- a/doc/encryption.md
+++ b/doc/encryption.md
@@ -23,12 +23,17 @@ defines one method:
 - (NSString *)encryptionKey;
 ```
 
-For now, it is up to you to safely store the key that you have to return with
-this method (if the method return nil, the database won't be encrypted
-regardless of the subspec defined in your `Podfile`).
+Alternatively, you can use the class
+[CDTEncryptionKeychainProvider][CDTEncryptionKeychainProvider]. It already
+implements this protocol which handles generating a strong key from a
+user-provided password and stores it safely in the keychain. However, if you
+decide to code your own class (and use this one as a reference), keep in mind
+that if the method returns nil, the database won't be encrypted regardless of
+the subspec defined in your `Podfile`.
 
 To end, call `CDTDatastoreManager:datastoreNamed:withEncryptionKeyProvider:error:`
 to create `CDTDatastores` with encrypted databases (datastores and indexes are
 encrypted but not attachments and extensions)
 
-[CDTEncryptionKeyProvider]: ../Classes/common/CDTEncryptionKey/CDTEncryptionKeyProvider.h
+[CDTEncryptionKeyProvider]: ../Classes/common/Encryption/CDTEncryptionKeyProvider.h
+[CDTEncryptionKeychainProvider]: ../Classes/common/Encryption/Keychain/CDTEncryptionKeychainProvider.h


### PR DESCRIPTION
*What:*
Implement a class that conforms to protocol `CDTEncryptionKeyProvider`, i.e. a class that generates a strong key and stores it safely in the keychain.

*Why:*
It is not easy to generate a good key for encryption purposes, also once it is generated it has to be stored in a way that no one but the authorised user can retrieve it. The class implemented here can be used as it is or as an example.

*How:*
It will be based on the classes introduced in PRs: #126, #127 & #128.

*Tests:*
* Provider generates a key if there is not one in the keychain.
* Provider retrieve the key in the keychain if there is one.
* It returns an hexadecimal string in both cases.

reviewer @mikerhodes 
reviewer @rhyshort 

**NOTE:** Wait to review this PR until PR #128  is closed. This branch will be rebased and there will be only one commit to review.