### PR TITLE
Add fts availability check to API

### DIFF
--- a/Classes/common/query/CDTQIndexCreator.m
+++ b/Classes/common/query/CDTQIndexCreator.m
@@ -54,7 +54,8 @@
 #pragma mark Instance methods
 
 /**
- Add a single, possibly compound, index for the given field names.
+ Add a single, possibly compound index for the given field names and ensure all indexing
+ constraints are met.
 
  @param fieldNames List of fieldnames in the sort format
  @param indexName Name of index to create.
@@ -64,6 +65,14 @@
 {
     if (!index) {
         return nil;
+    }
+    
+    if ([index.indexType.lowercaseString isEqualToString:@"text"]) {
+        if (![CDTQIndexManager ftsAvailableInDatabase:self.database]) {
+            LogError(@"Text search not supported.  To add support for text "
+                     @"search, enable FTS compile options in SQLite.");
+            return nil;
+        }
     }
 
     NSArray *fieldNames = [CDTQIndexCreator removeDirectionsFromFields:index.fieldNames];

--- a/Classes/common/query/CDTQIndexManager.h
+++ b/Classes/common/query/CDTQIndexManager.h
@@ -110,4 +110,9 @@ typedef NS_ENUM(NSInteger, CDTQQueryError) {
 /** Internal */
 + (NSString *)tableNameForIndex:(NSString *)indexName;
 
+/** Internal */
++ (BOOL)ftsAvailableInDatabase:(FMDatabaseQueue *)db;
+
+- (BOOL)isTextSearchEnabled;
+
 @end

--- a/Classes/common/query/CDTQQueryConstants.h
+++ b/Classes/common/query/CDTQQueryConstants.h
@@ -20,6 +20,8 @@ extern NSString *const NOT;
 
 extern NSString *const EXISTS;
 
+extern NSString *const TEXT;
+
 extern NSString *const EQ;
 
 extern NSString *const NE;
@@ -35,3 +37,5 @@ extern NSString *const GTE;
 extern NSString *const IN;
 
 extern NSString *const NIN;
+
+extern NSString *const SEARCH;

--- a/Classes/common/query/CDTQQueryConstants.m
+++ b/Classes/common/query/CDTQQueryConstants.m
@@ -22,6 +22,8 @@ NSString *const NOT = @"$not";
 
 NSString *const EXISTS = @"$exists";
 
+NSString *const TEXT = @"$text";
+
 NSString *const EQ = @"$eq";
 
 NSString *const NE = @"$ne";
@@ -37,3 +39,5 @@ NSString *const GTE = @"$gte";
 NSString *const IN = @"$in";
 
 NSString *const NIN = @"$nin";
+
+NSString *const SEARCH = @"$search";

--- a/Classes/common/query/CDTQQueryValidator.m
+++ b/Classes/common/query/CDTQQueryValidator.m
@@ -300,7 +300,18 @@
 
 #pragma validation class methods
 
+/**
+ * This method runs the list of clauses making up the selector through a series of
+ * validation steps and returns whether the clause list is valid or not.
+ *
+ * @param clauses An NSArray of clauses making up a query selector
+ * @param textClauseLimitReached A flag used to track the text clause limit
+ *                               throughout the validation process.  The
+ *                               current limit is one text clause per query.
+ * @return YES/NO whether the list of clauses passed validation.
+ */
 + (BOOL)validateCompoundOperatorClauses:(NSArray *)clauses
+                    withTextClauseLimit:(BOOL *)textClauseLimitReached
 {
     BOOL valid = NO;
 
@@ -323,12 +334,18 @@
             id compoundClauses = [obj objectForKey:key];
             if ([CDTQQueryValidator validateCompoundOperatorOperand:compoundClauses]) {
                 // validate array
-                valid = [CDTQQueryValidator validateCompoundOperatorClauses:compoundClauses];
+                valid = [CDTQQueryValidator validateCompoundOperatorClauses:compoundClauses
+                                                        withTextClauseLimit:textClauseLimitReached];
             }
         } else if (![key hasPrefix:@"$"]) {
             // this should have a dict
             // send this for validation
             valid = [CDTQQueryValidator validateClause:[obj objectForKey:key]];
+        } else if ([key.lowercaseString isEqualToString:TEXT]) {
+            // this should have a dict
+            // send this for validation
+            valid = [CDTQQueryValidator validateTextClause:clause[key]
+                                       withTextClauseLimit:textClauseLimitReached];
         } else {
             LogError(@"%@ operator cannot be a top level operator", key);
             break;
@@ -374,6 +391,46 @@
     return NO;
 }
 
+/**
+ * This method handles the special case where a text search clause is encountered.
+ * This case is special because a $text operator expects an NSDictionary value whose 
+ * key can only be the $search operator.
+ *
+ * @param clause The text clause to validate
+ * @param textClauseLimitReached A flag used to track the text clause limit
+ *                               throughout the validation process.  The
+ *                               current limit is one text clause per query.
+ * @return YES/NO whether the clause is valid
+ */
++ (BOOL)validateTextClause:(NSObject *)clause withTextClauseLimit:(BOOL *)textClauseLimitReached
+{
+    if (![clause isKindOfClass:[NSDictionary class]]) {
+        LogError(@"Text search expects an NSDictionary, found %@ instead.", clause);
+        return NO;
+    }
+    
+    NSDictionary *textClause = (NSDictionary *) clause;
+    if ([textClause count] != 1) {
+        LogError(@"Unexpected content %@ in text search.", textClause);
+        return NO;
+    }
+    
+    NSString *operator = [textClause allKeys][0];
+    if (![operator isEqualToString:SEARCH]) {
+        LogError(@"Invalid operator %@ in text search.", operator);
+        return NO;
+    }
+    
+    if (*textClauseLimitReached) {
+        LogError(@"Multiple text search clauses not allowed in a query.  "
+                  "Rewrite query to contain at most one text search clause.");
+        return NO;
+    }
+    
+    *textClauseLimitReached = YES;
+    return [CDTQQueryValidator validatePredicateValue:textClause[operator] forOperator:operator];
+}
+
 + (BOOL)validateListValues:(NSArray *)listValues
 {
     BOOL valid = YES;
@@ -392,10 +449,24 @@
 {
     if([operator isEqualToString:EXISTS]){
         return [CDTQQueryValidator validateExistsArgument:predicateValue];
+    } else if ([operator isEqualToString:SEARCH]) {
+        return [CDTQQueryValidator validateTextSearchArgument:predicateValue];
     } else {
         return (([predicateValue isKindOfClass:[NSString class]] ||
                  [predicateValue isKindOfClass:[NSNumber class]]));
     }
+}
+
++ (BOOL)validateTextSearchArgument:(NSObject *)textSearch
+{
+    BOOL valid = YES;
+    
+    if(![textSearch isKindOfClass:[NSString class]]){
+        valid = NO;
+        LogError(@"$search operator expects an NSString");
+    }
+    
+    return valid;
 }
 
 + (BOOL)validateExistsArgument:(NSObject *)exists
@@ -436,7 +507,9 @@
 
         if ([topLevelArg isKindOfClass:[NSArray class]]) {
             // safe we know its an NSArray
-            return [CDTQQueryValidator validateCompoundOperatorClauses:topLevelArg];
+            BOOL textClauseLimitReached = NO;
+            return [CDTQQueryValidator validateCompoundOperatorClauses:topLevelArg
+                                                   withTextClauseLimit:&textClauseLimitReached];
         }
     }
     return NO;

--- a/Classes/common/query/CDTQQueryValidator.m
+++ b/Classes/common/query/CDTQQueryValidator.m
@@ -344,8 +344,12 @@
         } else if ([key.lowercaseString isEqualToString:TEXT]) {
             // this should have a dict
             // send this for validation
-            valid = [CDTQQueryValidator validateTextClause:clause[key]
-                                       withTextClauseLimit:textClauseLimitReached];
+            
+            // TODO Enable text search as part of text search unit tests PR.
+            //valid = [CDTQQueryValidator validateTextClause:clause[key]
+            //                           withTextClauseLimit:textClauseLimitReached];
+            LogInfo(@"Text search is currently not supported.");
+            break;
         } else {
             LogError(@"%@ operator cannot be a top level operator", key);
             break;

--- a/Tests/Tests/DBQueryUtils.h
+++ b/Tests/Tests/DBQueryUtils.h
@@ -32,5 +32,6 @@
 -(int) rowCountForTable:(NSString *)table;
 -(void) checkTableRowCount:(NSDictionary *)initialRowCount
                modifiedBy:(NSDictionary *)modifiedRowCount;
++(NSSet *) compileOptions:(FMDatabaseQueue *)queue;
 
 @end

--- a/Tests/Tests/DBQueryUtils.m
+++ b/Tests/Tests/DBQueryUtils.m
@@ -185,5 +185,20 @@ NSString* const DBQueryUtilsErrorDomain = @"DBQueryUtilsErrorDomain";
     }
 }
 
++(NSSet *) compileOptions:(FMDatabaseQueue *)queue
+{
+    __block NSMutableArray *compileOptions = [NSMutableArray array];
+    
+    [queue inDatabase:^(FMDatabase *db){
+        FMResultSet *result = [db executeQuery:@"PRAGMA compile_options"];
+        while ([result next]) {
+            [compileOptions addObject:[result stringForColumnIndex:0]];
+        }
+        [result close];
+    }];
+    
+    return [NSSet setWithArray:compileOptions];
+}
+
 
 @end


### PR DESCRIPTION
_What_

Add a public method to the CDTQIndexManager that allows users of the library to check whether full text search is enabled in SQLite.

_Why_

Since Cloudant Query - mobile text search leverages SQLite FTS functionality and FTS is a compile option for SQLite, it is conceivable that FTS may not be enabled in SQLite. This method provides a check regarding SQLite FTS availability.

_How_

- Add a static method to the CDTQIndexManager to check the SQLite PRAGMA compile options for ENABLE_FTS3 and ENABLE_FTS3_PARENTHESIS.
- Add a public method to the CDTQIndexManager to return text search status.
- Add logic to the CDTQIndexCreator to halt any text index creation if FTS is not available in SQLite.

reviewer @mikerhodes 
reviewer @rhyshort

BugId: 46923