### PR TITLE
Add query text search documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.17.0 (Unreleased)
 
 - [REMOVE] The previous indexing/query legacy code has been removed.
+- [NEW] Added query text search support.  See [query documentation](https://github.com/cloudant/CDTDatastore/blob/master/doc/query.md) for details.
 
 ## 0.16.0 (2015-04-09)
 

--- a/doc/query.md
+++ b/doc/query.md
@@ -3,9 +3,12 @@
 Cloudant Query is inspired by MongoDB's query implementation, so users of MongoDB should feel
 at home using it in their mobile applications.
 
-The aim is that the query you use on Cloudant works for your mobile application.
+The aim is that the query you use on our cloud-based database works
+for your mobile application.
 
 ## Usage
+
+These notes assume familiarity with Cloudant Sync Datastore.
 
 This query engine uses indexes explicitly defined over the fields in the document. Multiple
 indexes can be created for use in different queries, the same field may end up indexed in
@@ -37,15 +40,18 @@ Secondly, these documents are in the datastore:
 ```objc
 @{ @"name": @"mike", 
    @"age": @12, 
-   @"pet": @{@"species": @"cat"} };
+   @"pet": @{@"species": @"cat"},
+   @"comment": @"Mike goes to middle school and likes reading books." };
 
 @{ @"name": @"mike", 
    @"age": @34, 
-   @"pet": @{@"species": @"dog"} };
+   @"pet": @{@"species": @"dog"},
+   @"comment": @"Mike is a doctor and likes reading books." };
 
 @{ @"name": @"fred", 
    @"age": @23, 
-   @"pet": @{@"species": @"cat"} };
+   @"pet": @{@"species": @"cat"},
+   @"comment": @"Fred works for a startup out of his home office." };
 ```
 
 ### Headers
@@ -62,23 +68,73 @@ The `CDTDatastore+Query` category adds the ability to manage query indexes and e
 
 ### Creating indexes
 
-In order to query documents, indexes need to be created over
-the fields to be queried against.
+In order to query documents, creating indexes over
+the fields to be queried against will typically enhance query 
+performance.  Currently we support two types of indexes.  The 
+first, a JSON index, is used by query clauses containing 
+comparison operators like `$eq`, `$lt`, and `$gt`.  Query clauses 
+containing these operators are based on standard SQLite indexes to 
+provide query results.  The second, a TEXT index, uses SQLite's 
+full text search (FTS) engine.  A query clause containing a 
+`$text` operator with a `$search` operator uses 
+[SQLite FTS SQL syntax][ftsHome] along with a TEXT index to 
+provide query results.
 
-Use `-ensureIndexed:withName:` to create indexes. These indexes are persistent
-across application restarts as they are saved to disk. They are kept up to date
-documents change; there's no need to call `-ensureIndexed:withName:` each
-time your applications starts, though there is no harm in doing so.
+Basic querying of fields benefits but does _not require_ a JSON 
+index. For example, `@{ @"name" : @{ @"$eq" : @"mike" } }` would 
+benefit from a JSON index on the `name` field but would succeed 
+even if there isn't an index on `name`. Text queries, by contrast, 
+_require_ an index. Therefore `@{ @"$text" : @{ @"$search" : @"doctor books" } }` would need a TEXT index on the `comment` 
+field (based on the content of the above documents).  A TEXT index 
+is used to perform term searches, phrase searches and prefix 
+searches (starts with... queries). Querying capabilities and 
+syntax are covered later in this document.
 
-The first argument to `-ensureIndexed:withName:` is a list of fields to
-put into this index. The second argument is a name for the index. This is used
-to delete indexes at a later stage and appears when you list the indexes
-in the database.
+[ftsHome]: http://www.sqlite.org/fts3.html#section_3
 
-A field can appear in more than one index. The query engine will select an
-appropriate index to use for a given query. However, the more indexes you have,
-the more disk space they will use and the greater overhead in keeping them
-up to date.
+Use the following methods to create a JSON index:
+
+```objc
+-(NSString *)ensureIndexed:(NSArray *)fieldNames 
+                  withName:(NSString *)indexName
+```
+
+Use either of the following methods to create a TEXT index:
+
+```objc
+-(NSString *)ensureIndexed:(NSArray *)fieldNames
+                  withName:(NSString *)indexName
+                      type:(NSString *)type
+
+// or 
+
+-(NSString *)ensureIndexed:(NSArray *)fieldNames
+                  withName:(NSString *)indexName
+                      type:(NSString *)type
+                  settings:(NSDictionary *)indexSettings
+```
+
+These indexes are persistent across application restarts as they 
+are saved to disk. They are kept up to date as documents change; 
+there's no need to call the `-ensureIndexed:...` method each time 
+your applications starts, though there is no harm in doing so.
+
+The first argument, `fieldNames`, is an array of fields to put into 
+the index. The second argument, `indexName`, is a name for the 
+index. This is used to delete indexes at a later stage and appears 
+when you list the indexes in the database.  The third argument, 
+`type`, defines what type of index to create.  Valid index 
+types are `json` and `text`.  If not provided, the index type 
+defaults to `json`.  The fourth argument, `indexSettings`, is 
+comprised of index parameters and their values.  Currently the 
+only valid index setting is `tokenize` and it can only apply to a 
+TEXT index.  If index settings are not provided for a TEXT index, 
+the `tokenize` parameter defaults to the value `simple`.
+
+A field can appear in more than one index. The query engine will 
+select an appropriate index to use for a given query. However, the 
+more indexes you have, the more disk space they will use and the 
+greater the overhead in keeping them up to date.
 
 To index values in sub-documents, use _dotted notation_. This notation puts
 the field names in the path to a particular value into a single string,
@@ -94,11 +150,81 @@ if (!name) {
 }
 ```
 
-`-ensureIndexed:withName:` returns the name of the index if it is successful,
-otherwise it returns `nil`.
+####Indexing for text search
 
-If an index needs to be changed, first delete the existing index, then call 
-`-ensureIndexed:withName:` with the new definition.
+Since text search relies on SQLite FTS, which is a compile time option, we must ensure that SQLite FTS is available.  To verify that text search is enabled and that a text index can be created use `-isTextSearchEnabled` before attempting to create a text index.  If text search is not enabled see [compiling and enabling SQLite FTS][enableFTS] for details. 
+
+[enableFTS]: http://www.sqlite.org/fts3.html#section_2
+
+```objc
+if ([ds isTextSearchEnabled]) {
+    // Create a text index over the name and comment fields.
+    NSString *name = [ds ensureIndexed:@[@"name", @"comment"]
+                              withName:@"basic_text_index"
+                                  type:@"text"];
+    if (name == nil) {
+        // there was an error creating the index
+    }
+}
+```
+
+Because text indexing relies on SQLite FTS functionality, any custom tokenizers need to be managed through SQLite.  SQLite comes standard with the "simple" default tokenizer as well as a Porter stemming algorithm tokenizer ("porter").  Please refer to [SQLite FTS tokenizers][fts] for additional information on custom tokenizers.
+
+[fts]: http://www.sqlite.org/fts3.html#tokenizer  
+
+When creating a text index, overriding the default tokenizer setting is done by providing a `tokenize` parameter setting as part of the index settings.  The value should be the same as the tokenizer name given to SQLite when registering that tokenizer.  In the example below we set the tokenizer to `porter`.
+
+```objc
+if ([ds isTextSearchEnabled]) {
+    Map<String, String> settings = new HashMap<String, String>();
+    settings.add("tokenize", "porter");
+    // Create a text index over the name and comment fields.
+    // Setting the tokenizer to "porter".
+    NSString *name = [ds ensureIndexed:@[@"name", @"comment"]
+                              withName:@"basic_text_index"
+                                  type:@"text"
+                              settings:@{@"tokenize": @"porter"}];
+    if (name == null) {
+        // there was an error creating the index
+    }
+}
+```
+
+The `-ensureIndexed:...` methods returns the name of the index if 
+it is successful, otherwise they returns `nil`.
+
+##### Restrictions
+
+- There is a limit of one text index per datastore.
+- Text indexes cannot be created on field names containing an `=` 
+sign. This is due to restrictions imposed by SQLite's virtual table syntax.
+
+####Viewing index definitions
+
+Use `-listIndexes` to retrieve a dictionary containing all of the query indexes in a datastore.  The key to the dictionary is the index name.
+
+The format of the dictionary returned by `-listinidexes` is:
+
+```objc
+@{ @"jsonIdxName": @{ @"fields": @[ @"field1", @"field2" ],
+                      @"type": @"json",
+                      @"name": @"jsonIdxName" },
+   
+   @"textIdxName": @{ @"fields": @[ @"field1", @"field2" ],
+                      @"type": @"text",
+                      @"name": @"textIdxName",
+                      @"settings": @"{tokenize: simple}"  },
+       ...
+ }
+```
+
+Note:  `settings` are returned as a JSON string.
+
+####Changing and removing indexes
+
+If an index needs to be changed, first delete the existing index 
+by calling `-deleteIndexNamed:` and provide the index name of the index to be deleted, then call the appropriate 
+`-ensureIndexed:...` method with the new definition.
 
 #### Indexing document metadata (_id and _rev)
 
@@ -137,6 +263,77 @@ To query for documents where `age` is greater than twelve use the `$gt` conditio
 ```
 
 See below for supported operators (Selections -> Conditions).
+
+#### Text search
+
+After creating a text index, a text clause may be used as part of 
+a query to perform full text search term matching, phrase 
+matching, and prefix matching.  A text clause can stand on its own 
+as a query or can be part of a compound query (see below).  Text 
+search supports either SQLite [Standard Query Syntax][ftsStandard] 
+or [Enhanced Query Syntax][ftsEnhanced].  This is dependent on 
+which syntax is enabled as part of SQLite FTS.  Typically SQLite 
+FTS on iOS comes configured with the SQLite Enhanced Query Syntax 
+(confirmed during testing on iOS 7.1, 8.1, 8.2 and 8.3).  See [SQLite 
+full text query][ftsQuery] for more details on syntax that is 
+possible with text search.
+
+[ftsQuery]: http://www.sqlite.org/fts3.html#section_3
+[ftsStandard]: http://www.sqlite.org/fts3.html#section_3_1
+[ftsEnhanced]: http://www.sqlite.org/fts3.html#section_3_2
+
+##### Restrictions
+
+- Only one text clause per query is permitted.
+- All clauses in a query must be satisfied by an index if that query contains a text search clause.
+- Both tokenizers, `simple` and `porter`, that come with text search by default are case-insensitive.
+
+To find documents that include all of the terms in `doctor books` use:
+
+```objc         
+NSDictionary *query = @{@"$text": @{@"$search": @"doctor books" }};
+```
+
+This query will match the following document because both `doctor` and `books` are found in its comment field.
+
+```objc
+@{ @"name": @"mike", 
+   @"age": @34, 
+   @"pet": @{@"species": @"dog"},
+   @"comment": @"Mike is a doctor and likes reading books." };
+```
+
+To find documents that include the phrase `is a doctor` use:
+
+```objc  
+NSDictionary *query = @{@"$text": @{@"$search": @"\"is a doctor\"" }};
+```
+
+This query will match the following document because the phrase `is a doctor` is found in its comment field.
+
+```objc
+@{ @"name": @"mike", 
+   @"age": @34, 
+   @"pet": @{@"species": @"dog"},
+   @"comment": @"Mike is a doctor and likes reading books." };
+```
+
+To find documents that include the prefix `doc` use:
+
+```objc              
+NSDictionary *query = @{@"$text": @{@"$search": @"doc*" }};
+```
+
+This query will match the following document because the prefix `doc` followed by the `*` wildcard matches `doctor` found in its comment field.
+
+```objc
+@{ @"name": @"mike", 
+   @"age": @34, 
+   @"pet": @{@"species": @"dog"},
+   @"comment": @"Mike is a doctor and likes reading books." };
+```
+
+These examples are a small sample of what can be done using text search.  Take a look at the [SQLite full text query][ftsQuery] documentation for more details.
 
 #### Compound queries
 
@@ -375,6 +572,7 @@ Right now the list of supported features is:
 - Limiting returned results.
 - Skipping results.
 - Queries can include unindexed fields.
+- Queries can include a text search clause, although if they do no unindexed fields may be used.
       
 Selectors -> combination
 
@@ -397,6 +595,10 @@ Selectors -> combination
 Selectors -> Condition -> Objects
 
 - `$exists`
+
+Selectors -> Condition -> Misc
+
+- `$text` in combination with `$search`
 
 Selectors -> Condition -> Array
 
@@ -511,6 +713,7 @@ Here:
 <em>expression</em> := 
     <em>compound-expression</em>
     <em>comparison-expression</em>
+    <em>text-search-expression</em>
 
 <em>compound-expression</em> := 
     <strong>{</strong> (&quot;$and&quot; | &quot;$nor&quot; | &quot;$or&quot;) <strong>:</strong> <strong>[</strong> <em>many-expressions</em> <strong>] }</strong>  // nor not implemented
@@ -534,6 +737,9 @@ Here:
     <strong>{</strong> &quot;$exists&quot; <strong>:</strong> <em>boolean</em> <strong>}</strong>
     <strong>{</strong> &quot;$type&quot; <strong>:</strong> <em>type</em> <strong>}</strong>  // not implemented
 
+<em>text-search-expression</em> :=     
+    <strong>{</strong> &quot;$text&quot; <strong>:</strong><strong> {</strong> &quot;$search&quot; <strong>:</strong> <em>string-value</em> <strong>}</strong> <strong>}</strong>
+
 <em>operator</em> := &quot;$gt&quot; | &quot;$gte&quot; | &quot;$lt&quot; | &quot;$lte&quot; | &quot;$eq&quot; | &quot;$ne&quot;
 
 // Obviously NSArray, but easier to express like this
@@ -544,6 +750,8 @@ Here:
 <em>field</em> := <em>NSString</em>  // a field name
 
 <em>simple-value</em> := <em>NSString</em> | <em>NSNumber</em>
+
+<em>string-value</em> := <em>NSString</em>
 
 <em>positive-integer</em> := <em>NSNumber</em>
 


### PR DESCRIPTION
_What_

Update query documentation to include details for text search support.

_Why_

Text search support was recently added to Query. We need to provide developers with documentation that assists them in using Query Text Search.

_How_

Add text search content to query.md

reviewer @mikerhodes 
reviewer @gadamc

BugID: 46163