### PR TITLE
Give CDTDatastore a reference to its Manager

### DIFF
--- a/Classes/common/CDTDatastore.h
+++ b/Classes/common/CDTDatastore.h
@@ -14,6 +14,7 @@
 //  and limitations under the License.
 
 #import <Foundation/Foundation.h>
+#import "CDTDatastoreManager.h"
 
 @class CDTDocumentRevision;
 @class CDTDocumentBody;
@@ -70,7 +71,15 @@ extern NSString *const CDTDatastoreChangeNotification;
 
 + (NSString *)versionString;
 
-- (id)initWithDatabase:(TD_Database *)database;
+/**
+ *
+ * Creates a CDTDatastore instance.
+ *
+ * @param manager this datastore's maanger, must not be nil.
+ * @param database the database where this datastore should save documents
+ *
+ */
+- (instancetype)initWithManager:(CDTDatastoreManager *)manager database:(TD_Database *)database;
 
 /**
  * The number of document in the datastore.

--- a/Classes/common/CDTDatastore.m
+++ b/Classes/common/CDTDatastore.m
@@ -39,6 +39,7 @@ NSString *const CDTDatastoreChangeNotification = @"CDTDatastoreChangeNotificatio
 
 @interface CDTDatastore ()
 
+@property (readonly) CDTDatastoreManager *manager;
 - (void)TDdbChanged:(NSNotification *)n;
 - (BOOL)validateBodyDictionary:(NSDictionary *)body error:(NSError *__autoreleasing *)error;
 
@@ -50,10 +51,11 @@ NSString *const CDTDatastoreChangeNotification = @"CDTDatastoreChangeNotificatio
 
 + (NSString *)versionString { return @CLOUDANT_SYNC_VERSION; }
 
-- (id)initWithDatabase:(TD_Database *)database
+- (instancetype)initWithManager:(CDTDatastoreManager *)manager database:(TD_Database *)database
 {
     self = [super init];
     if (self) {
+        NSParameterAssert(manager);
         _database = database;
         if (![_database open]) {
             return nil;
@@ -63,6 +65,7 @@ NSString *const CDTDatastoreChangeNotification = @"CDTDatastoreChangeNotificatio
         NSString *name = [database name];
         _extensionsDir =
             [dir stringByAppendingPathComponent:[NSString stringWithFormat:@"%@_extensions", name]];
+        _manager = manager;
 
         [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(TDdbChanged:)

--- a/Classes/common/CDTDatastoreManager.m
+++ b/Classes/common/CDTDatastoreManager.m
@@ -48,7 +48,7 @@ NSString *const CDTExtensionsDirName = @"_extensions";
     TD_Database *db = [self.manager databaseNamed:name];
 
     if (db) {
-        return [[CDTDatastore alloc] initWithDatabase:db];
+        return [[CDTDatastore alloc] initWithManager:self database:db];
     } else {
         if (error) {
             NSDictionary *userInfo = @{


### PR DESCRIPTION
Added internal property for CDTDatastoreManager to
CDTDatastore. CDTDatastore now requires CDTDatastoreManager
to be provided during it's init method.

BugzID 42816

reviewer @mikerhodes 
reviewer @indisoluble 