### PR TITLE
48131 Check if db is open before loading a revision

### DIFF
--- a/Classes/common/touchdb/TD_Database.m
+++ b/Classes/common/touchdb/TD_Database.m
@@ -854,12 +854,20 @@ static BOOL removeItemIfExists(NSString* path, NSError** outError)
 /** Do not call from fmdbqueue */
 - (TDStatus)loadRevisionBody:(TD_Revision*)rev options:(TDContentOptions)options
 {
-    __block TDStatus result;
-    __weak TD_Database* weakSelf = self;
-    [_fmdbQueue inDatabase:^(FMDatabase* db) {
-        TD_Database* strongSelf = weakSelf;
-        result = [strongSelf loadRevisionBody:rev options:options database:db];
-    }];
+    __block TDStatus result = kTDStatusDBError;
+
+    if ([self isOpen]) {
+        __weak TD_Database* weakSelf = self;
+        [_fmdbQueue inDatabase:^(FMDatabase* db) {
+          __strong TD_Database* strongSelf = weakSelf;
+          if (strongSelf) {
+              result = [strongSelf loadRevisionBody:rev options:options database:db];
+          }
+        }];
+    } else {
+        CDTLogDebug(CDTDATASTORE_LOG_CONTEXT, @"Database is not open");
+    }
+
     return result;
 }
 


### PR DESCRIPTION
*What:*
'testSyncReplicationErrorsWhenLocalDatabaseDeleted_pullDelegateDeletes' fails for some platforms.

*Why:*
This test initialises two replicators: pull & push, and it removes the local database while the replicators are running. However the `TD_Database` instance does not detect that the db was closed and deleted and it tries to load a revision, which ends raising an exception.

*How:*
Modify method `TD_Database:loadRevisionBody:options:`:
1. Check if the db is open. Only if it is open, try lo load a revision
2. In other case return error.

*Tests:*
No tests required.

**NOTICE**: The method we use to check if the db is open is not thread-safe, the changes in this PR fixes the problem but it is not a complete solution. In general, we have to improve `TD_Database` to safely use it in a multi-thread environment (check BugzID 48131 for more details)

reviewer @alfinkel 
reviewer @emlaver 
