### PR TITLE
48272 Create CloudantSyncEncryption.h

### DIFF
--- a/CDTDatastore.xcworkspace/contents.xcworkspacedata
+++ b/CDTDatastore.xcworkspace/contents.xcworkspacedata
@@ -143,6 +143,9 @@
                location = "group:CDTEncryptionKeySimpleProvider.m">
             </FileRef>
             <FileRef
+               location = "group:CloudantSyncEncryption.h">
+            </FileRef>
+            <FileRef
                location = "group:FMDatabase+EncryptionKey.h">
             </FileRef>
             <FileRef

--- a/Classes/common/CloudantSync.h
+++ b/Classes/common/CloudantSync.h
@@ -15,25 +15,20 @@
 
 #import <Foundation/Foundation.h>
 
-// Use subspec 'SQLCipher' to create encrypted databases. 'SQLCipher' also defines ENCRYPT_DATABASE.
-// The methods and classes to create encrypted databses are automatically imported in the project
-// only if ENCRYPT_DATABASE exists, i.e. unless you want this functionality, the methods and classes
-// will not be available and Xcode will not autocomplete the code with them.
-#ifdef ENCRYPT_DATABASE
-#import "CDTEncryptionKeyNilProvider.h"
-#import "CDTEncryptionKeychainProvider.h"
-#import "CDTEncryptionKeySimpleProvider.h"
-#import "CDTDatastoreManager+EncryptionKey.h"
-#else
 #import "CDTDatastoreManager.h"
-#endif
 
 #import "CDTDatastore.h"
 #import "CDTDatastore+Attachments.h"
+
+#import "CDTDatastore+Query.h"
+#import "CDTQResultSet.h"
+
 #import "CDTDocumentRevision.h"
 #import "CDTMutableDocumentRevision.h"
 #import "CDTDocumentBody.h"
+
 #import "CDTAttachment.h"
+
 #import "CDTFetchChanges.h"
 
 #import "CDTReplicator.h"
@@ -41,6 +36,3 @@
 #import "CDTPullReplication.h"
 #import "CDTReplicatorFactory.h"
 #import "CDTReplicatorDelegate.h"
-
-#import "CDTDatastore+Query.h"
-#import "CDTQResultSet.h"

--- a/Classes/common/Encryption/CloudantSyncEncryption.h
+++ b/Classes/common/Encryption/CloudantSyncEncryption.h
@@ -1,0 +1,19 @@
+//
+//  CloudantSyncEncryption.h
+//  CloudantSync
+//
+//  Created by Enrique de la Torre Fernandez on 17/06/2015.
+//  Copyright (c) 2015 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+#import "CDTEncryptionKeyNilProvider.h"
+#import "CDTEncryptionKeychainProvider.h"
+#import "CDTEncryptionKeySimpleProvider.h"
+#import "CDTDatastoreManager+EncryptionKey.h"

--- a/ReplicationAcceptance/ReplicationAcceptance/Attachments.m
+++ b/ReplicationAcceptance/ReplicationAcceptance/Attachments.m
@@ -12,6 +12,7 @@
 #import <UNIRest.h>
 #import <XCTest/XCTest.h>
 #import <CloudantSync.h>
+#import <CloudantSyncEncryption.h>
 #import <FMDatabase.h>
 #import "FMDatabaseQueue.h"
 

--- a/ReplicationAcceptance/ReplicationAcceptance/CloudantReplicationBase.m
+++ b/ReplicationAcceptance/ReplicationAcceptance/CloudantReplicationBase.m
@@ -9,6 +9,7 @@
 #import "CloudantReplicationBase.h"
 
 #import "CloudantSync.h"
+#import "CloudantSyncEncryption.h"
 
 #import "ReplicationSettings.h"
 

--- a/ReplicationAcceptance/ReplicationAcceptance/ReplicationAcceptance.m
+++ b/ReplicationAcceptance/ReplicationAcceptance/ReplicationAcceptance.m
@@ -11,6 +11,8 @@
 #import <XCTest/XCTest.h>
 
 #import <CloudantSync.h>
+#import <CloudantSyncEncryption.h>
+
 #import <UNIRest.h>
 #import <TRVSMonitor.h>
 

--- a/doc/encryption.md
+++ b/doc/encryption.md
@@ -68,6 +68,7 @@ podspec.
 #import "AppDelegate.h"
 
 #import <CloudantSync.h>
+#import <CloudantSyncEncryption.h>
 
 @implementation AppDelegate
 
@@ -125,6 +126,12 @@ podspec.
 @end
 ```
 
+Notice that below `#import <CloudantSync.h>` there is a extra import:
+`#import <CloudantSyncEncryption.h>`.
+[CloudantSyncEncryption.h][CloudantSyncEncryption.h] imports all the classes
+and methods that you need to encrypt a datastore. These methods will not be
+visible until you import this file.
+
 ## Encryption details
 
 Data in Cloudant Sync is stored in two formats:
@@ -158,3 +165,4 @@ instructions mentioned [here](https://www.zetetic.net/sqlcipher/open-source/).
 [CDTEncryptionKeychainProvider]: ../Classes/common/Encryption/Keychain/CDTEncryptionKeychainProvider.h
 [CDTEncryptionKeySimpleProvider]: ../Classes/common/Encryption/CDTEncryptionKeySimpleProvider.h
 [sqlcipher]: https://www.zetetic.net/sqlcipher/
+[CloudantSyncEncryption.h]: ../Classes/common/Encryption/CloudantSyncEncryption.h


### PR DESCRIPTION
*What:*
Move to a new header file the `imports` specific for encryption.

*Why:*
Originally, `CloudantSync.h` imported the classes and methods to encrypt a datastore if macro `ENCRYPT_DATABASE` was defined, in other case these classes and methods were not visible in Xcode. However, this macro is never set if the developer is working on a *Swift* app. More exactly, if a developer creates the bridging header file and includes: `import <CloudantSync.h>`, when he tries to type the methods to create encrypted datastores, Xcode does not recognise the selector because those methods were never imported.

*How:*
1. Edit `CloudantSync.h`. Create `CloudantSyncEncryption.h`
2. In every place where `CloudantSync.h` is imported, also imports `CloudantSyncEncryption.h`

*Tests:*
No tests required.

reviewer @emlaver 
reviewer @mikerhodes 