### PR TITLE
Add support for text index management in Query

### DIFF
--- a/Classes/common/query/CDTQIndexCreator.h
+++ b/Classes/common/query/CDTQIndexCreator.h
@@ -13,6 +13,7 @@
 //  and limitations under the License.
 
 #import <Foundation/Foundation.h>
+#import "CDTQIndex.h"
 
 @class FMDatabaseQueue;
 @class CDTDatastore;
@@ -27,9 +28,7 @@
  @param indexName Name of index to create.
  @returns name of created index
  */
-+ (NSString *)ensureIndexed:(NSArray * /* NSString */)fieldNames
-                   withName:(NSString *)indexName
-                       type:(NSString *)type
++ (NSString *)ensureIndexed:(CDTQIndex *)index
                  inDatabase:(FMDatabaseQueue *)database
               fromDatastore:(CDTDatastore *)datastore;
 
@@ -39,6 +38,7 @@
 
 + (NSArray /*CDTQSqlParts*/ *)insertMetadataStatementsForIndexName:(NSString *)indexName
                                                               type:(NSString *)indexType
+                                                          settings:(NSString *)indexSettings
                                                         fieldNames:
                                                             (NSArray /*NSString*/ *)fieldNames;
 
@@ -47,5 +47,9 @@
 
 + (CDTQSqlParts *)createIndexIndexStatementForIndexName:(NSString *)indexName
                                              fieldNames:(NSArray /*NSString*/ *)fieldNames;
+
++ (CDTQSqlParts *)createVirtualTableStatementForIndexName:(NSString *)indexName
+                                               fieldNames:(NSArray /*NSString*/ *)fieldNames
+                                                 settings:(NSDictionary *)indexSettings;
 
 @end

--- a/Classes/common/query/CDTQIndexManager.h
+++ b/Classes/common/query/CDTQIndexManager.h
@@ -90,6 +90,11 @@ typedef NS_ENUM(NSInteger, CDTQQueryError) {
                    withName:(NSString *)indexName
                        type:(NSString *)type;
 
+- (NSString *)ensureIndexed:(NSArray * /* NSString */)fieldNames
+                   withName:(NSString *)indexName
+                       type:(NSString *)type
+                   settings:(NSDictionary *)indexSettings;
+
 - (BOOL)deleteIndexNamed:(NSString *)indexName;
 
 - (BOOL)updateAllIndexes;

--- a/Classes/common/query/CDTQQuerySqlTranslator.m
+++ b/Classes/common/query/CDTQQuerySqlTranslator.m
@@ -280,6 +280,15 @@
 {
     NSString *chosenIndex = nil;
     for (NSString *indexName in indexes) {
+        
+        // TODO - Remove once the query component of full text search is added.
+        NSString *indexType = indexes[indexName][@"type"];
+        if ([indexType.lowercaseString isEqualToString:@"text"]) {
+            LogInfo(@"Full text search is not yet supported.  "
+                     "Text index %@ is being ignored.", indexName);
+            continue;
+        }
+        
         NSSet *providedFields = [NSSet setWithArray:indexes[indexName][@"fields"]];
         if ([neededFields isSubsetOfSet:providedFields]) {
             chosenIndex = indexName;

--- a/Tests/Tests/CDTQIndexManagerTests.m
+++ b/Tests/Tests/CDTQIndexManagerTests.m
@@ -179,6 +179,26 @@ SpecBegin(CDTQIndexManager)
             expect([im listIndexes][@"basic3"]).toNot.beNil();
 
         });
+        
+        it(@"text index", ^{
+            
+            CDTMutableDocumentRevision *rev = [CDTMutableDocumentRevision revision];
+            
+            rev.body = @{
+                         @"name" : @"mike",
+                         @"age" : @12,
+                         @"pet" : @{@"species" : @"cat", @"name" : @"mike"}
+                         };
+            [ds createDocumentFromRevision:rev error:nil];
+            
+            expect([im ensureIndexed:@[ @"name" ]
+                            withName:@"basic"
+                                type:@"text"]).to.equal(@"basic");
+            expect([im listIndexes][@"basic"]).toNot.beNil();
+            
+            expect([im deleteIndexNamed:@"basic"]).to.equal(@YES);
+            expect([im listIndexes][@"basic"]).to.beNil();
+        });
 
     });
 

--- a/Tests/Tests/CDTQIndexUpdaterTests.m
+++ b/Tests/Tests/CDTQIndexUpdaterTests.m
@@ -333,6 +333,47 @@ SpecBegin(CDTQIndexUpdater)
                 expect([updater sequenceNumberForIndex:@"basic"]).to.equal(7);
 
             });
+            
+            describe(@"when using a text index", ^{
+                it(@"sets correct sequence number", ^{
+                    
+                    expect([im ensureIndexed:@[ @"pet", @"name" ]
+                                    withName:@"basic"
+                                        type:@"text"]).toNot.beNil();
+                    
+                    FMDatabaseQueue *queue =
+                        (FMDatabaseQueue *)[im performSelector:@selector(database)];
+                    
+                    CDTQIndexUpdater *updater =
+                    [[CDTQIndexUpdater alloc] initWithDatabase:queue datastore:ds];
+                    expect([updater sequenceNumberForIndex:@"basic"]).to.equal(6);
+                    
+                    expect([updater updateAllIndexes:[im listIndexes]]).to.beTruthy();
+                    
+                    expect([updater sequenceNumberForIndex:@"basic"]).to.equal(6);
+                    
+                });
+                
+                it(@"sets correct sequence number after update", ^{
+                    expect([im ensureIndexed:@[ @"pet", @"name" ]
+                                    withName:@"basic"
+                                        type:@"text"]).toNot.beNil();
+                    FMDatabaseQueue *queue =
+                        (FMDatabaseQueue *)[im performSelector:@selector(database)];
+                    CDTQIndexUpdater *updater =
+                        [[CDTQIndexUpdater alloc] initWithDatabase:queue datastore:ds];
+                    
+                    CDTMutableDocumentRevision *rev = [CDTMutableDocumentRevision revision];
+                    rev.docId = @"newdoc";
+                    rev.body = @{ @"name" : @"fred", @"age" : @12 };
+                    [ds createDocumentFromRevision:rev error:nil];
+                    
+                    expect([updater updateAllIndexes:[im listIndexes]]).to.beTruthy();
+                    
+                    expect([updater sequenceNumberForIndex:@"basic"]).to.equal(7);
+                    
+                });
+            });
 
         });
     });


### PR DESCRIPTION
_What:_

The work contained within this PR adds functionality to Query that allows for the management of text indexes.  The functionality will remain disabled until the query "find" logic is implemented and delivered as part of a separate PR.

_Why:_

In order to support full text search queries we need to be able to manage text indexes along side json indexes.

_How:_

- The index manager API now contains an additional method that allows a developer using our library to specify text index settings.
- The index creator now creates a SQLite VIRTUAL table for a text index as well as limiting the datastore to one text index.
- A temporary section of code in the SQL translator disables the use of text indexes until the query logic is delivered as part of a separate PR.

_Tests:_

- A text index deletion test was added to the index manager tests.  A text index and a json index are handled in exactly the same manner.  This test confirms this behavior.
- Tests have been added to the index creator tests that test the creation of a text index and its behavior along side json indexes.
- Tests have been added to the index updater tests to test the updating of text index content due to changes to documents in the datastore.  A text index and a json index are handled in exactly the same manner.  These tests confirm this behavior.

reviewer @mikerhodes
reviewer @rhyshort 

BugId: 46369