### PR TITLE
Add full text query support

### DIFF
--- a/Classes/common/query/CDTQQueryConstants.h
+++ b/Classes/common/query/CDTQQueryConstants.h
@@ -20,6 +20,8 @@ extern NSString *const NOT;
 
 extern NSString *const EXISTS;
 
+extern NSString *const TEXT;
+
 extern NSString *const EQ;
 
 extern NSString *const NE;
@@ -35,3 +37,5 @@ extern NSString *const GTE;
 extern NSString *const IN;
 
 extern NSString *const NIN;
+
+extern NSString *const SEARCH;

--- a/Classes/common/query/CDTQQueryConstants.m
+++ b/Classes/common/query/CDTQQueryConstants.m
@@ -22,6 +22,8 @@ NSString *const NOT = @"$not";
 
 NSString *const EXISTS = @"$exists";
 
+NSString *const TEXT = @"$text";
+
 NSString *const EQ = @"$eq";
 
 NSString *const NE = @"$ne";
@@ -37,3 +39,5 @@ NSString *const GTE = @"$gte";
 NSString *const IN = @"$in";
 
 NSString *const NIN = @"$nin";
+
+NSString *const SEARCH = @"$search";

--- a/Classes/common/query/CDTQQuerySqlTranslator.m
+++ b/Classes/common/query/CDTQQuerySqlTranslator.m
@@ -25,6 +25,8 @@
 @property (nonatomic) BOOL atLeastOneIndexUsed;       // if NO, need to generate a return all query
 @property (nonatomic) BOOL atLeastOneIndexMissing;    // i.e., we need to use posthoc matcher
 @property (nonatomic) BOOL atLeastOneORIndexMissing;  //       we need to use posthoc matcher
+@property (nonatomic) BOOL textIndexRequired;         // A text index needed for a text search
+@property (nonatomic) BOOL textIndexMissing;          // if NO and is required, cannot perform query
 
 @end
 
@@ -73,10 +75,19 @@
     CDTQQueryNode *node =
         [CDTQQuerySqlTranslator translateQuery:query toUseIndexes:indexes state:state];
 
-    // If we haven't used a single index, we need to return a query
-    // which returns every document, so the posthoc matcher can
-    // run over every document to manually carry out the query.
-    if (!state.atLeastOneIndexUsed || state.atLeastOneORIndexMissing) {
+    if (state.textIndexMissing) {
+        LogError(@"No text index defined, cannot execute query containing a text search.");
+        return nil;
+    } else if (state.textIndexRequired && state.atLeastOneIndexMissing) {
+        LogError(@"Query %@ contains a text search but is missing json index(es).  "
+                  "All indexes must exist in order to execute a query containing a text search.  "
+                  "Create all necessary indexes for the query and re-execute.", query);
+        return nil;
+    } else if (!state.textIndexRequired &&
+                  (!state.atLeastOneIndexUsed || state.atLeastOneORIndexMissing)) {
+        // If we haven't used a single index, we need to return a query
+        // which returns every document, so the posthoc matcher can
+        // run over every document to manually carry out the query.
         NSSet *neededFields = [NSSet setWithObject:@"_id"];
         NSString *allDocsIndex =
             [CDTQQuerySqlTranslator chooseIndexForFields:neededFields fromIndexes:indexes];
@@ -126,22 +137,26 @@
         root = [[CDTQOrQueryNode alloc] init];
     }
 
-    //
-    // First handle the simple @"field": @{ @"$operator": @"value" } clauses. These are
-    // handled differently for AND and OR parents, so we need to have the conditional
-    // logic below.
-    //
+    // Compile a list of simple clauses to be handled below.  If a text clause is
+    // encountered, store it separately from the simple clauses since it will be
+    // handled later on its own.
 
     NSMutableArray *basicClauses = [NSMutableArray array];
-
+    __block NSObject *textClause = nil;
+    
     [clauses enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
         NSDictionary *clause = (NSDictionary *)obj;
         NSString *field = clause.allKeys[0];
         if (![field hasPrefix:@"$"]) {
             [basicClauses addObject:clauses[idx]];
+        } else if ([field.lowercaseString isEqualToString:TEXT]) {
+            textClause = clauses[idx];
         }
     }];
 
+    // Handle the simple "field": { "$operator": "value" } clauses. These are
+    // handled differently for AND and OR parents, so we need to have the
+    // conditional logic below.
     if (basicClauses.count > 0) {
         if (query[AND]) {
             // For an AND query, we require a single compound index and we generate a
@@ -217,6 +232,32 @@
             }
         }
     }
+    
+    // A text clause such as { "$text" : { "$search" : "foo bar baz" } }
+    // by nature uses its own text index.  It is therefore handled
+    // separately from other simple clauses.
+    if (textClause != nil) {
+        state.textIndexRequired = YES;
+        NSString *textIndex = [CDTQQuerySqlTranslator getTextIndexFromIndexes:indexes];
+        if (textIndex == nil || textIndex.length == 0) {
+            state.textIndexMissing = YES;
+        } else {
+            // The text clause must be an NSDictionary here otherwise it
+            // would not have passed the normalization/validation step.
+            textClause = (NSDictionary *)textClause;
+            CDTQSqlParts *select = [CDTQQuerySqlTranslator selectStatementForTextClause:textClause
+                                                                             usingIndex:textIndex];
+            if (!select) {
+                LogError(@"Error generating SELECT clause for %@", textClause);
+                return nil;
+            }
+            
+            CDTQSqlQueryNode *sql = [[CDTQSqlQueryNode alloc] init];
+            sql.sql = select;
+            
+            [root.children addObject:sql];
+        }
+    }
 
     //
     // AND and OR subclauses are handled identically whatever the parent is.
@@ -281,11 +322,9 @@
     NSString *chosenIndex = nil;
     for (NSString *indexName in indexes) {
         
-        // TODO - Remove once the query component of full text search is added.
+        // Don't choose a text index for a non-text query clause
         NSString *indexType = indexes[indexName][@"type"];
         if ([indexType.lowercaseString isEqualToString:@"text"]) {
-            LogInfo(@"Full text search is not yet supported.  "
-                     "Text index %@ is being ignored.", indexName);
             continue;
         }
         
@@ -297,6 +336,20 @@
     }
 
     return chosenIndex;
+}
+
++ (NSString *)getTextIndexFromIndexes:(NSDictionary *)indexes
+{
+    NSString *textIndex = nil;
+    for (NSString *indexName in [indexes allKeys]) {
+        NSString *indexType = indexes[indexName][@"type"];
+        if ([indexType.lowercaseString isEqualToString:@"text"]) {
+            textIndex = indexName;
+            break;
+        }
+    }
+    
+    return textIndex;
 }
 
 + (CDTQSqlParts *)wherePartsForAndClause:(NSArray *)clause usingIndex:(NSString *)indexName
@@ -492,6 +545,27 @@
     sql = [NSString stringWithFormat:sql, tableName, where.sqlWithPlaceholders];
 
     CDTQSqlParts *parts = [CDTQSqlParts partsForSql:sql parameters:where.placeholderValues];
+    return parts;
+}
+
++ (CDTQSqlParts *)selectStatementForTextClause:(NSDictionary *)textClause
+                                    usingIndex:(NSString *)indexName
+{
+    if (textClause.count == 0) {
+        return nil;  // no query here
+    }
+    
+    if (!indexName) {
+        return nil;
+    }
+    
+    NSString *tableName = [CDTQIndexManager tableNameForIndex:indexName];
+    NSString *search = textClause[TEXT][SEARCH];
+    
+    NSString *sql = @"SELECT _id FROM %@ WHERE %@ MATCH ?;";
+    sql = [NSString stringWithFormat:sql, tableName, tableName];
+    
+    CDTQSqlParts *parts = [CDTQSqlParts partsForSql:sql parameters:@[ search ]];
     return parts;
 }
 

--- a/Classes/common/query/CDTQQueryValidator.m
+++ b/Classes/common/query/CDTQQueryValidator.m
@@ -345,8 +345,12 @@
         } else if ([key.lowercaseString isEqualToString:TEXT]) {
             // this should have a dict
             // send this for validation
-            valid = [CDTQQueryValidator validateTextClause:clause[key]
-                                       withTextClauseLimit:textClauseLimitReached];
+            
+            // TODO Enable text search as part of text search unit tests PR.
+            //valid = [CDTQQueryValidator validateTextClause:clause[key]
+            //                           withTextClauseLimit:textClauseLimitReached];
+            LogInfo(@"Text search is currently not supported.");
+            break;
         } else {
             LogError(@"%@ operator cannot be a top level operator", key);
             break;


### PR DESCRIPTION
_What_

This PR adds support for the $text and $search operators in Query.

_Why_

The change is to provide full text search capabilities in Query.

_How_

The normalization/validation process is updated to handle the new operators and the SQL translation process is updated to ensure correct generation of SQL and node placement in the query node tree.

_Notes_

This PR does not include the unit tests. Unit tests will be included in a following PR. Logic has been temporarily added to deactivate the full text search logic until the unit tests are delivered.

reviewer @mikerhodes 
reviewer @rhyshort

BugId: 46775