### PR TITLE
Add fts availability check to API

### DIFF
--- a/Classes/common/query/CDTQIndexCreator.m
+++ b/Classes/common/query/CDTQIndexCreator.m
@@ -54,7 +54,8 @@
 #pragma mark Instance methods
 
 /**
- Add a single, possibly compound, index for the given field names.
+ Add a single, possibly compound index for the given field names and ensure all indexing
+ constraints are met.
 
  @param fieldNames List of fieldnames in the sort format
  @param indexName Name of index to create.
@@ -64,6 +65,14 @@
 {
     if (!index) {
         return nil;
+    }
+    
+    if ([index.indexType.lowercaseString isEqualToString:@"text"]) {
+        if (![CDTQIndexManager ftsAvailableInDatabase:self.database]) {
+            LogError(@"Text search not supported.  To add support for text "
+                     @"search, enable FTS compile options in SQLite.");
+            return nil;
+        }
     }
 
     NSArray *fieldNames = [CDTQIndexCreator removeDirectionsFromFields:index.fieldNames];

--- a/Classes/common/query/CDTQIndexManager.h
+++ b/Classes/common/query/CDTQIndexManager.h
@@ -66,6 +66,7 @@ typedef NS_ENUM(NSInteger, CDTQQueryError) {
 
 @property (nonatomic, strong) CDTDatastore *datastore;
 @property (nonatomic, strong) FMDatabaseQueue *database;
+@property (nonatomic, readonly, getter = isTextSearchEnabled) BOOL textSearchEnabled;
 
 /**
  Constructs a new CDTQIndexManager which indexes documents in `datastore`
@@ -109,5 +110,8 @@ typedef NS_ENUM(NSInteger, CDTQQueryError) {
 
 /** Internal */
 + (NSString *)tableNameForIndex:(NSString *)indexName;
+
+/** Internal */
++ (BOOL)ftsAvailableInDatabase:(FMDatabaseQueue *)db;
 
 @end

--- a/Classes/common/query/CDTQIndexManager.m
+++ b/Classes/common/query/CDTQIndexManager.m
@@ -65,6 +65,7 @@ static const int VERSION = 2;
 @interface CDTQIndexManager ()
 
 @property (nonatomic, strong) NSRegularExpression *validFieldName;
+@property (readwrite) BOOL textSearchEnabled;
 
 @end
 
@@ -135,6 +136,9 @@ static const int VERSION = 2;
             }
             return nil;
         }
+        
+        _textSearchEnabled = [CDTQIndexManager ftsAvailableInDatabase:_database];
+        
     }
     return self;
 }
@@ -368,6 +372,39 @@ static const int VERSION = 2;
 + (NSString *)tableNameForIndex:(NSString *)indexName
 {
     return [kCDTQIndexTablePrefix stringByAppendingString:indexName];
+}
+
++ (BOOL)ftsAvailableInDatabase:(FMDatabaseQueue *)db
+{
+    __block BOOL ftsOptionsExist = NO;
+    
+    [db inDatabase:^(FMDatabase *db) {
+        NSMutableArray *ftsCompileOptions =
+            [NSMutableArray arrayWithArray:@[ @"ENABLE_FTS3", @"ENABLE_FTS3_PARENTHESIS" ] ];
+        FMResultSet *rs = [db executeQuery:@"PRAGMA compile_options;"];
+        while ([rs next]) {
+            NSString *compileOption = [rs stringForColumnIndex:0];
+            [ftsCompileOptions removeObject:compileOption];
+            if (ftsCompileOptions.count == 0) {
+                ftsOptionsExist = YES;
+                break;
+            }
+        }
+        [rs close];
+    }];
+    
+    return ftsOptionsExist;
+}
+
+- (BOOL)isTextSearchEnabled
+{
+    if (!_textSearchEnabled) {
+        LogInfo(@"Based on SQLite compile options, "
+                @"text search is currently not supported.  "
+                @"To enable text search recompile SQLite with "
+                @"the full text saerch compile options turned on.");
+    }
+    return _textSearchEnabled;
 }
 
 #pragma mark Setup methods

--- a/Tests/Tests/CDTQIndexManagerTests.m
+++ b/Tests/Tests/CDTQIndexManagerTests.m
@@ -12,6 +12,7 @@
 #import <CDTQIndexCreator.h>
 #import <CDTQResultSet.h>
 #import <CDTQQueryExecutor.h>
+#import "DBQueryUtils.h"
 
 SpecBegin(CDTQIndexManager)
 
@@ -200,6 +201,60 @@ SpecBegin(CDTQIndexManager)
             expect([im listIndexes][@"basic"]).to.beNil();
         });
 
+    });
+
+    describe(@"when performing text search check", ^{
+        
+        __block NSString *factoryPath;
+        __block CDTDatastoreManager *factory;
+        __block CDTDatastore *ds;
+        __block CDTQIndexManager *im;
+        
+        beforeEach(^{
+            // Create a new CDTDatastoreFactory at a temp path
+            
+            NSString *tempDirectoryTemplate = [NSTemporaryDirectory()
+                stringByAppendingPathComponent:@"cloudant_sync_ios_tests.XXXXXX"];
+            const char *tempDirectoryTemplateCString =
+            [tempDirectoryTemplate fileSystemRepresentation];
+            char *tempDirectoryNameCString =
+            (char *)malloc(strlen(tempDirectoryTemplateCString) + 1);
+            strcpy(tempDirectoryNameCString, tempDirectoryTemplateCString);
+            
+            char *result = mkdtemp(tempDirectoryNameCString);
+            expect(result).to.beTruthy();
+            
+            factoryPath = [[NSFileManager defaultManager]
+                           stringWithFileSystemRepresentation:tempDirectoryNameCString
+                           length:strlen(result)];
+            free(tempDirectoryNameCString);
+            
+            NSError *error;
+            factory = [[CDTDatastoreManager alloc] initWithDirectory:factoryPath error:&error];
+            
+            ds = [factory datastoreNamed:@"test" error:nil];
+            expect(ds).toNot.beNil();
+            im = [CDTQIndexManager managerUsingDatastore:ds error:nil];
+            expect(im).toNot.beNil();
+        });
+        
+        afterEach(^{
+            // Delete the databases we used
+            
+            factory = nil;
+            NSError *error;
+            [[NSFileManager defaultManager] removeItemAtPath:factoryPath error:&error];
+        });
+        
+        it(@"validates that text search is available", ^{
+            NSSet *compileOptions = [DBQueryUtils compileOptions:im.database];
+            NSSet *ftsCompileOptions = [NSSet setWithArray:@[@"ENABLE_FTS3",
+                                                             @"ENABLE_FTS3_PARENTHESIS"]];
+            expect(compileOptions).to.beSupersetOf(ftsCompileOptions);
+            
+            expect([im isTextSearchEnabled]).to.equal(@YES);
+        });
+        
     });
 
 SpecEnd

--- a/Tests/Tests/DBQueryUtils.h
+++ b/Tests/Tests/DBQueryUtils.h
@@ -32,5 +32,6 @@
 -(int) rowCountForTable:(NSString *)table;
 -(void) checkTableRowCount:(NSDictionary *)initialRowCount
                modifiedBy:(NSDictionary *)modifiedRowCount;
++(NSSet *) compileOptions:(FMDatabaseQueue *)queue;
 
 @end

--- a/Tests/Tests/DBQueryUtils.m
+++ b/Tests/Tests/DBQueryUtils.m
@@ -185,5 +185,20 @@ NSString* const DBQueryUtilsErrorDomain = @"DBQueryUtilsErrorDomain";
     }
 }
 
++(NSSet *) compileOptions:(FMDatabaseQueue *)queue
+{
+    __block NSMutableArray *compileOptions = [NSMutableArray array];
+    
+    [queue inDatabase:^(FMDatabase *db){
+        FMResultSet *result = [db executeQuery:@"PRAGMA compile_options"];
+        while ([result next]) {
+            [compileOptions addObject:[result stringForColumnIndex:0]];
+        }
+        [result close];
+    }];
+    
+    return [NSSet setWithArray:compileOptions];
+}
+
 
 @end


### PR DESCRIPTION
_What_

Add a public method to the CDTQIndexManager that allows users of the library to check whether full text search is enabled in SQLite.

_Why_

Since Cloudant Query - mobile text search leverages SQLite FTS functionality and FTS is a compile option for SQLite, it is conceivable that FTS may not be enabled in SQLite. This method provides a check regarding SQLite FTS availability.

_How_

- Add a method to the CDTQIndexManager to check the SQLite PRAGMA compile options for ENABLE_FTS3 and ENABLE_FTS3_PARENTHESIS.
- Add a public method to the CDTQIndexManager to return text search status.
- Add logic to CDTQIndexCreator to halt any text index creation if FTS is not available in SQLite.

reviewer @mikerhodes 
reviewer @rhyshort

BugId: 46923