### PR TITLE
48270 Activate FTS on SQLCipher

### DIFF
--- a/CDTDatastore.podspec
+++ b/CDTDatastore.podspec
@@ -89,11 +89,14 @@ Pod::Spec.new do |s|
 
     sp.library = 'z'
 
-    # Some CDTDatastore classes use SQLite functions, we have to include
-    # 'SQLCipher' although 'FMDB/SQLCipher' also depends on 'SQLCipher' or they
-    # will not compile (linker will not find some symbols)
-    sp.dependency 'SQLCipher'
     sp.dependency 'FMDB/SQLCipher', '= 2.3'
+
+    # Some CDTDatastore classes use SQLite functions, therefore we have
+    # to include 'SQLCipher' although 'FMDB/SQLCipher' also depends on it
+    # or they will not compile (linker will not find some symbols).
+    # Also, we have to force cocoapods to configure SQLCipher with support
+    # for FTS.
+    sp.dependency 'SQLCipher/fts'
   end
 
   s.subspec 'common-dependencies' do |sp|

--- a/EncryptionTests/Encryption Tests/CDTQIndexManagerEncryptionTests.m
+++ b/EncryptionTests/Encryption Tests/CDTQIndexManagerEncryptionTests.m
@@ -23,6 +23,7 @@
 #import "FMDatabase+SQLCipher.h"
 
 #import "CDTQIndexManager.h"
+#import "DBQueryUtils.h"
 
 @interface CDTQIndexManagerEncryptionTests : CloudantSyncTests
 
@@ -207,6 +208,23 @@
 
     XCTAssertNil(im, @"indexManager is nil");
     XCTAssertNotNil(err, @"There is an error");
+}
+
+- (void)testTextSearchIsAvailable
+{
+    CDTHelperFixedKeyProvider *provider = [CDTHelperFixedKeyProvider provider];
+    CDTDatastore *datastore = [self.factory datastoreNamed:@"is_fts_activated"
+                                 withEncryptionKeyProvider:provider
+                                                     error:nil];
+    
+    CDTQIndexManager *im = [[CDTQIndexManager alloc] initUsingDatastore:datastore error:nil];
+
+    NSSet *compileOptions = [DBQueryUtils compileOptions:im.database];
+    NSSet *ftsCompileOptions = [NSSet setWithArray:@[ @"ENABLE_FTS3" ]];
+
+    XCTAssertTrue([ftsCompileOptions isSubsetOfSet:compileOptions]);
+
+    XCTAssertTrue([im isTextSearchEnabled], @"It should be activated");
 }
 
 @end

--- a/EncryptionTests/Encryption Tests/DatastoreEncryptionTests.m
+++ b/EncryptionTests/Encryption Tests/DatastoreEncryptionTests.m
@@ -23,6 +23,7 @@
 
 #import "CDTDatastoreManager+EncryptionKey.h"
 #import "CDTDatastore+EncryptionKey.h"
+#import "CDTDatastore+Query.h"
 
 @interface DatastoreEncryptionTests : CloudantSyncTests
 

--- a/EncryptionTests/EncryptionTests.xcodeproj/project.pbxproj
+++ b/EncryptionTests/EncryptionTests.xcodeproj/project.pbxproj
@@ -28,6 +28,8 @@
 		CDADD5C41AEFD715003CA9EF /* FMDatabase+SQLCipher.m in Sources */ = {isa = PBXBuildFile; fileRef = CDADD5C21AEFD715003CA9EF /* FMDatabase+SQLCipher.m */; };
 		CDCB7A331AB3AB51000D8FFC /* DatastoreManagerEncryptionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CDCB7A321AB3AB51000D8FFC /* DatastoreManagerEncryptionTests.m */; };
 		CDCB7A341AB3AB51000D8FFC /* DatastoreManagerEncryptionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CDCB7A321AB3AB51000D8FFC /* DatastoreManagerEncryptionTests.m */; };
+		CDDDE66D1B31BFC10098F13E /* DBQueryUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = CDDDE66C1B31BFC10098F13E /* DBQueryUtils.m */; };
+		CDDDE66E1B31BFC10098F13E /* DBQueryUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = CDDDE66C1B31BFC10098F13E /* DBQueryUtils.m */; };
 		CDEE6ECD1AAF3BD0002C96C0 /* CloudantTests+EncryptionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CDEE6ECC1AAF3BD0002C96C0 /* CloudantTests+EncryptionTests.m */; };
 		CDEE6ECE1AAF3BD0002C96C0 /* CloudantTests+EncryptionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CDEE6ECC1AAF3BD0002C96C0 /* CloudantTests+EncryptionTests.m */; };
 		F90D36E7E415768CD9A11DF8 /* libPods-osx.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9C7BC81EA72FBC2080CDD22E /* libPods-osx.a */; };
@@ -58,6 +60,8 @@
 		CDADD5C11AEFD715003CA9EF /* FMDatabase+SQLCipher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "FMDatabase+SQLCipher.h"; path = "../../Tests/Tests/Encryption/FMDatabase+SQLCipher.h"; sourceTree = "<group>"; };
 		CDADD5C21AEFD715003CA9EF /* FMDatabase+SQLCipher.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "FMDatabase+SQLCipher.m"; path = "../../Tests/Tests/Encryption/FMDatabase+SQLCipher.m"; sourceTree = "<group>"; };
 		CDCB7A321AB3AB51000D8FFC /* DatastoreManagerEncryptionTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DatastoreManagerEncryptionTests.m; sourceTree = "<group>"; };
+		CDDDE66B1B31BFC10098F13E /* DBQueryUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DBQueryUtils.h; path = ../../Tests/Tests/DBQueryUtils.h; sourceTree = "<group>"; };
+		CDDDE66C1B31BFC10098F13E /* DBQueryUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = DBQueryUtils.m; path = ../../Tests/Tests/DBQueryUtils.m; sourceTree = "<group>"; };
 		CDEE6ECB1AAF3BD0002C96C0 /* CloudantTests+EncryptionTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "CloudantTests+EncryptionTests.h"; path = "../../Tests/Tests/Encryption/CloudantTests+EncryptionTests.h"; sourceTree = "<group>"; };
 		CDEE6ECC1AAF3BD0002C96C0 /* CloudantTests+EncryptionTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "CloudantTests+EncryptionTests.m"; path = "../../Tests/Tests/Encryption/CloudantTests+EncryptionTests.m"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -134,6 +138,8 @@
 				CD48786B1A9BA6C80070EB63 /* CloudantSyncTests.m */,
 				CD5D68301AB347D700F0BF8A /* DatastoreEncryptionTests.m */,
 				CDCB7A321AB3AB51000D8FFC /* DatastoreManagerEncryptionTests.m */,
+				CDDDE66B1B31BFC10098F13E /* DBQueryUtils.h */,
+				CDDDE66C1B31BFC10098F13E /* DBQueryUtils.m */,
 				CDADD5C11AEFD715003CA9EF /* FMDatabase+SQLCipher.h */,
 				CDADD5C21AEFD715003CA9EF /* FMDatabase+SQLCipher.m */,
 				CD4878671A9BA5F90070EB63 /* TD_DatabaseEncryptionTests.m */,
@@ -351,6 +357,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CDDDE66D1B31BFC10098F13E /* DBQueryUtils.m in Sources */,
 				CD55A19B1AD56F2300A52281 /* CDTQIndexManagerEncryptionTests.m in Sources */,
 				CDEE6ECD1AAF3BD0002C96C0 /* CloudantTests+EncryptionTests.m in Sources */,
 				CD3FBCAD1AB05CAB0032376E /* CDTHelperFixedKeyProvider.m in Sources */,
@@ -367,6 +374,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CDDDE66E1B31BFC10098F13E /* DBQueryUtils.m in Sources */,
 				CD55A19C1AD56F2300A52281 /* CDTQIndexManagerEncryptionTests.m in Sources */,
 				CDEE6ECE1AAF3BD0002C96C0 /* CloudantTests+EncryptionTests.m in Sources */,
 				CD3FBCAE1AB05CAB0032376E /* CDTHelperFixedKeyProvider.m in Sources */,


### PR DESCRIPTION
*What:*
If you try to use full text indexing (FTS) on iOS with an encrypted datastore, it fails.

*Why:*
It turns out that SQLCipher's podspec doesn't build with FTS by default.

*How:*
Force cocoapods to compile SQLCipher with FTS. To do that, we simply have to replace this line in `CDTDatastore.podspec`:

```
sp.dependency 'SQLCipher'
```

With:

```
sp.dependency 'SQLCipher/fts'
```

*Tests:*
Add a couple of tests to EncryptionTests workspace:
* Text search is enabled for a CDTQIndexManager instance.
* Text search is enabled for a Datastore instance.

reviewer @alfinkel 
reviewer @rhyshort 