### PR TITLE
Check DatastoreManager passed to CDTReplicatorFactory

### DIFF
--- a/Classes/common/CDTReplicator/CDTReplicatorFactory.m
+++ b/Classes/common/CDTReplicator/CDTReplicatorFactory.m
@@ -45,9 +45,16 @@ static NSString *const CDTReplicatorFactoryErrorDomain = @"CDTReplicatorFactoryE
 {
     self = [super init];
     if (self) {
-        self.manager = dsManager;
-        TD_DatabaseManager *dbManager = dsManager.manager;
-        self.replicatorManager = [[TDReplicatorManager alloc] initWithDatabaseManager:dbManager];
+        
+        if(dsManager){
+            _manager = dsManager;
+            TD_DatabaseManager *dbManager = dsManager.manager;
+            _replicatorManager = [[TDReplicatorManager alloc] initWithDatabaseManager:dbManager];
+        } else {
+            self = nil;
+            CDTLogWarn(CDTREPLICATION_LOG_CONTEXT,
+                       @"Datastore manager is nil, there isn't a local datastore to replicate with.");
+        }
     }
     return self;
 }

--- a/Tests/Tests/CDTReplicationTests.m
+++ b/Tests/Tests/CDTReplicationTests.m
@@ -34,6 +34,13 @@
 
 @implementation CDTReplicationTests
 
+
+-(void)testReplicatorIsNilForNilDatastoreManager {
+    
+    XCTAssertNil([[CDTReplicatorFactory alloc] initWithDatastoreManager:nil], @"Replication factory should be nil");
+    
+}
+
 -(void)testDictionaryForPullReplicationDocument
 {
     NSString *remoteUrl = @"https://adam:cox@myaccount.cloudant.com/mydb";


### PR DESCRIPTION
Check if the DatastoreManager passed to CDTReplicatorFactory
is nil, if so CDTReplicatoryFacotry initWithDatastoreManager
returns nil.

BugzID 46518

Fixes #132

reviewer @gadamc 
reviewer @indisoluble  