### PR TITLE
Add $mod operator support to Query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [REMOVE] The previous indexing/query legacy code has been removed.
 - [NEW] Added query text search support.  See [query documentation](https://github.com/cloudant/CDTDatastore/blob/master/doc/query.md) for details.
+- [NEW] Added query support for the `$mod` operator.
 
 ## 0.16.0 (2015-04-09)
 

--- a/Classes/common/query/CDTQQueryConstants.h
+++ b/Classes/common/query/CDTQQueryConstants.h
@@ -39,3 +39,5 @@ extern NSString *const IN;
 extern NSString *const NIN;
 
 extern NSString *const SEARCH;
+
+extern NSString *const MOD;

--- a/Classes/common/query/CDTQQueryConstants.m
+++ b/Classes/common/query/CDTQQueryConstants.m
@@ -41,3 +41,5 @@ NSString *const IN = @"$in";
 NSString *const NIN = @"$nin";
 
 NSString *const SEARCH = @"$search";
+
+NSString *const MOD = @"$mod";

--- a/Classes/common/query/CDTQQuerySqlTranslator.m
+++ b/Classes/common/query/CDTQQuerySqlTranslator.m
@@ -368,7 +368,8 @@
         GTE : @">=",
         LT : @"<",
         LTE : @"<=",
-        IN : @"IN"
+        IN : @"IN",
+        MOD : @"%"
     };
 
     for (NSDictionary *component in clause) {
@@ -421,6 +422,13 @@
                     placeholder =
                         [CDTQQuerySqlTranslator placeholdersForList:inList
                                             updatingParameterValues:sqlParameters];
+                } else if ([operator isEqualToString:MOD]) {
+                    // The predicate dictionary value must be a two element NSArray
+                    // containing numbers here.  This was validated during normalization.
+                    NSArray *modulus = negatedPredicate[operator];
+                    placeholder = [NSString stringWithFormat:@"? %@ ?", operatorMap[EQ]];
+                    [sqlParameters addObject:modulus[0]];
+                    [sqlParameters addObject:modulus[1]];
                 } else {
                     // The predicate dictionary value must be either a
                     // NSString or a NSNumber here.
@@ -454,6 +462,13 @@
                     placeholder =
                         [CDTQQuerySqlTranslator placeholdersForList:inList
                                             updatingParameterValues:sqlParameters];
+                } else if ([operator isEqualToString:MOD]) {
+                    // The predicate dictionary value must be a two element NSArray
+                    // containing numbers here.  This was validated during normalization.
+                    NSArray *modulus = predicate[operator];
+                    placeholder = [NSString stringWithFormat:@"? %@ ?", operatorMap[EQ]];
+                    [sqlParameters addObject:modulus[0]];
+                    [sqlParameters addObject:modulus[1]];
                 } else {
                     NSObject * predicateValue = predicate[operator];
                     placeholder = @"?";

--- a/Tests/Tests/CDTQUnindexedMatcherTests.m
+++ b/Tests/Tests/CDTQUnindexedMatcherTests.m
@@ -349,6 +349,129 @@ describe(@"matches", ^{
                 expect([matcher matches:rev]).to.beFalsy();
             });
         });
+        
+        context(@"mod", ^{
+            it(@"matches when using int divisor", ^{
+                NSDictionary *selector =
+                    [CDTQQueryValidator normaliseAndValidateQuery:@{@"age": @{@"$mod": @[@3, @1]}}];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beTruthy();
+            });
+            
+            it(@"matches when using a negative divisor", ^{
+                NSDictionary *selector =
+                [CDTQQueryValidator normaliseAndValidateQuery:@{@"age": @{@"$mod": @[@-3, @1]}}];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beTruthy();
+            });
+            
+            it(@"matches by rounding down a double divisor", ^{
+                NSDictionary *selector =
+                    [CDTQQueryValidator normaliseAndValidateQuery:@{@"age": @{@"$mod": @[@(3.6),
+                                                                                         @(1.0)]}}];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beTruthy();
+                
+                selector = nil;
+                matcher = nil;
+                selector =
+                    [CDTQQueryValidator normaliseAndValidateQuery:@{@"age": @{@"$mod": @[@(3.2),
+                                                                                         @(1.0)]}}];
+                matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beTruthy();
+            });
+            
+            it(@"correctly does not match when using an int divisor", ^{
+                NSDictionary *selector =
+                [CDTQQueryValidator normaliseAndValidateQuery:@{@"age": @{@"$mod": @[@3, @2]}}];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beFalsy();
+            });
+            
+            it(@"correctly does not match when using a negative divisor", ^{
+                NSDictionary *selector =
+                [CDTQQueryValidator normaliseAndValidateQuery:@{@"age": @{@"$mod": @[@-3, @2]}}];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beFalsy();
+            });
+            
+            it(@"correctly does not match when using a negative remainder", ^{
+                NSDictionary *selector =
+                [CDTQQueryValidator normaliseAndValidateQuery:@{@"age": @{@"$mod": @[@-3, @-1]}}];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beFalsy();
+            });
+            
+            it(@"correctly does not match when using a double divisor", ^{
+                NSDictionary *selector =
+                [CDTQQueryValidator normaliseAndValidateQuery:@{@"age": @{@"$mod": @[@(3.6),
+                                                                                     @(2.0)]}}];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beFalsy();
+                
+                selector = nil;
+                matcher = nil;
+                selector =
+                [CDTQQueryValidator normaliseAndValidateQuery:@{@"age": @{@"$mod": @[@(3.2),
+                                                                                     @(2.0)]}}];
+                matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beFalsy();
+            });
+        });
+        
+        context(@"mod on negative field", ^{
+            
+            __block CDTDocumentRevision *negRev;
+            
+            beforeAll(^{
+                NSDictionary *body = @{
+                                       @"name" : @"phil",
+                                       @"score" : @-15,
+                                       @"pets" : @[ @"white_cat", @"black_cat" ],
+                                       @"address" : @{@"number" : @"1", @"road" : @"infinite loop"}
+                                       };
+                negRev = [[CDTDocumentRevision alloc] initWithDocId:@"dsfsdfdfs"
+                                                         revisionId:@"qweqeqwewqe"
+                                                               body:body
+                                                        attachments:nil];
+            });
+            
+            it(@"matches when using positive int divisor", ^{
+                NSDictionary *selector =
+                [CDTQQueryValidator normaliseAndValidateQuery:@{@"score": @{@"$mod": @[@2, @-1]}}];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:negRev]).to.beTruthy();
+            });
+            
+            it(@"matches when using negative int divisor", ^{
+                NSDictionary *selector =
+                [CDTQQueryValidator normaliseAndValidateQuery:@{@"score": @{@"$mod": @[@-2, @-1]}}];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:negRev]).to.beTruthy();
+            });
+            
+            it(@"correctly does not match when using a positive divisor", ^{
+                NSDictionary *selector =
+                [CDTQQueryValidator normaliseAndValidateQuery:@{@"score": @{@"$mod": @[@3, @1]}}];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:negRev]).to.beFalsy();
+            });
+            
+            it(@"correctly does not match when using a positive remainder", ^{
+                NSDictionary *selector =
+                [CDTQQueryValidator normaliseAndValidateQuery:@{@"score": @{@"$mod": @[@-2, @1]}}];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:negRev]).to.beFalsy();
+            });
+            
+            it(@"correctly does not match when using a negative divisor", ^{
+                NSDictionary *selector =
+                [CDTQQueryValidator normaliseAndValidateQuery:@{@"score": @{@"$mod": @[@-3, @1]}}];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:negRev]).to.beFalsy();
+            });
+            
+        });
     });
 
     context(@"compound", ^{

--- a/doc/query.md
+++ b/doc/query.md
@@ -203,7 +203,7 @@ sign. This is due to restrictions imposed by SQLite's virtual table syntax.
 
 Use `-listIndexes` to retrieve a dictionary containing all of the query indexes in a datastore.  The key to the dictionary is the index name.
 
-The format of the dictionary returned by `-listinidexes` is:
+The format of the dictionary returned by `-listindexes` is:
 
 ```objc
 @{ @"jsonIdxName": @{ @"fields": @[ @"field1", @"field2" ],
@@ -263,6 +263,23 @@ To query for documents where `age` is greater than twelve use the `$gt` conditio
 ```
 
 See below for supported operators (Selections -> Conditions).
+
+#### Modulo operation in queries
+
+Using the `$mod` operator in queries allows you to select documents based on the value of a field divided by an integer yielding a specific remainder.
+
+To query for documents where `age` divided by 5 has a remainder of  4, do the following:
+
+```objc
+@{ @"age": @{ @"$mod": [ @5, @4 ] } }
+```
+
+A few things to keep in mind when using `$mod` are:
+
+- The array argument to the `$mod` operator must contain two number elements. The first element is the divisor and the second element is the remainder.
+- Division by zero is not allowed so the divisor cannot be zero.
+- The dividend (field value), divisor, and the remainder can be positive or negative.
+- The dividend, divisor, and the remainder can be represented as whole numbers or by using decimal notation.  However internally, prior to performing the modulo arithmetic operation, all three are truncated to their logical whole number representations.  So, for example, the query `@{ @"age": @{ @"$mod": [ @5.6, @4.2 ] } }` will provide the same result as the query `@{ @"age": @{ @"$mod": [ @5, @4 ] } }`.
 
 #### Text search
 
@@ -599,6 +616,7 @@ Selectors -> Condition -> Objects
 Selectors -> Condition -> Misc
 
 - `$text` in combination with `$search`
+- `$mod`
 
 Selectors -> Condition -> Array
 
@@ -649,7 +667,6 @@ Selectors -> Condition -> Array
 
 Selectors -> Condition -> Misc
 
-- `$mod`
 - `$regex`
 
 
@@ -728,7 +745,7 @@ Here:
     <em>negation-expression</em>
     <strong>{</strong> <em>operator</em> <strong>:</strong> <em>simple-value</em> <strong>}</strong>
     <strong>{</strong> &quot;$regex&quot; <strong>:</strong> <em>NSRegularExpression</em> <strong>}</strong>  // not implemented
-    <strong>{</strong> &quot;$mod&quot; <strong>:</strong> <strong>[</strong> <em>divisor, remainder</em> <strong>] }</strong>  // not implemented
+    <strong>{</strong> &quot;$mod&quot; <strong>:</strong> <strong>[</strong> <em>non-zero-number, number</em> <strong>] }</strong>
     <strong>{</strong> &quot;$elemMatch&quot; <strong>: {</strong> <em>many-expressions</em> <strong>} }</strong>  // not implemented
     <strong>{</strong> &quot;$size&quot; <strong>:</strong> <em>positive-integer</em> <strong>}</strong>  // not implemented
     <strong>{</strong> &quot;$all&quot; <strong>:</strong> <em>array-value</em> <strong>}</strong>  // not implemented
@@ -752,6 +769,10 @@ Here:
 <em>simple-value</em> := <em>NSString</em> | <em>NSNumber</em>
 
 <em>string-value</em> := <em>NSString</em>
+
+<em>number</em> := <em>NSNumber</em>
+
+<em>non-zero-number</em> := <em>NSNumber</em>
 
 <em>positive-integer</em> := <em>NSNumber</em>
 


### PR DESCRIPTION
_What_

This PR adds support for the `$mod` operator for use in Query.

_Why_

In an effort to provide as much functionality to Query as is available elsewhere (such as MongoDB), we are adding support to the `$mod` operator so that users can write queries containing modulo arithmetic.

_How_

Add logic to the validator code, the SQLtranslator code, and the unindexed matcher code to support the safe use of `$mod` in queries.

_Tests_

- A series of validation tests have been added to CDTQQuerySqlTranslatorTests to exercise argument validation and query normalization for queries containing the `$mod` operator.
- A series of SQL WHERE clause generation tests have been added to CDTQQuerySqlTranslatorTests for queries containing the `$mod` operator.
- A series of execution tests have been added to CDTQQueryExecutorTests to exercise execution by the SQL engine and the unindexed matcher engine for queries containing the `$mod` operator.

reviewer @mikerhodes 
reviewer @gadamc 

BugId: 44632