### PR TITLE
46517 Check if a db is encrypted or not trying to read it

### DIFF
--- a/CDTDatastore.xcworkspace/contents.xcworkspacedata
+++ b/CDTDatastore.xcworkspace/contents.xcworkspacedata
@@ -96,6 +96,12 @@
             <FileRef
                location = "group:CDTEncryptionKeyProvider.h">
             </FileRef>
+            <FileRef
+               location = "group:FMDatabase+EncryptionKey.h">
+            </FileRef>
+            <FileRef
+               location = "group:FMDatabase+EncryptionKey.m">
+            </FileRef>
          </Group>
          <Group
             location = "container:"
@@ -281,12 +287,6 @@
             </FileRef>
             <FileRef
                location = "group:FMDatabase+LongLong.m">
-            </FileRef>
-            <FileRef
-               location = "group:FMDatabase+SQLCipher.h">
-            </FileRef>
-            <FileRef
-               location = "group:FMDatabase+SQLCipher.m">
             </FileRef>
          </Group>
          <Group

--- a/Classes/common/Encryption/FMDatabase+EncryptionKey.h
+++ b/Classes/common/Encryption/FMDatabase+EncryptionKey.h
@@ -1,0 +1,47 @@
+//
+//  FMDatabase+EncryptionKey.h
+//  CloudantSync
+//
+//  Created by Enrique de la Torre Fernandez on 27/04/2015.
+//  Copyright (c) 2015 IBM Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#import "FMDatabase.h"
+
+#import "CDTEncryptionKeyProvider.h"
+
+extern NSString *const FMDatabaseEncryptionKeyErrorDomain;
+
+/**
+ Errors for 'setKeyWithProvider:error:'
+ */
+typedef NS_ENUM(NSInteger, FMDatabaseEncryptionKeyError) {
+    FMDatabaseEncryptionKeyErrorKeyNotSet,
+    FMDatabaseEncryptionKeyErrorNoKeyProvidedForEncryptedDB,
+    FMDatabaseEncryptionKeyErrorWrongKeyOrDBNotEncrypted
+};
+
+@interface FMDatabase (EncryptionKey)
+
+/**
+ This method performs 3 steps:
+ - Get an encryption key from the provider
+ - Set the key (if there is any, a provider can return nil)
+ - Check that the db can be read
+
+ @param provider Returns the key to decipher the db (or nil)
+ @param error Output param, it will contain an error if the method does not succeed
+
+ @return `YES` if success, `NO` on error.
+ */
+- (BOOL)setKeyWithProvider:(id<CDTEncryptionKeyProvider>)provider error:(NSError **)error;
+
+@end

--- a/Classes/common/Encryption/FMDatabase+EncryptionKey.m
+++ b/Classes/common/Encryption/FMDatabase+EncryptionKey.m
@@ -1,0 +1,88 @@
+//
+//  FMDatabase+EncryptionKey.m
+//  CloudantSync
+//
+//  Created by Enrique de la Torre Fernandez on 27/04/2015.
+//  Copyright (c) 2015 IBM Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#import "FMDatabase+EncryptionKey.h"
+
+#import "CDTLogging.h"
+
+@implementation FMDatabase (EncryptionKey)
+
+NSString *const FMDatabaseEncryptionKeyErrorDomain = @"FMDatabaseEncryptionKeyErrorDomain";
+
+#pragma mark - Public methods
+- (BOOL)setKeyWithProvider:(id<CDTEncryptionKeyProvider>)provider error:(NSError **)error
+{
+    BOOL success = YES;
+    NSError *thisError = nil;
+    
+    // Get the key
+    NSString *encryptionKey = [provider encryptionKey];
+
+    // Set the key (if there is any)
+    if (encryptionKey) {
+        success = [self setKey:encryptionKey];
+        if (!success) {
+            CDTLogError(CDTDATASTORE_LOG_CONTEXT,
+                        @"Key to decrypt DB at %@ not set. DB can not be opened.",
+                        [self databasePath]);
+
+            NSString *desc = NSLocalizedString(@"Key to decrypt DB not set", nil);
+            thisError = [NSError errorWithDomain:FMDatabaseEncryptionKeyErrorDomain
+                                            code:FMDatabaseEncryptionKeyErrorKeyNotSet
+                                        userInfo:@{NSLocalizedDescriptionKey : desc}];
+        }
+    }
+
+    // Try to read the db
+    if (success) {
+        success = (sqlite3_exec(self.sqliteHandle, "SELECT count(*) FROM sqlite_master;", NULL,
+                                NULL, NULL) == SQLITE_OK);
+        if (!success) {
+            if (encryptionKey) {
+                CDTLogError(
+                    CDTDATASTORE_LOG_CONTEXT,
+                    @"DB at %@ can not be deciphered with provided key. DB can not be opened.",
+                    [self databasePath]);
+
+                NSString *desc = NSLocalizedString(
+                    @"DB can not be deciphered with provided key or DB is not encrypted", nil);
+                thisError =
+                    [NSError errorWithDomain:FMDatabaseEncryptionKeyErrorDomain
+                                        code:FMDatabaseEncryptionKeyErrorWrongKeyOrDBNotEncrypted
+                                    userInfo:@{NSLocalizedDescriptionKey : desc}];
+            } else {
+                CDTLogError(CDTDATASTORE_LOG_CONTEXT,
+                            @"DB at %@ is encrypted but no key was provided. DB can not be opened.",
+                            [self databasePath]);
+
+                NSString *desc = NSLocalizedString(@"DB is encrypted but no key was provided", nil);
+                thisError =
+                    [NSError errorWithDomain:FMDatabaseEncryptionKeyErrorDomain
+                                        code:FMDatabaseEncryptionKeyErrorNoKeyProvidedForEncryptedDB
+                                    userInfo:@{NSLocalizedDescriptionKey : desc}];
+            }
+        }
+    }
+
+    // Return
+    if (!success && error) {
+        *error = thisError;
+    }
+
+    return success;
+}
+
+@end

--- a/EncryptionTests/EncryptionTests.xcodeproj/project.pbxproj
+++ b/EncryptionTests/EncryptionTests.xcodeproj/project.pbxproj
@@ -24,6 +24,8 @@
 		CD55A19C1AD56F2300A52281 /* CDTQIndexManagerEncryptionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD55A19A1AD56F2300A52281 /* CDTQIndexManagerEncryptionTests.m */; };
 		CD5D68311AB347D700F0BF8A /* DatastoreEncryptionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD5D68301AB347D700F0BF8A /* DatastoreEncryptionTests.m */; };
 		CD5D68321AB347D700F0BF8A /* DatastoreEncryptionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD5D68301AB347D700F0BF8A /* DatastoreEncryptionTests.m */; };
+		CDADD5C31AEFD715003CA9EF /* FMDatabase+SQLCipher.m in Sources */ = {isa = PBXBuildFile; fileRef = CDADD5C21AEFD715003CA9EF /* FMDatabase+SQLCipher.m */; };
+		CDADD5C41AEFD715003CA9EF /* FMDatabase+SQLCipher.m in Sources */ = {isa = PBXBuildFile; fileRef = CDADD5C21AEFD715003CA9EF /* FMDatabase+SQLCipher.m */; };
 		CDCB7A331AB3AB51000D8FFC /* DatastoreManagerEncryptionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CDCB7A321AB3AB51000D8FFC /* DatastoreManagerEncryptionTests.m */; };
 		CDCB7A341AB3AB51000D8FFC /* DatastoreManagerEncryptionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CDCB7A321AB3AB51000D8FFC /* DatastoreManagerEncryptionTests.m */; };
 		CDEE6ECD1AAF3BD0002C96C0 /* CloudantTests+EncryptionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CDEE6ECC1AAF3BD0002C96C0 /* CloudantTests+EncryptionTests.m */; };
@@ -53,6 +55,8 @@
 		CD48786D1A9BA6C80070EB63 /* CloudantTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CloudantTests.m; path = ../../Tests/Tests/CloudantTests.m; sourceTree = "<group>"; };
 		CD55A19A1AD56F2300A52281 /* CDTQIndexManagerEncryptionTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTQIndexManagerEncryptionTests.m; sourceTree = "<group>"; };
 		CD5D68301AB347D700F0BF8A /* DatastoreEncryptionTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DatastoreEncryptionTests.m; sourceTree = "<group>"; };
+		CDADD5C11AEFD715003CA9EF /* FMDatabase+SQLCipher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "FMDatabase+SQLCipher.h"; path = "../../Tests/Tests/Encryption/FMDatabase+SQLCipher.h"; sourceTree = "<group>"; };
+		CDADD5C21AEFD715003CA9EF /* FMDatabase+SQLCipher.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "FMDatabase+SQLCipher.m"; path = "../../Tests/Tests/Encryption/FMDatabase+SQLCipher.m"; sourceTree = "<group>"; };
 		CDCB7A321AB3AB51000D8FFC /* DatastoreManagerEncryptionTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DatastoreManagerEncryptionTests.m; sourceTree = "<group>"; };
 		CDEE6ECB1AAF3BD0002C96C0 /* CloudantTests+EncryptionTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "CloudantTests+EncryptionTests.h"; path = "../../Tests/Tests/Encryption/CloudantTests+EncryptionTests.h"; sourceTree = "<group>"; };
 		CDEE6ECC1AAF3BD0002C96C0 /* CloudantTests+EncryptionTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "CloudantTests+EncryptionTests.m"; path = "../../Tests/Tests/Encryption/CloudantTests+EncryptionTests.m"; sourceTree = "<group>"; };
@@ -130,6 +134,8 @@
 				CD48786B1A9BA6C80070EB63 /* CloudantSyncTests.m */,
 				CD5D68301AB347D700F0BF8A /* DatastoreEncryptionTests.m */,
 				CDCB7A321AB3AB51000D8FFC /* DatastoreManagerEncryptionTests.m */,
+				CDADD5C11AEFD715003CA9EF /* FMDatabase+SQLCipher.h */,
+				CDADD5C21AEFD715003CA9EF /* FMDatabase+SQLCipher.m */,
 				CD4878671A9BA5F90070EB63 /* TD_DatabaseEncryptionTests.m */,
 				CD033B031A9BA2F600825DA9 /* Supporting Files */,
 			);
@@ -351,6 +357,7 @@
 				CD48786E1A9BA6C80070EB63 /* CloudantSyncTests.m in Sources */,
 				CDCB7A331AB3AB51000D8FFC /* DatastoreManagerEncryptionTests.m in Sources */,
 				CD5D68311AB347D700F0BF8A /* DatastoreEncryptionTests.m in Sources */,
+				CDADD5C31AEFD715003CA9EF /* FMDatabase+SQLCipher.m in Sources */,
 				CD4878681A9BA5F90070EB63 /* TD_DatabaseEncryptionTests.m in Sources */,
 				CD4878701A9BA6C80070EB63 /* CloudantTests.m in Sources */,
 			);
@@ -366,6 +373,7 @@
 				CD48786F1A9BA6C80070EB63 /* CloudantSyncTests.m in Sources */,
 				CDCB7A341AB3AB51000D8FFC /* DatastoreManagerEncryptionTests.m in Sources */,
 				CD5D68321AB347D700F0BF8A /* DatastoreEncryptionTests.m in Sources */,
+				CDADD5C41AEFD715003CA9EF /* FMDatabase+SQLCipher.m in Sources */,
 				CD4878691A9BA5F90070EB63 /* TD_DatabaseEncryptionTests.m in Sources */,
 				CD4878711A9BA6C80070EB63 /* CloudantTests.m in Sources */,
 			);

--- a/Tests/Tests.xcodeproj/project.pbxproj
+++ b/Tests/Tests.xcodeproj/project.pbxproj
@@ -102,6 +102,8 @@
 		CD3FBCA91AB05A170032376E /* CDTHelperOneUseKeyProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = CD3FBCA51AB05A170032376E /* CDTHelperOneUseKeyProvider.m */; };
 		CD94A6FE1AB8A24C006C8343 /* emptyencrypteddb.touchdb in Resources */ = {isa = PBXBuildFile; fileRef = CD94A6FD1AB8A24C006C8343 /* emptyencrypteddb.touchdb */; };
 		CD94A6FF1AB8A24C006C8343 /* emptyencrypteddb.touchdb in Resources */ = {isa = PBXBuildFile; fileRef = CD94A6FD1AB8A24C006C8343 /* emptyencrypteddb.touchdb */; };
+		CDADD5BF1AEFD643003CA9EF /* FMDatabase+SQLCipher.m in Sources */ = {isa = PBXBuildFile; fileRef = CDADD5BE1AEFD643003CA9EF /* FMDatabase+SQLCipher.m */; };
+		CDADD5C01AEFD643003CA9EF /* FMDatabase+SQLCipher.m in Sources */ = {isa = PBXBuildFile; fileRef = CDADD5BE1AEFD643003CA9EF /* FMDatabase+SQLCipher.m */; };
 		CDBC57361AE66CD700CF9E6B /* CDTEncryptionKeychainProviderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CDBC57351AE66CD700CF9E6B /* CDTEncryptionKeychainProviderTests.m */; };
 		CDBC57371AE66CD700CF9E6B /* CDTEncryptionKeychainProviderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CDBC57351AE66CD700CF9E6B /* CDTEncryptionKeychainProviderTests.m */; };
 		CDBC573A1AE6A06C00CF9E6B /* CDTMockEncryptionKeychainManager.m in Sources */ = {isa = PBXBuildFile; fileRef = CDBC57391AE6A06C00CF9E6B /* CDTMockEncryptionKeychainManager.m */; };
@@ -225,6 +227,8 @@
 		CD3FBCA41AB05A170032376E /* CDTHelperOneUseKeyProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDTHelperOneUseKeyProvider.h; sourceTree = "<group>"; };
 		CD3FBCA51AB05A170032376E /* CDTHelperOneUseKeyProvider.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTHelperOneUseKeyProvider.m; sourceTree = "<group>"; };
 		CD94A6FD1AB8A24C006C8343 /* emptyencrypteddb.touchdb */ = {isa = PBXFileReference; lastKnownFileType = file; name = emptyencrypteddb.touchdb; path = Assets/emptyencrypteddb.touchdb; sourceTree = "<group>"; };
+		CDADD5BD1AEFD643003CA9EF /* FMDatabase+SQLCipher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "FMDatabase+SQLCipher.h"; sourceTree = "<group>"; };
+		CDADD5BE1AEFD643003CA9EF /* FMDatabase+SQLCipher.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "FMDatabase+SQLCipher.m"; sourceTree = "<group>"; };
 		CDBC57351AE66CD700CF9E6B /* CDTEncryptionKeychainProviderTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTEncryptionKeychainProviderTests.m; sourceTree = "<group>"; };
 		CDBC57381AE6A06C00CF9E6B /* CDTMockEncryptionKeychainManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDTMockEncryptionKeychainManager.h; sourceTree = "<group>"; };
 		CDBC57391AE6A06C00CF9E6B /* CDTMockEncryptionKeychainManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTMockEncryptionKeychainManager.m; sourceTree = "<group>"; };
@@ -460,6 +464,8 @@
 				CD2188D21AE5711A0036F59F /* CloudantTests+EncryptionTests.m */,
 				CD2188D31AE5711A0036F59F /* DatastoreEncryptionTests.m */,
 				CD2188D41AE5711A0036F59F /* DatastoreManagerEncryptionTests.m */,
+				CDADD5BD1AEFD643003CA9EF /* FMDatabase+SQLCipher.h */,
+				CDADD5BE1AEFD643003CA9EF /* FMDatabase+SQLCipher.m */,
 				CD2188D51AE5711A0036F59F /* TD_DatabaseEncryptionTests.m */,
 			);
 			path = Encryption;
@@ -740,6 +746,7 @@
 				985A188719D2CC54000283E9 /* CDTDatastoreEvents.m in Sources */,
 				9F0D240B188E3C3A00D3D04E /* TDCollateJSONTests.m in Sources */,
 				EC0C83601AB217290051042F /* CDTQSQLOnlyQueryExecutor.m in Sources */,
+				CDADD5BF1AEFD643003CA9EF /* FMDatabase+SQLCipher.m in Sources */,
 				CD3FBCA81AB05A170032376E /* CDTHelperOneUseKeyProvider.m in Sources */,
 				CD2188D61AE5711A0036F59F /* CDTQIndexManagerEncryptionTests.m in Sources */,
 				CD2188EB1AE5764B0036F59F /* CDTEncryptionKeychainManagerTests.m in Sources */,
@@ -810,6 +817,7 @@
 				9F0D240C188E3C3A00D3D04E /* TDCollateJSONTests.m in Sources */,
 				9F0D24181893161000D3D04E /* TDReachabilityTests.m in Sources */,
 				EC0C83611AB217290051042F /* CDTQSQLOnlyQueryExecutor.m in Sources */,
+				CDADD5C01AEFD643003CA9EF /* FMDatabase+SQLCipher.m in Sources */,
 				CD3FBCA91AB05A170032376E /* CDTHelperOneUseKeyProvider.m in Sources */,
 				CD2188D71AE5711A0036F59F /* CDTQIndexManagerEncryptionTests.m in Sources */,
 				CD2188EC1AE5764B0036F59F /* CDTEncryptionKeychainManagerTests.m in Sources */,

--- a/Tests/Tests/Encryption/CloudantTests+EncryptionTests.h
+++ b/Tests/Tests/Encryption/CloudantTests+EncryptionTests.h
@@ -24,8 +24,6 @@
 #define kCDTQueryIndexFolder @"com.cloudant.sync.query"  // in CDTQIndexManager.m. Move it into .h?
 #define kCDTQueryIndexFilename @"indexes.sqlite"
 
-#define kCDTSQLiteStandardHeader @"SQLite format 3"
-
 @interface CloudantTests (EncryptionTests)
 
 /**

--- a/Tests/Tests/Encryption/FMDatabase+SQLCipher.h
+++ b/Tests/Tests/Encryption/FMDatabase+SQLCipher.h
@@ -1,9 +1,17 @@
 //
 //  FMDatabase+SQLCipher.h
-//  
+//  CloudantSync
 //
 //  Created by Enrique de la Torre Fernandez on 29/03/2015.
+//  Copyright (c) 2015 IBM Cloudant. All rights reserved.
 //
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
 //
 
 #import <FMDB/FMDatabase.h>
@@ -16,15 +24,6 @@ typedef enum {
 } FMDatabaseUnencrypted;
 
 @interface FMDatabase (SQLCipher)
-
-/**
- * Set encryption key and validate if the database can be deciphered with it
- *
- * @param key The key to be used.
- *
- * @return YES if success, NO is the key is not set or data can not deciphered with it
- */
-- (BOOL)setValidKey:(NSString*)key;
 
 /**
  * Check if a SQLite database is not encrypted. A SQLite file starts with 'SQLite format 3'; this

--- a/Tests/Tests/Encryption/FMDatabase+SQLCipher.m
+++ b/Tests/Tests/Encryption/FMDatabase+SQLCipher.m
@@ -1,9 +1,17 @@
 //
 //  FMDatabase+SQLCipher.m
-//  
+//  CloudantSync
 //
 //  Created by Enrique de la Torre Fernandez on 29/03/2015.
+//  Copyright (c) 2015 IBM Cloudant. All rights reserved.
 //
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
 //
 
 #import "FMDatabase+SQLCipher.h"
@@ -13,28 +21,6 @@
 NSString* const FMDatabaseStandardSQLiteHeader = @"SQLite format 3";
 
 @implementation FMDatabase (SQLCipher)
-
-#pragma mark - Public methods
-- (BOOL)setValidKey:(NSString *)key
-{
-    BOOL result = [self setKey:key];
-    if (!result) {
-        CDTLogError(CDTDATASTORE_LOG_CONTEXT,
-                    @"Key to de-encrypt DB at %@ not set. DB can not be opened.",
-                    [self databasePath]);
-    } else {
-        // Verify if it is the right key
-        result = (sqlite3_exec(self.sqliteHandle, "SELECT count(*) FROM sqlite_master;", NULL, NULL,
-                               NULL) == SQLITE_OK);
-        if (!result) {
-            CDTLogError(CDTDATASTORE_LOG_CONTEXT,
-                        @"DB at %@ can not be deciphered with provided key. DB can not be opened.",
-                        [self databasePath]);
-        }
-    }
-    
-    return result;
-}
 
 #pragma mark - Public class methods
 + (FMDatabaseUnencrypted)isDatabaseUnencryptedAtPath:(NSString *)path


### PR DESCRIPTION
*What:*
If a key provider does not return a value, we ensure that the database is not encrypted comparing the first 15 bytes of the file with 'SQLite format 3'. If the SQLite file does not start with that string, we assume that the db is not encrypted. But if the provider does return a key, we set the key and then we execute this select to check that the provided value is correct:

```
SELECT count(*) FROM sqlite_master;
```

However this select is going to fail if no key is set and the database in encrypted.
Instead of reading the beginning of the file, we can execute this select in all cases.

*Why:*
Because comparing the beginning of the file with a hardcoded string is not reliable, it could change with the next version of SQLite.

*How:*
We have to execute the `select` mentioned before in all cases: if a key is set or not.

*Tests:*
The tests already in place are sufficient 

reviewer @mikerhodes 
reviewer @rhyshort 

**NOTE:** Wait to review this PR until PR #133  is closed. This branch will be rebased and there will be only one commit to review.