### PR TITLE
Correctly generate attachment URLs for non-winning rev

### DIFF
--- a/Classes/common/CDTDocumentRevision.m
+++ b/Classes/common/CDTDocumentRevision.m
@@ -79,11 +79,17 @@
 
     // build the attachment objects
     for (NSString *key in [attachmentData allKeys]) {
-        NSURL *url = [NSURL URLWithString:key relativeToURL:documentURL];
+        
+        NSURLComponents *documentUrlComponents = [NSURLComponents componentsWithString:[documentURL absoluteString]];
+        NSString *documentPathString = documentUrlComponents.path;
+        NSString *attachmentPath = [NSString stringWithFormat:@"%@/%@", documentPathString,key];
+        documentUrlComponents.path = attachmentPath;
+        
+        
         CDTSavedHTTPAttachment *attachment =
             [CDTSavedHTTPAttachment createAttachmentWithName:key
                                                     JSONData:[attachmentData objectForKey:key]
-                                               attachmentURL:url
+                                               attachmentURL:[documentUrlComponents URL]
                                                        error:error];
         if (*error) {
             return nil;


### PR DESCRIPTION
Correctly generate attachment URLs for non-winning rev
by manually creating a  URL using URL components.

BugzId: 47846

reviewer @indisoluble 
reviewer @tomblench 