### PR TITLE
37117 `CDTDatastore:getAllDocuments` returns a conflicting document twice

### DIFF
--- a/Classes/common/CDTDatastore.m
+++ b/Classes/common/CDTDatastore.m
@@ -231,7 +231,7 @@ NSString *const CDTDatastoreChangeNotification = @"CDTDatastoreChangeNotificatio
 
     NSArray *result = [NSArray array];
     TDContentOptions contentOptions = kTDIncludeLocalSeq;
-    struct TDQueryOptions query = {.limit = (unsigned int)self.database.documentCount,
+    struct TDQueryOptions query = {.limit = UINT_MAX,
                                    .inclusiveEnd = YES,
                                    .skip = 0,
                                    .descending = NO,

--- a/Tests/Tests/DatastoreConflicts.m
+++ b/Tests/Tests/DatastoreConflicts.m
@@ -886,6 +886,59 @@
     
 }
 
+- (void)testGetAllDocumentsReturnsOneDocumentIfThereIsOnlyOneConflictingDocument
+{
+    [self addConflictingDocumentWithId:@"doc0" toDatastore:self.datastore];
 
+    NSArray *allDocs = [self.datastore getAllDocuments];
+
+    XCTAssertEqual(allDocs.count, 1, @"Return only 1 document, even if there are conflicts");
+}
+
+- (void)
+    testGetAllDocumentsReturnsTwoDocumentsIfThereIsOneConflictedDocumentAndOneNonConflictingDocument
+{
+    [self addConflictingDocumentWithId:@"doc0" toDatastore:self.datastore];
+    [self addNonConflictingDocumentWithBody:@{ @"key" : @"value" } toDatastore:self.datastore];
+
+    NSArray *allDocs = [self.datastore getAllDocuments];
+
+    XCTAssertEqual(allDocs.count, 2, @"Return only 2 documents, even if there are conflicts");
+}
+
+- (void)
+    testGetAllDocumentsReturnsAnOddNumberOfDocumentsIfThereIsOnlyAnOddNumberOfConflictingDocuments
+{
+    NSUInteger oddNumberOfConflictingDocuments = 21;
+
+    for (NSUInteger i = 0; i < oddNumberOfConflictingDocuments; i++) {
+        [self addConflictingDocumentWithId:[NSString stringWithFormat:@"doc%lu", (unsigned long)i]
+                               toDatastore:self.datastore];
+    }
+
+    NSArray *allDocs = [self.datastore getAllDocuments];
+
+    XCTAssertEqual(allDocs.count, oddNumberOfConflictingDocuments,
+                   @"Return only %lu documents, even if there are conflicts",
+                   (unsigned long)oddNumberOfConflictingDocuments);
+}
+
+- (void)
+    testGetAllDocumentsReturnsAEvenNumberOfDocumentsIfThereIsAnOddNumberOfConflictingDocumentsAndOneNonConflictingDocument
+{
+    NSUInteger oddNumberOfConflictingDocuments = 21;
+
+    for (NSUInteger i = 0; i < oddNumberOfConflictingDocuments; i++) {
+        [self addConflictingDocumentWithId:[NSString stringWithFormat:@"doc%lu", (unsigned long)i]
+                               toDatastore:self.datastore];
+    }
+    [self addNonConflictingDocumentWithBody:@{ @"key" : @"value" } toDatastore:self.datastore];
+
+    NSArray *allDocs = [self.datastore getAllDocuments];
+
+    XCTAssertEqual(allDocs.count, oddNumberOfConflictingDocuments + 1,
+                   @"Return only %lu documents, even if there are conflicts",
+                   (unsigned long)(oddNumberOfConflictingDocuments + 1));
+}
 
 @end


### PR DESCRIPTION
*What:*
In some cases, `CDTDatastore:getAllDocuments` returns a conflicting document twice, although each document is based on a different conflicting revision.

*Why:*
`CDTDatastore:getAllDocuments` uses `TD_Database:getDocsWithIDs:options:` to get all documents in a datastore. It first prepares the options:

```
    struct TDQueryOptions query = {.limit = (unsigned int)self.database.documentCount,
                                   .inclusiveEnd = YES,
                                   .skip = 0,
                                   .descending = NO,
                                   .includeDocs = YES,
                                   .content = contentOptions};
```

And then it calls the method:

```
        NSDictionary *dictResults = [self.database getDocsWithIDs:nil options:&query];
```

But `TD_Database:getDocsWithIDs:options:` reads the revisions, not the documents, and returns the winning revisions. The limit set by `CDTDatastore:getAllDocuments` refers to the total number of documents in the datastore but if there are conflicting documents, the number of revisions will be bigger than the number of documents. For example:

1. In the datastore there is one conflicting document with 2 revisions.
2.  `CDTDatastore:getAllDocuments` set the limit to 1 because there is only 1 document.
3. `CDTDatastore:getAllDocuments` calls `TD_Database:getDocsWithIDs:options:` with limit equal to 1, so `TD_Database:getDocsWithIDs:options:` reads only one revision and returns it as a document.
4. `CDTDatastore:getAllDocuments` updates the options and set **skip** to 1 because we already read one document (well, that is what we think) and calls  again `TD_Database:getDocsWithIDs:options:`. This time `TD_Database:getDocsWithIDs:options:` reads the second revision for the conflicting document and returns it as a new document.

We end with 2 documents although there is only 1 document in the datastore.

*How:*
Do not limit the query, replace:

```
    struct TDQueryOptions query = {.limit = (unsigned int)self.database.documentCount,
                                   .inclusiveEnd = YES,
                                   .skip = 0,
                                   .descending = NO,
                                   .includeDocs = YES,
                                   .content = contentOptions};
```

With:

```
    struct TDQueryOptions query = {.limit = UINT_MAX,
                                   .inclusiveEnd = YES,
                                   .skip = 0,
                                   .descending = NO,
                                   .includeDocs = YES,
                                   .content = contentOptions};
```

*Tests:*
To test this change we create documents with 2 conflicting revisions. So the key to force the error is to create an odd number of documents. For example:

1. I create 3 documents with 2 conflicting revision
2. The first time `CDTDatastore:getAllDocuments` calls `TD_Database:getDocsWithIDs:options:`, this last method will get 3 revisions: 2 for the first conflicting document and 1 for other conflicting document. It will return 2 documents.
3. The second time `CDTDatastore:getAllDocuments` calls `TD_Database:getDocsWithIDs:options:`,  `TD_Database:getDocsWithIDs:options:` will get the second revision for the document mentioned before and another 2 revisions for other conflicting document. It will return again 2 documents.

reviewer @alfinkel 
reviewer @rhyshort 

**NOTICE:** Although this change fixes the problem it is not a complete solution. The real problem is not the LIMIT but the way `TD_Database:getDocsWithIDs:options:` uses it. We already implemented a new version of this method [here](https://github.com/cloudant/CDTDatastore/blob/37117-getAllDocuments-returns-conflicted-doc-twice/Classes/common/touchdb/TD_Database.m#L1335), however we chose this path that is less invasive.

**Check BugzID 37117 for more details about the design and how it has evolved until the current point.**