### PR TITLE
Add ensureIndexed methods to datastore interface

### DIFF
--- a/Classes/common/query/CDTDatastore+Query.h
+++ b/Classes/common/query/CDTDatastore+Query.h
@@ -57,6 +57,39 @@
  */
 - (NSString *)ensureIndexed:(NSArray * /* NSString */)fieldNames
                    withName:(NSString *)indexName;
+/**
+ Create a new index based on an index type over a set of fields.
+ 
+ Index type can be either "json" or "text".  A TEXT index provides
+ the ability to perform text searches.
+ */
+- (NSString *)ensureIndexed:(NSArray * /* NSString */)fieldNames
+                   withName:(NSString *)indexName
+                       type:(NSString *)type;
+
+/**
+ Create a new index based on an index type with specific index 
+ settings over a set of fields.
+ 
+ Index settings currenly only apply to a TEXT index.
+ 
+ An example:
+ 
+ Where ds is your datastore and fields is an array of fieldnames...
+ 
+ [ds ensureIndexed: fields 
+          withName: @"text_idx"
+              type: @"text" 
+          settings: @{ @"tokenize": @"porter" }]
+ 
+ This will create a TEXT index named text_idx and override the
+ default tokenizer used to construct the TEXT index with the
+ "porter" algorithm tokenizer.
+ */
+- (NSString *)ensureIndexed:(NSArray * /* NSString */)fieldNames
+                   withName:(NSString *)indexName
+                       type:(NSString *)type
+                   settings:(NSDictionary *)indexSettings;
 
 /**
  Delete an index.
@@ -88,8 +121,8 @@
 /**
  Find document matching a query.
  
- See https://github.com/cloudant/CloudantQueryObjc for details of the
- query syntax and option meanings.
+ See https://github.com/cloudant/CDTDatastore/blob/master/doc/query.md 
+ for details of the query syntax and option meanings.
  
  Failures during query (e.g., invalid query) are logged rather than
  error being returned.

--- a/Classes/common/query/CDTDatastore+Query.h
+++ b/Classes/common/query/CDTDatastore+Query.h
@@ -26,6 +26,14 @@
 @interface CDTDatastore (Query)
 
 /**
+ Check to see if SQLite is compiled with the necessary compile options
+ to support full text search.
+ 
+ @return whether text search is available
+ */
+@property (nonatomic, readonly, getter = isTextSearchEnabled) BOOL textSearchEnabled;
+
+/**
  Return a list of the indexes defined.
  
  This is returned in a dictionary structure:

--- a/Classes/common/query/CDTDatastore+Query.m
+++ b/Classes/common/query/CDTDatastore+Query.m
@@ -44,6 +44,24 @@
     return [self.CDTQManager ensureIndexed:fieldNames withName:indexName];
 }
 
+- (NSString *)ensureIndexed:(NSArray *)fieldNames
+                   withName:(NSString *)indexName
+                       type:(NSString *)type
+{
+    return [self.CDTQManager ensureIndexed:fieldNames withName:indexName type:type];
+}
+
+- (NSString *)ensureIndexed:(NSArray *)fieldNames
+                   withName:(NSString *)indexName
+                       type:(NSString *)type
+                   settings:(NSDictionary *)indexSettings
+{
+    return [self.CDTQManager ensureIndexed:fieldNames
+                                  withName:indexName
+                                      type:type
+                                  settings:indexSettings];
+}
+
 - (CDTQResultSet *)find:(NSDictionary *)query
 {
     return [self.CDTQManager find:query];

--- a/Classes/common/query/CDTDatastore+Query.m
+++ b/Classes/common/query/CDTDatastore+Query.m
@@ -34,6 +34,11 @@
     return objc_getAssociatedObject(self, @selector(CDTQManager));
 }
 
+- (BOOL)isTextSearchEnabled
+{
+    return [self.CDTQManager isTextSearchEnabled];
+}
+
 - (NSDictionary *)listIndexes
 {
     return [self.CDTQManager listIndexes];

--- a/Tests/Tests/CDTDatastoreQueryTests.m
+++ b/Tests/Tests/CDTDatastoreQueryTests.m
@@ -113,6 +113,24 @@ SpecBegin(CDTDatastoreQuery) describe(@"When using datastore query", ^{
         [ds createDocumentFromRevision:rev error:nil];
         expect([ds updateAllIndexes]).to.beTruthy();
     });
+    
+    it(@"can create a text index", ^{
+        NSString *indexName = [ds ensureIndexed:@[ @"name" ] withName:@"text_idx" type:@"text"];
+        expect(indexName).to.equal(@"text_idx");
+    });
+    
+    it(@"can create a text index with defined settings", ^{
+        NSString *indexName = [ds ensureIndexed:@[ @"name" ]
+                                       withName:@"text_idx"
+                                           type:@"text"
+                                       settings:@{@"tokenize": @"porter"}];
+        expect(indexName).to.equal(@"text_idx");
+    });
+    
+    it(@"can check if text search is enabled", ^{
+        expect([ds isTextSearchEnabled]).to.equal(@YES);
+    });
+    
 });
 
 SpecEnd


### PR DESCRIPTION
_What_

The CDTDatastore+Query category is missing ensureIndexed methods that allow a developer to specify index type and index settings.  These methods need to be visible to the developer.

_Why_

In order to allow developers to utilize text search functionality they must have the ability to create TEXT indexes.  Without these additional methods, it is unclear as to how this can be done.

_How_ 

Add the following methods to CDTDatastore+Query

```objc
- (NSString *)ensureIndexed:(NSArray * /* NSString */)fieldNames
                   withName:(NSString *)indexName
                       type:(NSString *)type;
...
- (NSString *)ensureIndexed:(NSArray * /* NSString */)fieldNames
                   withName:(NSString *)indexName
                       type:(NSString *)type
                   settings:(NSDictionary *)indexSettings;
```

reviewer @mikerhodes 
reviewer @rhyshort 

BugId: 47232