### PR TITLE
Add tests for full text search query

### DIFF
--- a/Classes/common/query/CDTQQuerySqlTranslator.m
+++ b/Classes/common/query/CDTQQuerySqlTranslator.m
@@ -244,9 +244,9 @@
         } else {
             // The text clause must be an NSDictionary here otherwise it
             // would not have passed the normalization/validation step.
-            textClause = (NSDictionary *)textClause;
-            CDTQSqlParts *select = [CDTQQuerySqlTranslator selectStatementForTextClause:textClause
-                                                                             usingIndex:textIndex];
+            CDTQSqlParts *select =
+                [CDTQQuerySqlTranslator selectStatementForTextClause:(NSDictionary *)textClause
+                                                          usingIndex:textIndex];
             if (!select) {
                 LogError(@"Error generating SELECT clause for %@", textClause);
                 return nil;

--- a/Classes/common/query/CDTQQueryValidator.m
+++ b/Classes/common/query/CDTQQueryValidator.m
@@ -346,11 +346,8 @@
             // this should have a dict
             // send this for validation
             
-            // TODO Enable text search as part of text search unit tests PR.
-            //valid = [CDTQQueryValidator validateTextClause:clause[key]
-            //                           withTextClauseLimit:textClauseLimitReached];
-            LogInfo(@"Text search is currently not supported.");
-            break;
+            valid = [CDTQQueryValidator validateTextClause:clause[key]
+                                       withTextClauseLimit:textClauseLimitReached];
         } else {
             LogError(@"%@ operator cannot be a top level operator", key);
             break;

--- a/Tests/Tests.xcodeproj/project.pbxproj
+++ b/Tests/Tests.xcodeproj/project.pbxproj
@@ -114,6 +114,8 @@
 		EC0C83631AB217290051042F /* Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C833B1AB217290051042F /* Tests.m */; };
 		EC578D8A1AE67D60003D6006 /* CDTQIndexTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EC578D891AE67D60003D6006 /* CDTQIndexTests.m */; };
 		EC578D8B1AE67D60003D6006 /* CDTQIndexTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EC578D891AE67D60003D6006 /* CDTQIndexTests.m */; };
+		ECA0DC611AFD568D00E174BC /* CDTQTextSearchTests.m in Sources */ = {isa = PBXBuildFile; fileRef = ECA0DC601AFD568D00E174BC /* CDTQTextSearchTests.m */; };
+		ECA0DC621AFD568D00E174BC /* CDTQTextSearchTests.m in Sources */ = {isa = PBXBuildFile; fileRef = ECA0DC601AFD568D00E174BC /* CDTQTextSearchTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -198,6 +200,7 @@
 		EC0C833A1AB217290051042F /* CDTQSQLOnlyQueryExecutor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTQSQLOnlyQueryExecutor.m; sourceTree = "<group>"; };
 		EC0C833B1AB217290051042F /* Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Tests.m; sourceTree = "<group>"; };
 		EC578D891AE67D60003D6006 /* CDTQIndexTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTQIndexTests.m; sourceTree = "<group>"; };
+		ECA0DC601AFD568D00E174BC /* CDTQTextSearchTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTQTextSearchTests.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -260,6 +263,7 @@
 		27389E15185345FD0027A404 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				ECA0DC601AFD568D00E174BC /* CDTQTextSearchTests.m */,
 				EC578D891AE67D60003D6006 /* CDTQIndexTests.m */,
 				EC0C831F1AB217290051042F /* CDTDatastoreQueryTests.m */,
 				EC0C83201AB217290051042F /* CDTQFilterFieldsTest.m */,
@@ -590,6 +594,7 @@
 				EC0C835E1AB217290051042F /* CDTQSQLOnlyIndexManager.m in Sources */,
 				EC0C83421AB217290051042F /* CDTQIndexManagerTests.m in Sources */,
 				9F0D23F7188DF30D00D3D04E /* TDMultiStreamWriterTests.m in Sources */,
+				ECA0DC611AFD568D00E174BC /* CDTQTextSearchTests.m in Sources */,
 				27389E3618534E050027A404 /* DatastoreActions.m in Sources */,
 				27389E3518534E050027A404 /* CloudantSyncTests.m in Sources */,
 				9F0D24111890AD0C00D3D04E /* TDMultipartDownloaderTests.m in Sources */,
@@ -644,6 +649,7 @@
 				EC0C83431AB217290051042F /* CDTQIndexManagerTests.m in Sources */,
 				9F0D2400188DF96600D3D04E /* TD_DatabaseManagerTests.m in Sources */,
 				9F0D240F188F01DD00D3D04E /* TDMiscTests.m in Sources */,
+				ECA0DC621AFD568D00E174BC /* CDTQTextSearchTests.m in Sources */,
 				9F0D23F8188DF30D00D3D04E /* TDMultiStreamWriterTests.m in Sources */,
 				27CCEDD7187AD719006F3C66 /* DatastoreActions.m in Sources */,
 				9F0D24121890AD0C00D3D04E /* TDMultipartDownloaderTests.m in Sources */,

--- a/Tests/Tests/CDTQTextSearchTests.m
+++ b/Tests/Tests/CDTQTextSearchTests.m
@@ -1,0 +1,404 @@
+//
+//  CDTQTextSearchTests.m
+//  CloudantSync
+//
+//  Created by Al Finkelstein on 05/08/2015.
+//  Copyright (c) 2015 IBM Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#import <CloudantSync.h>
+#import <Specta.h>
+#import <Expecta.h>
+#import "Matchers/CDTQContainsAllElementsMatcher.h"
+
+SpecBegin(CDTQQueryExecutorTextSearch) describe(@"cdtq", ^{
+
+    __block NSString *factoryPath;
+    __block CDTDatastoreManager *factory;
+
+    beforeEach(^{
+        // Create a new CDTDatastoreFactory at a temp path
+
+        NSString *tempDirectoryTemplate = [NSTemporaryDirectory()
+            stringByAppendingPathComponent:@"cloudant_sync_ios_tests.XXXXXX"];
+        const char *tempDirectoryTemplateCString = [tempDirectoryTemplate fileSystemRepresentation];
+        char *tempDirectoryNameCString = (char *)malloc(strlen(tempDirectoryTemplateCString) + 1);
+        strcpy(tempDirectoryNameCString, tempDirectoryTemplateCString);
+
+        char *result = mkdtemp(tempDirectoryNameCString);
+        expect(result).to.beTruthy();
+
+        factoryPath = [[NSFileManager defaultManager]
+            stringWithFileSystemRepresentation:tempDirectoryNameCString
+                                        length:strlen(result)];
+        free(tempDirectoryNameCString);
+
+        NSError *error;
+        factory = [[CDTDatastoreManager alloc] initWithDirectory:factoryPath error:&error];
+    });
+
+    afterEach(^{
+        // Delete the databases we used
+
+        factory = nil;
+        NSError *error;
+        [[NSFileManager defaultManager] removeItemAtPath:factoryPath error:&error];
+    });
+
+    describe(@"when executing a text search", ^{
+
+        __block CDTDatastore *ds;
+        __block CDTQIndexManager *im;
+
+        beforeEach(^{
+            ds = [factory datastoreNamed:@"test" error:nil];
+            expect(ds).toNot.beNil();
+            
+            CDTMutableDocumentRevision* rev = [CDTMutableDocumentRevision revision];
+            
+            rev.docId = @"mike12";
+            rev.body = @{ @"name" : @"mike",
+                          @"age" : @12,
+                          @"pet" : @"cat",
+                          @"comment" : @"He lives in Bristol, UK and his best friend is Fred."};
+            [ds createDocumentFromRevision:rev error:nil];
+            
+            rev.docId = @"mike34";
+            rev.body = @{ @"name" : @"mike",
+                          @"age" : @34,
+                          @"pet" : @"dog",
+                          @"comment" : @"He lives in a van down by the river in Bristol."};
+            [ds createDocumentFromRevision:rev error:nil];
+            
+            rev.docId = @"mike72";
+            rev.body = @{ @"name" : @"mike",
+                          @"age" : @72,
+                          @"pet" : @"cat",
+                          @"comment" : @"He's retired and has memories of spending time "
+                                       @"with his cat Remus."};
+            [ds createDocumentFromRevision:rev error:nil];
+            
+            rev.docId = @"fred34";
+            rev.body = @{ @"name" : @"fred",
+                          @"age" : @34,
+                          @"pet" : @"cat",
+                          @"comment" : @"He lives next door to Mike and his cat Romulus "
+                                       @"is brother to Remus."};
+            [ds createDocumentFromRevision:rev error:nil];
+            
+            rev.docId = @"fred12";
+            rev.body = @{ @"name" : @"fred",
+                          @"age" : @12,
+                          @"pet" : @"cat",
+                          @"comment" : @"He lives in Bristol, UK and his best friend is Mike."};
+            [ds createDocumentFromRevision:rev error:nil];
+            
+            rev.docId = @"john34";
+            rev.body =
+                @{ @"name" : @"john",
+                   @"age" : @34,
+                   @"pet" : @"cat",
+                   @"comment" : @"وهو يعيش في بريستول، المملكة المتحدة، وأفضل صديق له هو مايك."};
+            [ds createDocumentFromRevision:rev error:nil];
+            
+            im = [CDTQIndexManager managerUsingDatastore:ds error:nil];
+            expect(im).toNot.beNil();
+        });
+
+        it(@"can perform a search consisting of a single text clause", ^{
+            expect([im ensureIndexed:@[ @"comment" ]
+                            withName:@"basic_text"
+                                type:@"text"]).toNot.beNil();
+            
+            NSDictionary* query = @{ @"$text" : @{@"$search" : @"lives in Bristol"} };
+            CDTQResultSet* result = [im find:query];
+            expect(result.documentIds).to.containAllElements(@[ @"mike12", @"mike34", @"fred12" ]);
+        });
+        
+        it(@"can perform a phrase search", ^{
+            expect([im ensureIndexed:@[ @"comment" ]
+                            withName:@"basic_text"
+                                type:@"text"]).toNot.beNil();
+            
+            NSDictionary* query = @{ @"$text" : @{@"$search" : @"\"lives in Bristol\""} };
+            CDTQResultSet* result = [im find:query];
+            expect(result.documentIds).to.containAllElements(@[ @"mike12", @"fred12" ]);
+        });
+        
+        it(@"can perform a search containing an apostrophe", ^{
+            expect([im ensureIndexed:@[ @"comment" ]
+                            withName:@"basic_text"
+                                type:@"text"]).toNot.beNil();
+            
+            NSDictionary* query = @{ @"$text" : @{@"$search" : @"he's retired"} };
+            CDTQResultSet* result = [im find:query];
+            expect(result.documentIds).to.containAllElements(@[ @"mike72" ]);
+        });
+        
+        it(@"can perform a search consisting of a single text clause with a sort", ^{
+            expect([im ensureIndexed:@[ @"name", @"comment" ]
+                            withName:@"basic_text"
+                                type:@"text"]).toNot.beNil();
+            
+            NSDictionary* query = @{ @"$text" : @{@"$search" : @"best friend"} };
+            NSArray *order = @[ @{ @"name" : @"asc" } ];
+            CDTQResultSet* result = [im find:query skip:0 limit:0 fields:nil sort: order];
+            expect(result.documentIds).to.containAllElements(@[ @"mike12", @"fred12" ]);
+            expect(result.documentIds[0]).to.equal(@"fred12");
+            expect(result.documentIds[1]).to.equal(@"mike12");
+        });
+        
+        it(@"can perform a compound AND query search containing a text clause", ^{
+            expect([im ensureIndexed:@[ @"name" ] withName:@"basic"]).toNot.beNil();
+            expect([im ensureIndexed:@[ @"comment" ]
+                            withName:@"basic_text"
+                                type:@"text"]).toNot.beNil();
+            
+            NSDictionary* query = @{ @"name" : @"mike",
+                                     @"$text" : @{@"$search" : @"best friend"} };
+            CDTQResultSet* result = [im find:query];
+            expect(result.documentIds).to.containAllElements(@[ @"mike12" ]);
+        });
+        
+        it(@"can perform a compound OR query search containing a text clause", ^{
+            expect([im ensureIndexed:@[ @"name" ] withName:@"basic"]).toNot.beNil();
+            expect([im ensureIndexed:@[ @"comment" ]
+                            withName:@"basic_text"
+                                type:@"text"]).toNot.beNil();
+            
+            NSDictionary* query = @{ @"$or" : @[ @{ @"name" : @"mike" },
+                                                 @{ @"$text" : @{@"$search" : @"best friend"} } ] };
+            CDTQResultSet* result = [im find:query];
+            expect(result.documentIds).to.containAllElements(@[ @"mike12",
+                                                                @"mike34",
+                                                                @"mike72",
+                                                                @"fred12" ]);
+        });
+        
+        it(@"returns nil for a text search without a text index", ^{
+            expect([im ensureIndexed:@[ @"name" ] withName:@"basic"]).toNot.beNil();
+            
+            NSDictionary* query = @{ @"name" : @"mike",
+                                     @"$text" : @{@"$search" : @"best friend"} };
+            expect([im find:query]).to.beNil();
+        });
+        
+        it(@"returns nil for query containing text clause when a needed json index is missing", ^{
+            // All fields in a TEXT index only apply to the text search portion of any query.
+            // So even though "name" exists in the text index, the clause that { "name" : "mike" }
+            // expects a JSON index that contains the "name" field.  Since, this query includes a
+            // text search clause then all clauses of the query must be satisfied by existing
+            // indexes.
+            expect([im ensureIndexed:@[ @"name", @"comment" ]
+                            withName:@"basic_text"
+                                type:@"text"]).toNot.beNil();
+            
+            NSDictionary* query = @{ @"$or" : @[ @{ @"name" : @"mike" },
+                                                 @{ @"$text" : @{@"$search" : @"best friend"} } ] };
+            expect([im find:query]).to.beNil();
+        });
+        
+        it(@"can perform a text search containing non-ascii values", ^{
+            expect([im ensureIndexed:@[ @"comment" ]
+                            withName:@"basic_text"
+                                type:@"text"]).toNot.beNil();
+            
+            NSDictionary* query = @{ @"$text" : @{@"$search" : @"\"صديق له هو\""} };
+            CDTQResultSet* result = [im find:query];
+            expect(result.documentIds).to.containAllElements(@[ @"john34" ]);
+        });
+        
+        it(@"returns empty result set for unmatched phrase search", ^{
+            expect([im ensureIndexed:@[ @"comment" ]
+                            withName:@"basic_text"
+                                type:@"text"]).toNot.beNil();
+            
+            NSDictionary* query = @{ @"$text" : @{@"$search" : @"\"remus romulus\""} };
+            CDTQResultSet* result = [im find:query];
+            expect(result).toNot.beNil();
+            expect(result.documentIds.count).to.equal(0);
+        });
+        
+        it(@"returns correct result set for non-contiguous word search", ^{
+            expect([im ensureIndexed:@[ @"comment" ]
+                            withName:@"basic_text"
+                                type:@"text"]).toNot.beNil();
+            
+            // The search predicate "Remus Romulus" normalizes to "Remus AND Romulus" in SQLite
+            NSDictionary* query = @{ @"$text" : @{@"$search" : @"remus romulus"} };
+            CDTQResultSet* result = [im find:query];
+            expect(result.documentIds).to.containAllElements(@[ @"fred34" ]);
+        });
+        
+        it(@"can perform text search using enhanced query syntax OR operator", ^{
+            expect([im ensureIndexed:@[ @"comment" ]
+                            withName:@"basic_text"
+                                type:@"text"]).toNot.beNil();
+            
+            // Enhanced Query Syntax - logical operators must be uppercase otherwise they will
+            // be treated as a search token
+            NSDictionary* query = @{ @"$text" : @{@"$search" : @"Remus OR Romulus"} };
+            CDTQResultSet* result = [im find:query];
+            expect(result.documentIds).to.containAllElements(@[ @"fred34", @"mike72" ]);
+        });
+        
+        it(@"can perform text search using enhanced query syntax NOT operator", ^{
+            expect([im ensureIndexed:@[ @"comment" ]
+                            withName:@"basic_text"
+                                type:@"text"]).toNot.beNil();
+            
+            // Enhanced Query Syntax - logical operators must be uppercase otherwise they will
+            // be treated as a search token
+            // - NOT operator only works between tokens as in (token1 NOT token2)
+            NSDictionary* query = @{ @"$text" : @{@"$search" : @"Remus NOT Romulus"} };
+            CDTQResultSet* result = [im find:query];
+            expect(result.documentIds).to.containAllElements(@[ @"mike72" ]);
+        });
+        
+        it(@"can perform text search using enhanced query syntax with parentheses", ^{
+            expect([im ensureIndexed:@[ @"comment" ]
+                            withName:@"basic_text"
+                                type:@"text"]).toNot.beNil();
+            
+            // Parentheses are used to override SQLite enhanced query syntax operator precedence
+            // - Operator precedence is NOT -> AND -> OR
+            NSDictionary* query = @{ @"$text" : @{@"$search" : @"(Remus OR Romulus) "
+                                                               @"AND \"lives next door\""} };
+            CDTQResultSet* result = [im find:query];
+            expect(result.documentIds).to.containAllElements(@[ @"fred34" ]);
+        });
+        
+        it(@"can perform text search using NEAR operator", ^{
+            expect([im ensureIndexed:@[ @"comment" ]
+                            withName:@"basic_text"
+                                type:@"text"]).toNot.beNil();
+            
+            // NEAR provides the ability to search for terms/phrases in proximity to each other
+            // - By specifying a value for NEAR as in NEAR/2 you can define the range of proximity.
+            //   If left out it defaults to 10
+            NSDictionary* query = @{ @"$text" : @{@"$search" : @"\"he lives\" NEAR/2 Bristol" } };
+            CDTQResultSet* result = [im find:query];
+            expect(result.documentIds).to.containAllElements(@[ @"mike12", @"fred12" ]);
+        });
+        
+        it(@"is case insensitive when using the default tokenizer", ^{
+            expect([im ensureIndexed:@[ @"comment" ]
+                            withName:@"basic_text"
+                                type:@"text"]).toNot.beNil();
+            
+            // Search is generally case-insensitive unless a custom tokenizer is provided
+            NSDictionary* query = @{ @"$text" : @{@"$search" : @"rEmUs RoMuLuS" } };
+            CDTQResultSet* result = [im find:query];
+            expect(result.documentIds).to.containAllElements(@[ @"fred34" ]);
+        });
+        
+        it(@"treats non-string field as a string when performing a text search", ^{
+            expect([im ensureIndexed:@[ @"age" ]
+                            withName:@"basic_text"
+                                type:@"text"]).toNot.beNil();
+            
+            NSDictionary* query = @{ @"$text" : @{@"$search" : @"12" } };
+            CDTQResultSet* result = [im find:query];
+            expect(result.documentIds).to.containAllElements(@[ @"mike12", @"fred12" ]);
+        });
+        
+        it(@"returns nil when text search criteria is not a string", ^{
+            expect([im ensureIndexed:@[ @"age" ]
+                            withName:@"basic_text"
+                                type:@"text"]).toNot.beNil();
+            
+            NSDictionary* query = @{ @"$text" : @{@"$search" : @12 } };
+            expect([im find:query]).to.beNil();
+        });
+        
+        it(@"can perform a text search across multiple fields", ^{
+            expect([im ensureIndexed:@[ @"name", @"comment" ]
+                            withName:@"basic_text"
+                                type:@"text"]).toNot.beNil();
+            
+            // Will find fred12 and fred34 as well as mike12 since Fred is also mentioned
+            // in mike12's comment
+            NSDictionary* query = @{ @"$text" : @{@"$search" : @"Fred" } };
+            CDTQResultSet* result = [im find:query];
+            expect(result.documentIds).to.containAllElements(@[ @"mike12", @"fred12", @"fred34" ]);
+        });
+        
+        it(@"can perform a text search targeting specific fields", ^{
+            expect([im ensureIndexed:@[ @"name", @"comment" ]
+                            withName:@"basic_text"
+                                type:@"text"]).toNot.beNil();
+            
+            // Will only find fred12 since he is the only named fred who's comment
+            // states that he "lives in Bristol"
+            NSDictionary* query = @{ @"$text" : @{@"$search" : @"name:fred "
+                                                               @"comment:lives in Bristol" } };
+            CDTQResultSet* result = [im find:query];
+            expect(result.documentIds).to.containAllElements(@[ @"fred12" ]);
+        });
+        
+        it(@"can perform a text search using prefix searches", ^{
+            expect([im ensureIndexed:@[ @"comment" ]
+                            withName:@"basic_text"
+                                type:@"text"]).toNot.beNil();
+            
+            NSDictionary* query = @{ @"$text" : @{@"$search" : @"liv* riv*" } };
+            CDTQResultSet* result = [im find:query];
+            expect(result.documentIds).to.containAllElements(@[ @"mike34" ]);
+        });
+        
+        it(@"retuns empty result set when missing wildcards in prefix searches", ^{
+            expect([im ensureIndexed:@[ @"comment" ]
+                            withName:@"basic_text"
+                                type:@"text"]).toNot.beNil();
+            
+            NSDictionary* query = @{ @"$text" : @{@"$search" : @"liv riv" } };
+            CDTQResultSet* result = [im find:query];
+            expect(result).toNot.beNil();
+            expect(result.documentIds.count).to.equal(0);
+        });
+        
+        it(@"can perform a text search using ID", ^{
+            expect([im ensureIndexed:@[ @"comment" ]
+                            withName:@"basic_text"
+                                type:@"text"]).toNot.beNil();
+            
+            NSDictionary* query = @{ @"$text" : @{@"$search" : @"_id:mike*" } };
+            CDTQResultSet* result = [im find:query];
+            expect(result.documentIds).to.containAllElements(@[ @"mike12", @"mike34", @"mike72" ]);
+        });
+        
+        it(@"can perform a text search using the Porter tokenizer stemmer", ^{
+            expect([im ensureIndexed:@[ @"comment" ]
+                            withName:@"basic_text"
+                                type:@"text"
+                            settings:@{ @"tokenize" : @"porter" }]).toNot.beNil();
+            
+            NSDictionary* query = @{ @"$text" : @{@"$search" : @"retire memory" } };
+            CDTQResultSet* result = [im find:query];
+            expect(result.documentIds).to.containAllElements(@[ @"mike72" ]);
+        });
+        
+        it(@"returns empty result set when using default tokenizer stemmer", ^{
+            expect([im ensureIndexed:@[ @"comment" ]
+                            withName:@"basic_text"
+                                type:@"text"]).toNot.beNil();
+            
+            NSDictionary* query = @{ @"$text" : @{@"$search" : @"retire memory" } };
+            CDTQResultSet* result = [im find:query];
+            expect(result).toNot.beNil();
+            expect(result.documentIds.count).to.equal(0);
+        });
+
+    });
+    
+});
+
+SpecEnd


### PR DESCRIPTION
_What_

Add unit tests for work included in PR https://github.com/cloudant/CDTDatastore/pull/141 and enable full text search functionality.

_Why_

Tests are needed to validate and exercise the full text search query code.

_How_

Add validation tests to CDTQQuerySqlTranslatorTests
Add translation tests to CDTQQuerySqlTranslatorTests
Create a CDTQTextSearchTests and add text search query execution tests to the class
Enable full text search functionality via the validator.

reviewer @mikerhodes 
reviewer @rhyshort

BugId: 46821