### PR TITLE
48361 Set minimun sql cipher version

### DIFF
--- a/CDTDatastore.podspec
+++ b/CDTDatastore.podspec
@@ -96,7 +96,7 @@ Pod::Spec.new do |s|
     # or they will not compile (linker will not find some symbols).
     # Also, we have to force cocoapods to configure SQLCipher with support
     # for FTS.
-    sp.dependency 'SQLCipher/fts'
+    sp.dependency 'SQLCipher/fts', '~> 3.1.0'
   end
 
   s.subspec 'common-dependencies' do |sp|


### PR DESCRIPTION
*What:*
Specify the SQLCipher version that we use to test our code.

*Why:*
Some people need to know on advance the version.

*How:*
Replace in `CDTDatastore.podspec`:
```
sp.dependency 'SQLCipher/fts'
```
With:
```
sp.dependency 'SQLCipher/fts', '~> 3.1.0'
```
More exactly, we will use any SQLCipher version from 3.1.0 up to 3.2 (but not included)

*Tests:*
No test required.

reviewer @emlaver 
reviewer @gadamc 