### PR TITLE
46052 Implement resultsLimit and moreComing in CDTFetchChanges

### DIFF
--- a/Classes/common/CDTFetchChanges.h
+++ b/Classes/common/CDTFetchChanges.h
@@ -67,6 +67,28 @@
  */
 @property (nonatomic, copy) NSString *startSequenceValue;
 
+/**
+ Use this property to limit the total number of results you want to get.
+ 
+ By default, its value 0 which means that it will returns as many as possible.
+ 
+ Set it before executing the operation or submitting it to a queue.
+ */
+@property(nonatomic, assign) NSUInteger resultsLimit;
+
+/**
+ It will be YES only if there are more results available.
+ 
+ A CDTFetchChanges instance will deliver all results available unless a limit is set with
+ resultsLimit.
+ 
+ This property will set to YES before calling fetchRecordChangesCompletionBlock.
+ 
+ @see resultsLimit
+ @see fetchRecordChangesCompletionBlock
+ */
+@property(nonatomic, readonly) BOOL moreComing;
+
 #pragma mark Callbacks
 
 /**

--- a/Tests/Tests.xcodeproj/project.pbxproj
+++ b/Tests/Tests.xcodeproj/project.pbxproj
@@ -80,6 +80,8 @@
 		CD196E681B18C6320039133F /* schema100_1Bonsai_2Lorem.touchdb in Resources */ = {isa = PBXBuildFile; fileRef = CD196E661B18C6320039133F /* schema100_1Bonsai_2Lorem.touchdb */; };
 		CD196E6D1B18CD090039133F /* TD_DatabaseBlobFilenamesTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD196E6C1B18CD090039133F /* TD_DatabaseBlobFilenamesTests.m */; };
 		CD196E6E1B18CD090039133F /* TD_DatabaseBlobFilenamesTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD196E6C1B18CD090039133F /* TD_DatabaseBlobFilenamesTests.m */; };
+		CD1C82511B42D7AA00DB7044 /* CDTFetchChangesTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD1C82501B42D7AA00DB7044 /* CDTFetchChangesTests.m */; };
+		CD1C82521B42D7AA00DB7044 /* CDTFetchChangesTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD1C82501B42D7AA00DB7044 /* CDTFetchChangesTests.m */; };
 		CD2188D61AE5711A0036F59F /* CDTQIndexManagerEncryptionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD2188D01AE5711A0036F59F /* CDTQIndexManagerEncryptionTests.m */; };
 		CD2188D71AE5711A0036F59F /* CDTQIndexManagerEncryptionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD2188D01AE5711A0036F59F /* CDTQIndexManagerEncryptionTests.m */; };
 		CD2188D81AE5711A0036F59F /* CloudantTests+EncryptionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CD2188D21AE5711A0036F59F /* CloudantTests+EncryptionTests.m */; };
@@ -222,6 +224,7 @@
 		CD0D10EB1AB09CE8003315B5 /* TD_DatabaseDeletionTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TD_DatabaseDeletionTests.m; sourceTree = "<group>"; };
 		CD196E661B18C6320039133F /* schema100_1Bonsai_2Lorem.touchdb */ = {isa = PBXFileReference; lastKnownFileType = file; name = schema100_1Bonsai_2Lorem.touchdb; path = Assets/schema100_1Bonsai_2Lorem.touchdb; sourceTree = "<group>"; };
 		CD196E6C1B18CD090039133F /* TD_DatabaseBlobFilenamesTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TD_DatabaseBlobFilenamesTests.m; sourceTree = "<group>"; };
+		CD1C82501B42D7AA00DB7044 /* CDTFetchChangesTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTFetchChangesTests.m; sourceTree = "<group>"; };
 		CD2188D01AE5711A0036F59F /* CDTQIndexManagerEncryptionTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTQIndexManagerEncryptionTests.m; sourceTree = "<group>"; };
 		CD2188D11AE5711A0036F59F /* CloudantTests+EncryptionTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "CloudantTests+EncryptionTests.h"; sourceTree = "<group>"; };
 		CD2188D21AE5711A0036F59F /* CloudantTests+EncryptionTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "CloudantTests+EncryptionTests.m"; sourceTree = "<group>"; };
@@ -338,6 +341,7 @@
 			children = (
 				CD2188CF1AE570480036F59F /* Encryption */,
 				CD3FBCA11AB05A170032376E /* Helpers */,
+				CD1C82501B42D7AA00DB7044 /* CDTFetchChangesTests.m */,
 				ECA0DC601AFD568D00E174BC /* CDTQTextSearchTests.m */,
 				EC578D891AE67D60003D6006 /* CDTQIndexTests.m */,
 				EC0C831F1AB217290051042F /* CDTDatastoreQueryTests.m */,
@@ -768,6 +772,7 @@
 				EC0C83601AB217290051042F /* CDTQSQLOnlyQueryExecutor.m in Sources */,
 				CDADD5BF1AEFD643003CA9EF /* FMDatabase+SQLCipher.m in Sources */,
 				CD3FBCA81AB05A170032376E /* CDTHelperOneUseKeyProvider.m in Sources */,
+				CD1C82511B42D7AA00DB7044 /* CDTFetchChangesTests.m in Sources */,
 				CD2188D61AE5711A0036F59F /* CDTQIndexManagerEncryptionTests.m in Sources */,
 				CD2188EB1AE5764B0036F59F /* CDTEncryptionKeychainManagerTests.m in Sources */,
 				CD2C67CC1B14897000B95B9C /* CDTEncryptionKeySimpleProviderTests.m in Sources */,
@@ -843,6 +848,7 @@
 				EC0C83611AB217290051042F /* CDTQSQLOnlyQueryExecutor.m in Sources */,
 				CDADD5C01AEFD643003CA9EF /* FMDatabase+SQLCipher.m in Sources */,
 				CD3FBCA91AB05A170032376E /* CDTHelperOneUseKeyProvider.m in Sources */,
+				CD1C82521B42D7AA00DB7044 /* CDTFetchChangesTests.m in Sources */,
 				CD2188D71AE5711A0036F59F /* CDTQIndexManagerEncryptionTests.m in Sources */,
 				CD2188EC1AE5764B0036F59F /* CDTEncryptionKeychainManagerTests.m in Sources */,
 				CD2C67CD1B14897000B95B9C /* CDTEncryptionKeySimpleProviderTests.m in Sources */,

--- a/Tests/Tests/CDTFetchChangesTests.m
+++ b/Tests/Tests/CDTFetchChangesTests.m
@@ -1,0 +1,258 @@
+//
+//  CDTFetchChangesTests.m
+//  Tests
+//
+//  Created by Enrique de la Torre Fernandez on 30/06/2015.
+//  Copyright (c) 2015 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#import <XCTest/XCTest.h>
+
+#import "CloudantSyncTests.h"
+
+#import "CDTFetchChanges.h"
+#import "CDTDatastore.h"
+#import "CDTDatastoreManager.h"
+#import "CDTMutableDocumentRevision.h"
+
+#define CDTFETCHANGESTESTS_TOTALDOCCOUNT 1100
+#define CDTFETCHANGESTESTS_DELETEDOCCOUNT 5
+
+@interface CDTFetchChangesTests : CloudantSyncTests
+
+@property (strong, nonatomic) CDTDatastore *datastore;
+@property (strong, nonatomic) NSString *startSequenceValue;
+
+@end
+
+@implementation CDTFetchChangesTests
+
+- (void)setUp
+{
+    [super setUp];
+
+    // Put setup code here. This method is called before the invocation of each test method in the
+    // class.
+    // Prepare datastore
+    self.datastore = [self.factory datastoreNamed:@"test_fetchchanges" error:nil];
+
+    // Get first sequence value
+    CDTFetchChanges *fetchChanges =
+        [[CDTFetchChanges alloc] initWithDatastore:self.datastore startSequenceValue:nil];
+
+    __block NSString *blockStartSequenceValue = nil;
+    fetchChanges.fetchRecordChangesCompletionBlock =
+        ^(NSString *newSequenceValue, NSString *startSequenceValue, NSError *fetchError) {
+          blockStartSequenceValue = newSequenceValue;
+        };
+
+    [fetchChanges start];
+
+    self.startSequenceValue = blockStartSequenceValue;
+
+    // Populate datatore
+    [CDTFetchChangesTests populateDatastore:self.datastore
+                              withDocuments:CDTFETCHANGESTESTS_TOTALDOCCOUNT];
+
+    for (NSInteger index = 0; index < CDTFETCHANGESTESTS_DELETEDOCCOUNT; index++) {
+        [self.datastore deleteDocumentWithId:[CDTFetchChangesTests docIdWithIndex:index] error:nil];
+    }
+}
+
+- (void)tearDown
+{
+    // Put teardown code here. This method is called after the invocation of each test method in the
+    // class.
+    self.startSequenceValue = nil;
+    self.datastore = nil;
+
+    [super tearDown];
+}
+
+- (void)testBasicCaseWorks
+{
+    CDTFetchChanges *fetchChanges =
+        [[CDTFetchChanges alloc] initWithDatastore:self.datastore
+                                startSequenceValue:self.startSequenceValue];
+
+    __block NSUInteger blockChangedDocCount = 0;
+    fetchChanges.documentChangedBlock = ^(CDTDocumentRevision *revision) {
+      blockChangedDocCount++;
+    };
+
+    __block NSUInteger blockDeletedDocCount = 0;
+    fetchChanges.documentWithIDWasDeletedBlock = ^(NSString *docId) {
+      blockDeletedDocCount++;
+    };
+
+    [fetchChanges start];
+
+    // Assert
+    XCTAssertEqual(blockChangedDocCount,
+                   (CDTFETCHANGESTESTS_TOTALDOCCOUNT - CDTFETCHANGESTESTS_DELETEDOCCOUNT),
+                   @"%d documents remains in the datastore",
+                   (CDTFETCHANGESTESTS_TOTALDOCCOUNT - CDTFETCHANGESTESTS_DELETEDOCCOUNT));
+    XCTAssertEqual(blockDeletedDocCount, CDTFETCHANGESTESTS_DELETEDOCCOUNT,
+                   @"%i documents were deleted", 0);
+}
+
+- (void)testResultLimitSmallerThanTheTotalNumberOfDocuments
+{
+    CDTFetchChanges *fetchChanges =
+        [[CDTFetchChanges alloc] initWithDatastore:self.datastore
+                                startSequenceValue:self.startSequenceValue];
+
+    NSUInteger limit = (CDTFETCHANGESTESTS_TOTALDOCCOUNT - 10);
+    fetchChanges.resultsLimit = limit;
+
+    __block NSUInteger blockChangedDocCount = 0;
+    fetchChanges.documentChangedBlock = ^(CDTDocumentRevision *revision) {
+      blockChangedDocCount++;
+    };
+
+    __block NSUInteger blockDeletedDocCount = 0;
+    fetchChanges.documentWithIDWasDeletedBlock = ^(NSString *docId) {
+      blockDeletedDocCount++;
+    };
+
+    [fetchChanges start];
+
+    // Assert
+    XCTAssertEqual((blockChangedDocCount + blockDeletedDocCount), limit,
+                   @"Total number of read documents must be equal to the limit");
+    XCTAssertTrue(fetchChanges.moreComing, @"I did not read all the documents in the datastore");
+}
+
+- (void)testResultLimitEqualToTheTotalNumberOfDocuments
+{
+    CDTFetchChanges *fetchChanges =
+        [[CDTFetchChanges alloc] initWithDatastore:self.datastore
+                                startSequenceValue:self.startSequenceValue];
+
+    fetchChanges.resultsLimit = CDTFETCHANGESTESTS_TOTALDOCCOUNT;
+
+    __block NSUInteger blockChangedDocCount = 0;
+    fetchChanges.documentChangedBlock = ^(CDTDocumentRevision *revision) {
+      blockChangedDocCount++;
+    };
+
+    __block NSUInteger blockDeletedDocCount = 0;
+    fetchChanges.documentWithIDWasDeletedBlock = ^(NSString *docId) {
+      blockDeletedDocCount++;
+    };
+
+    [fetchChanges start];
+
+    // Assert
+    XCTAssertEqual((blockChangedDocCount + blockDeletedDocCount), CDTFETCHANGESTESTS_TOTALDOCCOUNT,
+                   @"Total number of read documents must be equal to the limit");
+    XCTAssertFalse(fetchChanges.moreComing, @"I did read all documents, there are no more coming");
+}
+
+- (void)testResultLimitBiggerThanTheTotalNumberOfDocuments
+{
+    CDTFetchChanges *fetchChanges =
+        [[CDTFetchChanges alloc] initWithDatastore:self.datastore
+                                startSequenceValue:self.startSequenceValue];
+
+    NSUInteger limit = (CDTFETCHANGESTESTS_TOTALDOCCOUNT + 10);
+    fetchChanges.resultsLimit = limit;
+
+    __block NSUInteger blockChangedDocCount = 0;
+    fetchChanges.documentChangedBlock = ^(CDTDocumentRevision *revision) {
+      blockChangedDocCount++;
+    };
+
+    __block NSUInteger blockDeletedDocCount = 0;
+    fetchChanges.documentWithIDWasDeletedBlock = ^(NSString *docId) {
+      blockDeletedDocCount++;
+    };
+
+    [fetchChanges start];
+
+    // Assert
+    XCTAssertEqual((blockChangedDocCount + blockDeletedDocCount), CDTFETCHANGESTESTS_TOTALDOCCOUNT,
+                   @"We can only read the documents present in the datastore");
+    XCTAssertFalse(fetchChanges.moreComing, @"I did read all documents, there are no more coming");
+}
+
+- (void)testFetchAllChangesWithALimitWorks
+{
+    NSUInteger limit = (CDTFETCHANGESTESTS_TOTALDOCCOUNT - 10);
+
+    // First read
+    CDTFetchChanges *fetchChanges =
+        [[CDTFetchChanges alloc] initWithDatastore:self.datastore
+                                startSequenceValue:self.startSequenceValue];
+
+    fetchChanges.resultsLimit = limit;
+
+    __block NSUInteger blockChangedDocCount = 0;
+    fetchChanges.documentChangedBlock = ^(CDTDocumentRevision *revision) {
+      blockChangedDocCount++;
+    };
+
+    __block NSUInteger blockDeletedDocCount = 0;
+    fetchChanges.documentWithIDWasDeletedBlock = ^(NSString *docId) {
+      blockDeletedDocCount++;
+    };
+
+    __block NSString *blockStartSequenceValue = nil;
+    fetchChanges.fetchRecordChangesCompletionBlock =
+        ^(NSString *newSequenceValue, NSString *startSequenceValue, NSError *fetchError) {
+          blockStartSequenceValue = newSequenceValue;
+        };
+
+    [fetchChanges start];
+
+    // Second read
+    fetchChanges = [[CDTFetchChanges alloc] initWithDatastore:self.datastore
+                                           startSequenceValue:blockStartSequenceValue];
+
+    fetchChanges.resultsLimit = limit;
+
+    fetchChanges.documentChangedBlock = ^(CDTDocumentRevision *revision) {
+      blockChangedDocCount++;
+    };
+
+    fetchChanges.documentWithIDWasDeletedBlock = ^(NSString *docId) {
+      blockDeletedDocCount++;
+    };
+
+    [fetchChanges start];
+
+    // Assert
+    XCTAssertEqual(blockChangedDocCount,
+                   (CDTFETCHANGESTESTS_TOTALDOCCOUNT - CDTFETCHANGESTESTS_DELETEDOCCOUNT),
+                   @"%d documents remains in the datastore",
+                   (CDTFETCHANGESTESTS_TOTALDOCCOUNT - CDTFETCHANGESTESTS_DELETEDOCCOUNT));
+    XCTAssertEqual(blockDeletedDocCount, CDTFETCHANGESTESTS_DELETEDOCCOUNT,
+                   @"%i documents were deleted", 0);
+}
+
+#pragma mark - Private class methods
++ (void)populateDatastore:(CDTDatastore *)datastore withDocuments:(NSUInteger)counter
+{
+    for (NSUInteger i = 0; i < counter; i++) {
+        CDTMutableDocumentRevision *rev = [CDTMutableDocumentRevision revision];
+        rev.docId = [CDTFetchChangesTests docIdWithIndex:i];
+        rev.body = @{ [NSString stringWithFormat:@"hello-%lu", (unsigned long)i] : @"world" };
+
+        [datastore createDocumentFromRevision:rev error:nil];
+    }
+}
+
++ (NSString *)docIdWithIndex:(NSUInteger)index
+{
+    return [NSString stringWithFormat:@"docId-%lu", (unsigned long)index];
+}
+
+@end


### PR DESCRIPTION
*What:*
It's difficult to batch updates in `CDTQIndexUpdater` while recording the latest sequence number.

*Why:*
Because the sequence number is only delivered in the completion block. Therefore we insert batches of document changes into the index tables but don't update the last sequence number.

*How:*
Implementing `resultsLimit` and `moreComing` would allow the indexing code to more efficiently batch changes, while bookmarking where it's up to as it goes along.

*Tests:*
1. Set `resultsLimit` to a value smaller than the total number of documents in the datastore. The `CDTFetchChanges` instance has to return a number of documents equal to the limit and `moreComing` has to be `true`.
2. Set `resultsLimit` to the total number of values in the datastore. The `CDTFetchChanges` instance has to return all the documents in the datastore and `moreComing` has to be `false`.
3. Set `resultsLimit` to a number bigger than the total number of documents in the datastore. The `CDTFetchChanges` instance will return all the documents in the datastore and `moreComing` will be `false`.
4. Create a `CDTFetchChanges` instance with `resultsLimit` equal to a value smaller than the total number of documents in the datastore. Fetch the documents and save the sequence value and the number of documents read so far. Create a new  `CDTFetchChanges` instance with `resultsLimit` equal to a value smaller than the total number of documents in the datastore and fetch the rest of the documents using the sequence value mentioned before. The total number of documents read has to be equal to the total number of documents in the datastore.

reviewer @rhyshort 
reviewer @tomblench 