### PR TITLE
Fix to ensure that property type matches

### DIFF
--- a/Classes/common/touchdb/TDReachability.m
+++ b/Classes/common/touchdb/TDReachability.m
@@ -24,7 +24,7 @@ static void ClientCallback(SCNetworkReachabilityRef target, SCNetworkReachabilit
 
 @interface TDReachability ()
 @property (readwrite, nonatomic) BOOL reachabilityKnown;
-@property (readwrite, nonatomic) uint32_t reachabilityFlags;
+@property (readwrite, nonatomic) SCNetworkReachabilityFlags reachabilityFlags;
 - (void)flagsChanged:(SCNetworkReachabilityFlags)flags;
 @end
 


### PR DESCRIPTION
The property was declared differently in the protocol.
The problem was detected on Xcode7-beta.