### PR TITLE
Remove deprecated start method from CDTReplicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [NEW] Added query support for the `$size` operator.
 - [FIX] Fixed issue where at least one index had to be created before a query would execute.  You can now query for documents without the existence of any indexes.
+- [REMOVED] Removed deprecated method `start` on CDTReplicator, use `startWithError` instead.
 
 ## 0.17.1 (2015-06-24)
 

--- a/Classes/common/CDTReplicator/CDTReplicator.h
+++ b/Classes/common/CDTReplicator/CDTReplicator.h
@@ -185,11 +185,6 @@ typedef NS_ENUM(NSInteger, CDTReplicatorState) {
 - (BOOL)startWithError:(NSError *__autoreleasing *)error;
 
 /**
-  Use startWithError. This will be deprecated.
- */
-- (void)start __deprecated;
-
-/**
  * Stop an in-progress replication or attempt to stop a replication that has not yet started.
  *
  * Replications are queued on a separate thread. If the replication is already running,

--- a/Classes/common/CDTReplicator/CDTReplicator.m
+++ b/Classes/common/CDTReplicator/CDTReplicator.m
@@ -154,8 +154,6 @@ static NSString *const CDTReplicatorErrorDomain = @"CDTReplicatorErrorDomain";
 
 #pragma mark Lifecycle
 
-- (void)start { [self startWithError:nil]; }
-
 - (BOOL)startWithError:(NSError *__autoreleasing *)error;
 {
     @synchronized(self)

--- a/doc/replication.md
+++ b/doc/replication.md
@@ -67,7 +67,7 @@ devices. This web service needs to:
 
 Replications are set up in code on a device. Use `CDTPullReplication` and
 `CDTPushReplication` objects to create pre-configured `CDTReplicator` objects
-using a `CDTReplicatorFactory`. Then call `-start` on the `CDTReplicator` object
+using a `CDTReplicatorFactory`. Then call `-startWithError:` on the `CDTReplicator` object
 to start a replication. Each `CDTReplicator` object can be assigned a delegate
 to receive messages when replication completes or encounters an error.
 
@@ -98,11 +98,15 @@ CDTReplicator *replicator = [replicatorFactory oneWay:pushReplication error:&err
 
 // Check replicator isn't nil, if so check error
 
-// Start the replication and wait for it to complete
-[replicator start];
-while (replicator.isActive) {
-    [NSThread sleepForTimeInterval:1.0f];
-    NSLog(@" -> %@", [CDTReplicator stringForReplicatorState:replicator.state]);
+// Start the replication
+if ([replicator startWithError:&error]){
+    //handle error
+} else {
+    //wait for it to complete
+    while (replicator.isActive) {
+        [NSThread sleepForTimeInterval:1.0f];
+        NSLog(@" -> %@", [CDTReplicator stringForReplicatorState:replicator.state]);
+    }
 }
 ```
 
@@ -129,11 +133,15 @@ CDTReplicator *replicator = [replicatorFactory oneWay:pullReplication error:&err
 
 // Check replicator isn't nil, if so check error
 
-// Start the replication and wait for it to complete
-[replicator start];
-while (replicator.isActive) {
-    [NSThread sleepForTimeInterval:1.0f];
-    NSLog(@" -> %@", [CDTReplicator stringForReplicatorState:replicator.state]);
+// Start the replication
+if ([replicator startWithError:&error]){
+    //handle error
+} else {
+    //wait for it to complete
+    while (replicator.isActive) {
+        [NSThread sleepForTimeInterval:1.0f];
+        NSLog(@" -> %@", [CDTReplicator stringForReplicatorState:replicator.state]);
+    }
 }
 ```
 
@@ -185,5 +193,5 @@ CDTPushReplication *pushReplication = [CDTPushReplication replicationWithSource:
 NSError *error;
 self.replicator = [replicatorFactory oneWay:pushReplication error:&error];
 self.replicator.delegate = self.replicatorDelegate;
-[self.replicator start];
+[self.replicator startWithError:&error];
 ```


### PR DESCRIPTION
## What

Remove deprecated `start` method from CDTReplicator.

## Why

The main motivation behind removing it now, is because it will make it easier to use the replacement API for `start`, `startWithError:` because the method signature in Swift 2 becomes:

```swift
func start() throws
``` 
rather than 
```swift 
func startWithError() throws 
```

## Reviewer

reviewer @gadamc 
reviewer @tomblench 