### PR TITLE
Validate document body is valid json.

### DIFF
--- a/Classes/common/CDTDatastore.m
+++ b/Classes/common/CDTDatastore.m
@@ -379,6 +379,18 @@ NSString *const CDTDatastoreChangeNotification = @"CDTDatastoreChangeNotificatio
 
 - (BOOL)validateBodyDictionary:(NSDictionary *)body error:(NSError *__autoreleasing *)error
 {
+    
+    
+    //Firstly check if the document body is valid json
+    if(![NSJSONSerialization isValidJSONObject:body]){
+        //body isn't valid json, set error
+        if (error){
+            *error = TDStatusToNSError(kTDStatusBadJSON, nil);
+        }
+        
+        return NO;
+    }
+    
     // Check user hasn't provided _fields, which should be provided
     // as metadata in the CDTDocumentRevision object rather than
     // via _fields in the body dictionary.

--- a/Tests/Tests/DatastoreCRUD.m
+++ b/Tests/Tests/DatastoreCRUD.m
@@ -83,6 +83,41 @@
 
 #pragma mark - CREATE tests
 
+
+-(void) testDocumentWithInfinityValue
+{
+    NSError * error;
+    CDTMutableDocumentRevision * revision = [CDTMutableDocumentRevision revision];
+    revision.body = @{@"infinity":@(INFINITY)};
+    
+    CDTDocumentRevision * rev = [self.datastore createDocumentFromRevision:revision
+                                                                     error:&error];
+    
+    XCTAssertNil(rev,@"revision is not nil");
+    XCTAssertNotNil(error,@"Error should be set");
+    XCTAssertEqual(400,
+                   error.code,
+                   @"Error code should be 400, but was %ld",
+                   (long)error.code);
+}
+
+-(void) testDocumentWithNonSerialisableValue {
+    NSError * error;
+    CDTMutableDocumentRevision * revision = [CDTMutableDocumentRevision revision];
+    revision.body = @{@"nonserialisable":[NSDate date]};
+    
+    CDTDocumentRevision * rev = [self.datastore createDocumentFromRevision:revision
+                                                                     error:&error];
+    
+    XCTAssertNil(rev,@"revision is not nil");
+    XCTAssertNotNil(error,@"Error should be set");
+    XCTAssertEqual(400,
+                   error.code,
+                   @"Error code should be 400, but was %ld",
+                   (long)error.code);
+}
+
+
 -(void)testDocumentRevisionFactoryValidData
 {
     NSError * error;


### PR DESCRIPTION
Validate document body contains only valid json values
before attempting to save.

BugzID: 42641

Fixes #97


reviewer @mikerhodes 
reviewer @tomblench 