### PR TITLE
Remove most warnings when building as a cocoapod

### DIFF
--- a/Classes/common/Attachments/CDTAttachment.m
+++ b/Classes/common/Attachments/CDTAttachment.m
@@ -188,8 +188,6 @@
 {
     BOOL stub = [jsonData[@"stub"] boolValue];
     NSNumber *length = jsonData[@"length"];
-    NSString *digest = jsonData[@"digest"];
-    NSNumber *revpos = jsonData[@"revpos"];
     NSString *contentType = jsonData[@"content_type"];
     NSString *data = jsonData[@"data"];
     NSData *decodedData = nil;

--- a/Classes/common/CDTFetchChanges.m
+++ b/Classes/common/CDTFetchChanges.m
@@ -71,7 +71,7 @@
     SequenceNumber lastSequence = [self.mStartSequenceValue longLongValue];
 
     do {
-        if (self.cancelled) {
+        if ([self isCancelled]) {
             return;  // Bail early, don't call completion block
         }
 
@@ -86,7 +86,7 @@
         // Try our best to avoid calling the completion block if cancelled is set:
         //  - after the check in the loop above 
         //  - where there are no remaining changes, so we fall through to here
-        if (!self.cancelled) {
+        if (![self isCancelled]) {
             self.mFetchRecordChangesCompletionBlock(
                 [[NSNumber numberWithLongLong:lastSequence] stringValue], self.mStartSequenceValue,
                 nil);
@@ -109,7 +109,7 @@
 - (SequenceNumber)notifyChanges:(TD_RevisionList *)changes
                startingSequence:(SequenceNumber)startingSequence
 {
-    if (self.cancelled) {
+    if ([self isCancelled]) {
         return startingSequence;  // processed no changes
     }
 
@@ -127,7 +127,7 @@
     }
     
     for (TD_Revision *change in changes) {
-        if (self.cancelled) {
+        if ([self isCancelled]) {
             return lastSequence;  // We processed changes up to this sequence
         }
 

--- a/Classes/common/touchdb/TDMisc.h
+++ b/Classes/common/touchdb/TDMisc.h
@@ -63,11 +63,13 @@ NSURL* TDURLWithoutQuery(NSURL* url);
 /** Appends path components to a URL. These will NOT be URL-escaped, so you can include queries. */
 NSURL* TDAppendToURL(NSURL* baseURL, NSString* toAppend);
 
+#pragma clang diagnostic ignored "-Wcomment"
 /** Cleans username and password from a NSURL and returns a string. Use this function when needed
  to send an NSURL address to a log or console but do not want to expose credentials.
  
  If the NSURL does not have a password it returns NSURL -absoluteString. Otherwise, the string will 
  be of the form 'https://*****\@host:port/path?query#fragment' */
+#pragma clang diagnostic pop
 NSString* TDCleanURLtoString(NSURL* url);
 
 /** Filter block, used in replication. */

--- a/Classes/common/touchdb/TDRemoteRequest.m
+++ b/Classes/common/touchdb/TDRemoteRequest.m
@@ -337,7 +337,7 @@
 {
     if (!(_dontLog404 && error.code == kTDStatusNotFound &&
           $equal(error.domain, TDHTTPErrorDomain)))
-        CDTLogVerbose(CDTTD_REMOTE_REQUEST_CONTEXT, @"%@: Got error. domain %@, code %@", self, error.domain, error.code);
+        CDTLogVerbose(CDTTD_REMOTE_REQUEST_CONTEXT, @"%@: Got error. domain %@, code %@", self, error.domain, @(error.code));
 
     // If the error is likely transient, retry:
     if (TDMayBeTransientError(error) && [self retry]) return;

--- a/Classes/common/touchdb/TDStatus.h
+++ b/Classes/common/touchdb/TDStatus.h
@@ -16,7 +16,7 @@ typedef NS_ENUM(NSInteger, TDInternalErrors) {
 };
 
 /** TouchDB internal status/error codes. Superset of HTTP status codes. */
-typedef enum {
+typedef NS_ENUM(NSInteger, TDStatus) {
     kTDStatusOK = 200,
     kTDStatusCreated = 201,
     kTDStatusAccepted = 206,
@@ -47,7 +47,7 @@ typedef enum {
     kTDStatusException = 594,                 // Exception raised/caught
     kTDStatusAttachmentStreamError = 701,     // Error reading from stream when adding attachment
     kTDStatusAttachmentDiskSpaceError = 702,  // Not enough space on device for attachment
-} TDStatus;
+};
 
 static inline bool TDStatusIsError(TDStatus status) { return status >= 300; }
 

--- a/Classes/common/touchdb/TDStatus.m
+++ b/Classes/common/touchdb/TDStatus.m
@@ -69,7 +69,7 @@ NSError* TDStatusToNSErrorWithInfo(TDStatus status, NSURL* url, NSDictionary* ex
     status = TDStatusToHTTPStatus(status, &reason);
     NSMutableDictionary* info =
         $mdict({NSURLErrorKey, url}, {NSLocalizedFailureReasonErrorKey, reason},
-               { NSLocalizedDescriptionKey, $sprintf(@"%i %@", status, reason) });
+               { NSLocalizedDescriptionKey, $sprintf(@"%@ %@", @(status), reason) });
     if (extraInfo) [info addEntriesFromDictionary:extraInfo];
     return [NSError errorWithDomain:TDHTTPErrorDomain code:status userInfo:[info copy]];
 }

--- a/Classes/common/touchdb/TD_View.m
+++ b/Classes/common/touchdb/TD_View.m
@@ -391,8 +391,8 @@ static id fromJSON(NSData* json)
         {
             [r close];
             if (status >= kTDStatusBadRequest)
-                CDTLogWarn(CDTTD_VIEW_CONTEXT, @"TouchDB: Failed to rebuild view '%@': %d", _name,
-                        status);
+                CDTLogWarn(CDTTD_VIEW_CONTEXT, @"TouchDB: Failed to rebuild view '%@': %@", _name,
+                        @(status));
             *rollback = (status < kTDStatusBadRequest);
         }
     }];

--- a/Classes/vendor/MYUtilities/ExceptionUtils.m
+++ b/Classes/vendor/MYUtilities/ExceptionUtils.m
@@ -131,11 +131,15 @@ static void report( NSException *x ) {
 - (void) _showExceptionAlert: (NSException*)x
 {
     NSString *stack = [x my_callStack] ?:@"";
+
+#pragma clang diagnostic ignored "-Wformat-security"
     NSInteger r = NSRunCriticalAlertPanel( @"Internal Error!",
                             [NSString stringWithFormat: @"Uncaught exception: %@\n%@\n\n%@\n\n"
                              "Please report this bug (you can copy & paste the text).",
                              [x name], [x reason], stack],
                             @"Continue",@"Quit",nil);
+#pragma clang diagnostic pop
+
     if( r == NSAlertAlternateReturn )
         exit(1);
     MYSetExceptionReporter(&report);

--- a/Classes/vendor/MYUtilities/MYErrorUtils.m
+++ b/Classes/vendor/MYUtilities/MYErrorUtils.m
@@ -139,22 +139,19 @@ NSString* MYErrorName( NSString *domain, NSInteger code ) {
 #if !TARGET_OS_IPHONE || defined(__SEC_TYPES__)
     else if ($equal(domain,NSOSStatusErrorDomain)) {
         // If it's an OSStatus, check whether CarbonCore knows its name:
-        const char *name = NULL;
-#if !TARGET_OS_IPHONE
-        name = GetMacOSStatusErrorString((int)code);
-#endif
-        if (name && *name)
-            result = [NSString stringWithCString: name encoding: NSMacOSRomanStringEncoding];
-        else {
+        NSError *osErr = [NSError errorWithDomain:NSOSStatusErrorDomain code:code userInfo:nil];
+        result = [osErr localizedDescription];
+
 #if MYERRORUTILS_USE_SECURITY_API
+        if (!result) {
             result = (id) SecCopyErrorMessageString((OSStatus)code,NULL);
             if (result) {
                 [NSMakeCollectable(result) autorelease];
                 if ([result hasPrefix: @"OSStatus "])
                     result = nil; // just a generic message
             }
-#endif
         }
+#endif
     }
 #endif
     


### PR DESCRIPTION
I have been sitting on these for a while.  Reducing existing warnings make it easier to know if I've added any.
I have broken them up in a way that the individual commits can be cherry-picked if necessary.
If there is interest, I'd be happy to go after the remainder.
