### PR TITLE
Correct init chain for CDTDocumentRevision

### DIFF
--- a/Classes/common/CDTMutableDocumentRevision.h
+++ b/Classes/common/CDTMutableDocumentRevision.h
@@ -13,11 +13,39 @@
 @property (nonatomic, strong, readwrite) NSString *sourceRevId;
 @property (nonatomic, strong, readwrite) NSString *docId;
 
+/**
+ *   Creates an empty CDTMutableDocumentRevision
+ **/
 + (CDTMutableDocumentRevision *)revision;
 
-- (id)initWithDocumentId:(NSString *)documentId body:(NSMutableDictionary *)body;
+/**
+ * Initializes a CDTMutableDocumentRevision revision
+ *
+ * @param documentId The id of the document
+ * @param body The body of the document
+ *
+ **/
+- (instancetype)initWithDocumentId:(NSString *)documentId body:(NSMutableDictionary *)body;
 
-- (id)initWithSourceRevisionId:(NSString *)sourceRevId;
+/**
+ * Initializes a CDTMutableDocumentRevision
+ * 
+ * @param sourceRevId the parent revision id
+ **/
+- (instancetype)initWithSourceRevisionId:(NSString *)sourceRevId;
+
+/**
+ Initializes a CDTMutableDocumentRevision
+ 
+ @param documentId the id of the document
+ @param body the body of the document
+ @param attachments the document's attachments
+ @param sourceRevId the parent revision id
+ **/
+- (instancetype)initWithDocumentId:(NSString*) documentId
+                              body:(NSMutableDictionary *)body
+                       attachments: (NSMutableDictionary *)attachments
+                  sourceRevisionId:(NSString*)sourceRevId;
 
 - (void)setBody:(NSDictionary *)body;
 

--- a/Classes/common/CDTMutableDocumentRevision.m
+++ b/Classes/common/CDTMutableDocumentRevision.m
@@ -24,27 +24,37 @@
 
 + (CDTMutableDocumentRevision *)revision { return [[CDTMutableDocumentRevision alloc] init]; }
 
-- (id)initWithDocumentId:(NSString *)documentId body:(NSMutableDictionary *)body
-{
-    self = [super init];
 
-    if (self) {
-        // do set up
-        _docId = documentId;
-        _private_body = body;
-    }
-
-    return self;
+-(instancetype) init {
+    return [self initWithDocumentId:nil body:nil attachments:nil sourceRevisionId:nil];
 }
 
-- (id)initWithSourceRevisionId:(NSString *)sourceRevId
+- (instancetype)initWithDocumentId:(NSString *)documentId body:(NSMutableDictionary *)body
 {
-    self = [super init];
+    return [self initWithDocumentId:documentId body:body attachments:nil sourceRevisionId:nil];
+}
 
-    if (self) {
+- (instancetype)initWithSourceRevisionId:(NSString *)sourceRevId
+{
+    return [self initWithDocumentId:nil body:nil attachments:nil sourceRevisionId:sourceRevId];
+}
+
+- (instancetype)initWithDocumentId:(NSString*) documentId
+                              body:(NSMutableDictionary *)body
+                       attachments: (NSMutableDictionary *)attachments
+                  sourceRevisionId:(NSString*)sourceRevId {
+    
+    //deliberately call init rather than initWithDocId:revisionId:body:attachments:
+    // we need the revision id to be nil for the APIs on CDTDatastore to work.
+    self = [super init];
+    
+    if (self){
+        _docId = documentId;
+        _private_body = body ? body : [NSMutableDictionary dictionary];
+        _private_attachments = attachments ? attachments : [NSMutableDictionary dictionary];
         _sourceRevId = sourceRevId;
     }
-
+    
     return self;
 }
 


### PR DESCRIPTION
## What

Correct the init chain for CDTDocumentRevision so each init method
calls down into the full argument version of init. Change document body and attachments to initalize with a empty dictionary if nil is passed for their arguments.

## How

Make all the init methods call down to one single designated initialiser for `CDTMutableDocumentRevision`. The interface for `CDTMutableDocumentRevision` has changed as well, instead of `body` and `attachments` being defined as nil by default, they are now specified as empty dictionaries by default.

## Why

The implementation this replaces is confused, and doesn't use the designated initialiser, this work makes it so it matches the coding guidelines. It also improves the behaviour to make it easier to map into Swift using Nullability annotations.

## Reviewers

reviewer @alfinkel 
reviewer @mikerhodes  

BugzId: 45942