### PR TITLE
Add $size operator support to Query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CDTDatastore CHANGELOG
 
+## Unreleased
+
+- [NEW] Added query support for the `$size` operator.
+
 ## 0.17.1 (2015-06-24)
 
 - [FIX] Allow using encrypted datastores and FTS together.

--- a/Classes/common/query/CDTQQueryConstants.h
+++ b/Classes/common/query/CDTQQueryConstants.h
@@ -41,3 +41,5 @@ extern NSString *const NIN;
 extern NSString *const SEARCH;
 
 extern NSString *const MOD;
+
+extern NSString *const SIZE;

--- a/Classes/common/query/CDTQQueryConstants.m
+++ b/Classes/common/query/CDTQQueryConstants.m
@@ -43,3 +43,5 @@ NSString *const NIN = @"$nin";
 NSString *const SEARCH = @"$search";
 
 NSString *const MOD = @"$mod";
+
+NSString *const SIZE = @"$size";

--- a/Classes/common/query/CDTQQuerySqlTranslator.h
+++ b/Classes/common/query/CDTQQuerySqlTranslator.h
@@ -131,6 +131,11 @@
 + (NSArray *)fieldsForAndClause:(NSArray *)clause;
 
 /**
+ Checks for the existence of an operator in a query clause array
+*/
++ (BOOL)isOperator:(NSString *)operator inClause:(NSArray *)clause;
+
+/**
  Selects an index to use for a given query from the set provided.
 
  Here we're looking for the index which supports all the fields used in the query.

--- a/Classes/common/query/CDTQQuerySqlTranslator.m
+++ b/Classes/common/query/CDTQQuerySqlTranslator.m
@@ -305,8 +305,29 @@
     return [NSArray arrayWithArray:fieldNames];
 }
 
++ (BOOL)isOperator:(NSString *)operator inClause:(NSArray *)clause
+{
+    BOOL found = NO;
+    for (NSDictionary *term in clause) {
+        if (term.count == 1 && [term.allValues[0] isKindOfClass:[NSDictionary class]]) {
+            NSDictionary *predicate = (NSDictionary *) term.allValues[0];
+            if (predicate[operator]) {
+                found = YES;
+                break;
+            }
+        }
+    }
+    
+    return found;
+}
+
 + (NSString *)chooseIndexForAndClause:(NSArray *)clause fromIndexes:(NSDictionary *)indexes
 {
+    if ([CDTQQuerySqlTranslator isOperator:SIZE inClause:clause]) {
+        LogInfo(@"$size operator found in clause %@.  Indexes are not used with $size operations.",
+                clause);
+        return nil;
+    }
     NSSet *neededFields = [NSSet setWithArray:[self fieldsForAndClause:clause]];
 
     if (neededFields.count == 0) {

--- a/Classes/common/query/CDTQQueryValidator.m
+++ b/Classes/common/query/CDTQQueryValidator.m
@@ -427,7 +427,7 @@
     // to { "$not" : { "$eq" : "blah" } } before reaching this validation.  So
     // operators like $ne and $nin will be negated $eq and $in by the time this
     // validation is reached.
-    NSArray *validOperators =  @[ EQ, LT, GT, EXISTS, NOT, GTE, LTE, IN, MOD ];
+    NSArray *validOperators =  @[ EQ, LT, GT, EXISTS, NOT, GTE, LTE, IN, MOD, SIZE ];
 
     if ([clause count] == 1) {
         NSString *operator= [clause allKeys][0];

--- a/Tests/Tests/CDTQUnindexedMatcherTests.m
+++ b/Tests/Tests/CDTQUnindexedMatcherTests.m
@@ -35,6 +35,7 @@ describe(@"matches", ^{
             @"name" : @"mike",
             @"age" : @31,
             @"pets" : @[ @"white_cat", @"black_cat" ],
+            @"hobbies" : @[],
             @"address" : @{@"number" : @"1", @"road" : @"infinite loop"}
         };
         rev = [[CDTDocumentRevision alloc] initWithDocId:@"dsfsdfdfs"
@@ -469,6 +470,65 @@ describe(@"matches", ^{
                 [CDTQQueryValidator normaliseAndValidateQuery:@{@"score": @{@"$mod": @[@-3, @1]}}];
                 CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
                 expect([matcher matches:negRev]).to.beFalsy();
+            });
+            
+        });
+        
+        context(@"size", ^{
+            it(@"matches when using a positive integer", ^{
+                NSDictionary *selector =
+                [CDTQQueryValidator normaliseAndValidateQuery:@{ @"pets": @{ @"$size": @2 } } ];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beTruthy();
+            });
+            
+            it(@"does not match when using a positive integer", ^{
+                NSDictionary *selector =
+                [CDTQQueryValidator normaliseAndValidateQuery:@{ @"pets": @{ @"$size": @3 } } ];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beFalsy();
+            });
+            
+            it(@"does not match when field is not an array", ^{
+                NSDictionary *selector =
+                [CDTQQueryValidator normaliseAndValidateQuery:@{ @"name": @{ @"$size": @1 } } ];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beFalsy();
+            });
+            
+            it(@"does not match when using a negative integer", ^{
+                NSDictionary *selector =
+                [CDTQQueryValidator normaliseAndValidateQuery:@{ @"pets": @{ @"$size": @-2 } } ];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beFalsy();
+            });
+            
+            it(@"matches when using 0", ^{
+                NSDictionary *selector =
+                [CDTQQueryValidator normaliseAndValidateQuery:@{ @"hobbies": @{ @"$size": @0 } } ];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beTruthy();
+            });
+            
+            it(@"does not match when using 0 but field is missing", ^{
+                NSDictionary *selector =
+                [CDTQQueryValidator normaliseAndValidateQuery:@{ @"books": @{ @"$size": @0 } } ];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beFalsy();
+            });
+            
+            it(@"does not match when using a string", ^{
+                NSDictionary *selector =
+                [CDTQQueryValidator normaliseAndValidateQuery:@{ @"pets": @{ @"$size": @"2" } } ];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beFalsy();
+            });
+            
+            it(@"does not match when not using an integer", ^{
+                NSDictionary *selector =
+                [CDTQQueryValidator normaliseAndValidateQuery:@{ @"pets": @{ @"$size": @2.2 } } ];
+                CDTQUnindexedMatcher *matcher = [CDTQUnindexedMatcher matcherWithSelector:selector];
+                expect([matcher matches:rev]).to.beFalsy();
             });
             
         });

--- a/doc/query.md
+++ b/doc/query.md
@@ -629,6 +629,7 @@ Selectors -> Condition -> Array
 
 - `$in`
 - `$nin`
+- `$size`
 
 Implicit operators
 
@@ -667,10 +668,6 @@ Selectors -> combination
 Selectors -> Condition -> Objects
 
 - `$type`
-
-Selectors -> Condition -> Array
-
-- `$size`
 
 Selectors -> Condition -> Misc
 
@@ -754,7 +751,7 @@ Here:
     <strong>{</strong> &quot;$regex&quot; <strong>:</strong> <em>NSRegularExpression</em> <strong>}</strong>  // not implemented
     <strong>{</strong> &quot;$mod&quot; <strong>:</strong> <strong>[</strong> <em>non-zero-number, number</em> <strong>] }</strong>
     <strong>{</strong> &quot;$elemMatch&quot; <strong>: {</strong> <em>many-expressions</em> <strong>} }</strong>  // not implemented
-    <strong>{</strong> &quot;$size&quot; <strong>:</strong> <em>positive-integer</em> <strong>}</strong>  // not implemented
+    <strong>{</strong> &quot;$size&quot; <strong>:</strong> <em>positive-integer</em> <strong>}</strong>
     <strong>{</strong> &quot;$all&quot; <strong>:</strong> <em>array-value</em> <strong>}</strong>  // not implemented
     <strong>{</strong> &quot;$in&quot; <strong>:</strong> <em>array-value</em> <strong>}</strong>
     <strong>{</strong> &quot;$nin&quot; <strong>:</strong> <em>array-value</em> <strong>}</strong>


### PR DESCRIPTION
_What:_

This PR adds support for the $size operator for use in Query.  See [$size spec](https://github.com/cloudant/cloudant-sync/blob/master/specs/query_size_operator.md) for details.

_Why:_

In an effort to provide as much functionality to Query as is available elsewhere (such as MongoDB), we are adding support to the $size operator.  It provides a way to query for documents based on the size of an array that is a document field value.

_How:_

Add logic to the validator code, the SQLtranslator code, and the unindexed matcher code to support the use of `$size` in queries.  `$size` operator clauses are handled strictly by the unindexed matcher code.  There is no SQL translator component for `$size`.

_Tests:_

- Validation tests have been added to ensure that queries containing the `$size` operator are properly normalized and validated.
- Tests have been added to ensure that the new utility method used by the SQL translator to check for the `$size` operator functions as desired.
- Unindexed matcher tests have been added to ensure that the matcher functionality handles `$size` operations appropriately.
- Since the unindexed matcher handles all `$size` processing, execution tests have been added to ensure that `$size` query execution performs correctly.

reviewer @mikerhodes 
reviewer @rhyshort 

BugId: 44634