### PR TITLE
46372 Remove access to attachment file path

### DIFF
--- a/CDTDatastore.xcworkspace/contents.xcworkspacedata
+++ b/CDTDatastore.xcworkspace/contents.xcworkspacedata
@@ -22,6 +22,18 @@
             <FileRef
                location = "group:Classes/common/Attachments/CDTAttachment.m">
             </FileRef>
+            <FileRef
+               location = "group:Classes/common/Attachments/CDTBlobData.h">
+            </FileRef>
+            <FileRef
+               location = "group:Classes/common/Attachments/CDTBlobData.m">
+            </FileRef>
+            <FileRef
+               location = "group:Classes/common/Attachments/CDTBlobReader.h">
+            </FileRef>
+            <FileRef
+               location = "group:Classes/common/Attachments/CDTBlobWriter.h">
+            </FileRef>
          </Group>
          <Group
             location = "group:Encryption"

--- a/Classes/common/Attachments/CDTAttachment.h
+++ b/Classes/common/Attachments/CDTAttachment.h
@@ -19,6 +19,8 @@
 #import "TD_Database.h"
 #import "TD_Database+Attachments.h"
 
+#import "CDTBlobReader.h"
+
 /**
  Base class for attachments in the datastore.
 
@@ -73,11 +75,7 @@
 /** sha of file, used for file path on disk. */
 @property (nonatomic, readonly) NSData *key;
 
-/**
- Private constructor passed the path to the blob in the
- blob store.
- */
-- (instancetype)initWithPath:(NSString *)filePath
+- (instancetype)initWithBlob:(id<CDTBlobReader>)blob
                         name:(NSString *)name
                         type:(NSString *)type
                         size:(NSInteger)size

--- a/Classes/common/Attachments/CDTBlobData.h
+++ b/Classes/common/Attachments/CDTBlobData.h
@@ -1,0 +1,61 @@
+//
+//  CDTBlobData.h
+//  CloudantSync
+//
+//  Created by Enrique de la Torre Fernandez on 05/05/2015.
+//  Copyright (c) 2015 IBM Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "CDTBlobReader.h"
+#import "CDTBlobWriter.h"
+
+extern NSString *const CDTBlobDataErrorDomain;
+
+typedef NS_ENUM(NSInteger, CDTBlobDataError) {
+    CDTBlobDataErrorOperationNotPossibleIfBlobIsOpen
+};
+
+/**
+ Use this class to read from/write to an attachment. The data read from an attachment is returned
+ as it is, so make sure that the attachment is not encrypted. In the same way, the data provided is
+ written to the attachment without further processing.
+ 
+ To accomplish this purpose, this class conforms to 2 related protocols: CDTBlobReader &
+ CDTBlobWriter. About CDTBlobWriter:
+ 
+ - 'openForWriting'.- Call this method before calling 'CDTBlobWriter:appendData:'. The file informed
+ during the initialisation must exist on advance or it will fail.
+ - 'isBlobOpenForWriting'.- It will return YES after calling 'CDTBlobWriter:openForWriting' and
+ NO after calling 'CDTBlobWriter:close'. By default, a newly initialised blob is closed.
+ - 'close'.- Call it after adding all data to the attachment.
+ - 'appendData:'.- It will fail if 'CDTBlobWriter:isBlobOpenForWriting' is false.
+ - 'writeEntireBlobWithData:error:'.- This method overwrites the content of the file supplied during
+ the initialisation or creates it if it does not exist. However, it will fail if the blob is open.
+ 
+ And CDTBlobReader:
+ 
+ - 'dataWithError:'.- It will fail if the blob is open.
+ - 'inputStreamWithOutputLength:'.- As the previous method, it will fail if the blob is open.
+ 
+ @see CDTBlobReader
+ @see CDTBlobWriter
+ */
+@interface CDTBlobData : NSObject <CDTBlobReader, CDTBlobWriter>
+
+- (instancetype)init UNAVAILABLE_ATTRIBUTE;
+
+- (instancetype)initWithPath:(NSString *)path NS_DESIGNATED_INITIALIZER;
+
++ (instancetype)blobWithPath:(NSString *)path;
+
+@end

--- a/Classes/common/Attachments/CDTBlobData.m
+++ b/Classes/common/Attachments/CDTBlobData.m
@@ -1,0 +1,206 @@
+//
+//  CDTBlobData.m
+//  CloudantSync
+//
+//  Created by Enrique de la Torre Fernandez on 05/05/2015.
+//  Copyright (c) 2015 IBM Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#import "CDTBlobData.h"
+
+#import "CDTLogging.h"
+
+NSString *const CDTBlobDataErrorDomain = @"CDTBlobDataErrorDomain";
+
+@interface CDTBlobData ()
+
+@property (strong, nonatomic, readonly) NSString *path;
+
+@property (strong, nonatomic) NSFileHandle *outFileHandle;
+
+@end
+
+@implementation CDTBlobData
+
+#pragma mark - Init object
+- (instancetype)init { return [self initWithPath:nil]; }
+
+- (instancetype)initWithPath:(NSString *)path
+{
+    self = [super init];
+    if (self) {
+        if (path && ([path length] > 0)) {
+            _path = path;
+            _outFileHandle = nil;
+        } else {
+            CDTLogError(CDTDATASTORE_LOG_CONTEXT, @"A non-empty path is mandatory");
+
+            self = nil;
+        }
+    }
+
+    return self;
+}
+
+#pragma mark - Memory management
+- (void)dealloc { [self close]; }
+
+#pragma mark - CDTBlobReader methods
+- (NSData *)dataWithError:(NSError **)error
+{
+    NSData *data = nil;
+    NSError *thisError = nil;
+
+    if ([self isBlobOpenForWriting]) {
+        CDTLogDebug(CDTDATASTORE_LOG_CONTEXT,
+                    @"Blob at %@ is open. Close it before reading its content", self.path);
+
+        thisError = [CDTBlobData errorOperationNotPossibleIfBlobIsOpen];
+    } else {
+        data = [NSData dataWithContentsOfFile:self.path
+                                      options:NSDataReadingMappedIfSafe
+                                        error:&thisError];
+        if (!data) {
+            CDTLogDebug(CDTDATASTORE_LOG_CONTEXT,
+                        @"Data object could not be created with file %@: %@", self.path, thisError);
+        }
+    }
+
+    if (!data && error) {
+        *error = thisError;
+    }
+
+    return data;
+}
+
+- (NSInputStream *)inputStreamWithOutputLength:(UInt64 *)outputLength
+{
+    if ([self isBlobOpenForWriting]) {
+        CDTLogDebug(CDTDATASTORE_LOG_CONTEXT, @"Close blob in order to create an input stream");
+
+        return nil;
+    }
+
+    NSFileManager *defaultManager = [NSFileManager defaultManager];
+    if (![defaultManager fileExistsAtPath:self.path isDirectory:NO]) {
+        CDTLogDebug(CDTDATASTORE_LOG_CONTEXT, @"No file found in %@", self.path);
+        
+        return nil;
+    }
+    
+    NSInputStream *inputStream = [NSInputStream inputStreamWithFileAtPath:self.path];
+
+    if (inputStream && outputLength) {
+        NSError *error = nil;
+        NSDictionary *info = [defaultManager attributesOfItemAtPath:self.path error:&error];
+        if (info) {
+            *outputLength = [info fileSize];
+        } else {
+            CDTLogDebug(CDTDATASTORE_LOG_CONTEXT,
+                        @"Attributes for file %@ could not be obtained: %@", self.path, error);
+
+            inputStream = nil;
+        }
+    }
+
+    return inputStream;
+}
+
+#pragma mark - CDTBlobWriter methods
+- (BOOL)writeEntireBlobWithData:(NSData *)data error:(NSError **)error
+{
+    BOOL success = NO;
+    NSError *thisError = nil;
+
+    if ([self isBlobOpenForWriting]) {
+        CDTLogDebug(CDTDATASTORE_LOG_CONTEXT,
+                    @"Blob at %@ is open. Close it before saving the data", self.path);
+
+        thisError = [CDTBlobData errorOperationNotPossibleIfBlobIsOpen];
+    } else {
+        NSDataWritingOptions options = NSDataWritingAtomic;
+#if TARGET_OS_IPHONE
+        options |= NSDataWritingFileProtectionCompleteUnlessOpen;
+#endif
+
+        success = [data writeToFile:self.path options:options error:&thisError];
+        if (!success) {
+            CDTLogDebug(CDTDATASTORE_LOG_CONTEXT, @"Could not write data to file %@: %@", self.path,
+                        thisError);
+        }
+    }
+
+    if (!success && error) {
+        *error = thisError;
+    }
+
+    return success;
+}
+
+- (BOOL)isBlobOpenForWriting { return (self.outFileHandle != nil); }
+
+- (BOOL)openForWriting
+{
+    if ([self isBlobOpenForWriting]) {
+        CDTLogDebug(CDTDATASTORE_LOG_CONTEXT, @"Blob at %@ already open", self.path);
+
+        return YES;
+    }
+
+    self.outFileHandle = [NSFileHandle fileHandleForWritingAtPath:self.path];
+
+    return [self isBlobOpenForWriting];
+}
+
+- (BOOL)appendData:(NSData *)data
+{
+    if (![self isBlobOpenForWriting]) {
+        CDTLogDebug(CDTDATASTORE_LOG_CONTEXT, @"Blob at %@ is not open. No data can be added",
+                    self.path);
+
+        return NO;
+    }
+
+    [self.outFileHandle writeData:data];
+
+    return YES;
+}
+
+- (void)close
+{
+    if (![self isBlobOpenForWriting]) {
+        CDTLogDebug(CDTDATASTORE_LOG_CONTEXT, @"Blob at %@ already closed", self.path);
+
+        return;
+    }
+
+    [self.outFileHandle closeFile];
+    self.outFileHandle = nil;
+}
+
+#pragma mark - Public class methods
++ (instancetype)blobWithPath:(NSString *)path { return [[[self class] alloc] initWithPath:path]; }
+
+#pragma mark - Private class methods
++ (NSError *)errorOperationNotPossibleIfBlobIsOpen
+{
+    NSDictionary *userInfo = @{
+        NSLocalizedDescriptionKey :
+            NSLocalizedString(@"Close blob in order to perform this operation",
+                              @"Close blob in order to perform this operation")
+    };
+
+    return [NSError errorWithDomain:CDTBlobDataErrorDomain
+                               code:CDTBlobDataErrorOperationNotPossibleIfBlobIsOpen
+                           userInfo:userInfo];
+}
+
+@end

--- a/Classes/common/Attachments/CDTBlobReader.h
+++ b/Classes/common/Attachments/CDTBlobReader.h
@@ -1,0 +1,45 @@
+//
+//  CDTBlobReader.h
+//  CloudantSync
+//
+//  Created by Enrique de la Torre Fernandez on 05/05/2015.
+//  Copyright (c) 2015 IBM Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+
+/**
+ Define the methods to access the content of an attachment without exposing its path.
+ */
+@protocol CDTBlobReader
+
+/**
+ Load the content of an attachment in a NSData instance.
+ 
+ @param error Output param that will point to an error (in case there is any)
+ 
+ @return Content of the attachment as a NSData instance or nil if there is an error
+ 
+ @warning This operation is synchronous and reads the file content into memory before returning;
+ this may cause issues with larger files..
+ */
+- (NSData *)dataWithError:(NSError **)error;
+
+/**
+ Create an input stream to read from an attachment.
+ 
+ @param outputLength Output param with the size of the data in the attachment
+ 
+ @return Input stream to the attachment or nil if there is an error
+ */
+- (NSInputStream *)inputStreamWithOutputLength:(UInt64 *)outputLength;
+
+@end

--- a/Classes/common/Attachments/CDTBlobWriter.h
+++ b/Classes/common/Attachments/CDTBlobWriter.h
@@ -1,0 +1,66 @@
+//
+//  CDTBlobWriter.h
+//  CloudantSync
+//
+//  Created by Enrique de la Torre Fernandez on 06/05/2015.
+//  Copyright (c) 2015 IBM Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+
+/**
+ Define the methods to store data in an attachment without exposing its path.
+ */
+@protocol CDTBlobWriter <NSObject>
+
+/**
+ Overwrite the content of an attachment with the data provided as a parameter. If the file does
+ not exist, it will create it.
+ 
+ Notice that this method has to work properly with the other methods defined in this protocol, i.e.
+ will it succeed or will it fail if the blob is open?
+ 
+ @param data Data to store in the attachment
+ @param error Output param that will point to an error (if there is any)
+ 
+ @return YES (if the operation succeed) or NO (if there is an error)
+ */
+- (BOOL)writeEntireBlobWithData:(NSData *)data error:(NSError **)error;
+
+/**
+ @return YES if the attachment was open before or NO in other case
+ */
+- (BOOL)isBlobOpenForWriting;
+
+/**
+ Prepare an attachment to write data in it.
+ 
+ @return YES if the attachment was open (or it was already open) or NO in other case
+ */
+- (BOOL)openForWriting;
+
+/**
+ Add data to the end of the attachment.
+ 
+ Although this protocol does not enforce it, the attachment should be open before adding data.
+ 
+ @param data Data to append to the attachment
+ 
+ @return YES if the data was added or NO in other case.
+ */
+- (BOOL)appendData:(NSData *)data;
+
+/**
+ Use this method to signal that there are no more data to add.
+ */
+- (void)close;
+
+@end

--- a/Classes/common/Attachments/CDTDatastore+Attachments.m
+++ b/Classes/common/Attachments/CDTDatastore+Attachments.m
@@ -126,13 +126,13 @@ static NSString *const CDTAttachmentsErrorDomain = @"CDTAttachmentsErrorDomain";
         return nil;
     }
 
-    NSString *filePath = [self.database.attachmentStore pathForKey:*(TDBlobKey *)keyData.bytes];
+    id<CDTBlobReader> blob = [self.database.attachmentStore blobForKey:*(TDBlobKey *)keyData.bytes];
 
     NSString *type = [r stringForColumn:@"type"];
     NSInteger size = [r longForColumn:@"length"];
     NSInteger revpos = [r longForColumn:@"revpos"];
     TDAttachmentEncoding encoding = [r intForColumn:@"encoding"];
-    CDTSavedAttachment *attachment = [[CDTSavedAttachment alloc] initWithPath:filePath
+    CDTSavedAttachment *attachment = [[CDTSavedAttachment alloc] initWithBlob:blob
                                                                          name:name
                                                                          type:type
                                                                          size:size

--- a/Classes/common/Encryption/Keychain/CDTEncryptionKeychainProvider.m
+++ b/Classes/common/Encryption/Keychain/CDTEncryptionKeychainProvider.m
@@ -55,10 +55,14 @@
 - (NSString *)encryptionKey
 {
     NSData *data = nil;
-    if ([self.manager keyExists]) {
-        data = [self.manager loadKeyUsingPassword:self.password];
-    } else {
-        data = [self.manager generateAndSaveKeyProtectedByPassword:self.password];
+
+    @synchronized(self)
+    {
+        if ([self.manager keyExists]) {
+            data = [self.manager loadKeyUsingPassword:self.password];
+        } else {
+            data = [self.manager generateAndSaveKeyProtectedByPassword:self.password];
+        }
     }
     
     NSString *hexStr = (data ? TDHexFromBytes(data.bytes, data.length) : nil);

--- a/Classes/common/touchdb/TDBlobStore.h
+++ b/Classes/common/touchdb/TDBlobStore.h
@@ -16,6 +16,9 @@
 #import <CommonCrypto/CommonDigest.h>
 #endif
 
+#import "CDTBlobReader.h"
+#import "CDTBlobWriter.h"
+
 /** Key identifying a data blob. This happens to be a SHA-1 digest. */
 typedef struct TDBlobKey
 {
@@ -31,15 +34,13 @@ typedef struct TDBlobKey
 
 - (id)initWithPath:(NSString*)dir error:(NSError**)outError;
 
-- (NSData*)blobForKey:(TDBlobKey)key;
-- (NSInputStream*)blobInputStreamForKey:(TDBlobKey)key length:(UInt64*)outLength;
+- (id<CDTBlobReader>)blobForKey:(TDBlobKey)key;
 
 - (BOOL)storeBlob:(NSData*)blob creatingKey:(TDBlobKey*)outKey;
 - (BOOL)storeBlob:(NSData*)blob
       creatingKey:(TDBlobKey*)outKey
             error:(NSError* __autoreleasing*)outError;
 
-@property (readonly) NSString* path;
 @property (readonly) NSUInteger count;
 @property (readonly) NSArray* allKeys;
 @property (readonly) UInt64 totalDataSize;
@@ -48,10 +49,6 @@ typedef struct TDBlobKey
 
 + (TDBlobKey)keyForBlob:(NSData*)blob;
 + (NSData*)keyDataForBlob:(NSData*)blob;
-
-/** Returns the path of the file storing the attachment with the given key, or nil.
-    DO NOT MODIFY THIS FILE! */
-- (NSString*)pathForKey:(TDBlobKey)key;
 
 @end
 
@@ -66,7 +63,7 @@ typedef struct
    @private
     TDBlobStore* _store;
     NSString* _tempPath;
-    NSFileHandle* _out;
+    id<CDTBlobWriter> _blobWriter;
     UInt64 _length;
     SHA_CTX _shaCtx;
     MD5_CTX _md5Ctx;

--- a/Classes/common/touchdb/TDPusher.m
+++ b/Classes/common/touchdb/TDPusher.m
@@ -441,7 +441,11 @@ static TDStatus statusFromBulkDocsResponseItem(NSDictionary* item)
             [bodyStream setNextPartsHeaders:$dict({ @"Content-Disposition", disposition },
                                                   { @"Content-Type", contentType },
                                                   { @"Content-Encoding", contentEncoding })];
-            [bodyStream addFileURL:[_db fileForAttachmentDict:attachment]];
+            
+            id<CDTBlobReader> blob = [_db blobForAttachmentDict:attachment];
+            UInt64 length = 0;
+            NSInputStream* inputStream = [blob inputStreamWithOutputLength:&length];
+            [bodyStream addStream:inputStream length:length];
         }
     }
     if (!bodyStream) return NO;

--- a/Classes/common/touchdb/TD_Database+Attachments.h
+++ b/Classes/common/touchdb/TD_Database+Attachments.h
@@ -9,6 +9,9 @@
 //
 
 #import "TD_Database.h"
+
+#import "CDTBlobReader.h"
+
 @class TDBlobStoreWriter, TDMultipartWriter, FMDatabase;
 
 /** Types of encoding/compression of stored attachments. */
@@ -55,16 +58,16 @@ typedef enum { kTDAttachmentEncodingNone, kTDAttachmentEncodingGZIP } TDAttachme
                             encoding:(TDAttachmentEncoding *)outEncoding
                               status:(TDStatus *)outStatus;
 
-/** Returns the location of an attachment's file in the blob store. */
-- (NSString *)getAttachmentPathForSequence:(SequenceNumber)sequence
-                                     named:(NSString *)filename
-                                      type:(NSString **)outType
-                                  encoding:(TDAttachmentEncoding *)outEncoding
-                                    status:(TDStatus *)outStatus;
+/** Returns the blob for an attachment in the blob store. */
+- (id<CDTBlobReader>)getAttachmentBlobForSequence:(SequenceNumber)sequence
+                                            named:(NSString *)filename
+                                             type:(NSString **)outType
+                                         encoding:(TDAttachmentEncoding *)outEncoding
+                                           status:(TDStatus *)outStatus;
 
 /** Uses the "digest" field of the attachment dict to look up the attachment in the store and return
- * a file URL to it. DO NOT MODIFY THIS FILE! */
-- (NSURL *)fileForAttachmentDict:(NSDictionary *)attachmentDict;
+ * its blob. */
+- (id<CDTBlobReader>)blobForAttachmentDict:(NSDictionary *)attachmentDict;
 
 /** Deletes obsolete attachments from the database and blob store. */
 - (TDStatus)garbageCollectAttachments:(FMDatabase *)db;

--- a/Tests/Tests.xcodeproj/project.pbxproj
+++ b/Tests/Tests.xcodeproj/project.pbxproj
@@ -96,6 +96,8 @@
 		CD2188EC1AE5764B0036F59F /* CDTEncryptionKeychainManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD2188EA1AE5764B0036F59F /* CDTEncryptionKeychainManagerTests.m */; };
 		CD2188F01AE576740036F59F /* CDTMockEncryptionKeychainStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = CD2188EF1AE576740036F59F /* CDTMockEncryptionKeychainStorage.m */; };
 		CD2188F11AE576740036F59F /* CDTMockEncryptionKeychainStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = CD2188EF1AE576740036F59F /* CDTMockEncryptionKeychainStorage.m */; };
+		CD25B2841AFA49E2001113BB /* CDTBlobDataTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD25B2831AFA49E2001113BB /* CDTBlobDataTests.m */; };
+		CD25B2851AFA49E2001113BB /* CDTBlobDataTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD25B2831AFA49E2001113BB /* CDTBlobDataTests.m */; };
 		CD3FBCA61AB05A170032376E /* CDTHelperFixedKeyProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = CD3FBCA31AB05A170032376E /* CDTHelperFixedKeyProvider.m */; };
 		CD3FBCA71AB05A170032376E /* CDTHelperFixedKeyProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = CD3FBCA31AB05A170032376E /* CDTHelperFixedKeyProvider.m */; };
 		CD3FBCA81AB05A170032376E /* CDTHelperOneUseKeyProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = CD3FBCA51AB05A170032376E /* CDTHelperOneUseKeyProvider.m */; };
@@ -222,6 +224,7 @@
 		CD2188EA1AE5764B0036F59F /* CDTEncryptionKeychainManagerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTEncryptionKeychainManagerTests.m; sourceTree = "<group>"; };
 		CD2188EE1AE576740036F59F /* CDTMockEncryptionKeychainStorage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDTMockEncryptionKeychainStorage.h; sourceTree = "<group>"; };
 		CD2188EF1AE576740036F59F /* CDTMockEncryptionKeychainStorage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTMockEncryptionKeychainStorage.m; sourceTree = "<group>"; };
+		CD25B2831AFA49E2001113BB /* CDTBlobDataTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CDTBlobDataTests.m; path = Attachments/CDTBlobDataTests.m; sourceTree = "<group>"; };
 		CD3FBCA21AB05A170032376E /* CDTHelperFixedKeyProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDTHelperFixedKeyProvider.h; sourceTree = "<group>"; };
 		CD3FBCA31AB05A170032376E /* CDTHelperFixedKeyProvider.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTHelperFixedKeyProvider.m; sourceTree = "<group>"; };
 		CD3FBCA41AB05A170032376E /* CDTHelperOneUseKeyProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDTHelperOneUseKeyProvider.h; sourceTree = "<group>"; };
@@ -419,6 +422,7 @@
 			isa = PBXGroup;
 			children = (
 				985F84D3198BD3A4004D8713 /* AttachmentCRUD.m */,
+				CD25B2831AFA49E2001113BB /* CDTBlobDataTests.m */,
 			);
 			name = Attachments;
 			sourceTree = "<group>";
@@ -710,6 +714,7 @@
 				CD2188DE1AE5711A0036F59F /* TD_DatabaseEncryptionTests.m in Sources */,
 				EC0C834A1AB217290051042F /* CDTQQueryExecutorTests.m in Sources */,
 				EC0C83521AB217290051042F /* CDTQValueExtractorTests.m in Sources */,
+				CD25B2841AFA49E2001113BB /* CDTBlobDataTests.m in Sources */,
 				EC0C834C1AB217290051042F /* CDTQQuerySortTests.m in Sources */,
 				9F0D240E188F01DD00D3D04E /* TDMiscTests.m in Sources */,
 				EC0C835E1AB217290051042F /* CDTQSQLOnlyIndexManager.m in Sources */,
@@ -781,6 +786,7 @@
 				CD2188DF1AE5711A0036F59F /* TD_DatabaseEncryptionTests.m in Sources */,
 				EC0C83531AB217290051042F /* CDTQValueExtractorTests.m in Sources */,
 				EC0C834D1AB217290051042F /* CDTQQuerySortTests.m in Sources */,
+				CD25B2851AFA49E2001113BB /* CDTBlobDataTests.m in Sources */,
 				9F0D23F2188B4FA900D3D04E /* TDMultipartReaderTests.m in Sources */,
 				EC0C835F1AB217290051042F /* CDTQSQLOnlyIndexManager.m in Sources */,
 				EC0C83431AB217290051042F /* CDTQIndexManagerTests.m in Sources */,

--- a/Tests/Tests/Attachments/CDTBlobDataTests.m
+++ b/Tests/Tests/Attachments/CDTBlobDataTests.m
@@ -1,0 +1,201 @@
+//
+//  CDTBlobDataTests.m
+//  Tests
+//
+//  Created by Enrique de la Torre Fernandez on 05/05/2015.
+//  Copyright (c) 2015 IBM Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#import <XCTest/XCTest.h>
+
+#import "CDTBlobData.h"
+
+@interface CDTBlobDataTests : XCTestCase
+
+@property (strong, nonatomic) NSData *data;
+@property (strong, nonatomic) NSString *pathToExistingFile;
+@property (strong, nonatomic) CDTBlobData *blob;
+
+@property (strong, nonatomic) NSString *pathToNonExistingFile;
+@property (strong, nonatomic) CDTBlobData *blobForNotPrexistingFile;
+
+@end
+
+@implementation CDTBlobDataTests
+
+- (void)setUp
+{
+    [super setUp];
+
+    // Put setup code here. This method is called before the invocation of each test method in the
+    // class.
+    self.data = [@"text" dataUsingEncoding:NSUnicodeStringEncoding];
+
+    self.pathToExistingFile =
+        [NSTemporaryDirectory() stringByAppendingPathComponent:@"CDTBlobDataTests.txt"];
+    [[NSFileManager defaultManager] createFileAtPath:self.pathToExistingFile
+                                            contents:nil
+                                          attributes:nil];
+
+    self.blob = [[CDTBlobData alloc] initWithPath:self.pathToExistingFile];
+
+    self.pathToNonExistingFile =
+        [NSTemporaryDirectory() stringByAppendingPathComponent:@"nonExistingFile.txt"];
+    self.blobForNotPrexistingFile = [[CDTBlobData alloc] initWithPath:self.pathToNonExistingFile];
+}
+
+- (void)tearDown
+{
+    // Put teardown code here. This method is called after the invocation of each test method in the
+    // class.
+    self.blobForNotPrexistingFile = nil;
+    self.pathToNonExistingFile = nil;
+
+    self.blob = nil;
+
+    [[NSFileManager defaultManager] removeItemAtPath:self.pathToExistingFile error:nil];
+    self.pathToExistingFile = nil;
+
+    self.data = nil;
+
+    [super tearDown];
+}
+
+- (void)testInitWithPathEqualToNilFails
+{
+    XCTAssertNil([[CDTBlobData alloc] initWithPath:nil], @"A path is mandatory");
+}
+
+- (void)testInitWithEmptyPathFails
+{
+    XCTAssertNil([[CDTBlobData alloc] initWithPath:@""], @"A path is mandatory");
+}
+
+- (void)testInitWithNotValidPathSucceeds
+{
+    XCTAssertNotNil([[CDTBlobData alloc] initWithPath:@"This is not a path"],
+                    @"Any string is valid as long as it is not empty");
+}
+
+- (void)testBlobIsNotOpenAfterCreation
+{
+    XCTAssertFalse([self.blob isBlobOpenForWriting], @"After init, blob is not open");
+}
+
+- (void)testOpenForWritingFailsIfFileDoesNotExist
+{
+    XCTAssertFalse([self.blobForNotPrexistingFile openForWriting],
+                   @"If the file does not exist yet, it can not be open");
+}
+
+- (void)testOpenForWritingSucceedsIfFileExists
+{
+    XCTAssertTrue([self.blob openForWriting],
+                  @"If the file exists, we should be able to open it");
+}
+
+- (void)testOpenForWritingSucceedsIfAlreadyOpen
+{
+    [self.blob openForWriting];
+
+    XCTAssertTrue(
+        [self.blob openForWriting],
+        @"If the blob is already opened, open it again let the file open, thefore it succeeds");
+}
+
+- (void)testOpenForWritingSucceedsAfterClosingBlob
+{
+    [self.blob openForWriting];
+    [self.blob close];
+
+    XCTAssertTrue([self.blob openForWriting],
+                  @"As long as the file still exists, we should be able to open it again");
+}
+
+- (void)testAppendDataFailsIfBlobIsNotOpen
+{
+    XCTAssertFalse([self.blob appendData:self.data], @"Open blob before adding data");
+}
+
+- (void)testDataWithErrorFailsIfBlobIsOpen
+{
+    [self.blob openForWriting];
+
+    NSError *error = nil;
+    NSData *data = [self.blob dataWithError:&error];
+
+    XCTAssertNil(data, @"Blob can not be read if it is open");
+    XCTAssertTrue([error.domain isEqualToString:CDTBlobDataErrorDomain] &&
+                      error.code == CDTBlobDataErrorOperationNotPossibleIfBlobIsOpen,
+                  @"In this situation the expected error is: (%@, %li)", CDTBlobDataErrorDomain,
+                  (long)CDTBlobDataErrorOperationNotPossibleIfBlobIsOpen);
+}
+
+- (void)testDataWithErrorFailsIfFileDoesNotExist
+{
+    NSError *error = nil;
+    NSData *data = [self.blobForNotPrexistingFile dataWithError:&error];
+
+    XCTAssertNil(data, @"No data to read if file does not exist");
+    XCTAssertNotNil(error, @"An error must be informed");
+}
+
+- (void)testInputStreamWithOutputLengthFailsIfBlobIsOpen
+{
+    [self.blob openForWriting];
+
+    UInt64 length = 0;
+    XCTAssertNil([self.blob inputStreamWithOutputLength:&length],
+                 @"Close the blob in order to create an input stream bound to the same filea");
+}
+
+- (void)testInputStreamWithOutputLengthFailsIfFileDoesNotExist
+{
+    UInt64 length = 0;
+    XCTAssertNil([self.blobForNotPrexistingFile inputStreamWithOutputLength:&length],
+                 @"File must exist in order to create an input stream");
+}
+
+- (void)testInputStreamWithOutputLengthFailsIfFileDoesNotExistEvenIfIDoNotGetTheLength
+{
+    XCTAssertNil([self.blobForNotPrexistingFile inputStreamWithOutputLength:nil],
+                 @"File must exist in order to create an input stream");
+}
+
+- (void)testWriteEntireBlobWithDataFailsIfBlobIsOpen
+{
+    [self.blob openForWriting];
+
+    NSError *error = nil;
+    BOOL success = [self.blob writeEntireBlobWithData:self.data error:&error];
+
+    XCTAssertFalse(success, @"Close the blob in order to overwrite it");
+    XCTAssertTrue([error.domain isEqualToString:CDTBlobDataErrorDomain] &&
+                      error.code == CDTBlobDataErrorOperationNotPossibleIfBlobIsOpen,
+                  @"In this situation the expected error is: (%@, %li)", CDTBlobDataErrorDomain,
+                  (long)CDTBlobDataErrorOperationNotPossibleIfBlobIsOpen);
+}
+
+- (void)testWriteEntireBlobWithDataSucceedsIfFileExists
+{
+    XCTAssertTrue([self.blob writeEntireBlobWithData:self.data error:nil],
+                  @"The previous data will be overwritten with the next one");
+}
+
+- (void)testWriteEntireBlobWithDataSucceedsIfFileDoesNotExist
+{
+    BOOL success = [self.blobForNotPrexistingFile writeEntireBlobWithData:self.data error:nil];
+    [[NSFileManager defaultManager] removeItemAtPath:self.pathToNonExistingFile error:nil];
+    
+    XCTAssertTrue(success, @"A new file will be created");
+}
+
+@end

--- a/Tests/Tests/TDMultipartDownloaderTests.m
+++ b/Tests/Tests/TDMultipartDownloaderTests.m
@@ -63,11 +63,12 @@
               TDBlobStoreWriter* writer = [db attachmentWriterForAttachment: attachment];
               XCTAssertNotNil(writer, @"TDBlobStoreWriter is nil in %s", __PRETTY_FUNCTION__);
               XCTAssertTrue([writer install], @"TDBlobStoreWriter install returned NO in %s", __PRETTY_FUNCTION__);
-              NSData* blob = [db.attachmentStore blobForKey: writer.blobKey];
+              id<CDTBlobReader> blob = [db.attachmentStore blobForKey:writer.blobKey];
+              NSData *data = [blob dataWithError:nil];
 //              NSLog(@"Found %u bytes of data for attachment %@", (unsigned)blob.length, attachment);
               NSNumber* lengthObj = attachment[@"encoded_length"] ?: attachment[@"length"];
-              XCTAssertEqual(blob.length, [lengthObj unsignedLongLongValue], @"blob length and object length are not equal in %s", __PRETTY_FUNCTION__);
-              XCTAssertEqual(writer.length, blob.length, @"writer length and blog length are not equal in %s", __PRETTY_FUNCTION__);
+              XCTAssertEqual(data.length, [lengthObj unsignedLongLongValue], @"blob length and object length are not equal in %s", __PRETTY_FUNCTION__);
+              XCTAssertEqual(writer.length, data.length, @"writer length and blog length are not equal in %s", __PRETTY_FUNCTION__);
           }
           XCTAssertEqual(db.attachmentStore.count, attachments.count, @"db.attachmentStore.count and attachments.count are not equal in %s", __PRETTY_FUNCTION__);
           done = YES;


### PR DESCRIPTION
*What:*
Remove access to attachment file path.

*Why:*
We intent to encrypt the entire content in a datastore, that includes databases and attachments. The encryption for databases is already in place but we are still working on the attachments. The first step to reach this goal is to remove the direct access to the attachments through their paths. We can not allow other parts of the library to read an attachment as if it were a *normal* file because, it the attachment is encrypted, the data will not make any sense (obviously).

*How:*
1. Remove/hide method 'TDBlobStore:pathForKey:'.
2. Define protocol to access the content in an attachment: `CDTBlobReader`.
3. Define protocol to save data in an attachment: `CDTBlobWriter`
4. Implement class that conforms to both protocol: `CDTBlobData`. This way all the code related to access an attachment is in the same place.
5. Modify library to use the new class instead of accessing the files using their paths.

**Check case with BugzID 46372 for more details about the design and how it has evolved until the current point.**

*Tests:*
Tests are for the new class `CDTBlobData`, the rest of the code is already under coverage:
* A blob has to be created with a path (although the file does not have to exist on advance).
* A blob is not open after initialisation.
* To open a blob, a file must exist in the specified path.
* Add data to a blob fails if it was not open before.
* A blob has to be open to read its content.
* A blob can not be read if the file does not exist.
* A blob can not be created/overwritten if it is already open.

reviewer @mikerhodes 
reviewer @rhyshort 

**NOTE:** Wait to review this PR until PR #138  is closed. This branch will be rebased and there will be only commits related to this case.