### PR TITLE
46425 Deactivate key derivation in SQLCipher

### DIFF
--- a/CDTDatastore.podspec
+++ b/CDTDatastore.podspec
@@ -45,7 +45,7 @@ Pod::Spec.new do |s|
     # duplicated code, the resulting subspec will include at the same time
     # SQLite and SQLCipher.
 
-    sp.prefix_header_contents = '#import "CollectionUtils.h"', '#import "Logging.h"', '#import "Test.h"'
+    sp.prefix_header_contents = '#import "CollectionUtils.h"', '#import "Logging.h"', '#import "Test.h"', '#import "CDTMacros.h"'
 
     sp.source_files = 'Classes/**/*.{h,m}'
 
@@ -73,7 +73,7 @@ Pod::Spec.new do |s|
     # duplicated code, the resulting subspec will include at the same time
     # SQLite and SQLCipher.
 
-    sp.prefix_header_contents = '#import "CollectionUtils.h"', '#import "Logging.h"', '#import "Test.h"'
+    sp.prefix_header_contents = '#import "CollectionUtils.h"', '#import "Logging.h"', '#import "Test.h"', '#import "CDTMacros.h"'
 
     sp.source_files = 'Classes/**/*.{h,m}'
 

--- a/CDTDatastore.xcworkspace/contents.xcworkspacedata
+++ b/CDTDatastore.xcworkspace/contents.xcworkspacedata
@@ -546,6 +546,9 @@
          <FileRef
             location = "group:CDTFetchChanges.m">
          </FileRef>
+         <FileRef
+            location = "group:CDTMacros.h">
+         </FileRef>
       </Group>
       <Group
          location = "group:Classes/ios"

--- a/CDTDatastore.xcworkspace/contents.xcworkspacedata
+++ b/CDTDatastore.xcworkspace/contents.xcworkspacedata
@@ -100,6 +100,12 @@
                location = "group:CDTDatastoreManager+EncryptionKey.h">
             </FileRef>
             <FileRef
+               location = "group:CDTEncryptionKey.h">
+            </FileRef>
+            <FileRef
+               location = "group:CDTEncryptionKey.m">
+            </FileRef>
+            <FileRef
                location = "group:CDTEncryptionKeyNilProvider.h">
             </FileRef>
             <FileRef

--- a/Classes/common/CDTMacros.h
+++ b/Classes/common/CDTMacros.h
@@ -1,0 +1,36 @@
+//
+//  CDTMacros.h
+//  CloudantSync
+//
+//  Created by Enrique de la Torre Fernandez on 03/06/2015.
+//  Copyright (c) 2015 IBM Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#ifndef _CDTMacros_h
+#define _CDTMacros_h
+
+#ifndef NS_DESIGNATED_INITIALIZER
+#if __has_attribute(objc_designated_initializer)
+
+#define NS_DESIGNATED_INITIALIZER __attribute__((objc_designated_initializer))
+
+#else
+
+#define NS_DESIGNATED_INITIALIZER
+
+#endif
+#endif
+
+#ifndef UNAVAILABLE_ATTRIBUTE
+#define UNAVAILABLE_ATTRIBUTE
+#endif
+
+#endif

--- a/Classes/common/Encryption/CDTEncryptionKey.h
+++ b/Classes/common/Encryption/CDTEncryptionKey.h
@@ -1,0 +1,52 @@
+//
+//  CDTEncryptionKey.h
+//  CloudantSync
+//
+//  Created by Enrique de la Torre Fernandez on 12/05/2015.
+//  Copyright (c) 2015 IBM Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+
+/**
+ Use this class to pass around a DPK (Data Protection Key).
+
+ This class is essentially a wrapper for a NSData instance. However this instance has to have a
+ specific size: CDTENCRYPTIONKEY_KEYSIZE bytes. The reason for this is that we rely on SQLCipher to
+ encrypt databases and it requires a key of CDTENCRYPTIONKEY_KEYSIZE bytes.
+ */
+
+// Size (bytes) of the DPK (Data Protection Key)
+#define CDTENCRYPTIONKEY_KEYSIZE 32
+
+@interface CDTEncryptionKey : NSObject
+
+/**
+ Array of CDTENCRYPTIONKEY_KEYSIZE bytes with the DPK
+ */
+@property (assign, nonatomic, readonly) const void *bytes;
+
+- (instancetype)init UNAVAILABLE_ATTRIBUTE;
+
+/**
+ Initialise an encryption key with a buffer.
+
+ @param data Buffer of size CDTENCRYPTIONKEY_KEYSIZE bytes with the DPK
+ 
+ @warning If data.length is not CDTENCRYPTIONKEY_KEYSIZE, init will return nil
+ */
+- (instancetype)initWithData:(NSData *)data NS_DESIGNATED_INITIALIZER;
+
+- (BOOL)isEqualToEncryptionKey:(CDTEncryptionKey *)encryptionKey;
+
++ (instancetype)encryptionKeyWithData:(NSData *)data;
+
+@end

--- a/Classes/common/Encryption/CDTEncryptionKey.m
+++ b/Classes/common/Encryption/CDTEncryptionKey.m
@@ -1,0 +1,92 @@
+//
+//  CDTEncryptionKey.m
+//  CloudantSync
+//
+//  Created by Enrique de la Torre Fernandez on 12/05/2015.
+//  Copyright (c) 2015 IBM Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#import "CDTEncryptionKey.h"
+
+#import "CDTLogging.h"
+
+@interface CDTEncryptionKey ()
+
+@property (strong, nonatomic, readonly) NSData *data;
+
+@end
+
+@implementation CDTEncryptionKey
+
+#pragma mark - Synthesize properties
+- (const void *)bytes { return self.data.bytes; }
+
+#pragma mark - Init object
+- (instancetype)init { return [self initWithData:nil]; }
+
+- (instancetype)initWithData:(NSData *)data
+{
+    self = [super init];
+    if (self) {
+        if (data && (data.length == CDTENCRYPTIONKEY_KEYSIZE)) {
+            _data = data;
+        } else {
+            NSNumber *length = (data ? @(data.length) : nil);
+            CDTLogError(CDTDATASTORE_LOG_CONTEXT,
+                        @"No data provided or it does no have the right size: %@ (instead of %i)",
+                        length, CDTENCRYPTIONKEY_KEYSIZE);
+
+            self = nil;
+        }
+    }
+
+    return self;
+}
+
+#pragma mark - NSObject methods
+- (BOOL)isEqual:(id)object
+{
+    if (!object) {
+        return NO;
+    }
+
+    if (self == object) {
+        return YES;
+    }
+
+    if (![object isKindOfClass:[CDTEncryptionKey class]]) {
+        return NO;
+    }
+
+    return [self isEqualToEncryptionKey:(CDTEncryptionKey *)object];
+}
+
+- (NSUInteger)hash {
+    return [self.data hash];
+}
+
+#pragma mark - Public methods
+- (BOOL)isEqualToEncryptionKey:(CDTEncryptionKey *)encryptionKey
+{
+    if (!encryptionKey) {
+        return NO;
+    }
+
+    return [self.data isEqualToData:encryptionKey.data];
+}
+
+#pragma mark - Public class methods
++ (instancetype)encryptionKeyWithData:(NSData *)data
+{
+    return [[[self class] alloc] initWithData:data];
+}
+
+@end

--- a/Classes/common/Encryption/CDTEncryptionKeyNilProvider.m
+++ b/Classes/common/Encryption/CDTEncryptionKeyNilProvider.m
@@ -19,7 +19,7 @@
 @implementation CDTEncryptionKeyNilProvider
 
 #pragma mark - CDTEncryptionKeyProvider methods
-- (NSString *)encryptionKey { return nil; }
+- (CDTEncryptionKey *)encryptionKey { return nil; }
 
 #pragma mark - Public class methods
 + (instancetype)provider { return [[[self class] alloc] init]; }

--- a/Classes/common/Encryption/CDTEncryptionKeyProvider.h
+++ b/Classes/common/Encryption/CDTEncryptionKeyProvider.h
@@ -16,6 +16,8 @@
 
 #import <Foundation/Foundation.h>
 
+#import "CDTEncryptionKey.h"
+
 @protocol CDTEncryptionKeyProvider
 
 /**
@@ -27,6 +29,6 @@
  * @warning *Warning:* Encryption will not work unless subspec 'CDTDatastore/SQLCipher' is used.
  * However, data will not be encrypted if this method returns nil (regardless of the subspec).
  */
-- (NSString *)encryptionKey;
+- (CDTEncryptionKey *)encryptionKey;
 
 @end

--- a/Classes/common/Encryption/FMDatabase+EncryptionKey.h
+++ b/Classes/common/Encryption/FMDatabase+EncryptionKey.h
@@ -25,7 +25,7 @@ extern NSString *const FMDatabaseEncryptionKeyErrorDomain;
  */
 typedef NS_ENUM(NSInteger, FMDatabaseEncryptionKeyError) {
     FMDatabaseEncryptionKeyErrorKeyNotSet,
-    FMDatabaseEncryptionKeyErrorNoKeyProvidedForEncryptedDB,
+    FMDatabaseEncryptionKeyErrorDBCorruptedOrNoKeyProvided,
     FMDatabaseEncryptionKeyErrorWrongKeyOrDBNotEncrypted
 };
 

--- a/Classes/common/Encryption/FMDatabase+EncryptionKey.m
+++ b/Classes/common/Encryption/FMDatabase+EncryptionKey.m
@@ -16,6 +16,7 @@
 
 #import "FMDatabase+EncryptionKey.h"
 
+#import "TDMisc.h"
 #import "CDTLogging.h"
 
 @implementation FMDatabase (EncryptionKey)
@@ -29,11 +30,12 @@ NSString *const FMDatabaseEncryptionKeyErrorDomain = @"FMDatabaseEncryptionKeyEr
     NSError *thisError = nil;
     
     // Get the key
-    NSString *encryptionKey = [provider encryptionKey];
+    CDTEncryptionKey *encryptionKey = [provider encryptionKey];
 
     // Set the key (if there is any)
     if (encryptionKey) {
-        success = [self setKey:encryptionKey];
+        NSString *hexEncryptionKey = TDHexFromBytes(encryptionKey.bytes, CDTENCRYPTIONKEY_KEYSIZE);
+        success = [self setKey:hexEncryptionKey];
         if (!success) {
             CDTLogError(CDTDATASTORE_LOG_CONTEXT,
                         @"Key to decrypt DB at %@ not set. DB can not be opened.",

--- a/Classes/common/Encryption/Keychain/CDTEncryptionKeychainConstants.h
+++ b/Classes/common/Encryption/Keychain/CDTEncryptionKeychainConstants.h
@@ -22,9 +22,6 @@
 // Define the version of the implementation used to cipher/decipher DPKs
 #define CDTENCRYPTION_KEYCHAIN_VERSION @"1.0"
 
-// Size (bytes) of the DPK (Data Protection Key)
-#define CDTENCRYPTION_KEYCHAIN_ENCRYPTIONKEY_SIZE 32
-
 // PBKDF2: Size (bytes) of the salt value used to derive a user-provided password
 #define CDTENCRYPTION_KEYCHAIN_PBKDF2_SALT_SIZE 32
 

--- a/Classes/common/Encryption/Keychain/CDTEncryptionKeychainManager.h
+++ b/Classes/common/Encryption/Keychain/CDTEncryptionKeychainManager.h
@@ -16,6 +16,7 @@
 
 #import <Foundation/Foundation.h>
 
+#import "CDTEncryptionKey.h"
 #import "CDTEncryptionKeychainStorage.h"
 
 /**
@@ -57,7 +58,7 @@
  
  @return The DPK
  */
-- (NSData *)loadKeyUsingPassword:(NSString *)password;
+- (CDTEncryptionKey *)loadKeyUsingPassword:(NSString *)password;
 
 /**
  Generates a Data Protection Key (DPK), encrypts it, and stores it inside the keychain.
@@ -66,7 +67,7 @@
  
  @return The DPK
  */
-- (NSData *)generateAndSaveKeyProtectedByPassword:(NSString *)password;
+- (CDTEncryptionKey *)generateAndSaveKeyProtectedByPassword:(NSString *)password;
 
 /**
  Checks if the encrypted Data Protection Key (DPK) is inside the keychain.

--- a/Classes/common/Encryption/Keychain/CDTEncryptionKeychainManager.m
+++ b/Classes/common/Encryption/Keychain/CDTEncryptionKeychainManager.m
@@ -53,7 +53,7 @@
 }
 
 #pragma mark - Public methods
-- (NSData *)loadKeyUsingPassword:(NSString *)password
+- (CDTEncryptionKey *)loadKeyUsingPassword:(NSString *)password
 {
     CDTEncryptionKeychainData *data = [self.storage encryptionKeyData];
     if (!data || ![self validateEncryptionKeyData:data]) {
@@ -67,10 +67,10 @@
 
     NSData *dpk = [self decryptDpk:data.encryptedDPK usingAESWithKey:aesKey iv:data.iv];
 
-    return dpk;
+    return [CDTEncryptionKey encryptionKeyWithData:dpk];
 }
 
-- (NSData *)generateAndSaveKeyProtectedByPassword:(NSString *)password
+- (CDTEncryptionKey *)generateAndSaveKeyProtectedByPassword:(NSString *)password
 {
     NSData *dpk = nil;
 
@@ -85,7 +85,7 @@
         }
     }
 
-    return dpk;
+    return [CDTEncryptionKey encryptionKeyWithData:dpk];
 }
 
 - (BOOL)keyExists { return [self.storage encryptionKeyDataExists]; }
@@ -108,8 +108,8 @@
 
 - (NSData *)generateDpk
 {
-    NSData *dpk = [CDTEncryptionKeychainUtils
-        generateSecureRandomBytesWithLength:CDTENCRYPTION_KEYCHAIN_ENCRYPTIONKEY_SIZE];
+    NSData *dpk =
+        [CDTEncryptionKeychainUtils generateSecureRandomBytesWithLength:CDTENCRYPTIONKEY_KEYSIZE];
 
     return dpk;
 }

--- a/Classes/common/Encryption/Keychain/CDTEncryptionKeychainProvider.m
+++ b/Classes/common/Encryption/Keychain/CDTEncryptionKeychainProvider.m
@@ -18,7 +18,6 @@
 
 #import "CDTEncryptionKeychainManager.h"
 
-#import "TDMisc.h"
 #import "CDTLogging.h"
 
 @interface CDTEncryptionKeychainProvider ()
@@ -52,22 +51,20 @@
 }
 
 #pragma mark - CDTEncryptionKeyProvider methods
-- (NSString *)encryptionKey
+- (CDTEncryptionKey *)encryptionKey
 {
-    NSData *data = nil;
+    CDTEncryptionKey *key = nil;
 
     @synchronized(self)
     {
         if ([self.manager keyExists]) {
-            data = [self.manager loadKeyUsingPassword:self.password];
+            key = [self.manager loadKeyUsingPassword:self.password];
         } else {
-            data = [self.manager generateAndSaveKeyProtectedByPassword:self.password];
+            key = [self.manager generateAndSaveKeyProtectedByPassword:self.password];
         }
     }
-    
-    NSString *hexStr = (data ? TDHexFromBytes(data.bytes, data.length) : nil);
-    
-    return hexStr;
+
+    return key;
 }
 
 #pragma mark - Public class methods

--- a/Classes/common/touchdb/TD_Database.m
+++ b/Classes/common/touchdb/TD_Database.m
@@ -302,14 +302,14 @@ static BOOL removeItemIfExists(NSString* path, NSError** outError)
 + (BOOL)sameEncryptionKeyIn:(id<CDTEncryptionKeyProvider>)thisProvider
                         and:(id<CDTEncryptionKeyProvider>)otherProvider
 {
-    NSString *thisKey = [thisProvider encryptionKey];
-    NSString *otherKey = [otherProvider encryptionKey];
+    CDTEncryptionKey *thisKey = [thisProvider encryptionKey];
+    CDTEncryptionKey *otherKey = [otherProvider encryptionKey];
     
     BOOL sameKey = NO;
     if (thisKey == nil) {
         sameKey = (otherKey == nil);
     } else {
-        sameKey = ((otherKey != nil) && [otherKey isEqualToString:thisKey]);
+        sameKey = ((otherKey != nil) && [otherKey isEqualToEncryptionKey:thisKey]);
     }
 
     return sameKey;

--- a/EncryptionTests/Encryption Tests/CDTQIndexManagerEncryptionTests.m
+++ b/EncryptionTests/Encryption Tests/CDTQIndexManagerEncryptionTests.m
@@ -180,11 +180,7 @@
 {
     // Create datastore
     CDTHelperFixedKeyProvider *provider = [[CDTHelperFixedKeyProvider alloc] init];
-
-    NSString *otherKey =
-        [[provider encryptionKey] stringByAppendingString:[provider encryptionKey]];
-    provider = [[CDTHelperFixedKeyProvider alloc] initWithKey:otherKey];
-
+    
     CDTDatastore *datastore = [self.factory
                    datastoreNamed:@"create_query_index_textests_fixedprovider_fails_with_wrong_key"
         withEncryptionKeyProvider:provider

--- a/EncryptionTests/Encryption Tests/DatastoreEncryptionTests.m
+++ b/EncryptionTests/Encryption Tests/DatastoreEncryptionTests.m
@@ -111,11 +111,8 @@
     TD_Database *db = [[TD_Database alloc] initWithPath:path];
 
     // Init with another fixed provider
-    NSString *otherKey =
-        [fixedProvider.encryptionKey stringByAppendingString:fixedProvider.encryptionKey];
-    CDTHelperFixedKeyProvider *otherProvider =
-        [[CDTHelperFixedKeyProvider alloc] initWithKey:otherKey];
-
+    CDTHelperFixedKeyProvider *otherProvider = [fixedProvider negatedProvider];
+    
     XCTAssertNil([[CDTDatastore alloc] initWithManager:(CDTDatastoreManager *)@"manager"
                                               database:db
                                  encryptionKeyProvider:otherProvider],
@@ -187,10 +184,7 @@
         [TD_Database createEmptyDBAtPath:path withEncryptionKeyProvider:fixedProvider];
 
     // Init with another fixed provider
-    NSString *otherKey =
-        [fixedProvider.encryptionKey stringByAppendingString:fixedProvider.encryptionKey];
-    CDTHelperFixedKeyProvider *otherProvider =
-        [[CDTHelperFixedKeyProvider alloc] initWithKey:otherKey];
+    CDTHelperFixedKeyProvider *otherProvider = [fixedProvider negatedProvider];
 
     XCTAssertNil([[CDTDatastore alloc] initWithManager:(CDTDatastoreManager *)@"manager"
                                               database:db

--- a/EncryptionTests/Encryption Tests/DatastoreManagerEncryptionTests.m
+++ b/EncryptionTests/Encryption Tests/DatastoreManagerEncryptionTests.m
@@ -89,10 +89,7 @@
            withEncryptionKeyProvider:fixedProvider];
 
     // Get datastore
-    NSString *otherKey =
-        [fixedProvider.encryptionKey stringByAppendingString:fixedProvider.encryptionKey];
-    CDTHelperFixedKeyProvider *otherProvider =
-        [[CDTHelperFixedKeyProvider alloc] initWithKey:otherKey];
+    CDTHelperFixedKeyProvider *otherProvider = [fixedProvider negatedProvider];
 
     NSError *error = nil;
     CDTDatastore *datastore =
@@ -166,10 +163,7 @@
     [self.factory datastoreNamed:dbName withEncryptionKeyProvider:fixedProvider error:nil];
 
     // Get datastore
-    NSString *otherKey =
-        [fixedProvider.encryptionKey stringByAppendingString:fixedProvider.encryptionKey];
-    CDTHelperFixedKeyProvider *otherProvider =
-        [[CDTHelperFixedKeyProvider alloc] initWithKey:otherKey];
+    CDTHelperFixedKeyProvider *otherProvider = [fixedProvider negatedProvider];
 
     NSError *error = nil;
     CDTDatastore *datastore =

--- a/EncryptionTests/Encryption Tests/TD_DatabaseEncryptionTests.m
+++ b/EncryptionTests/Encryption Tests/TD_DatabaseEncryptionTests.m
@@ -73,7 +73,7 @@
 {
     CDTHelperFixedKeyProvider *provider = [[CDTHelperFixedKeyProvider alloc] init];
     NSString *path = [NSTemporaryDirectory()
-        stringByAppendingPathComponent:@"TD_DatabaseEncryptionTests_OpenNotFail"];
+        stringByAppendingPathComponent:@"TD_DBEncryptionTests_openNotFail"];
 
     TD_Database *db = [[TD_Database alloc] initWithPath:path];
 
@@ -132,10 +132,7 @@
     TD_Database *db = [[TD_Database alloc] initWithPath:path];
 
     // Open with another fixed provider
-    NSString *otherKey =
-        [fixedProvider.encryptionKey stringByAppendingString:fixedProvider.encryptionKey];
-    CDTHelperFixedKeyProvider *otherProvider =
-        [[CDTHelperFixedKeyProvider alloc] initWithKey:otherKey];
+    CDTHelperFixedKeyProvider *otherProvider = [fixedProvider negatedProvider];
 
     XCTAssertFalse([db openWithEncryptionKeyProvider:otherProvider],
                    @"An encrypted db can only be open with the same key it was created");
@@ -199,10 +196,7 @@
         [TD_Database createEmptyDBAtPath:path withEncryptionKeyProvider:fixedProvider];
 
     // Open with another fixed provider
-    NSString *otherKey =
-        [fixedProvider.encryptionKey stringByAppendingString:fixedProvider.encryptionKey];
-    CDTHelperFixedKeyProvider *otherProvider =
-        [[CDTHelperFixedKeyProvider alloc] initWithKey:otherKey];
+    CDTHelperFixedKeyProvider *otherProvider = [fixedProvider negatedProvider];
 
     XCTAssertFalse([db openWithEncryptionKeyProvider:otherProvider],
                    @"An encrypted db can only be open with the same key it was created");

--- a/EncryptionTests/Encryption Tests/TD_DatabaseEncryptionTests.m
+++ b/EncryptionTests/Encryption Tests/TD_DatabaseEncryptionTests.m
@@ -73,7 +73,7 @@
 {
     CDTHelperFixedKeyProvider *provider = [[CDTHelperFixedKeyProvider alloc] init];
     NSString *path = [NSTemporaryDirectory()
-        stringByAppendingPathComponent:@"TD_DBEncryptionTests_openNotFail"];
+        stringByAppendingPathComponent:@"TD_DatabaseEncryptionTests_openNotFail"];
 
     TD_Database *db = [[TD_Database alloc] initWithPath:path];
 

--- a/Tests/Tests/Encryption/Keychain/CDTEncryptionKeychainManagerTests.m
+++ b/Tests/Tests/Encryption/Keychain/CDTEncryptionKeychainManagerTests.m
@@ -149,8 +149,22 @@ NSString *const kCDTEncryptionKeychainManagerTestsDecryptDpk =
 
 - (void)testLoadKeyUsingPasswordDoesNotFailIfNumberOfIterationsIsNotAsExpected
 {
+    CDTMockEncryptionKeychainStorage *otherStorage =
+        [[CDTMockEncryptionKeychainStorage alloc] init];
+    CDTEncryptionKeychainManager *otherManager = [[CDTEncryptionKeychainManager alloc]
+        initWithStorage:(CDTEncryptionKeychainStorage *)otherStorage];
+    NSData *otherDpk = [otherManager generateDpk];
+    NSData *otherKey =
+        [otherManager pbkdf2DerivedKeyForPassword:self.password
+                                             salt:self.keychainData.salt
+                                       iterations:1
+                                           length:CDTENCRYPTION_KEYCHAIN_AES_KEY_SIZE];
+
+    NSData *otherEncryptedDpk =
+        [otherManager encryptDpk:otherDpk usingAESWithKey:otherKey iv:self.keychainData.iv];
+
     CDTEncryptionKeychainData *otherData =
-        [CDTEncryptionKeychainData dataWithEncryptedDPK:self.keychainData.encryptedDPK
+        [CDTEncryptionKeychainData dataWithEncryptedDPK:otherEncryptedDpk
                                                    salt:self.keychainData.salt
                                                      iv:self.keychainData.iv
                                              iterations:1
@@ -250,8 +264,8 @@ NSString *const kCDTEncryptionKeychainManagerTestsDecryptDpk =
 
 - (void)testKeychainDataToStoreDpkPerformsExpectedHighlevelSteps
 {
-    NSData *dpk = [CDTEncryptionKeychainUtils
-        generateSecureRandomBytesWithLength:CDTENCRYPTION_KEYCHAIN_ENCRYPTIONKEY_SIZE];
+    NSData *dpk =
+        [CDTEncryptionKeychainUtils generateSecureRandomBytesWithLength:CDTENCRYPTIONKEY_KEYSIZE];
     [self.manager keychainDataToStoreDpk:dpk encryptedWithPassword:self.password];
 
     NSSet *expectedSteps =

--- a/Tests/Tests/Encryption/Keychain/CDTEncryptionKeychainProviderTests.m
+++ b/Tests/Tests/Encryption/Keychain/CDTEncryptionKeychainProviderTests.m
@@ -93,17 +93,6 @@
                  @"If no data is generated, there is not key to return");
 }
 
-- (void)testEncryptionKeyReturnHexStringIfGenerateEncryptionKeyDataReturnsData
-{
-    self.mockManager.keyExistsResult = NO;
-    self.mockManager.generateAndSaveKeyProtectedByPasswordResult = self.encryptionKeyData;
-
-    NSString *key = [self.provider encryptionKey];
-
-    XCTAssertTrue([CDTEncryptionKeychainProviderTests isHexadecimalString:key],
-                  @"The key has to be a hexadecimal string");
-}
-
 - (void)testEncryptionKeyRetrieveEncryptionKeyDataIfDataWasGeneratedBefore
 {
     self.mockManager.keyExistsResult = YES;
@@ -121,17 +110,6 @@
 
     XCTAssertNil([self.provider encryptionKey],
                  @"If no data is retrieved, there is not key to return");
-}
-
-- (void)testEncryptionKeyReturnHexStringIfRetrieveEncryptionKeyDataReturnsData
-{
-    self.mockManager.keyExistsResult = YES;
-    self.mockManager.loadKeyUsingPasswordResult = self.encryptionKeyData;
-
-    NSString *key = [self.provider encryptionKey];
-
-    XCTAssertTrue([CDTEncryptionKeychainProviderTests isHexadecimalString:key],
-                  @"The key has to be a hexadecimal string");
 }
 
 #pragma mark - Private class methods

--- a/Tests/Tests/Encryption/Keychain/Mock/CDTMockEncryptionKeychainManager.h
+++ b/Tests/Tests/Encryption/Keychain/Mock/CDTMockEncryptionKeychainManager.h
@@ -16,6 +16,8 @@
 
 #import <Foundation/Foundation.h>
 
+#import "CDTEncryptionKey.h"
+
 #define CDTMOCKENCRYPTIONKEYCHAINMANAGER_DEFAULT_LOADKEY nil
 #define CDTMOCKENCRYPTIONKEYCHAINMANAGER_DEFAULT_GENERATEANDSAVEKEY nil
 #define CDTMOCKENCRYPTIONKEYCHAINMANAGER_DEFAULT_KEYEXISTS NO
@@ -24,10 +26,10 @@
 @interface CDTMockEncryptionKeychainManager : NSObject
 
 @property (assign, nonatomic) BOOL loadKeyUsingPasswordExecuted;
-@property (strong, nonatomic) NSData *loadKeyUsingPasswordResult;
+@property (strong, nonatomic) CDTEncryptionKey *loadKeyUsingPasswordResult;
 
 @property (assign, nonatomic) BOOL generateAndSaveKeyProtectedByPasswordExecuted;
-@property (strong, nonatomic) NSData *generateAndSaveKeyProtectedByPasswordResult;
+@property (strong, nonatomic) CDTEncryptionKey *generateAndSaveKeyProtectedByPasswordResult;
 
 @property (assign, nonatomic) BOOL keyExistsExecuted;
 @property (assign, nonatomic) BOOL keyExistsResult;
@@ -35,8 +37,8 @@
 @property (assign, nonatomic) BOOL clearKeyExecuted;
 @property (assign, nonatomic) BOOL clearKeyResult;
 
-- (NSData *)loadKeyUsingPassword:(NSString *)password;
-- (NSData *)generateAndSaveKeyProtectedByPassword:(NSString *)password;
+- (CDTEncryptionKey *)loadKeyUsingPassword:(NSString *)password;
+- (CDTEncryptionKey *)generateAndSaveKeyProtectedByPassword:(NSString *)password;
 - (BOOL)keyExists;
 - (BOOL)clearKey;
 

--- a/Tests/Tests/Encryption/Keychain/Mock/CDTMockEncryptionKeychainManager.m
+++ b/Tests/Tests/Encryption/Keychain/Mock/CDTMockEncryptionKeychainManager.m
@@ -45,14 +45,14 @@
 }
 
 #pragma mark - Public methods
-- (NSData *)loadKeyUsingPassword:(NSString *)password
+- (CDTEncryptionKey *)loadKeyUsingPassword:(NSString *)password
 {
     self.loadKeyUsingPasswordExecuted = YES;
 
     return self.loadKeyUsingPasswordResult;
 }
 
-- (NSData *)generateAndSaveKeyProtectedByPassword:(NSString *)password
+- (CDTEncryptionKey *)generateAndSaveKeyProtectedByPassword:(NSString *)password
 {
     self.generateAndSaveKeyProtectedByPasswordExecuted = YES;
 

--- a/Tests/Tests/Helpers/CDTHelperFixedKeyProvider.h
+++ b/Tests/Tests/Helpers/CDTHelperFixedKeyProvider.h
@@ -19,6 +19,8 @@
 
 @interface CDTHelperFixedKeyProvider : NSObject <CDTEncryptionKeyProvider>
 
-- (id)initWithKey:(NSString *)key;
+- (instancetype)initWithKey:(NSData *)key NS_DESIGNATED_INITIALIZER;
+
+- (instancetype)negatedProvider;
 
 @end

--- a/Tests/Tests/Helpers/CDTHelperFixedKeyProvider.m
+++ b/Tests/Tests/Helpers/CDTHelperFixedKeyProvider.m
@@ -17,32 +17,50 @@
 
 @interface CDTHelperFixedKeyProvider ()
 
-@property (strong, nonatomic, readonly) NSString *fixedKey;
+@property (strong, nonatomic, readonly) CDTEncryptionKey *fixedKey;
 
 @end
 
 @implementation CDTHelperFixedKeyProvider
 
 #pragma mark - Init object
-- (id)init
+- (instancetype)init
 {
-    return [self initWithKey:@"???"];
+    char buffer[CDTENCRYPTIONKEY_KEYSIZE];
+    memset(buffer, '*', sizeof(buffer));
+    
+    NSData *key = [NSData dataWithBytes:buffer length:sizeof(buffer)];
+    
+    return [self initWithKey:key];
 }
 
-- (id)initWithKey:(NSString *)key
+- (instancetype)initWithKey:(NSData *)key
 {
     self = [super init];
     if (self) {
-        _fixedKey = key;
+        _fixedKey = [CDTEncryptionKey encryptionKeyWithData:key];
     }
 
     return self;
 }
 
 #pragma mark - CDTEncryptionKeyProvider methods
-- (NSString *)encryptionKey { return self.fixedKey; }
+- (CDTEncryptionKey *)encryptionKey { return self.fixedKey; }
 
-#pragma mark - NSCopying methods
-- (id)copyWithZone:(NSZone *)zone { return [[[self class] alloc] initWithKey:self.fixedKey]; }
+#pragma mark - Public methods
+- (instancetype)negatedProvider
+{
+    const char *fixedKeyBytes = self.fixedKey.bytes;
+
+    char negatedFixedKeyBytes[CDTENCRYPTIONKEY_KEYSIZE];
+    for (NSUInteger i = 0; i < CDTENCRYPTIONKEY_KEYSIZE; i++) {
+        negatedFixedKeyBytes[i] = ~fixedKeyBytes[i];
+    }
+
+    NSData *negatedFixedKey =
+        [NSData dataWithBytes:negatedFixedKeyBytes length:sizeof(negatedFixedKeyBytes)];
+
+    return [[CDTHelperFixedKeyProvider alloc] initWithKey:negatedFixedKey];
+}
 
 @end

--- a/Tests/Tests/Helpers/CDTHelperOneUseKeyProvider.m
+++ b/Tests/Tests/Helpers/CDTHelperOneUseKeyProvider.m
@@ -17,14 +17,14 @@
 
 @interface CDTHelperOneUseKeyProvider ()
 
-@property (strong, nonatomic) NSString *thisKey;
+@property (strong, nonatomic) CDTEncryptionKey *thisKey;
 
 @end
 
 @implementation CDTHelperOneUseKeyProvider
 
 #pragma mark - Init object
-- (id)init
+- (instancetype)init
 {
     self = [super init];
     if (self) {
@@ -35,17 +35,19 @@
 }
 
 #pragma mark - CDTEncryptionKeyProvider methods
-- (NSString *)encryptionKey
+- (CDTEncryptionKey *)encryptionKey
 {
-    NSString *key = self.thisKey;
+    CDTEncryptionKey *key = self.thisKey;
     if (!self.thisKey) {
-        self.thisKey = @"???";
+        char buffer[CDTENCRYPTIONKEY_KEYSIZE];
+        memset(buffer, '*', sizeof(buffer));
+        
+        NSData *data = [NSData dataWithBytes:buffer length:sizeof(buffer)];
+        
+        self.thisKey = [CDTEncryptionKey encryptionKeyWithData:data];
     }
 
     return key;
 }
-
-#pragma mark - NSCopying methods
-- (id)copyWithZone:(NSZone *)zone { return [[[self class] alloc] init]; }
 
 @end

--- a/doc/encryption.md
+++ b/doc/encryption.md
@@ -20,8 +20,12 @@ Then, implement a class that conforms to protocol
 defines one method:
 
 ```
-- (NSString *)encryptionKey;
+- (CDTEncryptionKey *)encryptionKey;
 ```
+
+See that the method returns a [CDTEncryptionKey][CDTEncryptionKey] instance. The
+main purpose of this class is to ensure that the key has the right size
+(256 bits).
 
 Alternatively, you can use the class
 [CDTEncryptionKeychainProvider][CDTEncryptionKeychainProvider]. It already
@@ -35,5 +39,6 @@ To end, call `CDTDatastoreManager:datastoreNamed:withEncryptionKeyProvider:error
 to create `CDTDatastores` with encrypted databases (datastores and indexes are
 encrypted but not attachments and extensions)
 
+[CDTEncryptionKey]: ../Classes/common/Encryption/CDTEncryptionKey.h
 [CDTEncryptionKeyProvider]: ../Classes/common/Encryption/CDTEncryptionKeyProvider.h
 [CDTEncryptionKeychainProvider]: ../Classes/common/Encryption/Keychain/CDTEncryptionKeychainProvider.h


### PR DESCRIPTION
*What:*
Set the key to cipher the database with [PRAGMA key = "x'...'"](https://www.zetetic.net/sqlcipher/sqlcipher-api/#key), instead of [sqlite3_key](https://www.zetetic.net/sqlcipher/sqlcipher-api/#sqlite3_key).

*Why:*
`sqlite3_key` does the same that `PRAGMA key = '...'`, this means that the key provided is interpreted as a **passphrase** and converted to a **key using PBKDF2 key derivation**. But the key that we provide is already strong and it can and must be used as it is. With `PRAGMA key = "x'...'"` we can pass our key to SQLCipher and no further transformation will be performed.

*How:*
1. SQLCipher requires a 32 bytes length key. Add a new class named `CDTEncryptionKey` to enforce that the key has the right size. `CDTEncryptionKeyProvider` will return a `CDTEncryptionKey` instance instead of a string.
2. `CDTEncryptionKey` has to return a buffer, not a string. We will pass the key to SQLCipher as a hexadecimal string but later on we will use this same key to cipher the attachments, in this case we need the buffer.
3. Update the code to set the key with `PRAGMA key = "x'...'"`. *NOTE*: If we execute this command on SQLite, it will not fail; we have to detect if SQLCipher is included (use macro `ENCRYPT_DATABASE `) and act accordingly. 

**Check case with BugzID 46425 for more details about the design and how it has evolved until the current point.**

*Tests:*
No more tests added, only updated to work with `CDTEncryptionKey`.

reviewer @mikerhodes 
reviewer @rhyshort 

**NOTE:** Wait to review this PR until PR #140  is closed. This branch will be rebased and there will be only commits related to this case.