### PR TITLE
Relax FTS availability check to support both standard and enhanced query syntax

### DIFF
--- a/Classes/common/query/CDTQIndexManager.m
+++ b/Classes/common/query/CDTQIndexManager.m
@@ -379,8 +379,7 @@ static const int VERSION = 2;
     __block BOOL ftsOptionsExist = NO;
     
     [db inDatabase:^(FMDatabase *db) {
-        NSMutableArray *ftsCompileOptions =
-            [NSMutableArray arrayWithArray:@[ @"ENABLE_FTS3", @"ENABLE_FTS3_PARENTHESIS" ] ];
+        NSMutableArray *ftsCompileOptions = [NSMutableArray arrayWithArray:@[ @"ENABLE_FTS3" ] ];
         FMResultSet *rs = [db executeQuery:@"PRAGMA compile_options;"];
         while ([rs next]) {
             NSString *compileOption = [rs stringForColumnIndex:0];


### PR DESCRIPTION
_What_

This PR changes the check for full text search availability in SQLite to include support for either query syntax.

_Why_

Currently, if FTS is available with standard query syntax the FTS availability check will not allow a text index to be created.  This restriction needs to be relaxed so that text search can be used regardless of which query syntax is currently supported by SQLite.

_How_

Remove the check for the `ENABLE_FTS3_PARENTHESIS` compile option and leave only the `ENABLE_FTS3` compile option check.

reviewer @mikerhodes 
reviewer @rhyshort 

BugId: 47321