### PR TITLE
45943 Deleting document fails with a mutable document revision

### DIFF
--- a/Classes/common/CDTDatastore.m
+++ b/Classes/common/CDTDatastore.m
@@ -727,11 +727,21 @@ NSString *const CDTDatastoreChangeNotification = @"CDTDatastoreChangeNotificatio
         return nil;
     }
 
+    // A mutable document revision stores the revId in other property
+    NSString *prevRevisionID = nil;
+    if ([revision isKindOfClass:[CDTMutableDocumentRevision class]]) {
+        prevRevisionID = ((CDTMutableDocumentRevision *)revision).sourceRevId;
+    } else {
+        prevRevisionID = revision.revId;
+    }
+
     TD_Revision *td_revision =
         [[TD_Revision alloc] initWithDocID:revision.docId revID:nil deleted:YES];
     TDStatus status;
-    TD_Revision *new = [self.database putRevision : td_revision prevRevisionID
-                        : revision.revId allowConflict : NO status : &status];
+    TD_Revision *new = [self.database putRevision:td_revision
+                                   prevRevisionID:prevRevisionID
+                                    allowConflict:NO
+                                           status:&status];
     if (TDStatusIsError(status)) {
         if (error) {
             *error = TDStatusToNSError(status, nil);

--- a/Tests/Tests/DatastoreCRUD.m
+++ b/Tests/Tests/DatastoreCRUD.m
@@ -1797,6 +1797,26 @@
     
 }
 
+- (void)testDeleteMutableDocumentRevision
+{
+    NSString *docId = @"testDeleteWithMutableDocumentRevision";
+
+    CDTMutableDocumentRevision *mutableRev = [CDTMutableDocumentRevision revision];
+    mutableRev.docId = docId;
+    mutableRev.body = @{ @"hello" : @"world" };
+    CDTDocumentRevision *rev = [self.datastore createDocumentFromRevision:mutableRev error:nil];
+
+    mutableRev = [rev mutableCopy];
+
+    NSError *error = nil;
+    rev = [self.datastore deleteDocumentFromRevision:mutableRev error:&error];
+    XCTAssertNotNil(rev, @"Delete opeation should not fail: %@", error);
+
+    CDTDocumentRevision *deletedRev =
+        [self.datastore getDocumentWithId:docId rev:rev.revId error:&error];
+    XCTAssertNotNil(deletedRev, @"A deleted document is still in the datastore: %@", error);
+    XCTAssertTrue(deletedRev.deleted, @"This document should be set as deleted");
+}
 
 #pragma mark - Other Tests
 


### PR DESCRIPTION
*What:*
Using a CDTMutableDocumentRevsion to delete a document fails. It fails with a "conflict" message, even though the object's sourceRevId is correct.

*Why:*
Method `CDTDatastore:deleteDocumentFromRevision:error:` tries to get the revision ID from the property `revision.revId`; however a `CDTMutableDocumentRevision` stores this value in `sourceRevId`.

*How:*
Check if `revision` is an instance of `CDTMutableDocumentRevision` and in that case, take the revision if from property `sourceRevId`

*Tests:*
One extra tests in `DatastoreCRUD.m`:
* Create a document. Get a mutable copy. Delete the document with the mutable copy.

reviewer @rhyshort 
reviewer @emlaver 
reviewer @tomblench 
