### PR TITLE
47447 Implement a simple key provider

### DIFF
--- a/CDTDatastore.xcworkspace/contents.xcworkspacedata
+++ b/CDTDatastore.xcworkspace/contents.xcworkspacedata
@@ -137,6 +137,12 @@
                location = "group:CDTEncryptionKeyProvider.h">
             </FileRef>
             <FileRef
+               location = "group:CDTEncryptionKeySimpleProvider.h">
+            </FileRef>
+            <FileRef
+               location = "group:CDTEncryptionKeySimpleProvider.m">
+            </FileRef>
+            <FileRef
                location = "group:FMDatabase+EncryptionKey.h">
             </FileRef>
             <FileRef

--- a/Classes/common/CloudantSync.h
+++ b/Classes/common/CloudantSync.h
@@ -21,6 +21,7 @@
 // will not be available and Xcode will not autocomplete the code with them.
 #ifdef ENCRYPT_DATABASE
 #import "CDTEncryptionKeychainProvider.h"
+#import "CDTEncryptionKeySimpleProvider.h"
 #import "CDTDatastoreManager+EncryptionKey.h"
 #else
 #import "CDTDatastoreManager.h"

--- a/Classes/common/Encryption/CDTEncryptionKeySimpleProvider.h
+++ b/Classes/common/Encryption/CDTEncryptionKeySimpleProvider.h
@@ -1,0 +1,38 @@
+//
+//  CDTEncryptionKeySimpleProvider.h
+//  CloudantSync
+//
+//  Created by Enrique de la Torre Fernandez on 26/05/2015.
+//  Copyright (c) 2015 IBM Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "CDTEncryptionKeyProvider.h"
+
+/**
+ This is a very simple implementation of a key provider. Initialise it with the key you want to use
+ to cipher the datastore and it will return it each time 'encryptionKey' is called.
+ 
+ Notice that the key provided has to conform to the restrictions enforced by CDTEncryptionKey.
+ 
+ @see CDTEncryptionKeyProvider
+ @see CDTEncryptionKey
+ */
+@interface CDTEncryptionKeySimpleProvider : NSObject <CDTEncryptionKeyProvider>
+
+- (instancetype)init UNAVAILABLE_ATTRIBUTE;
+
+- (instancetype)initWithKey:(NSData *)key NS_DESIGNATED_INITIALIZER;
+
++ (instancetype)providerWithKey:(NSData *)key;
+
+@end

--- a/Classes/common/Encryption/CDTEncryptionKeySimpleProvider.m
+++ b/Classes/common/Encryption/CDTEncryptionKeySimpleProvider.m
@@ -1,0 +1,53 @@
+//
+//  CDTEncryptionKeySimpleProvider.m
+//  CloudantSync
+//
+//  Created by Enrique de la Torre Fernandez on 26/05/2015.
+//  Copyright (c) 2015 IBM Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#import "CDTEncryptionKeySimpleProvider.h"
+
+#import "CDTLogging.h"
+
+@interface CDTEncryptionKeySimpleProvider ()
+
+@property (strong, nonatomic, readonly) CDTEncryptionKey *thisKey;
+
+@end
+
+@implementation CDTEncryptionKeySimpleProvider
+
+- (instancetype)init { return [self initWithKey:nil]; }
+
+- (instancetype)initWithKey:(NSData *)key
+{
+    self = [super init];
+    if (self) {
+        _thisKey = [CDTEncryptionKey encryptionKeyWithData:key];
+        if (!_thisKey) {
+            CDTLogError(CDTDATASTORE_LOG_CONTEXT,
+                        @"Key could not be created with provided data. Abort initialisation");
+
+            self = nil;
+        }
+    }
+
+    return self;
+}
+
+#pragma mark - CDTEncryptionKeyProvider methods
+- (CDTEncryptionKey *)encryptionKey { return self.thisKey; }
+
+#pragma mark - Public class methods
++ (instancetype)providerWithKey:(NSData *)key { return [[[self class] alloc] initWithKey:key]; }
+
+@end

--- a/EncryptionTests/Encryption Tests/CDTQIndexManagerEncryptionTests.m
+++ b/EncryptionTests/Encryption Tests/CDTQIndexManagerEncryptionTests.m
@@ -81,7 +81,7 @@
 
 - (void)testCreateQueryIndexManagerWithFixedKeyProvider
 {
-    CDTHelperFixedKeyProvider *provider = [[CDTHelperFixedKeyProvider alloc] init];
+    CDTHelperFixedKeyProvider *provider = [CDTHelperFixedKeyProvider provider];
     CDTDatastore *datastore = [self.factory datastoreNamed:@"create_query_index_tests_fixedprovider"
                                  withEncryptionKeyProvider:provider
                                                      error:nil];
@@ -96,7 +96,7 @@
 - (void)testCreateQueryIndexManagerWithFixedKeyProviderCiphersIndex
 {
     // Create index
-    CDTHelperFixedKeyProvider *provider = [[CDTHelperFixedKeyProvider alloc] init];
+    CDTHelperFixedKeyProvider *provider = [CDTHelperFixedKeyProvider provider];
     CDTDatastore *datastore =
         [self.factory datastoreNamed:@"create_query_index_textests_fixedprovider_cipher"
             withEncryptionKeyProvider:provider
@@ -146,7 +146,7 @@
 - (void)testCreateQueryIndexManagerWithFixedKeyProviderFailsIfDBExistsAndItIsNotEncrypted
 {
     // Create datastore
-    CDTHelperFixedKeyProvider *provider = [[CDTHelperFixedKeyProvider alloc] init];
+    CDTHelperFixedKeyProvider *provider = [CDTHelperFixedKeyProvider provider];
     CDTDatastore *datastore =
         [self.factory datastoreNamed:
                           @"create_query_index_textests_fixedprovider_fails_with_noncipher_db"
@@ -179,7 +179,7 @@
 - (void)testCreateQueryIndexManagerWithFixedKeyProviderFailsIfDBIsEncryptedButKeyIsWrong
 {
     // Create datastore
-    CDTHelperFixedKeyProvider *provider = [[CDTHelperFixedKeyProvider alloc] init];
+    CDTHelperFixedKeyProvider *provider = [CDTHelperFixedKeyProvider provider];
     
     CDTDatastore *datastore = [self.factory
                    datastoreNamed:@"create_query_index_textests_fixedprovider_fails_with_wrong_key"

--- a/EncryptionTests/Encryption Tests/DatastoreEncryptionTests.m
+++ b/EncryptionTests/Encryption Tests/DatastoreEncryptionTests.m
@@ -32,7 +32,7 @@
 
 - (void)testEncryptionKeyProviderReturnsTheSameProviderUsedToCreateTheDatastore
 {
-    CDTHelperFixedKeyProvider *provider = [[CDTHelperFixedKeyProvider alloc] init];
+    CDTHelperFixedKeyProvider *provider = [CDTHelperFixedKeyProvider provider];
 
     CDTDatastore *datastore = [self.factory datastoreNamed:@"test_copyprovider"
                                  withEncryptionKeyProvider:provider
@@ -68,7 +68,7 @@
     TD_Database *db = [[TD_Database alloc] initWithPath:path];
 
     // Init with fixed key provider
-    CDTHelperFixedKeyProvider *fixedProvider = [[CDTHelperFixedKeyProvider alloc] init];
+    CDTHelperFixedKeyProvider *fixedProvider = [CDTHelperFixedKeyProvider provider];
 
     XCTAssertNil(
         [[CDTDatastore alloc] initWithManager:(CDTDatastoreManager *)@"manager"
@@ -80,7 +80,7 @@
 - (void)testInitReturnsNilIfEncryptionKeyProviderReturnsNilAndDBIsEncrypted
 {
     // Create encrypted db
-    CDTHelperFixedKeyProvider *fixedProvider = [[CDTHelperFixedKeyProvider alloc] init];
+    CDTHelperFixedKeyProvider *fixedProvider = [CDTHelperFixedKeyProvider provider];
 
     NSString *path = [NSTemporaryDirectory()
         stringByAppendingPathComponent:@"datastoreEncryptionTests_encryptDB"];
@@ -101,7 +101,7 @@
 - (void)testInitReturnsNilIfEncryptionKeyProviderDoesNotReturnTheKeyUsedToCipherTheDatabase
 {
     // Create encrypted db
-    CDTHelperFixedKeyProvider *fixedProvider = [[CDTHelperFixedKeyProvider alloc] init];
+    CDTHelperFixedKeyProvider *fixedProvider = [CDTHelperFixedKeyProvider provider];
 
     NSString *path = [NSTemporaryDirectory()
         stringByAppendingPathComponent:@"datastoreEncryptionTests_encryptDBWrongKey"];
@@ -145,7 +145,7 @@
     TD_Database *db = [TD_Database createEmptyDBAtPath:path withEncryptionKeyProvider:nilProvider];
 
     // Init with fixed key provider
-    CDTHelperFixedKeyProvider *fixedProvider = [[CDTHelperFixedKeyProvider alloc] init];
+    CDTHelperFixedKeyProvider *fixedProvider = [CDTHelperFixedKeyProvider provider];
 
     XCTAssertNil(
         [[CDTDatastore alloc] initWithManager:(CDTDatastoreManager *)@"manager"
@@ -157,7 +157,7 @@
 - (void)testInitReturnsNilIfEncryptionKeyProviderReturnsNilWithAnAlreadyOpenEncryptedDB
 {
     // Create encrypted db
-    CDTHelperFixedKeyProvider *fixedProvider = [[CDTHelperFixedKeyProvider alloc] init];
+    CDTHelperFixedKeyProvider *fixedProvider = [CDTHelperFixedKeyProvider provider];
 
     NSString *path = [NSTemporaryDirectory()
         stringByAppendingPathComponent:@"datastoreEncryptionTests_alreadyOpenEncryptDB"];
@@ -176,7 +176,7 @@
 - (void)testInitReturnsNilIfEncryptionKeyProviderDoesNotReturnTheKeyUsedToOpenTheDatabase
 {
     // Create encrypted db
-    CDTHelperFixedKeyProvider *fixedProvider = [[CDTHelperFixedKeyProvider alloc] init];
+    CDTHelperFixedKeyProvider *fixedProvider = [CDTHelperFixedKeyProvider provider];
 
     NSString *path = [NSTemporaryDirectory()
         stringByAppendingPathComponent:@"datastoreEncryptionTests_encryptDBWrongKey_again"];

--- a/EncryptionTests/Encryption Tests/DatastoreManagerEncryptionTests.m
+++ b/EncryptionTests/Encryption Tests/DatastoreManagerEncryptionTests.m
@@ -46,7 +46,7 @@
            withEncryptionKeyProvider:nilProvider];
 
     // Get datastore
-    CDTHelperFixedKeyProvider *fixedProvider = [[CDTHelperFixedKeyProvider alloc] init];
+    CDTHelperFixedKeyProvider *fixedProvider = [CDTHelperFixedKeyProvider provider];
 
     NSError *error = nil;
     CDTDatastore *datastore =
@@ -61,7 +61,7 @@
 - (void)testDatastoreNamedReturnsNilIfEncryptionKeyProviderReturnsNilAndDBIsEncrypted
 {
     // Create encrypted db
-    CDTHelperFixedKeyProvider *fixedProvider = [[CDTHelperFixedKeyProvider alloc] init];
+    CDTHelperFixedKeyProvider *fixedProvider = [CDTHelperFixedKeyProvider provider];
 
     NSString *dbName = @"testdatastoremanager_encryptdb";
     [TD_Database createEmptyDBAtPath:[self pathForDBName:dbName]
@@ -82,7 +82,7 @@
 - (void)testDatastoreNamedReturnsNilIfEncryptionKeyProviderDoesNotReturnTheKeyUsedToCipherTheDatabase
 {
     // Create encrypted db
-    CDTHelperFixedKeyProvider *fixedProvider = [[CDTHelperFixedKeyProvider alloc] init];
+    CDTHelperFixedKeyProvider *fixedProvider = [CDTHelperFixedKeyProvider provider];
 
     NSString *dbName = @"testdatastoremanager_encryptdbwrongkey";
     [TD_Database createEmptyDBAtPath:[self pathForDBName:dbName]
@@ -122,7 +122,7 @@
     [self.factory datastoreNamed:dbName withEncryptionKeyProvider:nilProvider error:nil];
 
     // Get datastore
-    CDTHelperFixedKeyProvider *fixedProvider = [[CDTHelperFixedKeyProvider alloc] init];
+    CDTHelperFixedKeyProvider *fixedProvider = [CDTHelperFixedKeyProvider provider];
 
     NSError *error = nil;
     CDTDatastore *datastore =
@@ -137,7 +137,7 @@
 - (void)testDatastoreNamedReturnsNilIfEncryptionKeyProviderReturnsNilWithAnAlreadyOpenEncryptedDB
 {
     // Create encrypted db
-    CDTHelperFixedKeyProvider *fixedProvider = [[CDTHelperFixedKeyProvider alloc] init];
+    CDTHelperFixedKeyProvider *fixedProvider = [CDTHelperFixedKeyProvider provider];
 
     NSString *dbName = @"testdatastoremanager_alreadyopenencryptdb";
     [self.factory datastoreNamed:dbName withEncryptionKeyProvider:fixedProvider error:nil];
@@ -157,7 +157,7 @@
 - (void)testDatastoreNamedReturnsNilIfEncryptionKeyProviderDoesNotReturnTheKeyUsedToOpenTheDatabase
 {
     // Create encrypted db
-    CDTHelperFixedKeyProvider *fixedProvider = [[CDTHelperFixedKeyProvider alloc] init];
+    CDTHelperFixedKeyProvider *fixedProvider = [CDTHelperFixedKeyProvider provider];
 
     NSString *dbName = @"testdatastoremanager_encryptdbwrongkey_again";
     [self.factory datastoreNamed:dbName withEncryptionKeyProvider:fixedProvider error:nil];

--- a/EncryptionTests/Encryption Tests/TD_DatabaseEncryptionTests.m
+++ b/EncryptionTests/Encryption Tests/TD_DatabaseEncryptionTests.m
@@ -46,7 +46,7 @@
 - (void)testCreateEmptyWithFixedKeyProviderCiphersDatabase
 {
     // Create db
-    CDTHelperFixedKeyProvider *provider = [[CDTHelperFixedKeyProvider alloc] init];
+    CDTHelperFixedKeyProvider *provider = [CDTHelperFixedKeyProvider provider];
 
     NSString *path = [NSTemporaryDirectory()
         stringByAppendingPathComponent:@"TD_DatabaseEncryptionTests_DoCipherDb"];
@@ -71,7 +71,7 @@
 
 - (void)testOpenDoesNotFailIfEncryptionKeyProviderReturnsAValue
 {
-    CDTHelperFixedKeyProvider *provider = [[CDTHelperFixedKeyProvider alloc] init];
+    CDTHelperFixedKeyProvider *provider = [CDTHelperFixedKeyProvider provider];
     NSString *path = [NSTemporaryDirectory()
         stringByAppendingPathComponent:@"TD_DatabaseEncryptionTests_openNotFail"];
 
@@ -94,7 +94,7 @@
     TD_Database *db = [[TD_Database alloc] initWithPath:path];
 
     // Open with fixed key provider
-    CDTHelperFixedKeyProvider *fixedProvider = [[CDTHelperFixedKeyProvider alloc] init];
+    CDTHelperFixedKeyProvider *fixedProvider = [CDTHelperFixedKeyProvider provider];
 
     XCTAssertFalse([db openWithEncryptionKeyProvider:fixedProvider],
                    @"A non-encrypted db can not be open with an encryption key");
@@ -103,7 +103,7 @@
 - (void)testOpenFailsIfEncryptionKeyProviderReturnsNilWithAnEncryptedDatabase
 {
     // Create encrypted db
-    CDTHelperFixedKeyProvider *fixedProvider = [[CDTHelperFixedKeyProvider alloc] init];
+    CDTHelperFixedKeyProvider *fixedProvider = [CDTHelperFixedKeyProvider provider];
 
     NSString *path = [NSTemporaryDirectory()
         stringByAppendingPathComponent:@"TD_DatabaseEncryptionTests_encryptDB"];
@@ -122,7 +122,7 @@
 - (void)testOpenFailsIfEncryptionKeyProviderDoesNotReturnTheKeyUsedToCipherTheDatabase
 {
     // Create encrypted db
-    CDTHelperFixedKeyProvider *fixedProvider = [[CDTHelperFixedKeyProvider alloc] init];
+    CDTHelperFixedKeyProvider *fixedProvider = [CDTHelperFixedKeyProvider provider];
 
     NSString *path = [NSTemporaryDirectory()
         stringByAppendingPathComponent:@"TD_DatabaseEncryptionTests_encryptDBWrongKey"];
@@ -162,7 +162,7 @@
     TD_Database *db = [TD_Database createEmptyDBAtPath:path withEncryptionKeyProvider:nilProvider];
 
     // Re-open with fixed key provider
-    CDTHelperFixedKeyProvider *fixedProvider = [[CDTHelperFixedKeyProvider alloc] init];
+    CDTHelperFixedKeyProvider *fixedProvider = [CDTHelperFixedKeyProvider provider];
 
     XCTAssertFalse([db openWithEncryptionKeyProvider:fixedProvider],
                    @"A non-encrypted db can not be open with an encryption key");
@@ -171,7 +171,7 @@
 - (void)testReopenFailsIfEncryptionKeyProviderReturnsNilWithAnEncryptedDatabase
 {
     // Create encrypted db
-    CDTHelperFixedKeyProvider *fixedProvider = [[CDTHelperFixedKeyProvider alloc] init];
+    CDTHelperFixedKeyProvider *fixedProvider = [CDTHelperFixedKeyProvider provider];
 
     NSString *path = [NSTemporaryDirectory()
         stringByAppendingPathComponent:@"TD_DatabaseEncryptionTests_reOpenEncryptDB"];
@@ -188,7 +188,7 @@
 - (void)testReopenFailsIfEncryptionKeyProviderDoesNotReturnTheKeyUsedToCipherTheDatabase
 {
     // Create encrypted db
-    CDTHelperFixedKeyProvider *fixedProvider = [[CDTHelperFixedKeyProvider alloc] init];
+    CDTHelperFixedKeyProvider *fixedProvider = [CDTHelperFixedKeyProvider provider];
 
     NSString *path = [NSTemporaryDirectory()
         stringByAppendingPathComponent:@"TD_DatabaseEncryptionTests_reOpenEncryptDBWrongKey"];

--- a/Tests/Tests.xcodeproj/project.pbxproj
+++ b/Tests/Tests.xcodeproj/project.pbxproj
@@ -98,6 +98,8 @@
 		CD2188F11AE576740036F59F /* CDTMockEncryptionKeychainStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = CD2188EF1AE576740036F59F /* CDTMockEncryptionKeychainStorage.m */; };
 		CD25B2841AFA49E2001113BB /* CDTBlobDataTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD25B2831AFA49E2001113BB /* CDTBlobDataTests.m */; };
 		CD25B2851AFA49E2001113BB /* CDTBlobDataTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD25B2831AFA49E2001113BB /* CDTBlobDataTests.m */; };
+		CD2C67CC1B14897000B95B9C /* CDTEncryptionKeySimpleProviderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD2C67CB1B14897000B95B9C /* CDTEncryptionKeySimpleProviderTests.m */; };
+		CD2C67CD1B14897000B95B9C /* CDTEncryptionKeySimpleProviderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD2C67CB1B14897000B95B9C /* CDTEncryptionKeySimpleProviderTests.m */; };
 		CD3FBCA61AB05A170032376E /* CDTHelperFixedKeyProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = CD3FBCA31AB05A170032376E /* CDTHelperFixedKeyProvider.m */; };
 		CD3FBCA71AB05A170032376E /* CDTHelperFixedKeyProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = CD3FBCA31AB05A170032376E /* CDTHelperFixedKeyProvider.m */; };
 		CD3FBCA81AB05A170032376E /* CDTHelperOneUseKeyProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = CD3FBCA51AB05A170032376E /* CDTHelperOneUseKeyProvider.m */; };
@@ -233,6 +235,7 @@
 		CD2188EE1AE576740036F59F /* CDTMockEncryptionKeychainStorage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDTMockEncryptionKeychainStorage.h; sourceTree = "<group>"; };
 		CD2188EF1AE576740036F59F /* CDTMockEncryptionKeychainStorage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTMockEncryptionKeychainStorage.m; sourceTree = "<group>"; };
 		CD25B2831AFA49E2001113BB /* CDTBlobDataTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CDTBlobDataTests.m; path = Attachments/CDTBlobDataTests.m; sourceTree = "<group>"; };
+		CD2C67CB1B14897000B95B9C /* CDTEncryptionKeySimpleProviderTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTEncryptionKeySimpleProviderTests.m; sourceTree = "<group>"; };
 		CD3FBCA21AB05A170032376E /* CDTHelperFixedKeyProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDTHelperFixedKeyProvider.h; sourceTree = "<group>"; };
 		CD3FBCA31AB05A170032376E /* CDTHelperFixedKeyProvider.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTHelperFixedKeyProvider.m; sourceTree = "<group>"; };
 		CD3FBCA41AB05A170032376E /* CDTHelperOneUseKeyProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDTHelperOneUseKeyProvider.h; sourceTree = "<group>"; };
@@ -477,6 +480,7 @@
 			children = (
 				CD4818761B0E0DBF00E2CB64 /* Attachments */,
 				CD2188E01AE571250036F59F /* Keychain */,
+				CD2C67CB1B14897000B95B9C /* CDTEncryptionKeySimpleProviderTests.m */,
 				CD2188D01AE5711A0036F59F /* CDTQIndexManagerEncryptionTests.m */,
 				CD2188D11AE5711A0036F59F /* CloudantTests+EncryptionTests.h */,
 				CD2188D21AE5711A0036F59F /* CloudantTests+EncryptionTests.m */,
@@ -783,6 +787,7 @@
 				CD3FBCA81AB05A170032376E /* CDTHelperOneUseKeyProvider.m in Sources */,
 				CD2188D61AE5711A0036F59F /* CDTQIndexManagerEncryptionTests.m in Sources */,
 				CD2188EB1AE5764B0036F59F /* CDTEncryptionKeychainManagerTests.m in Sources */,
+				CD2C67CC1B14897000B95B9C /* CDTEncryptionKeySimpleProviderTests.m in Sources */,
 				9F0D24171893161000D3D04E /* TDReachabilityTests.m in Sources */,
 				CDBC573A1AE6A06C00CF9E6B /* CDTMockEncryptionKeychainManager.m in Sources */,
 				EC0C834E1AB217290051042F /* CDTQQuerySqlTranslatorTests.m in Sources */,
@@ -859,6 +864,7 @@
 				CD3FBCA91AB05A170032376E /* CDTHelperOneUseKeyProvider.m in Sources */,
 				CD2188D71AE5711A0036F59F /* CDTQIndexManagerEncryptionTests.m in Sources */,
 				CD2188EC1AE5764B0036F59F /* CDTEncryptionKeychainManagerTests.m in Sources */,
+				CD2C67CD1B14897000B95B9C /* CDTEncryptionKeySimpleProviderTests.m in Sources */,
 				EC0C834F1AB217290051042F /* CDTQQuerySqlTranslatorTests.m in Sources */,
 				CDBC573B1AE6A06C00CF9E6B /* CDTMockEncryptionKeychainManager.m in Sources */,
 				EC0C835B1AB217290051042F /* CDTQMatcherIndexManager.m in Sources */,

--- a/Tests/Tests/Encryption/Attachments/CDTBlobEncryptedDataTests.m
+++ b/Tests/Tests/Encryption/Attachments/CDTBlobEncryptedDataTests.m
@@ -73,7 +73,7 @@
     ivStr = @"00000cc00f00000f0ce0000000f00000";
     self.otherIVData = dataFromHexadecimalString(ivStr);
 
-    CDTHelperFixedKeyProvider *provider = [[CDTHelperFixedKeyProvider alloc] initWithKey:keyData];
+    CDTHelperFixedKeyProvider *provider = [CDTHelperFixedKeyProvider providerWithKey:keyData];
     self.encryptionKey = [provider encryptionKey];
 
     self.plainData = [@"摇;摃:xx👹⌚️👽" dataUsingEncoding:NSUnicodeStringEncoding];

--- a/Tests/Tests/Encryption/Attachments/CDTBlobHandleFactoryTests.m
+++ b/Tests/Tests/Encryption/Attachments/CDTBlobHandleFactoryTests.m
@@ -67,7 +67,7 @@
 - (void)testFactoryWithFixedProviderCreatesBlobHandlesForEncryptedAttachments
 {
     CDTBlobHandleFactory *factory = [[CDTBlobHandleFactory alloc]
-                                     initWithEncryptionKeyProvider:[[CDTHelperFixedKeyProvider alloc] init]];
+                                     initWithEncryptionKeyProvider:[CDTHelperFixedKeyProvider provider]];
     
     id<CDTBlobReader> reader = [factory readerWithPath:@"///This is not a path"];
     id<CDTBlobWriter> writer = [factory writerWithPath:@"///This is not a path"];

--- a/Tests/Tests/Encryption/CDTEncryptionKeySimpleProviderTests.m
+++ b/Tests/Tests/Encryption/CDTEncryptionKeySimpleProviderTests.m
@@ -1,0 +1,71 @@
+//
+//  CDTEncryptionKeySimpleProviderTests.m
+//  Tests
+//
+//  Created by Enrique de la Torre Fernandez on 26/05/2015.
+//  Copyright (c) 2015 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+#import <XCTest/XCTest.h>
+
+#import "CDTEncryptionKeySimpleProvider.h"
+
+@interface CDTEncryptionKeySimpleProviderTests : XCTestCase
+
+@end
+
+@implementation CDTEncryptionKeySimpleProviderTests
+
+- (void)setUp
+{
+    [super setUp];
+
+    // Put setup code here. This method is called before the invocation of each test method in the
+    // class.
+}
+
+- (void)tearDown
+{
+    // Put teardown code here. This method is called after the invocation of each test method in the
+    // class.
+
+    [super tearDown];
+}
+
+- (void)testInitWithNilFails
+{
+    XCTAssertNil([[CDTEncryptionKeySimpleProvider alloc] initWithKey:nil], @"Data is mandatory");
+}
+
+- (void)testInitWithWrongDataLength
+{
+    char buffer[2 * CDTENCRYPTIONKEY_KEYSIZE];
+    memset(buffer, '*', sizeof(buffer));
+
+    NSData *data = [NSData dataWithBytes:buffer length:sizeof(buffer)];
+
+    XCTAssertNil([[CDTEncryptionKeySimpleProvider alloc] initWithKey:data],
+                 @"Data length has to be %i", CDTENCRYPTIONKEY_KEYSIZE);
+}
+
+- (void)testEncryptionKeyReturnsExpectedData
+{
+    char buffer[CDTENCRYPTIONKEY_KEYSIZE];
+    memset(buffer, '*', sizeof(buffer));
+
+    NSData *data = [NSData dataWithBytes:buffer length:sizeof(buffer)];
+
+    CDTEncryptionKeySimpleProvider *provider =
+        [[CDTEncryptionKeySimpleProvider alloc] initWithKey:data];
+
+    XCTAssertEqualObjects(data, [[provider encryptionKey] data], @"Unexpected result");
+}
+
+@end

--- a/Tests/Tests/Encryption/DatastoreEncryptionTests.m
+++ b/Tests/Tests/Encryption/DatastoreEncryptionTests.m
@@ -68,7 +68,7 @@
     TD_Database *db = [[TD_Database alloc] initWithPath:path];
 
     // Init with fixed key provider
-    CDTHelperFixedKeyProvider *fixedProvider = [[CDTHelperFixedKeyProvider alloc] init];
+    CDTHelperFixedKeyProvider *fixedProvider = [CDTHelperFixedKeyProvider provider];
 
     XCTAssertNil(
         [[CDTDatastore alloc] initWithManager:(CDTDatastoreManager *)@"manager"
@@ -86,7 +86,7 @@
     TD_Database *db = [[TD_Database alloc] initWithPath:path];
 
     // Init with fixed key provider
-    CDTHelperFixedKeyProvider *fixedProvider = [[CDTHelperFixedKeyProvider alloc] init];
+    CDTHelperFixedKeyProvider *fixedProvider = [CDTHelperFixedKeyProvider provider];
 
     XCTAssertNil([[CDTDatastore alloc] initWithManager:(CDTDatastoreManager *)@"manager"
                                               database:db
@@ -139,7 +139,7 @@
     TD_Database *db = [TD_Database createEmptyDBAtPath:path withEncryptionKeyProvider:nilProvider];
 
     // Init with fixed key provider
-    CDTHelperFixedKeyProvider *fixedProvider = [[CDTHelperFixedKeyProvider alloc] init];
+    CDTHelperFixedKeyProvider *fixedProvider = [CDTHelperFixedKeyProvider provider];
 
     XCTAssertNil(
         [[CDTDatastore alloc] initWithManager:(CDTDatastoreManager *)@"manager"

--- a/Tests/Tests/Encryption/DatastoreManagerEncryptionTests.m
+++ b/Tests/Tests/Encryption/DatastoreManagerEncryptionTests.m
@@ -46,7 +46,7 @@
            withEncryptionKeyProvider:nilProvider];
 
     // Get datastore
-    CDTHelperFixedKeyProvider *fixedProvider = [[CDTHelperFixedKeyProvider alloc] init];
+    CDTHelperFixedKeyProvider *fixedProvider = [CDTHelperFixedKeyProvider provider];
 
     NSError *error = nil;
     CDTDatastore *datastore =
@@ -69,7 +69,7 @@
                                                  error:nil];
 
     // Get datastore
-    CDTHelperFixedKeyProvider *fixedProvider = [[CDTHelperFixedKeyProvider alloc] init];
+    CDTHelperFixedKeyProvider *fixedProvider = [CDTHelperFixedKeyProvider provider];
 
     NSError *error = nil;
     CDTDatastore *datastore =
@@ -131,7 +131,7 @@
     [self.factory datastoreNamed:dbName withEncryptionKeyProvider:nilProvider error:nil];
 
     // Get datastore
-    CDTHelperFixedKeyProvider *fixedProvider = [[CDTHelperFixedKeyProvider alloc] init];
+    CDTHelperFixedKeyProvider *fixedProvider = [CDTHelperFixedKeyProvider provider];
 
     NSError *error = nil;
     CDTDatastore *datastore =

--- a/Tests/Tests/Encryption/TDBlobStoreEncryptionTests.m
+++ b/Tests/Tests/Encryption/TDBlobStoreEncryptionTests.m
@@ -57,7 +57,7 @@
     self.encryptedBlobStorePath = [NSTemporaryDirectory()
         stringByAppendingPathComponent:@"blobStoreEncryptionTests_encryptedData"];
 
-    provider = [[CDTHelperFixedKeyProvider alloc] init];
+    provider = [CDTHelperFixedKeyProvider provider];
     self.encryptedBlobStore = [[TDBlobStore alloc] initWithPath:self.encryptedBlobStorePath
                                           encryptionKeyProvider:provider
                                                           error:nil];

--- a/Tests/Tests/Encryption/TD_DatabaseEncryptionTests.m
+++ b/Tests/Tests/Encryption/TD_DatabaseEncryptionTests.m
@@ -47,7 +47,7 @@
 - (void)testCreateEmptyWithFixedKeyProviderFails
 {
     // Create db
-    CDTHelperFixedKeyProvider *provider = [[CDTHelperFixedKeyProvider alloc] init];
+    CDTHelperFixedKeyProvider *provider = [CDTHelperFixedKeyProvider provider];
 
     NSString *path = [NSTemporaryDirectory()
         stringByAppendingPathComponent:@"TD_DatabaseEncryptionTests_DoCipherDb"];
@@ -71,7 +71,7 @@
 
 - (void)testOpenFailsIfEncryptionKeyProviderReturnsAValue
 {
-    CDTHelperFixedKeyProvider *provider = [[CDTHelperFixedKeyProvider alloc] init];
+    CDTHelperFixedKeyProvider *provider = [CDTHelperFixedKeyProvider provider];
     NSString *path = [NSTemporaryDirectory()
         stringByAppendingPathComponent:@"TD_DatabaseEncryptionTests_OpenFails"];
 
@@ -94,7 +94,7 @@
     TD_Database *db = [[TD_Database alloc] initWithPath:path];
 
     // Open with fixed key provider
-    CDTHelperFixedKeyProvider *fixedProvider = [[CDTHelperFixedKeyProvider alloc] init];
+    CDTHelperFixedKeyProvider *fixedProvider = [CDTHelperFixedKeyProvider provider];
 
     XCTAssertFalse([db openWithEncryptionKeyProvider:fixedProvider],
                    @"A non-encrypted db can not be open with an encryption key");
@@ -109,7 +109,7 @@
     TD_Database *db = [[TD_Database alloc] initWithPath:path];
 
     // Open with fixed key provider
-    CDTHelperFixedKeyProvider *fixedProvider = [[CDTHelperFixedKeyProvider alloc] init];
+    CDTHelperFixedKeyProvider *fixedProvider = [CDTHelperFixedKeyProvider provider];
 
     XCTAssertFalse([db openWithEncryptionKeyProvider:fixedProvider],
                    @"Although the key provided is the key used to encrypt the database, the db can "
@@ -156,7 +156,7 @@
     TD_Database *db = [TD_Database createEmptyDBAtPath:path withEncryptionKeyProvider:nilProvider];
 
     // Re-open with fixed key provider
-    CDTHelperFixedKeyProvider *fixedProvider = [[CDTHelperFixedKeyProvider alloc] init];
+    CDTHelperFixedKeyProvider *fixedProvider = [CDTHelperFixedKeyProvider provider];
 
     XCTAssertFalse([db openWithEncryptionKeyProvider:fixedProvider],
                    @"A non-encrypted db can not be open with an encryption key");

--- a/Tests/Tests/Helpers/CDTHelperFixedKeyProvider.h
+++ b/Tests/Tests/Helpers/CDTHelperFixedKeyProvider.h
@@ -15,12 +15,12 @@
 
 #import <Foundation/Foundation.h>
 
-#import "CDTEncryptionKeyProvider.h"
+#import "CDTEncryptionKeySimpleProvider.h"
 
-@interface CDTHelperFixedKeyProvider : NSObject <CDTEncryptionKeyProvider>
-
-- (instancetype)initWithKey:(NSData *)key NS_DESIGNATED_INITIALIZER;
+@interface CDTHelperFixedKeyProvider : CDTEncryptionKeySimpleProvider
 
 - (instancetype)negatedProvider;
+
++ (instancetype)provider;
 
 @end

--- a/Tests/Tests/Helpers/CDTHelperFixedKeyProvider.m
+++ b/Tests/Tests/Helpers/CDTHelperFixedKeyProvider.m
@@ -17,40 +17,14 @@
 
 @interface CDTHelperFixedKeyProvider ()
 
-@property (strong, nonatomic, readonly) CDTEncryptionKey *fixedKey;
-
 @end
 
 @implementation CDTHelperFixedKeyProvider
 
-#pragma mark - Init object
-- (instancetype)init
-{
-    char buffer[CDTENCRYPTIONKEY_KEYSIZE];
-    memset(buffer, '*', sizeof(buffer));
-    
-    NSData *key = [NSData dataWithBytes:buffer length:sizeof(buffer)];
-    
-    return [self initWithKey:key];
-}
-
-- (instancetype)initWithKey:(NSData *)key
-{
-    self = [super init];
-    if (self) {
-        _fixedKey = [CDTEncryptionKey encryptionKeyWithData:key];
-    }
-
-    return self;
-}
-
-#pragma mark - CDTEncryptionKeyProvider methods
-- (CDTEncryptionKey *)encryptionKey { return self.fixedKey; }
-
 #pragma mark - Public methods
 - (instancetype)negatedProvider
 {
-    const char *fixedKeyBytes = self.fixedKey.data.bytes;
+    const char *fixedKeyBytes = [[[self encryptionKey] data] bytes];
 
     char negatedFixedKeyBytes[CDTENCRYPTIONKEY_KEYSIZE];
     for (NSUInteger i = 0; i < CDTENCRYPTIONKEY_KEYSIZE; i++) {
@@ -61,6 +35,17 @@
         [NSData dataWithBytes:negatedFixedKeyBytes length:sizeof(negatedFixedKeyBytes)];
 
     return [[CDTHelperFixedKeyProvider alloc] initWithKey:negatedFixedKey];
+}
+
+#pragma mark - Public class methods
++ (instancetype)provider
+{
+    char buffer[CDTENCRYPTIONKEY_KEYSIZE];
+    memset(buffer, '*', sizeof(buffer));
+    
+    NSData *key = [NSData dataWithBytes:buffer length:sizeof(buffer)];
+    
+    return [[CDTHelperFixedKeyProvider alloc] initWithKey:key];
 }
 
 @end

--- a/doc/encryption.md
+++ b/doc/encryption.md
@@ -1,8 +1,6 @@
-# Encrypt databases
+# Encrypt datastores
 
-This is an experimental feature, use with caution.
-
-CDTDatastore is able to create encrypted databases. To do so, first edit your
+CDTDatastore is able to create encrypted datastores. To do so, first edit your
 `Podfile` and replace:
 
 ```
@@ -28,17 +26,24 @@ main purpose of this class is to ensure that the key has the right size
 (256 bits).
 
 Alternatively, you can use the class
-[CDTEncryptionKeychainProvider][CDTEncryptionKeychainProvider]. It already
-implements this protocol which handles generating a strong key from a
-user-provided password and stores it safely in the keychain. However, if you
-decide to code your own class (and use this one as a reference), keep in mind
-that if the method returns nil, the database won't be encrypted regardless of
-the subspec defined in your `Podfile`.
+[CDTEncryptionKeySimpleProvider][CDTEncryptionKeySimpleProvider]. This class
+implements the protocol `CDTEncryptionKeyProvider` and  it is initialised with a
+raw key of the size mentioned before. Its behaviour is quite simple: whenever
+the method `CDTEncryptionKeyProvider:encryptionKey` is called, it returns the
+key. However, in this case you are responsible for creating a strong key and
+storing it safely. If you do not want to worry about this, you can use
+[CDTEncryptionKeychainProvider][CDTEncryptionKeychainProvider]. This class
+handles generating a strong key from a user-provided password and stores it
+safely in the keychain.
+
+It is up to you to code your own class but keep in mind that if the
+`CDTEncryptionKeyProvider:encryptionKey` returns nil, the datastore won't be
+encrypted regardless of the subspec defined in your `Podfile`.
 
 To end, call `CDTDatastoreManager:datastoreNamed:withEncryptionKeyProvider:error:`
-to create `CDTDatastores` with encrypted databases (datastores and indexes are
-encrypted but not attachments and extensions)
+to create encrypted datastores.
 
 [CDTEncryptionKey]: ../Classes/common/Encryption/CDTEncryptionKey.h
 [CDTEncryptionKeyProvider]: ../Classes/common/Encryption/CDTEncryptionKeyProvider.h
 [CDTEncryptionKeychainProvider]: ../Classes/common/Encryption/Keychain/CDTEncryptionKeychainProvider.h
+[CDTEncryptionKeySimpleProvider]: ../Classes/common/Encryption/CDTEncryptionKeySimpleProvider.h


### PR DESCRIPTION
*What:*
Implement a new class called `CDTEncryptionKeySimpleProvider` that conforms to `CDTEncryptionKeyProvider` and simply holds a developer-provided key.

*Why:*
It's useful to provide `CDTEncryptionKeySimpleProvider` as an example of the simplest thing which could work.

*How:*
This class is initialised with a `NSData` instance of 32 bytes length. When the method `CDTEncryptionKeyProvider:encryptionKey` is called, it return the `NSData` instance wrapped in a `CDTEncryptionKey`.

*Tests:*
1. Initialisation fails if no data is provided.
2. Initialisation fails if the data does not have the right size.
3. It returns the expected key.

reviewer @mikerhodes 
reviewer @rhyshort 

**NOTE:** Wait to review this PR until PR #153  is closed. This branch will be rebased and there will be only commits related to this case.