### PR TITLE
48048 Remove files not related to an attachment in db

### DIFF
--- a/Classes/common/touchdb/TDBlobStore.h
+++ b/Classes/common/touchdb/TDBlobStore.h
@@ -99,11 +99,11 @@ typedef struct TDBlobKey
  @param keysToKeep Keys for attachments that you do not want to delete
  @param db A database
  
- @return Number of attachments deleted or -1 if there is an error
+ @return YES if it succeeds or NO if there is an error
  
  @warning DO NOT ROLLBACK this operation, it will not recreate the attachments.
  */
-- (NSInteger)deleteBlobsExceptWithKeys:(NSSet*)keysToKeep withDatabase:(FMDatabase *)db;
+- (BOOL)deleteBlobsExceptWithKeys:(NSSet*)keysToKeep withDatabase:(FMDatabase *)db;
 
 @end
 

--- a/Classes/common/touchdb/TDBlobStore.m
+++ b/Classes/common/touchdb/TDBlobStore.m
@@ -237,7 +237,6 @@ NSString *const CDTBlobStoreErrorDomain = @"CDTBlobStoreErrorDomain";
     for (NSString* oneFilename in remainingFiles) {
         if ([filesToKeep containsObject:oneFilename]) {
             // Do not delete file. It is an exception.
-
             continue;
         }
 

--- a/Classes/common/touchdb/TDBlobStore.m
+++ b/Classes/common/touchdb/TDBlobStore.m
@@ -214,37 +214,37 @@ NSString *const CDTBlobStoreErrorDomain = @"CDTBlobStoreErrorDomain";
     }
 
     // Delete files not related to an attachments
-    [self deleteFilesExceptWithFilenames:filesToKeep];
+    [TDBlobStore deleteFilesNotInSet:filesToKeep fromPath:_path];
 
     // Return
     return success;
 }
 
-- (void)deleteFilesExceptWithFilenames:(NSSet*)filesToKeep
++ (void)deleteFilesNotInSet:(NSSet*)filesToKeep fromPath:(NSString *)path
 {
     NSFileManager* defaultManager = [NSFileManager defaultManager];
 
     // Read directory
     NSError* thisError = nil;
-    NSArray* remainingFiles = [defaultManager contentsOfDirectoryAtPath:_path error:&thisError];
-    if (!remainingFiles) {
-        CDTLogError(CDTDATASTORE_LOG_CONTEXT, @"Can not read dir %@: %@", _path, thisError);
+    NSArray* currentFiles = [defaultManager contentsOfDirectoryAtPath:path error:&thisError];
+    if (!currentFiles) {
+        CDTLogError(CDTDATASTORE_LOG_CONTEXT, @"Can not read dir %@: %@", path, thisError);
         return;
     }
 
     // Delete all files but exceptions
-    for (NSString* oneFilename in remainingFiles) {
-        if ([filesToKeep containsObject:oneFilename]) {
+    for (NSString* filename in currentFiles) {
+        if ([filesToKeep containsObject:filename]) {
             // Do not delete file. It is an exception.
             continue;
         }
 
-        NSString* filePath = [TDBlobStore blobPathWithStorePath:_path blobFilename:oneFilename];
+        NSString* filePath = [TDBlobStore blobPathWithStorePath:path blobFilename:filename];
 
         if (![defaultManager removeItemAtPath:filePath error:&thisError]) {
             CDTLogError(CDTDATASTORE_LOG_CONTEXT,
                         @"%@: Failed to delete '%@' not related to an attachment: %@", self,
-                        oneFilename, thisError);
+                        filename, thisError);
         }
     }
 }

--- a/Classes/common/touchdb/TDBlobStore.m
+++ b/Classes/common/touchdb/TDBlobStore.m
@@ -229,7 +229,6 @@ NSString *const CDTBlobStoreErrorDomain = @"CDTBlobStoreErrorDomain";
     NSArray* remainingFiles = [defaultManager contentsOfDirectoryAtPath:_path error:&thisError];
     if (!remainingFiles) {
         CDTLogError(CDTDATASTORE_LOG_CONTEXT, @"Can not read dir %@: %@", _path, thisError);
-
         return;
     }
 

--- a/Classes/common/touchdb/TD_Database+Attachments.m
+++ b/Classes/common/touchdb/TD_Database+Attachments.m
@@ -818,11 +818,11 @@
         [allKeys addObject:[r dataForColumnIndex:0]];
     }
     [r close];
-    NSInteger numDeleted = [_attachments deleteBlobsExceptWithKeys:allKeys withDatabase:db];
-    if (numDeleted < 0) {
+    BOOL blobDeleted = [_attachments deleteBlobsExceptWithKeys:allKeys withDatabase:db];
+    if (!blobDeleted) {
         return kTDStatusAttachmentError;
     }
-    CDTLogInfo(CDTDATASTORE_LOG_CONTEXT, @"Deleted %d attachments", (int)numDeleted);
+    CDTLogInfo(CDTDATASTORE_LOG_CONTEXT, @"Attachments deleted");
     return kTDStatusOK;
 }
 

--- a/Classes/common/touchdb/TD_Database+Attachments.m
+++ b/Classes/common/touchdb/TD_Database+Attachments.m
@@ -822,7 +822,7 @@
     if (!blobDeleted) {
         return kTDStatusAttachmentError;
     }
-    CDTLogInfo(CDTDATASTORE_LOG_CONTEXT, @"Attachments deleted");
+    CDTLogInfo(CDTDATASTORE_LOG_CONTEXT, @"Unneeded attachment blobs deleted");
     return kTDStatusOK;
 }
 


### PR DESCRIPTION
*What:*
Modify `TDBlobStore:deleteBlobsExceptWithKeys:withDatabase:` to delete all the files in the `TDBlobStore` folder excepts those specify in **keysToKeep**.

*Why:*
This method loops through the filenames in the database and deletes them from database and disk but if a file is only in the disk, it will never be deleted.

How can this happen? `TDBlobStore:storeBlob:creatingKey:withDatabase:error:` receives a `FMDatabase` instance as a parameter, it will use this instance to record in the database the filename for the new attachment. If this operation is cancelled (rollback), the entry with the filename will be discarded but the file will not be removed from disk.

*How:*
1. Get from db the filenames for the files to delete. Delete them from disk and db unless they are an exception.
2. Get all the remaining files in the `TDBlobStore` folder, delete all of them unless they are an exception.

*Tests:*
* Prepare a blob store with 2 attachment and 2 extra files not related to any attachment. Delete all attachments but 1. At the end of the operation, only one file (the exception) should remain.

reviewer @emlaver 
reviewer @tomblench 
reviewer @mikerhodes 