### PR TITLE
Fix query without any index capability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - [NEW] Added query support for the `$size` operator.
+- [FIX] Fixed issue where at least one index had to be created before a query would execute.  You can now query for documents without the existence of any indexes.
 
 ## 0.17.1 (2015-06-24)
 

--- a/Classes/common/CDTDatastore.h
+++ b/Classes/common/CDTDatastore.h
@@ -136,6 +136,14 @@ extern NSString *const CDTDatastoreChangeNotification;
 - (NSArray *)getAllDocuments;
 
 /**
+ * Enumerates the current winning revision for all documents in the
+ * datastore and return a list of their document identifiers.
+ *
+ * @return NSArray of NSStrings
+ */
+- (NSArray *)getAllDocumentIds;
+
+/**
  * Enumerate the current winning revisions for all documents in the
  * datastore.
  *

--- a/Classes/common/CDTDatastore.m
+++ b/Classes/common/CDTDatastore.m
@@ -288,6 +288,33 @@ NSString *const CDTDatastoreChangeNotification = @"CDTDatastoreChangeNotificatio
     return result;
 }
 
+- (NSArray *)getAllDocumentIds
+{
+    if (![self ensureDatabaseOpen]) {
+        return nil;
+    }
+    
+    NSMutableArray *result = [NSMutableArray array];
+    struct TDQueryOptions query = {.limit = UINT_MAX,
+                                   .inclusiveEnd = YES,
+                                   .skip = 0,
+                                   .descending = NO,
+                                   .includeDocs = NO};
+    
+    NSDictionary *dictResults;
+    do {
+        dictResults = [self.database getDocsWithIDs:nil options:&query];
+        for (NSDictionary *row in dictResults[@"rows"]) {
+            [result addObject:row[@"id"]];
+        }
+        
+        query.skip = query.skip + query.limit;
+    } while (((NSArray *)dictResults[@"rows"]).count > 0);
+    
+    return [NSArray arrayWithArray:result];
+    
+}
+
 - (NSArray *)getAllDocumentsOffset:(NSUInteger)offset
                              limit:(NSUInteger)limit
                         descending:(BOOL)descending

--- a/Classes/common/query/CDTQQueryExecutor.m
+++ b/Classes/common/query/CDTQQueryExecutor.m
@@ -254,20 +254,23 @@ const NSUInteger kSmallResultSetSizeThreshold = 500;
 
     } else if ([node isKindOfClass:[CDTQSqlQueryNode class]]) {
         CDTQSqlQueryNode *sqlNode = (CDTQSqlQueryNode *)node;
-        CDTQSqlParts *sqlParts = sqlNode.sql;
-
-        NSMutableArray *docIds = [NSMutableArray array];
-
-        FMResultSet *rs = [db executeQuery:sqlParts.sqlWithPlaceholders
-                      withArgumentsInArray:sqlParts.placeholderValues];
-        while ([rs next]) {
-            [docIds addObject:[rs stringForColumn:@"_id"]];
+        NSMutableArray *docIds;
+        if (sqlNode.sql) {
+            CDTQSqlParts *sqlParts = sqlNode.sql;
+            FMResultSet *rs = [db executeQuery:sqlParts.sqlWithPlaceholders
+                          withArgumentsInArray:sqlParts.placeholderValues];
+            docIds = [NSMutableArray array];
+            while ([rs next]) {
+                [docIds addObject:[rs stringForColumn:@"_id"]];
+            }
+            [rs close];
+        } else {
+            // No SQL exists so we are now forced to go directly to the
+            // document datastore to retrieve the list of document ids.
+            docIds = [NSMutableArray arrayWithArray:[self.datastore getAllDocumentIds]];
         }
 
-        [rs close];
-
         return [NSSet setWithArray:docIds];
-
     } else {
         return nil;
     }

--- a/Tests/Tests/CDTQQueryExecutorTests.m
+++ b/Tests/Tests/CDTQQueryExecutorTests.m
@@ -1756,6 +1756,18 @@ sharedExamplesFor(@"queries without covering indexes", ^(NSDictionary* data) {
             expect(result.documentIds.count).to.equal(2);
             expect(result.documentIds).to.beSupersetOf(@[ @"mike72", @"fred12" ]);
         });
+        
+        it(@"query without any user defined indexes", ^{
+            // No user defined indexes found.  Retrieves document ids directly from the datastore.
+            expect([im deleteIndexNamed:@"basic"]).to.beTruthy();
+            expect([im deleteIndexNamed:@"pet"]).to.beTruthy();
+            expect([im listIndexes].count).to.equal(0);
+            
+            NSDictionary* query = @{ @"town" : @"bristol" };
+            CDTQResultSet* result = [im find:query];
+            expect(result.documentIds).to.containsInAnyOrder(@[ @"mike72", @"fred12" ]);
+        });
+        
     });
     
     describe(@"when executing queries containing $size operator", ^{

--- a/Tests/Tests/DatastoreCRUD.m
+++ b/Tests/Tests/DatastoreCRUD.m
@@ -764,6 +764,40 @@
     //[self getAllDocuments_testCountAndOffset:objectCount expectedDbObjects:reversedObjects descending:YES];
 }
 
+-(void)testGetAllDocumentIds
+{
+    XCTAssertEqual([self.datastore getAllDocumentIds].count, 0, @"No documents should exist.");
+    
+    NSError *error;
+    int objectCount = 1000;
+    NSArray *bodies = [self generateDocuments:objectCount];
+    NSMutableArray *dbObjects = [NSMutableArray arrayWithCapacity:objectCount];
+    for (int i = 0; i < objectCount; i++) {
+        // Results will be ordered by docId, so give an orderable ID.
+        error = nil;
+        NSString *docId = [NSString stringWithFormat:@"hello-%04d", i];
+        CDTMutableDocumentRevision *rev = [CDTMutableDocumentRevision revision];
+        rev.docId = docId;
+        rev.body = bodies[i];
+        CDTDocumentRevision *ob = [self.datastore createDocumentFromRevision:rev error:&error];
+        XCTAssertNil(error, @"Error creating document");
+        [dbObjects addObject:ob];
+    }
+    
+    XCTAssertEqual([self.datastore getAllDocumentIds].count,
+                   objectCount,
+                   @"There should be %d document ids.", objectCount);
+    
+    NSArray *docIds = [self.datastore getAllDocumentIds];
+    for (int i = 0; i < objectCount; i++) {
+        NSString *found = docIds[i];
+        NSString *expected = [NSString stringWithFormat:@"hello-%04d", i];
+        XCTAssertTrue([found isEqualToString:expected],
+                      @"Expecting %@ but found %@", expected, found);
+    }
+    
+}
+
 -(void)assertIdAndRevisionAndShallowContentExpected:(CDTDocumentRevision *)expected actual:(CDTDocumentRevision *)actual
 {
     XCTAssertEqualObjects([actual docId], [expected docId], @"docIDs don't match");

--- a/Tests/Tests/Mocks/CDTQMatcherQueryExecutor.h
+++ b/Tests/Tests/Mocks/CDTQMatcherQueryExecutor.h
@@ -10,4 +10,6 @@
 
 @interface CDTQMatcherQueryExecutor : CDTQQueryExecutor
 
+- (instancetype)initWithDatabase:(FMDatabaseQueue *)database datastore:(CDTDatastore *)datastore;
+
 @end


### PR DESCRIPTION
_What:_

There is a bug in Query that requires at least one index be created before any query can execute.

_Why:_

The desired behavior is to allow for querying of documents regardless of the existence of any indexes.

_How:_

Remove the logic that causes a query to fail when no indexes are found and replace it with logic that catches the condition and instead retrieves a full list of document ids from the main datastore for the post-hoc matcher to use when generating the query results.

This logic is found in the SQL translator and the query executor.  Additionally a new method to retrieve just a list of document ids needs to be added to the datastore API.

reviewer @mikerhodes 
reviewer @gadamc 

BugId: 45362