### PR TITLE
47318 Encrypt attachments

### DIFF
--- a/CDTDatastore.xcworkspace/contents.xcworkspacedata
+++ b/CDTDatastore.xcworkspace/contents.xcworkspacedata
@@ -53,6 +53,12 @@
                <FileRef
                   location = "group:CDTBlobEncryptedData+Internal.h">
                </FileRef>
+               <FileRef
+                  location = "group:CDTBlobHandleFactory.h">
+               </FileRef>
+               <FileRef
+                  location = "group:CDTBlobHandleFactory.m">
+               </FileRef>
             </Group>
             <Group
                location = "group:Keychain"

--- a/CDTDatastore.xcworkspace/contents.xcworkspacedata
+++ b/CDTDatastore.xcworkspace/contents.xcworkspacedata
@@ -39,6 +39,22 @@
             location = "group:Encryption"
             name = "Encryption">
             <Group
+               location = "group:Attachments"
+               name = "Attachments">
+               <FileRef
+                  location = "group:CDTBlobEncryptedData.h">
+               </FileRef>
+               <FileRef
+                  location = "group:CDTBlobEncryptedData.m">
+               </FileRef>
+               <FileRef
+                  location = "group:CDTBlobEncryptedDataConstants.h">
+               </FileRef>
+               <FileRef
+                  location = "group:CDTBlobEncryptedData+Internal.h">
+               </FileRef>
+            </Group>
+            <Group
                location = "group:Keychain"
                name = "Keychain">
                <FileRef

--- a/Classes/common/Attachments/CDTBlobData.h
+++ b/Classes/common/Attachments/CDTBlobData.h
@@ -27,25 +27,13 @@ typedef NS_ENUM(NSInteger, CDTBlobDataError) {
 };
 
 /**
- Use this class to read from/write to an attachment. The data read from an attachment is returned
- as it is, so make sure that the attachment is not encrypted. In the same way, the data provided is
- written to the attachment without further processing.
+ Use this class to read/write an attachment. The data read from an attachment is returned as it is,
+ so make sure that the attachment is not encrypted. In the same way, the data provided is written to
+ disk without further processing.
  
- To accomplish this purpose, this class conforms to 2 related protocols: CDTBlobReader &
- CDTBlobWriter. About CDTBlobWriter:
- 
- - 'openForWriting'.- Call this method before calling 'CDTBlobWriter:appendData:'. The file informed
- during the initialisation is created at this point if it does not exists. If it exists, its content
- is removed.
- - 'isBlobOpenForWriting'.- It will return YES after calling 'CDTBlobWriter:openForWriting' and NO after
- calling 'CDTBlobWriter:close'. By default, a newly initialised blob is closed.
- - 'close'.- Call it after adding all data to the attachment. Notice that this method will not
- delete the file created with 'CDTBlobWriter: openForWriting' if no data is added.
- - 'appendData:'.- It will fail if 'CDTBlobWriter: isBlobOpenForWriting' is false.
- - 'writeEntireBlobWithData:error:'.- This method overwrites the content of the file supplied during the
- initialisation or creates it if it does not exist. However, it will fail if the blob is open.
- 
- And CDTBlobReader:
+ To accomplish this purpose, this class conforms to 2 related protocols: 'CDTBlobReader' &
+ 'CDTBlobWriter'. Notice the beaviour of the methods defined in 'CDTBlobReader' in relation to
+ 'CDTBlobWriter':
  
  - 'dataWithError:'.- It will fail if the blob is open.
  - 'inputStreamWithOutputLength:'.- As the previous method, it will fail if the blob is open.

--- a/Classes/common/Attachments/CDTBlobData.h
+++ b/Classes/common/Attachments/CDTBlobData.h
@@ -22,6 +22,7 @@
 extern NSString *const CDTBlobDataErrorDomain;
 
 typedef NS_ENUM(NSInteger, CDTBlobDataError) {
+    CDTBlobDataErrorNoDataProvided,
     CDTBlobDataErrorOperationNotPossibleIfBlobIsOpen
 };
 
@@ -34,13 +35,15 @@ typedef NS_ENUM(NSInteger, CDTBlobDataError) {
  CDTBlobWriter. About CDTBlobWriter:
  
  - 'openForWriting'.- Call this method before calling 'CDTBlobWriter:appendData:'. The file informed
- during the initialisation must exist on advance or it will fail.
- - 'isBlobOpenForWriting'.- It will return YES after calling 'CDTBlobWriter:openForWriting' and
- NO after calling 'CDTBlobWriter:close'. By default, a newly initialised blob is closed.
- - 'close'.- Call it after adding all data to the attachment.
- - 'appendData:'.- It will fail if 'CDTBlobWriter:isBlobOpenForWriting' is false.
- - 'writeEntireBlobWithData:error:'.- This method overwrites the content of the file supplied during
- the initialisation or creates it if it does not exist. However, it will fail if the blob is open.
+ during the initialisation is created at this point if it does not exists. If it exists, its content
+ is removed.
+ - 'isBlobOpenForWriting'.- It will return YES after calling 'CDTBlobWriter:openForWriting' and NO after
+ calling 'CDTBlobWriter:close'. By default, a newly initialised blob is closed.
+ - 'close'.- Call it after adding all data to the attachment. Notice that this method will not
+ delete the file created with 'CDTBlobWriter: openForWriting' if no data is added.
+ - 'appendData:'.- It will fail if 'CDTBlobWriter: isBlobOpenForWriting' is false.
+ - 'writeEntireBlobWithData:error:'.- This method overwrites the content of the file supplied during the
+ initialisation or creates it if it does not exist. However, it will fail if the blob is open.
  
  And CDTBlobReader:
  

--- a/Classes/common/Attachments/CDTBlobData.m
+++ b/Classes/common/Attachments/CDTBlobData.m
@@ -162,6 +162,12 @@ NSString *const CDTBlobDataErrorDomain = @"CDTBlobDataErrorDomain";
 
 - (BOOL)appendData:(NSData *)data
 {
+    if (!data) {
+        CDTLogDebug(CDTDATASTORE_LOG_CONTEXT, @"Data is nil. No data added to %@", self.path);
+
+        return NO;
+    }
+
     if (![self isBlobOpenForWriting]) {
         CDTLogDebug(CDTDATASTORE_LOG_CONTEXT, @"Blob at %@ is not open. No data can be added",
                     self.path);

--- a/Classes/common/Attachments/CDTBlobData.m
+++ b/Classes/common/Attachments/CDTBlobData.m
@@ -176,7 +176,7 @@ NSString *const CDTBlobDataErrorDomain = @"CDTBlobDataErrorDomain";
 
     self.outFileHandle = [NSFileHandle fileHandleForWritingAtPath:self.path];
 
-    return [self isBlobOpenForWriting];
+    return YES;
 }
 
 - (BOOL)appendData:(NSData *)data

--- a/Classes/common/Attachments/CDTBlobReader.h
+++ b/Classes/common/Attachments/CDTBlobReader.h
@@ -17,7 +17,7 @@
 #import <Foundation/Foundation.h>
 
 /**
- Define the methods to access the content of an attachment without exposing its path.
+ Define methods to access the content of an attachment without exposing its path.
  */
 @protocol CDTBlobReader <NSObject>
 

--- a/Classes/common/Attachments/CDTBlobReader.h
+++ b/Classes/common/Attachments/CDTBlobReader.h
@@ -19,7 +19,7 @@
 /**
  Define the methods to access the content of an attachment without exposing its path.
  */
-@protocol CDTBlobReader
+@protocol CDTBlobReader <NSObject>
 
 /**
  Load the content of an attachment in a NSData instance.

--- a/Classes/common/Attachments/CDTBlobWriter.h
+++ b/Classes/common/Attachments/CDTBlobWriter.h
@@ -17,7 +17,7 @@
 #import <Foundation/Foundation.h>
 
 /**
- Define the methods to store data in an attachment without exposing its path.
+ Define methods to store data in an attachment without exposing its path.
  */
 @protocol CDTBlobWriter <NSObject>
 
@@ -25,8 +25,7 @@
  Overwrite the content of an attachment with the data provided as a parameter. If the file does
  not exist, it will create it.
  
- Notice that this method has to work properly with the other methods defined in this protocol, i.e.
- will it succeed or will it fail if the blob is open?
+ If the blob is open, this method will fail.
  
  @param data Data to store in the attachment
  @param error Output param that will point to an error (if there is any)
@@ -36,12 +35,17 @@
 - (BOOL)writeEntireBlobWithData:(NSData *)data error:(NSError **)error;
 
 /**
+ By default, a blob is closed until it is open.
+ 
  @return YES if the attachment was open before or NO in other case
  */
 - (BOOL)isBlobOpenForWriting;
 
 /**
  Prepare an attachment to write data in it.
+ 
+ If the file does not exist, it will create it now. If the file exists, it will delete the existing
+ content and move the pointer to the begining of the file.
  
  @return YES if the attachment was open (or it was already open) or NO in other case
  */
@@ -50,7 +54,7 @@
 /**
  Add data to the end of the attachment.
  
- Although this protocol does not enforce it, the attachment should be open before adding data.
+ The blob has to be open before calling this method, otherwise it will fail.
  
  @param data Data to append to the attachment
  
@@ -60,6 +64,9 @@
 
 /**
  Use this method to signal that there are no more data to add.
+ 
+ @warning Notice that, even if no data is added to the blob, the file created with
+ 'openBlobToAddData' will not be removed.
  */
 - (void)close;
 

--- a/Classes/common/Encryption/Attachments/CDTBlobEncryptedData+Internal.h
+++ b/Classes/common/Encryption/Attachments/CDTBlobEncryptedData+Internal.h
@@ -16,6 +16,9 @@
 
 #import "CDTBlobEncryptedData.h"
 
+/**
+ This category is only for testing purposes.
+ */
 @interface CDTBlobEncryptedData (Internal)
 
 - (NSData *)generateAESIv;

--- a/Classes/common/Encryption/Attachments/CDTBlobEncryptedData+Internal.h
+++ b/Classes/common/Encryption/Attachments/CDTBlobEncryptedData+Internal.h
@@ -1,0 +1,22 @@
+//
+//  CDTBlobEncryptedData+Internal.h
+//  CloudantSync
+//
+//  Created by Enrique de la Torre Fernandez on 21/05/2015.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#import "CDTBlobEncryptedData.h"
+
+@interface CDTBlobEncryptedData (Internal)
+
+- (NSData *)generateAESIv;
+
+@end

--- a/Classes/common/Encryption/Attachments/CDTBlobEncryptedData.h
+++ b/Classes/common/Encryption/Attachments/CDTBlobEncryptedData.h
@@ -29,6 +29,39 @@ typedef NS_ENUM(NSInteger, CDTBlobEncryptedDataError) {
     CDTBlobEncryptedDataErrorNoDataProvided
 };
 
+/**
+ Use this class to read/write an encrypted attachment.
+ 
+ An attachment has the following structure:
+ 
+ --------------------------------------------------------------------------
+ |  Version - 1-byte  |  IV - 16-bytes |          Encrypted blob          |
+ --------------------------------------------------------------------------
+ |                  header             |              body                |
+ --------------------------------------------------------------------------
+ 
+ As its counterpart 'CDTBlobData', this class conforms to protocols 'CDTBlobReader' &
+ 'CDTBlobWriter'. Notice the beaviour of the methods defined in 'CDTBlobReader' in relation to
+ 'CDTBlobWriter':
+ 
+ - 'dataWithError:'.- It will fail if the blob is open.
+ - 'inputStreamWithOutputLength:'.- As the previous method, it will fail if the blob is open.
+ 
+ Also, notice some details about the methods defined in 'CDTBlobWriter':
+ 
+ - 'dataWithError:'.- An encrypted attachment will always have a header but it might not have a
+ body. In that case, this method will return an empty 'NSData' instance and no error will be
+ returned.
+ - 'createBlobWithData:error:'.- If the data passed to this method is an empty 'NSData' instance,
+ it will create an attachment with a header but not a body.
+ - 'openBlobToAddData'.- As decribed in the documentation for this protocol, this method will create
+ a file or it will delete the existing content. This implementation will also add a header to the
+ file.
+ 
+ @see CDTBlobData
+ @see CDTBlobReader
+ @see CDTBlobWriter
+ */
 @interface CDTBlobEncryptedData : NSObject <CDTBlobReader, CDTBlobWriter>
 
 - (instancetype)init UNAVAILABLE_ATTRIBUTE;

--- a/Classes/common/Encryption/Attachments/CDTBlobEncryptedData.h
+++ b/Classes/common/Encryption/Attachments/CDTBlobEncryptedData.h
@@ -1,0 +1,41 @@
+//
+//  CDTBlobEncryptedData.h
+//  CloudantSync
+//
+//  Created by Enrique de la Torre Fernandez on 21/05/2015.
+//  Copyright (c) 2015 IBM Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "CDTBlobReader.h"
+#import "CDTBlobWriter.h"
+
+#import "CDTEncryptionKey.h"
+
+extern NSString *const CDTBlobEncryptedDataErrorDomain;
+
+typedef NS_ENUM(NSInteger, CDTBlobEncryptedDataError) {
+    CDTBlobEncryptedDataErrorFileTooSmall,
+    CDTBlobEncryptedDataErrorWrongVersion,
+    CDTBlobEncryptedDataErrorNoDataProvided
+};
+
+@interface CDTBlobEncryptedData : NSObject <CDTBlobReader, CDTBlobWriter>
+
+- (instancetype)init UNAVAILABLE_ATTRIBUTE;
+
+- (instancetype)initWithPath:(NSString *)path
+               encryptionKey:(CDTEncryptionKey *)encryptionKey NS_DESIGNATED_INITIALIZER;
+
++ (instancetype)blobWithPath:(NSString *)path encryptionKey:(CDTEncryptionKey *)encryptionKey;
+
+@end

--- a/Classes/common/Encryption/Attachments/CDTBlobEncryptedData.m
+++ b/Classes/common/Encryption/Attachments/CDTBlobEncryptedData.m
@@ -1,0 +1,311 @@
+//
+//  CDTBlobEncryptedData.m
+//  CloudantSync
+//
+//  Created by Enrique de la Torre Fernandez on 21/05/2015.
+//  Copyright (c) 2015 IBM Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#import "CDTBlobEncryptedData.h"
+#import "CDTBlobEncryptedDataConstants.h"
+
+#import "CDTBlobData.h"
+
+#import "CDTEncryptionKeychainUtils.h"
+
+#import "CDTLogging.h"
+
+#define CDTBLOBENCRYPTEDDATA_IV_SIZE kCCBlockSizeAES128
+
+NSString *const CDTBlobEncryptedDataErrorDomain = @"CDTBlobEncryptedDataErrorDomain";
+
+@interface CDTBlobEncryptedData ()
+
+@property (strong, nonatomic, readonly) NSData *key;
+@property (strong, nonatomic, readonly) CDTBlobData *blob;
+
+@property (strong, nonatomic) NSData *currentIV;
+@property (strong, nonatomic) NSMutableData *currentData;
+
+@end
+
+@implementation CDTBlobEncryptedData
+
+#pragma mark - Init object
+- (instancetype)init { return [self initWithPath:nil encryptionKey:nil]; }
+
+- (instancetype)initWithPath:(NSString *)path encryptionKey:(CDTEncryptionKey *)encryptionKey
+{
+    self = [super init];
+    if (self) {
+        CDTBlobData *thisBlob = [CDTBlobData blobWithPath:path];
+
+        if (!thisBlob) {
+            CDTLogError(CDTDATASTORE_LOG_CONTEXT, @"Cannot create blob data with path %@", path);
+
+            self = nil;
+        } else if (!encryptionKey) {
+            CDTLogError(CDTDATASTORE_LOG_CONTEXT, @"Supply an encryption key");
+
+            self = nil;
+        } else {
+            _key = encryptionKey.data;
+            _blob = thisBlob;
+
+            _currentIV = nil;
+            _currentData = nil;
+        }
+    }
+
+    return self;
+}
+
+#pragma mark - Memory management
+- (void)dealloc { [self close]; }
+
+#pragma mark - CDTBlobReader methods
+- (NSData *)dataWithError:(NSError **)error
+{
+    // Read file
+    NSError *thisError = nil;
+    NSData *fileData = [self.blob dataWithError:&thisError];
+    BOOL success = (fileData != nil);
+
+    // Check data size
+    if (success) {
+        NSUInteger fileMinimunSize = CDTBLOBENCRYPTEDDATA_ENCRYPTEDDATA_LOCATION;
+
+        success = (fileData.length >= fileMinimunSize);
+        if (!success) {
+            thisError = [CDTBlobEncryptedData errorFileTooSmall];
+        }
+    }
+
+    // Check version
+    if (success) {
+        CDTBLOBENCRYPTEDDATA_VERSION_TYPE version;
+        [fileData getBytes:&version
+                     range:NSMakeRange(CDTBLOBENCRYPTEDDATA_VERSION_LOCATION, sizeof(version))];
+
+        success = (version == CDTBLOBENCRYPTEDDATA_VERSION_VALUE);
+        if (!success) {
+            CDTLogDebug(CDTDATASTORE_LOG_CONTEXT,
+                        @"Wrong version: %ui. File is not encrypted or it is corrupted", version);
+
+            thisError = [CDTBlobEncryptedData errorWrongVersion];
+        }
+    }
+
+    // Decrypt data
+    NSData *data = nil;
+    if (success) {
+        NSUInteger lengthEncryptedData =
+            (fileData.length - CDTBLOBENCRYPTEDDATA_ENCRYPTEDDATA_LOCATION);
+        if (lengthEncryptedData == 0) {
+            data = [NSData data];
+        } else {
+            // Get IV
+            NSData *iv = [fileData subdataWithRange:NSMakeRange(CDTBLOBENCRYPTEDDATA_IV_LOCATION,
+                                                                CDTBLOBENCRYPTEDDATA_IV_SIZE)];
+
+            // Get encrypted data
+            NSData *encryptedData =
+                [fileData subdataWithRange:NSMakeRange(CDTBLOBENCRYPTEDDATA_ENCRYPTEDDATA_LOCATION,
+                                                       lengthEncryptedData)];
+
+            // Use AES
+            data = [CDTEncryptionKeychainUtils dataForAESEncryptedData:encryptedData
+                                                                   key:self.key
+                                                                    iv:iv];
+        }
+    }
+
+    // Return
+    if (!success && error) {
+        *error = thisError;
+    }
+
+    return data;
+}
+
+- (NSInputStream *)inputStreamWithOutputLength:(UInt64 *)outputLength
+{
+    NSData *data = [self dataWithError:nil];
+    if (!data) {
+        return nil;
+    }
+
+    if (outputLength) {
+        *outputLength = data.length;
+    }
+
+    return [NSInputStream inputStreamWithData:data];
+}
+
+#pragma mark - CDTBlobWriter methods
+- (BOOL)writeEntireBlobWithData:(NSData *)data error:(NSError **)error
+{
+    // Validate data
+    if (!data) {
+        CDTLogDebug(CDTDATASTORE_LOG_CONTEXT, @"Data is nil");
+
+        if (error) {
+            *error = [CDTBlobEncryptedData errorNoDataProvided];
+        }
+
+        return NO;
+    }
+
+    // Generate file content
+    // Header
+    NSData *iv = [self generateAESIv];
+    NSMutableData *fileData = [CDTBlobEncryptedData generateHeaderWithIV:iv];
+
+    // Encrypted data
+    if (data.length > 0) {
+        NSData *encryptedData =
+            [CDTEncryptionKeychainUtils aesEncryptedDataForData:data key:self.key iv:iv];
+
+        [fileData appendData:encryptedData];
+    }
+
+    // Save data
+    return [self.blob writeEntireBlobWithData:fileData error:error];
+}
+
+- (BOOL)isBlobOpenForWriting { return [self.blob isBlobOpenForWriting]; }
+
+- (BOOL)openForWriting
+{
+    if ([self.blob isBlobOpenForWriting]) {
+        CDTLogDebug(CDTDATASTORE_LOG_CONTEXT, @"Blob already open");
+
+        return YES;
+    }
+
+    if (![self.blob openForWriting]) {
+        return NO;
+    }
+
+    self.currentIV = [self generateAESIv];
+    self.currentData = [NSMutableData data];
+
+    NSMutableData *headerData = [CDTBlobEncryptedData generateHeaderWithIV:self.currentIV];
+    [self.blob appendData:headerData];
+
+    return YES;
+}
+
+- (BOOL)appendData:(NSData *)data
+{
+    if (![self.blob isBlobOpenForWriting]) {
+        CDTLogDebug(CDTDATASTORE_LOG_CONTEXT, @"Blob is not open. No data can be added");
+
+        return NO;
+    }
+
+    if (!data) {
+        CDTLogDebug(CDTDATASTORE_LOG_CONTEXT, @"Data is nil");
+
+        return NO;
+    }
+
+    [self.currentData appendData:data];
+
+    return YES;
+}
+
+- (void)close
+{
+    if (![self.blob isBlobOpenForWriting]) {
+        CDTLogDebug(CDTDATASTORE_LOG_CONTEXT, @"Blob already closed");
+
+        return;
+    }
+
+    if (self.currentData.length > 0) {
+        NSData *encryptedData = [CDTEncryptionKeychainUtils aesEncryptedDataForData:self.currentData
+                                                                                key:self.key
+                                                                                 iv:self.currentIV];
+        [self.blob appendData:encryptedData];
+    }
+
+    [self.blob close];
+
+    self.currentIV = nil;
+    self.currentData = nil;
+}
+
+#pragma mark - CDTBlobEncryptedData+Internal methods
+- (NSData *)generateAESIv
+{
+    NSData *iv = [CDTEncryptionKeychainUtils
+        generateSecureRandomBytesWithLength:CDTBLOBENCRYPTEDDATA_IV_SIZE];
+
+    return iv;
+}
+
+#pragma mark - Public class methods
++ (instancetype)blobWithPath:(NSString *)path encryptionKey:(CDTEncryptionKey *)encryptionKey
+{
+    return [[[self class] alloc] initWithPath:path encryptionKey:encryptionKey];
+}
+
+#pragma mark - Private class methods
++ (NSMutableData *)generateHeaderWithIV:(NSData *)iv
+{
+    // Version
+    CDTBLOBENCRYPTEDDATA_VERSION_TYPE version = CDTBLOBENCRYPTEDDATA_VERSION_VALUE;
+    NSMutableData *headerData = [NSMutableData dataWithBytes:&version length:sizeof(version)];
+
+    // IV
+    [headerData appendData:iv];
+
+    return headerData;
+}
+
++ (NSError *)errorFileTooSmall
+{
+    NSDictionary *userInfo = @{
+        NSLocalizedDescriptionKey : NSLocalizedString(
+            @"File does not reach the minimun size. It is not encrypted or it is corrupted",
+            @"File does not reach the minimun size. It is not encrypted or it is corrupted")
+    };
+
+    return [NSError errorWithDomain:CDTBlobEncryptedDataErrorDomain
+                               code:CDTBlobEncryptedDataErrorFileTooSmall
+                           userInfo:userInfo];
+}
+
++ (NSError *)errorWrongVersion
+{
+    NSDictionary *userInfo = @{
+        NSLocalizedDescriptionKey :
+            NSLocalizedString(@"Wrong version or file is not encrypted or it is corrupted",
+                              @"Wrong version or file is not encrypted or it is corrupted")
+    };
+
+    return [NSError errorWithDomain:CDTBlobEncryptedDataErrorDomain
+                               code:CDTBlobEncryptedDataErrorWrongVersion
+                           userInfo:userInfo];
+}
+
++ (NSError *)errorNoDataProvided
+{
+    NSDictionary *userInfo =
+        @{ NSLocalizedDescriptionKey : NSLocalizedString(@"Supply data", @"Supply data") };
+
+    return [NSError errorWithDomain:CDTBlobEncryptedDataErrorDomain
+                               code:CDTBlobEncryptedDataErrorNoDataProvided
+                           userInfo:userInfo];
+}
+
+@end

--- a/Classes/common/Encryption/Attachments/CDTBlobEncryptedDataConstants.h
+++ b/Classes/common/Encryption/Attachments/CDTBlobEncryptedDataConstants.h
@@ -1,0 +1,31 @@
+//
+//  CDTBlobEncryptedDataConstants.h
+//  CloudantSync
+//
+//  Created by Enrique de la Torre Fernandez on 21/05/2015.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#ifndef _CDTBlobEncryptedDataConstants_h
+#define _CDTBlobEncryptedDataConstants_h
+
+#import <CommonCrypto/CommonCryptor.h>
+
+#define CDTBLOBENCRYPTEDDATA_VERSION_LOCATION 0
+#define CDTBLOBENCRYPTEDDATA_VERSION_TYPE UInt8
+#define CDTBLOBENCRYPTEDDATA_VERSION_VALUE (CDTBLOBENCRYPTEDDATA_VERSION_TYPE)1
+
+#define CDTBLOBENCRYPTEDDATA_IV_LOCATION \
+    (CDTBLOBENCRYPTEDDATA_VERSION_LOCATION + sizeof(CDTBLOBENCRYPTEDDATA_VERSION_TYPE))
+
+#define CDTBLOBENCRYPTEDDATA_ENCRYPTEDDATA_LOCATION \
+    (CDTBLOBENCRYPTEDDATA_IV_LOCATION + kCCBlockSizeAES128)
+
+#endif

--- a/Classes/common/Encryption/Attachments/CDTBlobEncryptedDataConstants.h
+++ b/Classes/common/Encryption/Attachments/CDTBlobEncryptedDataConstants.h
@@ -3,6 +3,7 @@
 //  CloudantSync
 //
 //  Created by Enrique de la Torre Fernandez on 21/05/2015.
+//  Copyright (c) 2015 IBM Cloudant. All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
 //  except in compliance with the License. You may obtain a copy of the License at

--- a/Classes/common/Encryption/Attachments/CDTBlobEncryptedDataConstants.h
+++ b/Classes/common/Encryption/Attachments/CDTBlobEncryptedDataConstants.h
@@ -19,13 +19,20 @@
 
 #import <CommonCrypto/CommonCryptor.h>
 
+// Version: where this value starts
 #define CDTBLOBENCRYPTEDDATA_VERSION_LOCATION 0
+
+// Version: data type (use it to get its size on disk)
 #define CDTBLOBENCRYPTEDDATA_VERSION_TYPE UInt8
+
+// Version: current value
 #define CDTBLOBENCRYPTEDDATA_VERSION_VALUE (CDTBLOBENCRYPTEDDATA_VERSION_TYPE)1
 
+// IV: where this value starts
 #define CDTBLOBENCRYPTEDDATA_IV_LOCATION \
     (CDTBLOBENCRYPTEDDATA_VERSION_LOCATION + sizeof(CDTBLOBENCRYPTEDDATA_VERSION_TYPE))
 
+// Data: where this value starts
 #define CDTBLOBENCRYPTEDDATA_ENCRYPTEDDATA_LOCATION \
     (CDTBLOBENCRYPTEDDATA_IV_LOCATION + kCCBlockSizeAES128)
 

--- a/Classes/common/Encryption/Attachments/CDTBlobHandleFactory.h
+++ b/Classes/common/Encryption/Attachments/CDTBlobHandleFactory.h
@@ -1,8 +1,8 @@
 //
-//  CDTBlobEncryptedData+Internal.h
+//  CDTBlobHandleFactory.h
 //  CloudantSync
 //
-//  Created by Enrique de la Torre Fernandez on 21/05/2015.
+//  Created by Enrique de la Torre Fernandez on 22/05/2015.
 //  Copyright (c) 2015 IBM Cloudant. All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
@@ -14,10 +14,24 @@
 //  and limitations under the License.
 //
 
-#import "CDTBlobEncryptedData.h"
+#import <Foundation/Foundation.h>
 
-@interface CDTBlobEncryptedData (Internal)
+#import "CDTEncryptionKeyProvider.h"
 
-- (NSData *)generateAESIv;
+#import "CDTBlobReader.h"
+#import "CDTBlobWriter.h"
+
+@interface CDTBlobHandleFactory : NSObject
+
+- (instancetype)init UNAVAILABLE_ATTRIBUTE;
+
+- (instancetype)initWithEncryptionKeyProvider:(id<CDTEncryptionKeyProvider>)provider
+    NS_DESIGNATED_INITIALIZER;
+
+- (id<CDTBlobReader>)readerWithPath:(NSString *)path;
+
+- (id<CDTBlobWriter>)writerWithPath:(NSString *)path;
+
++ (instancetype)factoryWithEncryptionKeyProvider:(id<CDTEncryptionKeyProvider>)provider;
 
 @end

--- a/Classes/common/Encryption/Attachments/CDTBlobHandleFactory.h
+++ b/Classes/common/Encryption/Attachments/CDTBlobHandleFactory.h
@@ -21,10 +21,30 @@
 #import "CDTBlobReader.h"
 #import "CDTBlobWriter.h"
 
+/**
+ Given an encryption key provider, this class creates instances that conforms to protocols:
+ CDTBlobReader & CDTBlobWriter; and are able to encrypt/decrypt an attachment depending on the key
+ returned by the provider.
+ 
+ If the key provider return nil, the instances of CDTBlobReader & CDTBlobWriter will not cipher the
+ data. In other case, the information will be ciphered before saving to disk and deciphering
+ beforing returning it.
+ 
+ @see CDTEncryptionKeyProvider
+ @see CDTBlobReader
+ @see CDTBlobWriter
+ */
 @interface CDTBlobHandleFactory : NSObject
 
 - (instancetype)init UNAVAILABLE_ATTRIBUTE;
 
+/**
+ Initialise a factory
+ 
+ @param provider An encryption key provider
+ 
+ @warning The key provider is mandatory; if it is not supplied, an exception will be raised.
+ */
 - (instancetype)initWithEncryptionKeyProvider:(id<CDTEncryptionKeyProvider>)provider
     NS_DESIGNATED_INITIALIZER;
 
@@ -32,6 +52,13 @@
 
 - (id<CDTBlobWriter>)writerWithPath:(NSString *)path;
 
+/**
+ Return an instance of this class or a subclass that inherits from this one.
+ 
+ @param provider An encryption key provider
+ 
+ @warning The key provider is mandatory; if it is not supplied, an exception will be raised.
+ */
 + (instancetype)factoryWithEncryptionKeyProvider:(id<CDTEncryptionKeyProvider>)provider;
 
 @end

--- a/Classes/common/Encryption/Attachments/CDTBlobHandleFactory.m
+++ b/Classes/common/Encryption/Attachments/CDTBlobHandleFactory.m
@@ -1,0 +1,64 @@
+//
+//  CDTBlobHandleFactory.m
+//  CloudantSync
+//
+//  Created by Enrique de la Torre Fernandez on 22/05/2015.
+//  Copyright (c) 2015 IBM Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#import "CDTBlobHandleFactory.h"
+
+#import "CDTBlobData.h"
+#import "CDTBlobEncryptedData.h"
+
+@interface CDTBlobHandleFactory ()
+
+@property (strong, nonatomic, readonly) CDTEncryptionKey *encryptionKeyOrNil;
+
+@end
+
+@implementation CDTBlobHandleFactory
+
+#pragma mark - Init object
+- (instancetype)init { return [self initWithEncryptionKeyProvider:nil]; }
+
+- (instancetype)initWithEncryptionKeyProvider:(id<CDTEncryptionKeyProvider>)provider
+{
+    Assert(provider, @"Key provider is mandatory. Supply a CDTNilEncryptionKeyProvider instead.");
+
+    self = [super init];
+    if (self) {
+        _encryptionKeyOrNil = [provider encryptionKey];
+    }
+
+    return self;
+}
+
+#pragma mark - Public methods
+- (id<CDTBlobReader>)readerWithPath:(NSString *)path { return [self blobWithPath:path]; }
+
+- (id<CDTBlobWriter>)writerWithPath:(NSString *)path { return [self blobWithPath:path]; }
+
+#pragma mark - Private methods
+- (id<CDTBlobReader, CDTBlobWriter>)blobWithPath:(NSString *)path
+{
+    return (self.encryptionKeyOrNil
+                ? [CDTBlobEncryptedData blobWithPath:path encryptionKey:self.encryptionKeyOrNil]
+                : [CDTBlobData blobWithPath:path]);
+}
+
+#pragma mark - Public class methods
++ (instancetype)factoryWithEncryptionKeyProvider:(id<CDTEncryptionKeyProvider>)provider
+{
+    return [[[self class] alloc] initWithEncryptionKeyProvider:provider];
+}
+
+@end

--- a/Classes/common/Encryption/CDTEncryptionKey.h
+++ b/Classes/common/Encryption/CDTEncryptionKey.h
@@ -30,9 +30,9 @@
 @interface CDTEncryptionKey : NSObject
 
 /**
- Array of CDTENCRYPTIONKEY_KEYSIZE bytes with the DPK
+ CDTENCRYPTIONKEY_KEYSIZE bytes buffer with the DPK
  */
-@property (assign, nonatomic, readonly) const void *bytes;
+@property (strong, nonatomic, readonly) NSData *data;
 
 - (instancetype)init UNAVAILABLE_ATTRIBUTE;
 

--- a/Classes/common/Encryption/CDTEncryptionKey.m
+++ b/Classes/common/Encryption/CDTEncryptionKey.m
@@ -20,14 +20,16 @@
 
 @interface CDTEncryptionKey ()
 
-@property (strong, nonatomic, readonly) NSData *data;
+@property (strong, nonatomic, readonly) NSData *privateData;
 
 @end
 
 @implementation CDTEncryptionKey
 
 #pragma mark - Synthesize properties
-- (const void *)bytes { return self.data.bytes; }
+- (NSData *)data {
+    return [self.privateData copy];
+}
 
 #pragma mark - Init object
 - (instancetype)init { return [self initWithData:nil]; }
@@ -37,7 +39,7 @@
     self = [super init];
     if (self) {
         if (data && (data.length == CDTENCRYPTIONKEY_KEYSIZE)) {
-            _data = data;
+            _privateData = [data copy];
         } else {
             NSNumber *length = (data ? @(data.length) : nil);
             CDTLogError(CDTDATASTORE_LOG_CONTEXT,
@@ -70,7 +72,7 @@
 }
 
 - (NSUInteger)hash {
-    return [self.data hash];
+    return [self.privateData hash];
 }
 
 #pragma mark - Public methods
@@ -80,7 +82,7 @@
         return NO;
     }
 
-    return [self.data isEqualToData:encryptionKey.data];
+    return [self.privateData isEqualToData:encryptionKey.privateData];
 }
 
 #pragma mark - Public class methods

--- a/Classes/common/Encryption/FMDatabase+EncryptionKey.m
+++ b/Classes/common/Encryption/FMDatabase+EncryptionKey.m
@@ -92,7 +92,7 @@ NSString *const FMDatabaseEncryptionKeyErrorDomain = @"FMDatabaseEncryptionKeyEr
 - (BOOL)setEncryptionKey:(CDTEncryptionKey *)encryptionKey
 {
 #ifdef ENCRYPT_DATABASE
-    NSString *hexEncryptionKey = TDHexFromBytes(encryptionKey.bytes, CDTENCRYPTIONKEY_KEYSIZE);
+    NSString *hexEncryptionKey = TDHexFromBytes(encryptionKey.data.bytes, CDTENCRYPTIONKEY_KEYSIZE);
     NSString *pragmaSetKey =
         [NSString stringWithFormat:@"PRAGMA key = \"x'%@'\";", hexEncryptionKey];
 

--- a/Classes/common/touchdb/TDBlobStore.h
+++ b/Classes/common/touchdb/TDBlobStore.h
@@ -46,6 +46,13 @@ typedef struct TDBlobKey
 
 @property (readonly) NSUInteger count;
 @property (readonly) NSArray* allKeys;
+
+/**
+ Total size of files on disk.
+ 
+ Notice that if the files are encrypted, this size might be bigger that the total size of the
+ decrypted files.
+ */
 @property (readonly) UInt64 totalDataSize;
 
 - (NSInteger)deleteBlobsExceptWithKeys:(NSSet*)keysToKeep;

--- a/Classes/common/touchdb/TDBlobStore.h
+++ b/Classes/common/touchdb/TDBlobStore.h
@@ -16,6 +16,7 @@
 #import <CommonCrypto/CommonDigest.h>
 #endif
 
+#import "CDTEncryptionKeyProvider.h"
 #import "CDTBlobReader.h"
 #import "CDTBlobWriter.h"
 
@@ -32,7 +33,9 @@ typedef struct TDBlobKey
     NSString* _tempDir;
 }
 
-- (id)initWithPath:(NSString*)dir error:(NSError**)outError;
+- (id)initWithPath:(NSString *)dir
+    encryptionKeyProvider:(id<CDTEncryptionKeyProvider>)provider
+                    error:(NSError **)outError;
 
 - (id<CDTBlobReader>)blobForKey:(TDBlobKey)key;
 

--- a/Classes/common/touchdb/TDBlobStore.m
+++ b/Classes/common/touchdb/TDBlobStore.m
@@ -23,7 +23,7 @@
 
 #import "TDStatus.h"
 
-#import "CDTBlobData.h"
+#import "CDTBlobHandleFactory.h"
 
 #ifdef GNUSTEP
 #define NSDataReadingMappedIfSafe NSMappedRead
@@ -32,24 +32,37 @@
 
 #define kFileExtension "blob"
 
+@interface TDBlobStore ()
+
+@property (strong, nonatomic, readonly) CDTBlobHandleFactory *blobHandleFactory;
+
+@end
+
 @implementation TDBlobStore
 
-- (id)initWithPath:(NSString*)dir error:(NSError**)outError
+- (id)initWithPath:(NSString *)dir
+    encryptionKeyProvider:(id<CDTEncryptionKeyProvider>)provider
+                    error:(NSError **)outError
 {
     Assert(dir);
+    Assert(provider, @"Key provider is mandatory. Supply a CDTNilEncryptionKeyProvider instead.");
+
     self = [super init];
     if (self) {
         _path = [dir copy];
+        _blobHandleFactory = [CDTBlobHandleFactory factoryWithEncryptionKeyProvider:provider];
+
         BOOL isDir;
         if (![[NSFileManager defaultManager] fileExistsAtPath:dir isDirectory:&isDir] || !isDir) {
             if (![[NSFileManager defaultManager] createDirectoryAtPath:dir
                                            withIntermediateDirectories:NO
                                                             attributes:nil
                                                                  error:outError]) {
-                return nil;
+                self = nil;
             }
         }
     }
+
     return self;
 }
 
@@ -102,7 +115,7 @@
 {
     NSString *path = [self pathForKey:key];
     
-    return [CDTBlobData blobWithPath:path];
+    return [self.blobHandleFactory readerWithPath:path];
 }
 
 - (BOOL)storeBlob:(NSData*)blob creatingKey:(TDBlobKey*)outKey
@@ -122,7 +135,7 @@
     if (success) {
         CDTLogDebug(CDTDATASTORE_LOG_CONTEXT, @"File %@ already exists", path);
     } else {
-        id<CDTBlobWriter> writer = [CDTBlobData blobWithPath:path];
+        id<CDTBlobWriter> writer = [self.blobHandleFactory writerWithPath:path];
 
         NSError *thisError = nil;
         success = [writer writeEntireBlobWithData:blob error:&thisError];
@@ -250,7 +263,7 @@
             return nil;
         }
         
-        _blobWriter = [CDTBlobData blobWithPath:_tempPath];
+        _blobWriter = [store.blobHandleFactory writerWithPath:_tempPath];
         if (![_blobWriter openForWriting]) {
             return nil;
         }

--- a/Classes/common/touchdb/TDBlobStore.m
+++ b/Classes/common/touchdb/TDBlobStore.m
@@ -249,15 +249,7 @@
         if (!_tempPath) {
             return nil;
         }
-        NSDictionary* attributes = nil;
-#if TARGET_OS_IPHONE
-        attributes = @{NSFileProtectionKey : NSFileProtectionCompleteUnlessOpen};
-#endif
-        if (![[NSFileManager defaultManager] createFileAtPath:_tempPath
-                                                     contents:nil
-                                                   attributes:attributes]) {
-            return nil;
-        }
+        
         _blobWriter = [CDTBlobData blobWithPath:_tempPath];
         if (![_blobWriter openForWriting]) {
             return nil;

--- a/Classes/common/touchdb/TD_Database.m
+++ b/Classes/common/touchdb/TD_Database.m
@@ -496,7 +496,9 @@ static BOOL removeItemIfExists(NSString* path, NSError** outError)
         // Open attachment store:
         NSString* attachmentsPath = strongSelf.attachmentStorePath;
         NSError* error;
-        _attachments = [[TDBlobStore alloc] initWithPath:attachmentsPath error:&error];
+        _attachments = [[TDBlobStore alloc] initWithPath:attachmentsPath
+                                   encryptionKeyProvider:provider
+                                                   error:&error];
         if (!_attachments) {
             CDTLogWarn(CDTDATASTORE_LOG_CONTEXT, @"%@: Couldn't open attachment store at %@", self,
                     attachmentsPath);

--- a/Tests/Tests.xcodeproj/project.pbxproj
+++ b/Tests/Tests.xcodeproj/project.pbxproj
@@ -114,6 +114,8 @@
 		CDBC57371AE66CD700CF9E6B /* CDTEncryptionKeychainProviderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CDBC57351AE66CD700CF9E6B /* CDTEncryptionKeychainProviderTests.m */; };
 		CDBC573A1AE6A06C00CF9E6B /* CDTMockEncryptionKeychainManager.m in Sources */ = {isa = PBXBuildFile; fileRef = CDBC57391AE6A06C00CF9E6B /* CDTMockEncryptionKeychainManager.m */; };
 		CDBC573B1AE6A06C00CF9E6B /* CDTMockEncryptionKeychainManager.m in Sources */ = {isa = PBXBuildFile; fileRef = CDBC57391AE6A06C00CF9E6B /* CDTMockEncryptionKeychainManager.m */; };
+		CDD025191B0F5C7C007D185D /* CDTBlobHandleFactoryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CDD025181B0F5C7C007D185D /* CDTBlobHandleFactoryTests.m */; };
+		CDD0251A1B0F5C7C007D185D /* CDTBlobHandleFactoryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CDD025181B0F5C7C007D185D /* CDTBlobHandleFactoryTests.m */; };
 		EC0C833C1AB217290051042F /* CDTDatastoreQueryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C831F1AB217290051042F /* CDTDatastoreQueryTests.m */; };
 		EC0C833D1AB217290051042F /* CDTDatastoreQueryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C831F1AB217290051042F /* CDTDatastoreQueryTests.m */; };
 		EC0C833E1AB217290051042F /* CDTQFilterFieldsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C83201AB217290051042F /* CDTQFilterFieldsTest.m */; };
@@ -242,6 +244,7 @@
 		CDBC57351AE66CD700CF9E6B /* CDTEncryptionKeychainProviderTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTEncryptionKeychainProviderTests.m; sourceTree = "<group>"; };
 		CDBC57381AE6A06C00CF9E6B /* CDTMockEncryptionKeychainManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDTMockEncryptionKeychainManager.h; sourceTree = "<group>"; };
 		CDBC57391AE6A06C00CF9E6B /* CDTMockEncryptionKeychainManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTMockEncryptionKeychainManager.m; sourceTree = "<group>"; };
+		CDD025181B0F5C7C007D185D /* CDTBlobHandleFactoryTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTBlobHandleFactoryTests.m; sourceTree = "<group>"; };
 		EC0C831F1AB217290051042F /* CDTDatastoreQueryTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTDatastoreQueryTests.m; sourceTree = "<group>"; };
 		EC0C83201AB217290051042F /* CDTQFilterFieldsTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTQFilterFieldsTest.m; sourceTree = "<group>"; };
 		EC0C83211AB217290051042F /* CDTQIndexCreatorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTQIndexCreatorTests.m; sourceTree = "<group>"; };
@@ -524,6 +527,7 @@
 			isa = PBXGroup;
 			children = (
 				CD4818771B0E0E1200E2CB64 /* CDTBlobEncryptedDataTests.m */,
+				CDD025181B0F5C7C007D185D /* CDTBlobHandleFactoryTests.m */,
 			);
 			path = Attachments;
 			sourceTree = "<group>";
@@ -761,6 +765,7 @@
 				9F4E646B19DC815B00FE37E1 /* CDTReplicationTests.m in Sources */,
 				EC0C83461AB217290051042F /* CDTQInvalidQuerySyntax.m in Sources */,
 				98BB740019E5927600C57866 /* CloudantTests.m in Sources */,
+				CDD025191B0F5C7C007D185D /* CDTBlobHandleFactoryTests.m in Sources */,
 				9F0D2402188DFE8600D3D04E /* TD_RevisionTests.m in Sources */,
 				EC0C833E1AB217290051042F /* CDTQFilterFieldsTest.m in Sources */,
 				9F4E646D19DC815B00FE37E1 /* SetUpDatastore.m in Sources */,
@@ -835,6 +840,7 @@
 				9F4E646C19DC815B00FE37E1 /* CDTReplicationTests.m in Sources */,
 				EC0C83471AB217290051042F /* CDTQInvalidQuerySyntax.m in Sources */,
 				98BB740119E5927600C57866 /* CloudantTests.m in Sources */,
+				CDD0251A1B0F5C7C007D185D /* CDTBlobHandleFactoryTests.m in Sources */,
 				985A188B19D2CCEB000283E9 /* DatastoreConflicts.m in Sources */,
 				EC0C833F1AB217290051042F /* CDTQFilterFieldsTest.m in Sources */,
 				9F4E646E19DC815B00FE37E1 /* SetUpDatastore.m in Sources */,

--- a/Tests/Tests.xcodeproj/project.pbxproj
+++ b/Tests/Tests.xcodeproj/project.pbxproj
@@ -102,6 +102,10 @@
 		CD3FBCA71AB05A170032376E /* CDTHelperFixedKeyProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = CD3FBCA31AB05A170032376E /* CDTHelperFixedKeyProvider.m */; };
 		CD3FBCA81AB05A170032376E /* CDTHelperOneUseKeyProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = CD3FBCA51AB05A170032376E /* CDTHelperOneUseKeyProvider.m */; };
 		CD3FBCA91AB05A170032376E /* CDTHelperOneUseKeyProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = CD3FBCA51AB05A170032376E /* CDTHelperOneUseKeyProvider.m */; };
+		CD4818781B0E0E1200E2CB64 /* CDTBlobEncryptedDataTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD4818771B0E0E1200E2CB64 /* CDTBlobEncryptedDataTests.m */; };
+		CD4818791B0E0E1200E2CB64 /* CDTBlobEncryptedDataTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD4818771B0E0E1200E2CB64 /* CDTBlobEncryptedDataTests.m */; };
+		CD48187C1B0E3BF100E2CB64 /* CDTHelperMisc.m in Sources */ = {isa = PBXBuildFile; fileRef = CD48187B1B0E3BF100E2CB64 /* CDTHelperMisc.m */; };
+		CD48187D1B0E3BF100E2CB64 /* CDTHelperMisc.m in Sources */ = {isa = PBXBuildFile; fileRef = CD48187B1B0E3BF100E2CB64 /* CDTHelperMisc.m */; };
 		CD94A6FE1AB8A24C006C8343 /* emptyencrypteddb.touchdb in Resources */ = {isa = PBXBuildFile; fileRef = CD94A6FD1AB8A24C006C8343 /* emptyencrypteddb.touchdb */; };
 		CD94A6FF1AB8A24C006C8343 /* emptyencrypteddb.touchdb in Resources */ = {isa = PBXBuildFile; fileRef = CD94A6FD1AB8A24C006C8343 /* emptyencrypteddb.touchdb */; };
 		CDADD5BF1AEFD643003CA9EF /* FMDatabase+SQLCipher.m in Sources */ = {isa = PBXBuildFile; fileRef = CDADD5BE1AEFD643003CA9EF /* FMDatabase+SQLCipher.m */; };
@@ -229,6 +233,9 @@
 		CD3FBCA31AB05A170032376E /* CDTHelperFixedKeyProvider.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTHelperFixedKeyProvider.m; sourceTree = "<group>"; };
 		CD3FBCA41AB05A170032376E /* CDTHelperOneUseKeyProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDTHelperOneUseKeyProvider.h; sourceTree = "<group>"; };
 		CD3FBCA51AB05A170032376E /* CDTHelperOneUseKeyProvider.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTHelperOneUseKeyProvider.m; sourceTree = "<group>"; };
+		CD4818771B0E0E1200E2CB64 /* CDTBlobEncryptedDataTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTBlobEncryptedDataTests.m; sourceTree = "<group>"; };
+		CD48187A1B0E3BF100E2CB64 /* CDTHelperMisc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDTHelperMisc.h; sourceTree = "<group>"; };
+		CD48187B1B0E3BF100E2CB64 /* CDTHelperMisc.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTHelperMisc.m; sourceTree = "<group>"; };
 		CD94A6FD1AB8A24C006C8343 /* emptyencrypteddb.touchdb */ = {isa = PBXFileReference; lastKnownFileType = file; name = emptyencrypteddb.touchdb; path = Assets/emptyencrypteddb.touchdb; sourceTree = "<group>"; };
 		CDADD5BD1AEFD643003CA9EF /* FMDatabase+SQLCipher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "FMDatabase+SQLCipher.h"; sourceTree = "<group>"; };
 		CDADD5BE1AEFD643003CA9EF /* FMDatabase+SQLCipher.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "FMDatabase+SQLCipher.m"; sourceTree = "<group>"; };
@@ -462,6 +469,7 @@
 		CD2188CF1AE570480036F59F /* Encryption */ = {
 			isa = PBXGroup;
 			children = (
+				CD4818761B0E0DBF00E2CB64 /* Attachments */,
 				CD2188E01AE571250036F59F /* Keychain */,
 				CD2188D01AE5711A0036F59F /* CDTQIndexManagerEncryptionTests.m */,
 				CD2188D11AE5711A0036F59F /* CloudantTests+EncryptionTests.h */,
@@ -504,10 +512,20 @@
 			children = (
 				CD3FBCA21AB05A170032376E /* CDTHelperFixedKeyProvider.h */,
 				CD3FBCA31AB05A170032376E /* CDTHelperFixedKeyProvider.m */,
+				CD48187A1B0E3BF100E2CB64 /* CDTHelperMisc.h */,
+				CD48187B1B0E3BF100E2CB64 /* CDTHelperMisc.m */,
 				CD3FBCA41AB05A170032376E /* CDTHelperOneUseKeyProvider.h */,
 				CD3FBCA51AB05A170032376E /* CDTHelperOneUseKeyProvider.m */,
 			);
 			path = Helpers;
+			sourceTree = "<group>";
+		};
+		CD4818761B0E0DBF00E2CB64 /* Attachments */ = {
+			isa = PBXGroup;
+			children = (
+				CD4818771B0E0E1200E2CB64 /* CDTBlobEncryptedDataTests.m */,
+			);
+			path = Attachments;
 			sourceTree = "<group>";
 		};
 		EC0C832B1AB217290051042F /* Matchers */ = {
@@ -748,6 +766,7 @@
 				9F4E646D19DC815B00FE37E1 /* SetUpDatastore.m in Sources */,
 				EC0C83541AB217290051042F /* CDTQContainsAllElementsMatcher.m in Sources */,
 				985A188A19D2CCEB000283E9 /* DatastoreConflicts.m in Sources */,
+				CD48187C1B0E3BF100E2CB64 /* CDTHelperMisc.m in Sources */,
 				985A188719D2CC54000283E9 /* CDTDatastoreEvents.m in Sources */,
 				9F0D240B188E3C3A00D3D04E /* TDCollateJSONTests.m in Sources */,
 				EC0C83601AB217290051042F /* CDTQSQLOnlyQueryExecutor.m in Sources */,
@@ -763,6 +782,7 @@
 				CD2188E81AE574A20036F59F /* CDTEncryptionKeychainDataTests.m in Sources */,
 				EC0C83561AB217290051042F /* CDTQEitherMatcher.m in Sources */,
 				EC0C83401AB217290051042F /* CDTQIndexCreatorTests.m in Sources */,
+				CD4818781B0E0E1200E2CB64 /* CDTBlobEncryptedDataTests.m in Sources */,
 				CDBC57361AE66CD700CF9E6B /* CDTEncryptionKeychainProviderTests.m in Sources */,
 				9F95D61018CF6A580006D349 /* DBQueryUtils.m in Sources */,
 				EC0C83441AB217290051042F /* CDTQIndexUpdaterTests.m in Sources */,
@@ -820,6 +840,7 @@
 				9F4E646E19DC815B00FE37E1 /* SetUpDatastore.m in Sources */,
 				EC0C83551AB217290051042F /* CDTQContainsAllElementsMatcher.m in Sources */,
 				985A188819D2CC54000283E9 /* CDTDatastoreEvents.m in Sources */,
+				CD48187D1B0E3BF100E2CB64 /* CDTHelperMisc.m in Sources */,
 				9F0D240C188E3C3A00D3D04E /* TDCollateJSONTests.m in Sources */,
 				9F0D24181893161000D3D04E /* TDReachabilityTests.m in Sources */,
 				EC0C83611AB217290051042F /* CDTQSQLOnlyQueryExecutor.m in Sources */,
@@ -835,6 +856,7 @@
 				CD2188E91AE574A20036F59F /* CDTEncryptionKeychainDataTests.m in Sources */,
 				9F95D61118CF6A580006D349 /* DBQueryUtils.m in Sources */,
 				EC0C83411AB217290051042F /* CDTQIndexCreatorTests.m in Sources */,
+				CD4818791B0E0E1200E2CB64 /* CDTBlobEncryptedDataTests.m in Sources */,
 				CDBC57371AE66CD700CF9E6B /* CDTEncryptionKeychainProviderTests.m in Sources */,
 				27CCEDD6187AD70C006F3C66 /* CloudantSyncTests.m in Sources */,
 				EC0C83451AB217290051042F /* CDTQIndexUpdaterTests.m in Sources */,

--- a/Tests/Tests.xcodeproj/project.pbxproj
+++ b/Tests/Tests.xcodeproj/project.pbxproj
@@ -116,6 +116,8 @@
 		CDBC573B1AE6A06C00CF9E6B /* CDTMockEncryptionKeychainManager.m in Sources */ = {isa = PBXBuildFile; fileRef = CDBC57391AE6A06C00CF9E6B /* CDTMockEncryptionKeychainManager.m */; };
 		CDD025191B0F5C7C007D185D /* CDTBlobHandleFactoryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CDD025181B0F5C7C007D185D /* CDTBlobHandleFactoryTests.m */; };
 		CDD0251A1B0F5C7C007D185D /* CDTBlobHandleFactoryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CDD025181B0F5C7C007D185D /* CDTBlobHandleFactoryTests.m */; };
+		CDD0251C1B0F631C007D185D /* TDBlobStoreEncryptionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CDD0251B1B0F631C007D185D /* TDBlobStoreEncryptionTests.m */; };
+		CDD0251D1B0F631C007D185D /* TDBlobStoreEncryptionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CDD0251B1B0F631C007D185D /* TDBlobStoreEncryptionTests.m */; };
 		EC0C833C1AB217290051042F /* CDTDatastoreQueryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C831F1AB217290051042F /* CDTDatastoreQueryTests.m */; };
 		EC0C833D1AB217290051042F /* CDTDatastoreQueryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C831F1AB217290051042F /* CDTDatastoreQueryTests.m */; };
 		EC0C833E1AB217290051042F /* CDTQFilterFieldsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = EC0C83201AB217290051042F /* CDTQFilterFieldsTest.m */; };
@@ -245,6 +247,7 @@
 		CDBC57381AE6A06C00CF9E6B /* CDTMockEncryptionKeychainManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDTMockEncryptionKeychainManager.h; sourceTree = "<group>"; };
 		CDBC57391AE6A06C00CF9E6B /* CDTMockEncryptionKeychainManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTMockEncryptionKeychainManager.m; sourceTree = "<group>"; };
 		CDD025181B0F5C7C007D185D /* CDTBlobHandleFactoryTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTBlobHandleFactoryTests.m; sourceTree = "<group>"; };
+		CDD0251B1B0F631C007D185D /* TDBlobStoreEncryptionTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TDBlobStoreEncryptionTests.m; sourceTree = "<group>"; };
 		EC0C831F1AB217290051042F /* CDTDatastoreQueryTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTDatastoreQueryTests.m; sourceTree = "<group>"; };
 		EC0C83201AB217290051042F /* CDTQFilterFieldsTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTQFilterFieldsTest.m; sourceTree = "<group>"; };
 		EC0C83211AB217290051042F /* CDTQIndexCreatorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTQIndexCreatorTests.m; sourceTree = "<group>"; };
@@ -482,6 +485,7 @@
 				CDADD5BD1AEFD643003CA9EF /* FMDatabase+SQLCipher.h */,
 				CDADD5BE1AEFD643003CA9EF /* FMDatabase+SQLCipher.m */,
 				CD2188D51AE5711A0036F59F /* TD_DatabaseEncryptionTests.m */,
+				CDD0251B1B0F631C007D185D /* TDBlobStoreEncryptionTests.m */,
 			);
 			path = Encryption;
 			sourceTree = "<group>";
@@ -796,6 +800,7 @@
 				CD0D10EC1AB09CE8003315B5 /* TD_DatabaseDeletionTests.m in Sources */,
 				CD3FBCA61AB05A170032376E /* CDTHelperFixedKeyProvider.m in Sources */,
 				CD2188DA1AE5711A0036F59F /* DatastoreEncryptionTests.m in Sources */,
+				CDD0251C1B0F631C007D185D /* TDBlobStoreEncryptionTests.m in Sources */,
 				9F0D24141892E9B800D3D04E /* TDPusherTests.m in Sources */,
 				EC578D8A1AE67D60003D6006 /* CDTQIndexTests.m in Sources */,
 			);
@@ -871,6 +876,7 @@
 				CD0D10ED1AB09CE8003315B5 /* TD_DatabaseDeletionTests.m in Sources */,
 				CD3FBCA71AB05A170032376E /* CDTHelperFixedKeyProvider.m in Sources */,
 				CD2188DB1AE5711A0036F59F /* DatastoreEncryptionTests.m in Sources */,
+				CDD0251D1B0F631C007D185D /* TDBlobStoreEncryptionTests.m in Sources */,
 				9F0D24151892E9B800D3D04E /* TDPusherTests.m in Sources */,
 				EC578D8B1AE67D60003D6006 /* CDTQIndexTests.m in Sources */,
 			);

--- a/Tests/Tests/Attachments/CDTBlobDataTests.m
+++ b/Tests/Tests/Attachments/CDTBlobDataTests.m
@@ -21,8 +21,8 @@
 @interface CDTBlobDataTests : XCTestCase
 
 @property (strong, nonatomic) NSData *data;
-@property (strong, nonatomic) NSString *pathToExistingFile;
-@property (strong, nonatomic) CDTBlobData *blob;
+@property (strong, nonatomic) NSString *pathToNotEmptyFile;
+@property (strong, nonatomic) CDTBlobData *blobForNotEmptyFile;
 
 @property (strong, nonatomic) NSString *pathToNonExistingFile;
 @property (strong, nonatomic) CDTBlobData *blobForNotPrexistingFile;
@@ -39,13 +39,13 @@
     // class.
     self.data = [@"text" dataUsingEncoding:NSUnicodeStringEncoding];
 
-    self.pathToExistingFile =
+    self.pathToNotEmptyFile =
         [NSTemporaryDirectory() stringByAppendingPathComponent:@"CDTBlobDataTests.txt"];
-    [[NSFileManager defaultManager] createFileAtPath:self.pathToExistingFile
-                                            contents:nil
-                                          attributes:nil];
 
-    self.blob = [[CDTBlobData alloc] initWithPath:self.pathToExistingFile];
+    NSData *otherData = [@"Lorem ipsum" dataUsingEncoding:NSASCIIStringEncoding];
+    [otherData writeToFile:self.pathToNotEmptyFile atomically:YES];
+
+    self.blobForNotEmptyFile = [[CDTBlobData alloc] initWithPath:self.pathToNotEmptyFile];
 
     self.pathToNonExistingFile =
         [NSTemporaryDirectory() stringByAppendingPathComponent:@"nonExistingFile.txt"];
@@ -57,12 +57,14 @@
     // Put teardown code here. This method is called after the invocation of each test method in the
     // class.
     self.blobForNotPrexistingFile = nil;
+
+    [[NSFileManager defaultManager] removeItemAtPath:self.pathToNonExistingFile error:nil];
     self.pathToNonExistingFile = nil;
 
-    self.blob = nil;
+    self.blobForNotEmptyFile = nil;
 
-    [[NSFileManager defaultManager] removeItemAtPath:self.pathToExistingFile error:nil];
-    self.pathToExistingFile = nil;
+    [[NSFileManager defaultManager] removeItemAtPath:self.pathToNotEmptyFile error:nil];
+    self.pathToNotEmptyFile = nil;
 
     self.data = nil;
 
@@ -87,57 +89,70 @@
 
 - (void)testBlobIsNotOpenAfterCreation
 {
-    XCTAssertFalse([self.blob isBlobOpenForWriting], @"After init, blob is not open");
+    XCTAssertFalse([self.blobForNotEmptyFile isBlobOpenForWriting],
+                   @"After init, blob is not open");
 }
 
-- (void)testOpenForWritingFailsIfFileDoesNotExist
+- (void)testOpenBlobToAddDataSucceedsIfFileDoesNotExist
 {
-    XCTAssertFalse([self.blobForNotPrexistingFile openForWriting],
-                   @"If the file does not exist yet, it can not be open");
+    XCTAssertTrue(
+        [self.blobForNotPrexistingFile openForWriting],
+        @"It does not matter if the file does not exist, it will be created before opening it");
 }
 
 - (void)testOpenForWritingSucceedsIfFileExists
 {
-    XCTAssertTrue([self.blob openForWriting],
+    XCTAssertTrue([self.blobForNotEmptyFile openForWriting],
                   @"If the file exists, we should be able to open it");
 }
 
 - (void)testOpenForWritingSucceedsIfAlreadyOpen
 {
-    [self.blob openForWriting];
+    [self.blobForNotEmptyFile openForWriting];
 
     XCTAssertTrue(
-        [self.blob openForWriting],
+        [self.blobForNotEmptyFile openForWriting],
         @"If the blob is already opened, open it again let the file open, thefore it succeeds");
 }
 
-- (void)testOpenForWritingSucceedsAfterClosingBlob
+- (void)testOpenBlobToAddDataClearTheContentOfTheFile
 {
-    [self.blob openForWriting];
-    [self.blob close];
+    [self.blobForNotEmptyFile openForWriting];
 
-    XCTAssertTrue([self.blob openForWriting],
+    NSData *fileData = [NSData dataWithContentsOfFile:self.pathToNotEmptyFile];
+
+    XCTAssertTrue([fileData length] == 0, @"The file should be empty after opening the blob");
+}
+
+- (void)testOpenBlobToAddDataSucceedsAfterClosingBlob
+{
+    [self.blobForNotEmptyFile openForWriting];
+    [self.blobForNotEmptyFile close];
+
+    XCTAssertTrue([self.blobForNotEmptyFile openForWriting],
                   @"As long as the file still exists, we should be able to open it again");
 }
 
 - (void)testAppendDataFailsIfBlobIsNotOpen
 {
-    XCTAssertFalse([self.blob appendData:self.data], @"Open blob before adding data");
+    XCTAssertFalse([self.blobForNotEmptyFile appendData:self.data],
+                   @"Open blob before adding data");
 }
 
 - (void)testAppendDataFailsIfDataIsNil
 {
-    [self.blob openForWriting];
+    [self.blobForNotEmptyFile openForWriting];
 
-    XCTAssertFalse([self.blob appendData:nil], @"It should fail if there is no data to add");
+    XCTAssertFalse([self.blobForNotEmptyFile appendData:nil],
+                   @"It should fail if there is no data to add");
 }
 
 - (void)testDataWithErrorFailsIfBlobIsOpen
 {
-    [self.blob openForWriting];
+    [self.blobForNotEmptyFile openForWriting];
 
     NSError *error = nil;
-    NSData *data = [self.blob dataWithError:&error];
+    NSData *data = [self.blobForNotEmptyFile dataWithError:&error];
 
     XCTAssertNil(data, @"Blob can not be read if it is open");
     XCTAssertTrue([error.domain isEqualToString:CDTBlobDataErrorDomain] &&
@@ -157,10 +172,10 @@
 
 - (void)testInputStreamWithOutputLengthFailsIfBlobIsOpen
 {
-    [self.blob openForWriting];
+    [self.blobForNotEmptyFile openForWriting];
 
     UInt64 length = 0;
-    XCTAssertNil([self.blob inputStreamWithOutputLength:&length],
+    XCTAssertNil([self.blobForNotEmptyFile inputStreamWithOutputLength:&length],
                  @"Close the blob in order to create an input stream bound to the same filea");
 }
 
@@ -179,10 +194,10 @@
 
 - (void)testWriteEntireBlobWithDataFailsIfBlobIsOpen
 {
-    [self.blob openForWriting];
+    [self.blobForNotEmptyFile openForWriting];
 
     NSError *error = nil;
-    BOOL success = [self.blob writeEntireBlobWithData:self.data error:&error];
+    BOOL success = [self.blobForNotEmptyFile writeEntireBlobWithData:self.data error:&error];
 
     XCTAssertFalse(success, @"Close the blob in order to overwrite it");
     XCTAssertTrue([error.domain isEqualToString:CDTBlobDataErrorDomain] &&
@@ -193,16 +208,62 @@
 
 - (void)testWriteEntireBlobWithDataSucceedsIfFileExists
 {
-    XCTAssertTrue([self.blob writeEntireBlobWithData:self.data error:nil],
+    XCTAssertTrue([self.blobForNotEmptyFile writeEntireBlobWithData:self.data error:nil],
                   @"The previous data will be overwritten with the next one");
 }
 
 - (void)testWriteEntireBlobWithDataSucceedsIfFileDoesNotExist
 {
     BOOL success = [self.blobForNotPrexistingFile writeEntireBlobWithData:self.data error:nil];
-    [[NSFileManager defaultManager] removeItemAtPath:self.pathToNonExistingFile error:nil];
-    
+
     XCTAssertTrue(success, @"A new file will be created");
+}
+
+- (void)testWriteEntireBlobWithDataFailsIfDataIsNil
+{
+    NSError *error = nil;
+    BOOL success = [self.blobForNotEmptyFile writeEntireBlobWithData:nil error:&error];
+
+    XCTAssertFalse(success, @"Provide some data to create the blob");
+    XCTAssertTrue([error.domain isEqualToString:CDTBlobDataErrorDomain] &&
+                      error.code == CDTBlobDataErrorNoDataProvided,
+                  @"In this situation the expected error is: (%@, %li)", CDTBlobDataErrorDomain,
+                  (long)CDTBlobDataErrorNoDataProvided);
+}
+
+- (void)testWriteEntireBlobWithDataOverwritesThePreviousContent
+{
+    [self.blobForNotEmptyFile writeEntireBlobWithData:self.data error:nil];
+
+    NSData *fileData = [NSData dataWithContentsOfFile:self.pathToNotEmptyFile];
+
+    XCTAssertEqualObjects(
+        fileData, self.data,
+        @"After creating a blob, the only content in the file should be the data we just provided");
+}
+
+- (void)testAppendDataOverwritesThePreviousContent
+{
+    [self.blobForNotEmptyFile openForWriting];
+    [self.blobForNotEmptyFile appendData:self.data];
+    [self.blobForNotEmptyFile appendData:self.data];
+    [self.blobForNotEmptyFile close];
+
+    NSMutableData *expectedData = [NSMutableData dataWithData:self.data];
+    [expectedData appendData:self.data];
+
+    NSData *fileData = [NSData dataWithContentsOfFile:self.pathToNotEmptyFile];
+
+    XCTAssertEqualObjects(fileData, expectedData, @"Only the added data should be in the file");
+}
+
+- (void)testFileCreatedAfterOpeningABlobIsNotDeletedAfterClosingEvenIfNoDataIsAdded
+{
+    [self.blobForNotPrexistingFile openForWriting];
+    [self.blobForNotPrexistingFile close];
+
+    XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath:self.pathToNonExistingFile],
+                  @"The blob creates a file, it is user responsability to delete it");
 }
 
 @end

--- a/Tests/Tests/Attachments/CDTBlobDataTests.m
+++ b/Tests/Tests/Attachments/CDTBlobDataTests.m
@@ -125,6 +125,13 @@
     XCTAssertFalse([self.blob appendData:self.data], @"Open blob before adding data");
 }
 
+- (void)testAppendDataFailsIfDataIsNil
+{
+    [self.blob openForWriting];
+
+    XCTAssertFalse([self.blob appendData:nil], @"It should fail if there is no data to add");
+}
+
 - (void)testDataWithErrorFailsIfBlobIsOpen
 {
     [self.blob openForWriting];

--- a/Tests/Tests/Encryption/Attachments/CDTBlobEncryptedDataTests.m
+++ b/Tests/Tests/Encryption/Attachments/CDTBlobEncryptedDataTests.m
@@ -1,0 +1,605 @@
+//
+//  CDTBlobEncryptedDataTests.m
+//  Tests
+//
+//  Created by Enrique de la Torre Fernandez on 21/05/2015.
+//  Copyright (c) 2015 IBM Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#import <XCTest/XCTest.h>
+
+#import "CDTBlobEncryptedData+Internal.h"
+#import "CDTBlobEncryptedDataConstants.h"
+
+#import "CDTHelperMisc.h"
+#import "CDTHelperFixedKeyProvider.h"
+
+#import "TDBase64.h"
+
+@interface CDTBlobCustomEncryptedData : CDTBlobEncryptedData
+
+@property (strong, nonatomic) NSData *iv;
+
+- (instancetype)initWithPath:(NSString *)path
+               encryptionKey:(CDTEncryptionKey *)encryptionKey
+                          iv:(NSData *)iv NS_DESIGNATED_INITIALIZER;
+
+@end
+
+@interface CDTBlobEncryptedDataTests : XCTestCase
+
+@property (strong, nonatomic) NSData *ivData;
+@property (strong, nonatomic) NSData *otherIVData;
+
+@property (strong, nonatomic) CDTEncryptionKey *encryptionKey;
+
+@property (strong, nonatomic) NSData *plainData;
+@property (strong, nonatomic) NSData *encryptedData;
+@property (strong, nonatomic) NSData *otherPlainData;
+@property (strong, nonatomic) NSData *otherEncryptedData;
+@property (strong, nonatomic) NSData *headerData;
+@property (strong, nonatomic) NSMutableData *headerPlusEncryptedData;
+
+@property (strong, nonatomic) NSString *pathToNotEmptyFile;
+@property (strong, nonatomic) CDTBlobCustomEncryptedData *blobForNotEmptyFile;
+
+@property (strong, nonatomic) NSString *pathToNonExistingFile;
+@property (strong, nonatomic) CDTBlobCustomEncryptedData *blobForNotPrexistingFile;
+
+@end
+
+@implementation CDTBlobEncryptedDataTests
+
+- (void)setUp
+{
+    [super setUp];
+
+    // Put setup code here. This method is called before the invocation of each test method in the
+    // class.
+    NSString *keyStr = @"3271b0b2ae09cf10128893abba0871b64ea933253378d0c65bcbe05befe636c3";
+    NSData *keyData = dataFromHexadecimalString(keyStr);
+
+    NSString *ivStr = @"10327cc29f13539f8ce5378318f46137";
+    self.ivData = dataFromHexadecimalString(ivStr);
+
+    ivStr = @"00000cc00f00000f0ce0000000f00000";
+    self.otherIVData = dataFromHexadecimalString(ivStr);
+
+    CDTHelperFixedKeyProvider *provider = [[CDTHelperFixedKeyProvider alloc] initWithKey:keyData];
+    self.encryptionKey = [provider encryptionKey];
+
+    self.plainData = [@"摇;摃:xx👹⌚️👽" dataUsingEncoding:NSUnicodeStringEncoding];
+    self.encryptedData = [TDBase64 decode:@"H6nWVwfuGB8hDv/dFVUXbU2yb07NzE2vf3HttPF/qps="];
+
+    self.otherPlainData = [@"摇;摃:§婘栰" dataUsingEncoding:NSUnicodeStringEncoding];
+    self.otherEncryptedData = [TDBase64 decode:@"+B/AXr0PQrxQSAdMnE8BKKUymEak2akCuGGHIY99lNU="];
+
+    char buffer[sizeof(CDTBLOBENCRYPTEDDATA_VERSION_TYPE) + self.ivData.length];
+    memset(buffer + CDTBLOBENCRYPTEDDATA_VERSION_LOCATION, CDTBLOBENCRYPTEDDATA_VERSION_VALUE,
+           sizeof(CDTBLOBENCRYPTEDDATA_VERSION_TYPE));
+    memcpy(buffer + CDTBLOBENCRYPTEDDATA_IV_LOCATION, self.ivData.bytes, self.ivData.length);
+    self.headerData = [NSData dataWithBytes:buffer length:sizeof(buffer)];
+
+    self.headerPlusEncryptedData = [NSMutableData dataWithData:self.headerData];
+    [self.headerPlusEncryptedData appendData:self.encryptedData];
+
+    self.pathToNotEmptyFile = [NSTemporaryDirectory()
+        stringByAppendingPathComponent:@"CDTBlobEncryptedDataTests_notEmpty.txt"];
+    [self.headerPlusEncryptedData writeToFile:self.pathToNotEmptyFile atomically:YES];
+
+    self.blobForNotEmptyFile =
+        [[CDTBlobCustomEncryptedData alloc] initWithPath:self.pathToNotEmptyFile
+                                           encryptionKey:self.encryptionKey
+                                                      iv:self.ivData];
+
+    self.pathToNonExistingFile = [NSTemporaryDirectory()
+        stringByAppendingPathComponent:@"CDTBlobEncryptedDataTests_noExists.txt"];
+
+    self.blobForNotPrexistingFile =
+        [[CDTBlobCustomEncryptedData alloc] initWithPath:self.pathToNonExistingFile
+                                           encryptionKey:self.encryptionKey
+                                                      iv:self.ivData];
+}
+
+- (void)tearDown
+{
+    // Put teardown code here. This method is called after the invocation of each test method in the
+    // class.
+    self.blobForNotPrexistingFile = nil;
+
+    [[NSFileManager defaultManager] removeItemAtPath:self.pathToNonExistingFile error:nil];
+    self.pathToNonExistingFile = nil;
+
+    self.blobForNotEmptyFile = nil;
+
+    [[NSFileManager defaultManager] removeItemAtPath:self.pathToNotEmptyFile error:nil];
+    self.pathToNotEmptyFile = nil;
+
+    self.headerPlusEncryptedData = nil;
+    self.headerData = nil;
+    self.otherEncryptedData = nil;
+    self.otherPlainData = nil;
+    self.encryptedData = nil;
+    self.plainData = nil;
+
+    self.encryptionKey = nil;
+
+    self.otherIVData = nil;
+    self.ivData = nil;
+
+    [super tearDown];
+}
+
+- (void)testInitWithPathEqualToNilFails
+{
+    XCTAssertNil([[CDTBlobEncryptedData alloc] initWithPath:nil encryptionKey:self.encryptionKey],
+                 @"A path is mandatory");
+}
+
+- (void)testInitWithEmptyPathFails
+{
+    XCTAssertNil([[CDTBlobEncryptedData alloc] initWithPath:@"" encryptionKey:self.encryptionKey],
+                 @"A path is mandatory");
+}
+
+- (void)testInitWithNotValidPathSucceeds
+{
+    XCTAssertNotNil([[CDTBlobEncryptedData alloc] initWithPath:@"///This is not a path"
+                                                 encryptionKey:self.encryptionKey],
+                    @"Any string is valid as long as it is not empty");
+}
+
+- (void)testInitWithEncryptionKeyEqualToNilFails
+{
+    XCTAssertNil(
+        [[CDTBlobEncryptedData alloc] initWithPath:self.pathToNonExistingFile encryptionKey:nil],
+        @"An encryption key is mandatory");
+}
+
+- (void)testDataWithErrorFailsIfBlobIsOpen
+{
+    [self.blobForNotEmptyFile openForWriting];
+
+    NSError *error = nil;
+    NSData *data = [self.blobForNotEmptyFile dataWithError:&error];
+
+    XCTAssertNil(data, @"Blob can not be read if it is open");
+    XCTAssertNotNil(error, @"An error is expected in this case");
+}
+
+- (void)testDataWithErrorFailsIfFileDoesNotExist
+{
+    NSError *error = nil;
+    NSData *data = [self.blobForNotPrexistingFile dataWithError:&error];
+
+    XCTAssertNil(data, @"No data to read if file does not exist");
+    XCTAssertNotNil(error, @"An error must be informed");
+}
+
+- (void)testDataWithErrorFailsIfFileDoesNotHaveTheMinimumSize
+{
+    NSData *fileData =
+        [self.headerData subdataWithRange:NSMakeRange(0, self.headerData.length - 1)];
+    [fileData writeToFile:self.pathToNotEmptyFile atomically:YES];
+
+    NSError *error = nil;
+    NSData *data = [self.blobForNotEmptyFile dataWithError:&error];
+
+    XCTAssertNil(data, @"Data is not encrypted or is corrupted");
+    XCTAssertTrue(error && [error.domain isEqualToString:CDTBlobEncryptedDataErrorDomain] &&
+                      (error.code == CDTBlobEncryptedDataErrorFileTooSmall),
+                  @"In this situation the expected error is: (%@, %li)",
+                  CDTBlobEncryptedDataErrorDomain, CDTBlobEncryptedDataErrorFileTooSmall);
+}
+
+- (void)testDataWithErrorFailsIfFileStartsWithVersion0
+{
+    NSMutableData *fileData = [NSMutableData dataWithData:self.headerData];
+    
+    CDTBLOBENCRYPTEDDATA_VERSION_TYPE wrongVersion = 0;
+    [fileData replaceBytesInRange:NSMakeRange(CDTBLOBENCRYPTEDDATA_VERSION_LOCATION,
+                                              sizeof(CDTBLOBENCRYPTEDDATA_VERSION_TYPE))
+                        withBytes:&wrongVersion];
+    
+    [fileData writeToFile:self.pathToNotEmptyFile atomically:YES];
+    
+    NSError *error = nil;
+    NSData *data = [self.blobForNotEmptyFile dataWithError:&error];
+    
+    XCTAssertNil(data, @"Data is not encrypted, is corrupted or the version is wrong");
+    XCTAssertTrue(error && [error.domain isEqualToString:CDTBlobEncryptedDataErrorDomain] &&
+                  (error.code == CDTBlobEncryptedDataErrorWrongVersion),
+                  @"In this situation the expected error is: (%@, %li)",
+                  CDTBlobEncryptedDataErrorDomain, CDTBlobEncryptedDataErrorWrongVersion);
+}
+
+- (void)testDataWithErrorFailsIfFileDoesNotStartWithCorrectVersion
+{
+    NSMutableData *fileData = [NSMutableData dataWithData:self.headerData];
+
+    CDTBLOBENCRYPTEDDATA_VERSION_TYPE wrongVersion = (CDTBLOBENCRYPTEDDATA_VERSION_VALUE + 1);
+    [fileData replaceBytesInRange:NSMakeRange(CDTBLOBENCRYPTEDDATA_VERSION_LOCATION,
+                                              sizeof(CDTBLOBENCRYPTEDDATA_VERSION_TYPE))
+                        withBytes:&wrongVersion];
+
+    [fileData writeToFile:self.pathToNotEmptyFile atomically:YES];
+
+    NSError *error = nil;
+    NSData *data = [self.blobForNotEmptyFile dataWithError:&error];
+
+    XCTAssertNil(data, @"Data is not encrypted, is corrupted or the version is wrong");
+    XCTAssertTrue(error && [error.domain isEqualToString:CDTBlobEncryptedDataErrorDomain] &&
+                      (error.code == CDTBlobEncryptedDataErrorWrongVersion),
+                  @"In this situation the expected error is: (%@, %li)",
+                  CDTBlobEncryptedDataErrorDomain, CDTBlobEncryptedDataErrorWrongVersion);
+}
+
+- (void)testDataWithErrorReturnsEmptyIfThereIsNotEncryptedData
+{
+    [self.headerData writeToFile:self.pathToNotEmptyFile atomically:YES];
+
+    NSError *error = nil;
+    NSData *data = [self.blobForNotEmptyFile dataWithError:&error];
+
+    XCTAssertTrue(data && (data.length == 0),
+                  @"It is OK is there is not encrypted data but it has to return an empty buffer");
+    XCTAssertNil(error, @"No error to report");
+}
+
+- (void)testDataWithErrorReturnsExpectedData
+{
+    NSError *error = nil;
+    NSData *data = [self.blobForNotEmptyFile dataWithError:&error];
+
+    XCTAssertEqualObjects(data, self.plainData, @"Unexpected result");
+    XCTAssertNil(error, @"No error to report");
+}
+
+- (void)testInputStreamWithOutputLengthFailsIfBlobIsOpen
+{
+    [self.blobForNotEmptyFile openForWriting];
+
+    UInt64 length = 0;
+    XCTAssertNil([self.blobForNotEmptyFile inputStreamWithOutputLength:&length],
+                 @"Close the blob in order to create an input stream bound to the same file");
+}
+
+- (void)testInputStreamWithOutputLengthFailsIfFileDoesNotExist
+{
+    UInt64 length = 0;
+    XCTAssertNil([self.blobForNotPrexistingFile inputStreamWithOutputLength:&length],
+                 @"File must exist in order to create an input stream");
+}
+
+- (void)testInputStreamWithOutputLengthFailsIfFileDoesNotExistEvenIfIDoNotGetTheLength
+{
+    XCTAssertNil([self.blobForNotPrexistingFile inputStreamWithOutputLength:nil],
+                 @"File must exist in order to create an input stream");
+}
+
+- (void)testWriteEntireBlobWithDataFailsIfBlobIsOpen
+{
+    [self.blobForNotEmptyFile openForWriting];
+
+    NSError *error = nil;
+    BOOL success =
+        [self.blobForNotEmptyFile writeEntireBlobWithData:self.otherPlainData error:&error];
+
+    XCTAssertFalse(success, @"Close the blob in order to overwrite it");
+    XCTAssertNotNil(error, @"An error is expected in this situation");
+}
+
+- (void)testWriteEntireBlobWithDataSucceedsIfFileExists
+{
+    NSError *error = nil;
+    BOOL success =
+        [self.blobForNotEmptyFile writeEntireBlobWithData:self.otherPlainData error:&error];
+
+    XCTAssertTrue(success, @"The previous data will be overwritten with the next one");
+    XCTAssertNil(error, @"No error to report");
+}
+
+- (void)testWriteEntireBlobWithDataSucceedsIfFileDoesNotExist
+{
+    NSError *error = nil;
+    BOOL success =
+        [self.blobForNotPrexistingFile writeEntireBlobWithData:self.plainData error:&error];
+
+    XCTAssertTrue(success, @"A new file will be created");
+    XCTAssertNil(error, @"No error to report");
+}
+
+- (void)testWriteEntireBlobWithDataFailsIfDataIsNil
+{
+    NSError *error = nil;
+    BOOL success = [self.blobForNotEmptyFile writeEntireBlobWithData:nil error:&error];
+
+    XCTAssertFalse(success, @"Provide some data to create the blob");
+    XCTAssertTrue(error && [error.domain isEqualToString:CDTBlobEncryptedDataErrorDomain] &&
+                      error.code == CDTBlobEncryptedDataErrorNoDataProvided,
+                  @"In this situation the expected error is: (%@, %li)",
+                  CDTBlobEncryptedDataErrorDomain, (long)CDTBlobEncryptedDataErrorNoDataProvided);
+}
+
+- (void)testWriteEntireBlobWithDataSucceedsIfDataIsEmpty
+{
+    NSError *error = nil;
+    BOOL success =
+        [self.blobForNotPrexistingFile writeEntireBlobWithData:[NSData data] error:&error];
+
+    XCTAssertTrue(success, @"A new file will be created");
+    XCTAssertNil(error, @"No error to report");
+}
+
+- (void)testWriteEntireBlobWithDataCreatesFileWithExpectedData
+{
+    [self.blobForNotPrexistingFile writeEntireBlobWithData:self.plainData error:nil];
+
+    NSData *fileData = [NSData dataWithContentsOfFile:self.pathToNonExistingFile];
+
+    XCTAssertEqualObjects(fileData, self.headerPlusEncryptedData, @"Unexpected result");
+}
+
+- (void)testwriteEntireBlobWithEmptyDataCreatesFileWithExpectedData
+{
+    [self.blobForNotPrexistingFile writeEntireBlobWithData:[NSData data] error:nil];
+
+    NSData *fileData = [NSData dataWithContentsOfFile:self.pathToNonExistingFile];
+
+    XCTAssertEqualObjects(fileData, self.headerData, @"Unexpected result");
+}
+
+- (void)testWriteEntireBlobWithDataOverwritesThePreviousContent
+{
+    [self.blobForNotEmptyFile writeEntireBlobWithData:self.otherPlainData error:nil];
+
+    NSData *fileData = [NSData dataWithContentsOfFile:self.pathToNotEmptyFile];
+
+    NSMutableData *expectedData = [NSMutableData dataWithData:self.headerData];
+    [expectedData appendData:self.otherEncryptedData];
+
+    XCTAssertEqualObjects(fileData, expectedData, @"Unexpected result");
+}
+
+- (void)testWriteEntireBlobWithDataGeneratesDifferentFileDatas
+{
+    [self.blobForNotPrexistingFile writeEntireBlobWithData:self.plainData error:nil];
+    NSData *fileData = [NSData dataWithContentsOfFile:self.pathToNonExistingFile];
+
+    self.blobForNotPrexistingFile.iv = self.otherIVData;
+
+    [self.blobForNotPrexistingFile writeEntireBlobWithData:self.plainData error:nil];
+    NSData *otherFileData = [NSData dataWithContentsOfFile:self.pathToNonExistingFile];
+
+    XCTAssertNotEqualObjects(fileData, otherFileData,
+                             @"Different IVs should generate different encrypted data");
+}
+
+- (void)testOpenForWritingSucceedsIfFileDoesNotExist
+{
+    XCTAssertTrue(
+        [self.blobForNotPrexistingFile openForWriting],
+        @"It does not matter if the file does not exist, it will be created before opening it");
+}
+
+- (void)testOpenForWritingSucceedsIfFileExists
+{
+    XCTAssertTrue([self.blobForNotEmptyFile openForWriting],
+                  @"If the file exists, we should be able to open it");
+}
+
+- (void)testOpenForWritingFailsIfPathIsNotValid
+{
+    CDTBlobEncryptedData *blob = [[CDTBlobEncryptedData alloc] initWithPath:@"///This is not a path"
+                                                              encryptionKey:self.encryptionKey];
+
+    XCTAssertFalse([blob openForWriting], @"It should fail if the path is not valid");
+}
+
+- (void)testOpenForWritingCreatesFileOnlyWithHeader
+{
+    [self.blobForNotPrexistingFile openForWriting];
+
+    BOOL fileExists = [[NSFileManager defaultManager] fileExistsAtPath:self.pathToNonExistingFile];
+    NSData *fileData = [NSData dataWithContentsOfFile:self.pathToNonExistingFile];
+
+    XCTAssertTrue(fileExists, @"A file is created after opening the blob");
+    XCTAssertEqualObjects(fileData, self.headerData,
+                          @"The only content in the file should be the header");
+}
+
+- (void)testOpenForWritingSucceedsIfAlreadyOpen
+{
+    [self.blobForNotEmptyFile openForWriting];
+
+    XCTAssertTrue(
+        [self.blobForNotEmptyFile openForWriting],
+        @"If the blob is already opened, open it again let the file open, thefore it succeeds");
+}
+
+- (void)testOpenForWritingClearTheContentOfTheFile
+{
+    [self.blobForNotEmptyFile openForWriting];
+
+    NSData *fileData = [NSData dataWithContentsOfFile:self.pathToNotEmptyFile];
+
+    XCTAssertEqualObjects(fileData, self.headerData,
+                          @"The only content in the file should be the header");
+}
+
+- (void)testOpenForWritingDoesNotClearTheContentOfTheFileIfItIsAlreadyOpen
+{
+    [self.blobForNotPrexistingFile openForWriting];
+    [self.blobForNotPrexistingFile appendData:self.plainData];
+
+    [self.blobForNotPrexistingFile openForWriting];
+
+    [self.blobForNotPrexistingFile close];
+
+    NSData *fileData = [NSData dataWithContentsOfFile:self.pathToNonExistingFile];
+
+    XCTAssertEqualObjects(fileData, self.headerPlusEncryptedData,
+                          @"If it is already open, do not clear it");
+}
+
+- (void)testOpenForWritingSucceedsAfterClosingBlob
+{
+    [self.blobForNotEmptyFile openForWriting];
+    [self.blobForNotEmptyFile close];
+
+    XCTAssertTrue([self.blobForNotEmptyFile openForWriting],
+                  @"As long as the file still exists, we should be able to open it again");
+}
+
+- (void)testBlobIsNotOpenAfterCreatingIt
+{
+    XCTAssertFalse([self.blobForNotEmptyFile isBlobOpenForWriting],
+                   @"After init, blob is not open");
+}
+
+- (void)testBlobIsOpenAfterOpeningIt
+{
+    [self.blobForNotEmptyFile openForWriting];
+
+    XCTAssertTrue([self.blobForNotEmptyFile isBlobOpenForWriting], @"Obviously, it is open");
+}
+
+- (void)testBlobIsNotOpenAfterClosingIt
+{
+    [self.blobForNotEmptyFile openForWriting];
+    [self.blobForNotEmptyFile close];
+
+    XCTAssertFalse([self.blobForNotEmptyFile isBlobOpenForWriting], @"Obviously, it is closed");
+}
+
+- (void)testAppendDataFailsIfBlobIsNotOpen
+{
+    XCTAssertFalse([self.blobForNotEmptyFile appendData:self.plainData],
+                   @"Open blob before adding data");
+}
+
+- (void)testAppendDataFailsIfDataIsNil
+{
+    [self.blobForNotEmptyFile openForWriting];
+
+    XCTAssertFalse([self.blobForNotEmptyFile appendData:nil],
+                   @"It should fail if there is no data to add");
+}
+
+- (void)testAppendDataDoesNotIncreasesTheSizeOfTheFile
+{
+    [self.blobForNotEmptyFile openForWriting];
+
+    NSData *fileData = [NSData dataWithContentsOfFile:self.pathToNotEmptyFile];
+    NSUInteger previousFileDataLength = fileData.length;
+
+    [self.blobForNotEmptyFile appendData:self.otherPlainData];
+
+    fileData = [NSData dataWithContentsOfFile:self.pathToNotEmptyFile];
+
+    XCTAssertEqual(fileData.length, previousFileDataLength,
+                   @"'addData:' does not update the file, 'closeBlob' does it");
+}
+
+- (void)testCloseBlobWithoutAddingDataGeneratesOnlyAHeader
+{
+    [self.blobForNotEmptyFile openForWriting];
+    [self.blobForNotEmptyFile close];
+
+    NSData *fileData = [NSData dataWithContentsOfFile:self.pathToNotEmptyFile];
+
+    XCTAssertEqualObjects(fileData, self.headerData, @"Unexpected result");
+}
+
+- (void)testAppendDataOverwritesThePreviousContent
+{
+    [self.blobForNotEmptyFile openForWriting];
+    [self.blobForNotEmptyFile appendData:self.otherPlainData];
+    [self.blobForNotEmptyFile close];
+
+    NSMutableData *expectedData = [NSMutableData dataWithData:self.headerData];
+    [expectedData appendData:self.otherEncryptedData];
+
+    NSData *fileData = [NSData dataWithContentsOfFile:self.pathToNotEmptyFile];
+
+    XCTAssertEqualObjects(fileData, expectedData, @"Only the added data should be in the file");
+}
+
+- (void)testCloseBlobGeneratesDifferentFileDatas
+{
+    [self.blobForNotPrexistingFile openForWriting];
+    [self.blobForNotPrexistingFile appendData:self.plainData];
+    [self.blobForNotPrexistingFile close];
+    NSData *fileData = [NSData dataWithContentsOfFile:self.pathToNonExistingFile];
+
+    self.blobForNotPrexistingFile.iv = self.otherIVData;
+
+    [self.blobForNotPrexistingFile openForWriting];
+    [self.blobForNotPrexistingFile appendData:self.plainData];
+    [self.blobForNotPrexistingFile close];
+    NSData *otherFileData = [NSData dataWithContentsOfFile:self.pathToNonExistingFile];
+
+    XCTAssertNotEqualObjects(fileData, otherFileData,
+                             @"Different IVs should generate different encrypted data");
+}
+
+- (void)testOpenBlobTwiceDoesNotChangeTheIV
+{
+    [self.blobForNotPrexistingFile openForWriting];
+
+    self.blobForNotPrexistingFile.iv = self.otherIVData;
+    [self.blobForNotPrexistingFile openForWriting];
+
+    [self.blobForNotPrexistingFile appendData:self.plainData];
+    [self.blobForNotPrexistingFile close];
+
+    NSData *fileData = [NSData dataWithContentsOfFile:self.pathToNonExistingFile];
+
+    XCTAssertEqualObjects(
+        fileData, self.headerPlusEncryptedData,
+        @"Once the blob is open, the IV does not change until it is closed and open again ");
+}
+
+- (void)testFileCreatedAfterOpeningABlobIsNotDeletedAfterClosingEvenIfNoDataIsAdded
+{
+    [self.blobForNotPrexistingFile openForWriting];
+    [self.blobForNotPrexistingFile close];
+
+    XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath:self.pathToNonExistingFile],
+                  @"The blob creates a file, it is user responsability to delete it");
+}
+
+@end
+
+@implementation CDTBlobCustomEncryptedData
+
+#pragma mark - Init object
+- (instancetype)initWithPath:(NSString *)path encryptionKey:(CDTEncryptionKey *)encryptionKey
+{
+    return [self initWithPath:path encryptionKey:encryptionKey iv:nil];
+}
+
+- (instancetype)initWithPath:(NSString *)path
+               encryptionKey:(CDTEncryptionKey *)encryptionKey
+                          iv:(NSData *)iv
+{
+    self = [super initWithPath:path encryptionKey:encryptionKey];
+    if (self) {
+        _iv = iv;
+    }
+
+    return self;
+}
+
+#pragma mark - CDTBlobEncryptedData+Internal methods
+- (NSData *)generateAESIv { return (self.iv ? self.iv : [super generateAESIv]); }
+
+@end

--- a/Tests/Tests/Encryption/Attachments/CDTBlobHandleFactoryTests.m
+++ b/Tests/Tests/Encryption/Attachments/CDTBlobHandleFactoryTests.m
@@ -1,0 +1,79 @@
+//
+//  CDTBlobHandleFactoryTests.m
+//  Tests
+//
+//  Created by Enrique de la Torre Fernandez on 22/05/2015.
+//  Copyright (c) 2015 IBM Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#import <XCTest/XCTest.h>
+
+#import "CDTBlobHandleFactory.h"
+
+#import "CDTBlobData.h"
+#import "CDTBlobEncryptedData.h"
+
+#import "CDTHelperFixedKeyProvider.h"
+#import "CDTEncryptionKeyNilProvider.h"
+
+@interface CDTBlobHandleFactoryTests : XCTestCase
+
+@end
+
+@implementation CDTBlobHandleFactoryTests
+
+- (void)setUp
+{
+    [super setUp];
+    
+    // Put setup code here. This method is called before the invocation of each test method in the
+    // class.
+}
+
+- (void)tearDown
+{
+    // Put teardown code here. This method is called after the invocation of each test method in the
+    // class.
+    
+    [super tearDown];
+}
+
+- (void)testInitRaiseExceptionIfProviderIsNil
+{
+    XCTAssertThrows([[CDTBlobHandleFactory alloc] initWithEncryptionKeyProvider:nil],
+                    @"A key provider is always mandatory");
+}
+
+- (void)testFactoryWithNilProviderCreatesBlobHandlesForNonEncryptedAttachments
+{
+    CDTBlobHandleFactory *factory = [[CDTBlobHandleFactory alloc]
+                                     initWithEncryptionKeyProvider:[CDTEncryptionKeyNilProvider provider]];
+    
+    id<CDTBlobReader> reader = [factory readerWithPath:@"///This is not a path"];
+    id<CDTBlobWriter> writer = [factory writerWithPath:@"///This is not a path"];
+    
+    XCTAssertTrue([reader isKindOfClass:[CDTBlobData class]], @"Unexpected type");
+    XCTAssertTrue([writer isKindOfClass:[CDTBlobData class]], @"Unexpected type");
+}
+
+- (void)testFactoryWithFixedProviderCreatesBlobHandlesForEncryptedAttachments
+{
+    CDTBlobHandleFactory *factory = [[CDTBlobHandleFactory alloc]
+                                     initWithEncryptionKeyProvider:[[CDTHelperFixedKeyProvider alloc] init]];
+    
+    id<CDTBlobReader> reader = [factory readerWithPath:@"///This is not a path"];
+    id<CDTBlobWriter> writer = [factory writerWithPath:@"///This is not a path"];
+    
+    XCTAssertTrue([reader isKindOfClass:[CDTBlobEncryptedData class]], @"Unexpected type");
+    XCTAssertTrue([writer isKindOfClass:[CDTBlobEncryptedData class]], @"Unexpected type");
+}
+
+@end

--- a/Tests/Tests/Encryption/Keychain/CDTEncryptionKeychainUtilsAESTests.m
+++ b/Tests/Tests/Encryption/Keychain/CDTEncryptionKeychainUtilsAESTests.m
@@ -18,6 +18,8 @@
 
 #import "CDTEncryptionKeychainUtils+AES.h"
 
+#import "CDTHelperMisc.h"
+
 #import "TDBase64.h"
 
 @interface CDTEncryptionKeychainUtilsAESTests : XCTestCase
@@ -38,8 +40,8 @@
     NSString *keyStr = @"3271b0b2ae09cf10128893abba0871b64ea933253378d0c65bcbe05befe636c3";
     NSString *ivStr = @"10327cc29f13539f8ce5378318f46137";
 
-    self.key = [CDTEncryptionKeychainUtilsAESTests dataFromHexadecimalString:keyStr];
-    self.iv = [CDTEncryptionKeychainUtilsAESTests dataFromHexadecimalString:ivStr];
+    self.key = dataFromHexadecimalString(keyStr);
+    self.iv = dataFromHexadecimalString(ivStr);
 }
 
 - (void)tearDown
@@ -142,41 +144,6 @@
                                            iv:self.iv];
     result = [[NSString alloc] initWithData:data encoding:NSUnicodeStringEncoding];
     XCTAssertEqualObjects(expectedPlainText, result, @"Unexpected result");
-}
-
-
-#pragma mark - Private class methods
-+ (NSData *)dataFromHexadecimalString:(NSString *)hexString
-{
-    /*
-     The string represent the hexadecimal values that should be used, so the string "4962"
-     represents byte values 0x49  0x62.
-     Note that the strings are twice the size since every two characters in the string
-     corresponds to a single byte.
-     */
-    if (([hexString length] % 2) != 0) {
-        return nil;
-    }
-    
-    NSUInteger size = ([hexString length] / (NSUInteger)2);
-    unsigned char buff[size];
-    
-    @autoreleasepool
-    {
-        for (NSUInteger i = 0; i < size; i++) {
-            NSString *hexChrStr = [hexString substringWithRange:NSMakeRange(i * 2, 2)];
-            
-            NSScanner *scanner = [[NSScanner alloc] initWithString:hexChrStr];
-            uint currInt;
-            [scanner scanHexInt:&currInt];
-            
-            buff[i] = (char)currInt;
-        }
-    }
-    
-    NSData *data = [NSData dataWithBytes:buff length:size];
-    
-    return data;
 }
 
 @end

--- a/Tests/Tests/Encryption/TDBlobStoreEncryptionTests.m
+++ b/Tests/Tests/Encryption/TDBlobStoreEncryptionTests.m
@@ -1,0 +1,203 @@
+//
+//  TDBlobStoreEncryptionTests.m
+//  Tests
+//
+//  Created by Enrique de la Torre Fernandez on 22/05/2015.
+//  Copyright (c) 2015 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+#import <XCTest/XCTest.h>
+
+#import "TDBlobStore.h"
+
+#import "CDTHelperFixedKeyProvider.h"
+#import "CDTEncryptionKeyNilProvider.h"
+
+#import "TDMisc.h"
+
+@interface TDBlobStoreEncryptionTests : XCTestCase
+
+@property (strong, nonatomic) NSString *blobStorePath;
+@property (strong, nonatomic) TDBlobStore *blobStore;
+@property (strong, nonatomic) TDBlobStoreWriter *blobStoreWriter;
+
+@property (strong, nonatomic) NSString *encryptedBlobStorePath;
+@property (strong, nonatomic) TDBlobStore *encryptedBlobStore;
+@property (strong, nonatomic) TDBlobStoreWriter *encryptedBlobStoreWriter;
+
+@property (strong, nonatomic) NSData *plainData;
+@property (strong, nonatomic) NSString *hexExpectedSHA1Digest;
+
+@end
+
+@implementation TDBlobStoreEncryptionTests
+
+- (void)setUp
+{
+    [super setUp];
+
+    // Put setup code here. This method is called before the invocation of each test method in the
+    // class.
+    self.blobStorePath = [NSTemporaryDirectory()
+        stringByAppendingPathComponent:@"blobStoreEncryptionTests_plainData"];
+
+    id<CDTEncryptionKeyProvider> provider = [[CDTEncryptionKeyNilProvider alloc] init];
+    self.blobStore = [[TDBlobStore alloc] initWithPath:self.blobStorePath
+                                 encryptionKeyProvider:provider
+                                                 error:nil];
+    self.blobStoreWriter = [[TDBlobStoreWriter alloc] initWithStore:self.blobStore];
+
+    self.encryptedBlobStorePath = [NSTemporaryDirectory()
+        stringByAppendingPathComponent:@"blobStoreEncryptionTests_encryptedData"];
+
+    provider = [[CDTHelperFixedKeyProvider alloc] init];
+    self.encryptedBlobStore = [[TDBlobStore alloc] initWithPath:self.encryptedBlobStorePath
+                                          encryptionKeyProvider:provider
+                                                          error:nil];
+    self.encryptedBlobStoreWriter =
+        [[TDBlobStoreWriter alloc] initWithStore:self.encryptedBlobStore];
+
+    self.plainData = [@"摇;摃:§婘栰" dataUsingEncoding:NSUTF8StringEncoding];
+    self.hexExpectedSHA1Digest = @"0cb5ad21ca38f03ccc1139223019af3623394976";
+}
+
+- (void)tearDown
+{
+    // Put teardown code here. This method is called after the invocation of each test method in the
+    // class.
+    NSFileManager *defaultManager = [NSFileManager defaultManager];
+
+    self.hexExpectedSHA1Digest = nil;
+    self.plainData = nil;
+
+    self.encryptedBlobStoreWriter = nil;
+    self.encryptedBlobStore = nil;
+
+    [defaultManager removeItemAtPath:self.encryptedBlobStorePath error:nil];
+    self.encryptedBlobStorePath = nil;
+
+    self.blobStoreWriter = nil;
+    self.blobStore = nil;
+
+    [defaultManager removeItemAtPath:self.blobStorePath error:nil];
+    self.blobStorePath = nil;
+
+    [super tearDown];
+}
+
+- (void)testStoreBlobReturnsExpectedKey
+{
+    TDBlobKey encryptedBlobKey;
+    [self.encryptedBlobStore storeBlob:self.plainData creatingKey:&encryptedBlobKey];
+    NSString *hexEncryptedBlobKey =
+        TDHexFromBytes(encryptedBlobKey.bytes, sizeof(encryptedBlobKey.bytes));
+
+    XCTAssertEqualObjects(hexEncryptedBlobKey, self.hexExpectedSHA1Digest,
+                          @"Both should be the same");
+}
+
+- (void)testStoreBlobSavesEncryptedData
+{
+    TDBlobKey blobKey;
+    [self.blobStore storeBlob:self.plainData creatingKey:&blobKey];
+
+    NSFileManager *defaultManager = [NSFileManager defaultManager];
+    NSArray *fileArray = [defaultManager contentsOfDirectoryAtPath:self.blobStorePath error:nil];
+    NSData *fileData = [NSData
+        dataWithContentsOfFile:[self.blobStorePath stringByAppendingPathComponent:fileArray[0]]];
+
+    [self.encryptedBlobStore storeBlob:self.plainData creatingKey:&blobKey];
+
+    fileArray = [defaultManager contentsOfDirectoryAtPath:self.encryptedBlobStorePath error:nil];
+    NSData *fileEncryptedData =
+        [NSData dataWithContentsOfFile:[self.encryptedBlobStorePath
+                                           stringByAppendingPathComponent:fileArray[0]]];
+
+    XCTAssertNotEqualObjects(fileData, fileEncryptedData,
+                             @"Same plain data but the content of the files should be different");
+}
+
+- (void)testBlobForKeyReturnsReaderAbleToReadDataPreviouslySaved
+{
+    TDBlobKey blobKey;
+    [self.encryptedBlobStore storeBlob:self.plainData creatingKey:&blobKey];
+
+    id<CDTBlobReader> reader = [self.encryptedBlobStore blobForKey:blobKey];
+
+    XCTAssertEqualObjects(self.plainData, [reader dataWithError:nil],
+                          @"It has to return the same data previously saved");
+}
+
+- (void)testBlobStoreWriterReturnsExpectedKey
+{
+    NSData *subData01 = [self.plainData subdataWithRange:NSMakeRange(0, self.plainData.length / 2)];
+    NSData *subData02 = [self.plainData
+        subdataWithRange:NSMakeRange(subData01.length, self.plainData.length - subData01.length)];
+
+    [self.encryptedBlobStoreWriter appendData:subData01];
+    [self.encryptedBlobStoreWriter appendData:subData02];
+    [self.encryptedBlobStoreWriter finish];
+    [self.encryptedBlobStoreWriter install];
+
+    NSString *hexEncryptedBlobKey =
+        TDHexFromBytes(self.encryptedBlobStoreWriter.blobKey.bytes,
+                       sizeof(self.encryptedBlobStoreWriter.blobKey.bytes));
+
+    XCTAssertEqualObjects(hexEncryptedBlobKey, self.hexExpectedSHA1Digest,
+                          @"Both should be the same");
+}
+
+- (void)testBlobStoreWriterSavesEncryptedData
+{
+    NSData *subData01 = [self.plainData subdataWithRange:NSMakeRange(0, self.plainData.length / 2)];
+    NSData *subData02 = [self.plainData
+        subdataWithRange:NSMakeRange(subData01.length, self.plainData.length - subData01.length)];
+
+    [self.encryptedBlobStoreWriter appendData:subData01];
+    [self.encryptedBlobStoreWriter appendData:subData02];
+    [self.encryptedBlobStoreWriter finish];
+    [self.encryptedBlobStoreWriter install];
+
+    NSFileManager *defaultManager = [NSFileManager defaultManager];
+    NSArray *fileArray =
+        [defaultManager contentsOfDirectoryAtPath:self.encryptedBlobStorePath error:nil];
+    NSData *fileEncryptedData =
+        [NSData dataWithContentsOfFile:[self.encryptedBlobStorePath
+                                           stringByAppendingPathComponent:fileArray[0]]];
+
+    TDBlobKey blobKey;
+    [self.blobStore storeBlob:self.plainData creatingKey:&blobKey];
+
+    fileArray = [defaultManager contentsOfDirectoryAtPath:self.blobStorePath error:nil];
+    NSData *fileData = [NSData
+        dataWithContentsOfFile:[self.blobStorePath stringByAppendingPathComponent:fileArray[0]]];
+
+    XCTAssertNotEqualObjects(fileData, fileEncryptedData,
+                             @"Same plain data but the content of the files should be different");
+}
+
+- (void)testBlobForKeyReturnsReaderAbleToReadDataSavedWithABlobStoreWriter
+{
+    NSData *subData01 = [self.plainData subdataWithRange:NSMakeRange(0, self.plainData.length / 2)];
+    NSData *subData02 = [self.plainData
+        subdataWithRange:NSMakeRange(subData01.length, self.plainData.length - subData01.length)];
+
+    [self.encryptedBlobStoreWriter appendData:subData01];
+    [self.encryptedBlobStoreWriter appendData:subData02];
+    [self.encryptedBlobStoreWriter finish];
+    [self.encryptedBlobStoreWriter install];
+
+    id<CDTBlobReader> reader = [self.encryptedBlobStore blobForKey:self.encryptedBlobStoreWriter.blobKey];
+
+    XCTAssertEqualObjects(self.plainData, [reader dataWithError:nil],
+                          @"It has to return the same data previously saved");
+}
+
+@end

--- a/Tests/Tests/Helpers/CDTHelperFixedKeyProvider.m
+++ b/Tests/Tests/Helpers/CDTHelperFixedKeyProvider.m
@@ -50,7 +50,7 @@
 #pragma mark - Public methods
 - (instancetype)negatedProvider
 {
-    const char *fixedKeyBytes = self.fixedKey.bytes;
+    const char *fixedKeyBytes = self.fixedKey.data.bytes;
 
     char negatedFixedKeyBytes[CDTENCRYPTIONKEY_KEYSIZE];
     for (NSUInteger i = 0; i < CDTENCRYPTIONKEY_KEYSIZE; i++) {

--- a/Tests/Tests/Helpers/CDTHelperMisc.h
+++ b/Tests/Tests/Helpers/CDTHelperMisc.h
@@ -1,0 +1,18 @@
+//
+//  CDTHelperMisc.h
+//  Tests
+//
+//  Created by Enrique de la Torre Fernandez on 21/05/2015.
+//  Copyright (c) 2015 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+NSData *dataFromHexadecimalString(NSString *hexString);

--- a/Tests/Tests/Helpers/CDTHelperMisc.m
+++ b/Tests/Tests/Helpers/CDTHelperMisc.m
@@ -1,0 +1,49 @@
+//
+//  CDTHelperMisc.m
+//  Tests
+//
+//  Created by Enrique de la Torre Fernandez on 21/05/2015.
+//  Copyright (c) 2015 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+#import "CDTHelperMisc.h"
+
+NSData *dataFromHexadecimalString(NSString *hexString)
+{
+    /*
+     The string represent the hexadecimal values that should be used, so the string "4962"
+     represents byte values 0x49  0x62.
+     Note that the strings are twice the size since every two characters in the string
+     corresponds to a single byte.
+     */
+    if (([hexString length] % 2) != 0) {
+        return nil;
+    }
+
+    NSUInteger size = ([hexString length] / (NSUInteger)2);
+    unsigned char buff[size];
+
+    @autoreleasepool
+    {
+        for (NSUInteger i = 0; i < size; i++) {
+            NSString *hexChrStr = [hexString substringWithRange:NSMakeRange(i * 2, 2)];
+
+            NSScanner *scanner = [[NSScanner alloc] initWithString:hexChrStr];
+            uint currInt;
+            [scanner scanHexInt:&currInt];
+
+            buff[i] = (char)currInt;
+        }
+    }
+
+    NSData *data = [NSData dataWithBytes:buff length:size];
+
+    return data;
+}


### PR DESCRIPTION
*What:*
`TDBlobStore` has to be able to handle encrypted attachments.

*Why:*
We have to cipher the entire datastore, i.e. databases and **attachments**.

*How:*
1. Implement a new class named `CDTBlobEncryptedData` that conforms to protocols `CDTBlobReader` & `CDTBlobWriter`. This class relies on `CDTBlobData` and `CDTEncryptionKeychainUtils` to generate encrypted attachments (for more details about the structure of theses attachments check [encryption-at-rest.md](https://github.com/cloudant/cloudant-sync/blob/master/specs/encryption-at-rest.md)).
2. Factory named `CDTBlobHandleFactory` to create instances that conform to `CDTBlobReader` & `CDTBlobWriter`.
3. Modify `TDBlobStore` to use `CDTBlobHandleFactory`. So the factory is responsible for creating an instance able to handle an encrypted attachment or plain data depending of the value/key returned by the key provider.

*Tests:*
* `CDTBlobEncryptedData`.- Passes the same tests that `CDTBlobData` and:
    1. Generate attachments with the correct structure.

* `CDTBlobHandleFactory`
    1. Create instances of `CDTBlobData` is the key provider returns nil.
    2. Create instances of `CDTBlobEncryptedData` is the key provider returns an instance of `CDTEncryptionKey`.

* `TDBlobStore`
    1. Generate the same SHA1 digest if the attachments are encrypted.
    2. It is able to generate encrypted files.
    3. It is still able to return plain data even if the attachments are encrypted before saving to disk.

reviewer @mikerhodes 
reviewer @rhyshort 

**NOTE:** Wait to review this PR until PR #144  is closed. This branch will be rebased and there will be only commits related to this case.