### PR TITLE
Ground work for replaying requests with CDTURLSession

### DIFF
--- a/CDTDatastore.xcworkspace/contents.xcworkspacedata
+++ b/CDTDatastore.xcworkspace/contents.xcworkspacedata
@@ -11,6 +11,12 @@
             location = "container:"
             name = "HTTP">
             <FileRef
+               location = "group:Classes/common/HTTP/CDTURLSessionTask.m">
+            </FileRef>
+            <FileRef
+               location = "group:Classes/common/HTTP/CDTURLSessionTask.h">
+            </FileRef>
+            <FileRef
                location = "group:Classes/common/HTTP/CDTURLSession.h">
             </FileRef>
             <FileRef

--- a/Classes/common/HTTP/CDTURLSession.h
+++ b/Classes/common/HTTP/CDTURLSession.h
@@ -13,6 +13,7 @@
 //  and limitations under the License.
 
 #import <Foundation/Foundation.h>
+#import "CDTURLSessionTask.h"
 
 @class CDTURLSessionFilterContext;
 
@@ -27,7 +28,7 @@
  * Initalises a CDTURLSession without a delegate. Calling this method will result in 
  * completionHandlers being called on the thread which called this method.
  **/
-- (instancetype) init;
+- (instancetype)init;
 
 /**
  * Initalise a CDTURLSession.
@@ -35,7 +36,8 @@
  * @param delegate an object that implements NSURLSessionDelegate protocol
  * @param thread the thread which callbacks should be run on
  **/
--(instancetype) initWithDelegate:(id<NSURLSessionDelegate>)delegate callbackThread:(NSThread*)thread;
+- (instancetype)initWithDelegate:(id<NSURLSessionDelegate>)delegate
+                  callbackThread:(NSThread *)thread;
 
 /**
  * Performs a data task for a request.
@@ -43,10 +45,10 @@
  * @param request The request to make
  * @param completionHandler A block to call when the request completes
  *
- * @return returns a data task to used the make the request. `resume` needs to be called
+ * @return returns a task to used the make the request. `resume` needs to be called
  * in order for the task to start making the request.
  */
-- (NSURLSessionDataTask *)dataTaskWithRequest:(NSURLRequest *)request
-                            completionHandler:(void (^)(NSData *data, NSURLResponse *response, NSError *error))completionHandler;
+- (CDTURLSessionTask *)dataTaskWithRequest:(NSURLRequest *)request
+                         completionHandler:(void (^)(NSData *data, NSURLResponse *response, NSError *error))completionHandler;
 
 @end

--- a/Classes/common/HTTP/CDTURLSession.m
+++ b/Classes/common/HTTP/CDTURLSession.m
@@ -48,8 +48,8 @@
     return self;
 }
 
-- (NSURLSessionDataTask *)dataTaskWithRequest:(NSURLRequest *)request
-                            completionHandler:(void (^)(NSData *data,
+- (CDTURLSessionTask *)dataTaskWithRequest:(NSURLRequest *)request
+                         completionHandler:(void (^)(NSData *data,
                                                         NSURLResponse *response,
                                                         NSError *error))completionHandler
 {
@@ -71,7 +71,7 @@
         
     } ];
     
-    return task;
+    return [[CDTURLSessionTask alloc]initWithTask:task];
     
 }
 

--- a/Classes/common/HTTP/CDTURLSessionTask.h
+++ b/Classes/common/HTTP/CDTURLSessionTask.h
@@ -1,0 +1,48 @@
+//
+//  CDTURLSessionTask.h
+//
+//
+//  Created by Rhys Short on 20/08/2015.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+#import <Foundation/Foundation.h>
+#import "CDTMacros.h"
+
+@interface CDTURLSessionTask : NSObject
+
+/*
+ * The current state of the task within the session.
+ */
+@property (readonly) NSURLSessionTaskState state;
+
+/*
+ * The NSURLSessionTask backing this one
+ */
+@property (nonnull,readonly) NSURLSessionTask *task;
+
+- (nullable instancetype)init UNAVAILABLE_ATTRIBUTE;
+/*
+ * Initalises an instance of CDTURLSessionTask
+ *
+ *  @param task the NSURLSessionTask to be wrapped
+ */
+- (nullable instancetype)initWithTask:(nonnull NSURLSessionTask *)task NS_DESIGNATED_INITIALIZER;
+
+/*
+ * Resumes the execution of this task
+ */
+- (void)resume;
+
+/* 
+ * Marks the task as canceled, and triggers the delegate method
+ * URLSession:task:didCompleteWithError:
+ */
+- (void)cancel;
+
+@end

--- a/Classes/common/HTTP/CDTURLSessionTask.m
+++ b/Classes/common/HTTP/CDTURLSessionTask.m
@@ -1,0 +1,33 @@
+//
+//  CDTURLSessionTask.h
+//
+//
+//  Created by Rhys Short on 20/08/2015.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+#import "CDTURLSessionTask.h"
+
+@implementation CDTURLSessionTask
+
+- (instancetype)init { return nil; }
+- (instancetype)initWithTask:(NSURLSessionTask *)task
+{
+    NSParameterAssert(task);
+    self = [super init];
+    if (self) {
+        _task = task;
+    }
+    return self;
+}
+
+- (void)resume { [self.task resume]; }
+- (void)cancel { [self.task cancel]; }
+- (NSURLSessionTaskState)state { return self.task.state; }
+@end
+

--- a/Classes/common/touchdb/ChangeTracker/TDURLConnectionChangeTracker.m
+++ b/Classes/common/touchdb/ChangeTracker/TDURLConnectionChangeTracker.m
@@ -38,7 +38,7 @@
 @property (strong, nonatomic) NSDate* startTime;
 @property (nonatomic, readwrite) NSUInteger totalRetries;
 @property (nonatomic, strong) CDTURLSession * session;
-@property (nonatomic, strong) NSURLSessionDataTask * task;
+@property (nonatomic, strong) CDTURLSessionTask * task;
 @end
 
 @implementation TDURLConnectionChangeTracker

--- a/Classes/common/touchdb/TDRemoteRequest.m
+++ b/Classes/common/touchdb/TDRemoteRequest.m
@@ -40,7 +40,7 @@
 @interface TDRemoteRequest()
 
 @property CDTURLSession *session;
-@property (nonatomic, strong) NSURLSessionDataTask *task;
+@property (nonatomic, strong) CDTURLSessionTask *task;
 
 @end
 

--- a/Tests/Tests.xcodeproj/project.pbxproj
+++ b/Tests/Tests.xcodeproj/project.pbxproj
@@ -31,6 +31,8 @@
 		985A188B19D2CCEB000283E9 /* DatastoreConflicts.m in Sources */ = {isa = PBXBuildFile; fileRef = 985A188919D2CCEB000283E9 /* DatastoreConflicts.m */; };
 		985F84D4198BD3A4004D8713 /* AttachmentCRUD.m in Sources */ = {isa = PBXBuildFile; fileRef = 985F84D3198BD3A4004D8713 /* AttachmentCRUD.m */; };
 		985F84D5198BDA6D004D8713 /* AttachmentCRUD.m in Sources */ = {isa = PBXBuildFile; fileRef = 985F84D3198BD3A4004D8713 /* AttachmentCRUD.m */; };
+		989158DE1B8B7D6300FFF509 /* CDTURLSessionTaskTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 989158DD1B8B7D6300FFF509 /* CDTURLSessionTaskTests.m */; };
+		989158DF1B8B7D6300FFF509 /* CDTURLSessionTaskTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 989158DD1B8B7D6300FFF509 /* CDTURLSessionTaskTests.m */; };
 		989E6E22198799AE00FB8510 /* DatastoreCRUD.m in Sources */ = {isa = PBXBuildFile; fileRef = 989E6E21198799AE00FB8510 /* DatastoreCRUD.m */; };
 		989E6E23198799AE00FB8510 /* DatastoreCRUD.m in Sources */ = {isa = PBXBuildFile; fileRef = 989E6E21198799AE00FB8510 /* DatastoreCRUD.m */; };
 		98BB740019E5927600C57866 /* CloudantTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98BB73FF19E5927600C57866 /* CloudantTests.m */; };
@@ -192,6 +194,7 @@
 		985A188619D2CC54000283E9 /* CDTDatastoreEvents.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CDTDatastoreEvents.m; path = Events/CDTDatastoreEvents.m; sourceTree = "<group>"; };
 		985A188919D2CCEB000283E9 /* DatastoreConflicts.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DatastoreConflicts.m; sourceTree = "<group>"; };
 		985F84D3198BD3A4004D8713 /* AttachmentCRUD.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AttachmentCRUD.m; path = Attachments/AttachmentCRUD.m; sourceTree = "<group>"; };
+		989158DD1B8B7D6300FFF509 /* CDTURLSessionTaskTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTURLSessionTaskTests.m; sourceTree = "<group>"; };
 		989E6E21198799AE00FB8510 /* DatastoreCRUD.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DatastoreCRUD.m; sourceTree = "<group>"; };
 		98BB73FE19E5927600C57866 /* CloudantTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CloudantTests.h; sourceTree = "<group>"; };
 		98BB73FF19E5927600C57866 /* CloudantTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CloudantTests.m; sourceTree = "<group>"; };
@@ -339,6 +342,7 @@
 		27389E15185345FD0027A404 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				989158DC1B8B7D3D00FFF509 /* HTTP */,
 				CD2188CF1AE570480036F59F /* Encryption */,
 				CD3FBCA11AB05A170032376E /* Helpers */,
 				CD1C82501B42D7AA00DB7044 /* CDTFetchChangesTests.m */,
@@ -473,6 +477,14 @@
 				03034DD60492427AC73C43CD /* Pods-osx.release.xcconfig */,
 			);
 			name = Pods;
+			sourceTree = "<group>";
+		};
+		989158DC1B8B7D3D00FFF509 /* HTTP */ = {
+			isa = PBXGroup;
+			children = (
+				989158DD1B8B7D6300FFF509 /* CDTURLSessionTaskTests.m */,
+			);
+			name = HTTP;
 			sourceTree = "<group>";
 		};
 		CD2188CF1AE570480036F59F /* Encryption */ = {
@@ -759,6 +771,7 @@
 				EC0C833C1AB217290051042F /* CDTDatastoreQueryTests.m in Sources */,
 				985F84D4198BD3A4004D8713 /* AttachmentCRUD.m in Sources */,
 				98DDEB9F1A41CD3400767178 /* DatastoreManagerTests.m in Sources */,
+				989158DE1B8B7D6300FFF509 /* CDTURLSessionTaskTests.m in Sources */,
 				9F4E646B19DC815B00FE37E1 /* CDTReplicationTests.m in Sources */,
 				EC0C83461AB217290051042F /* CDTQInvalidQuerySyntax.m in Sources */,
 				98BB740019E5927600C57866 /* CloudantTests.m in Sources */,
@@ -835,6 +848,7 @@
 				EC0C833D1AB217290051042F /* CDTDatastoreQueryTests.m in Sources */,
 				9F0D2403188DFE8600D3D04E /* TD_RevisionTests.m in Sources */,
 				98DDEBA01A41CD3400767178 /* DatastoreManagerTests.m in Sources */,
+				989158DF1B8B7D6300FFF509 /* CDTURLSessionTaskTests.m in Sources */,
 				9F4E646C19DC815B00FE37E1 /* CDTReplicationTests.m in Sources */,
 				EC0C83471AB217290051042F /* CDTQInvalidQuerySyntax.m in Sources */,
 				98BB740119E5927600C57866 /* CloudantTests.m in Sources */,

--- a/Tests/Tests/CDTURLSessionTaskTests.m
+++ b/Tests/Tests/CDTURLSessionTaskTests.m
@@ -1,0 +1,45 @@
+//
+//  CDTURLSessionTaskTests.m
+//  Tests
+//
+//  Created by Rhys Short on 24/08/2015.
+//
+//
+
+#import <XCTest/XCTest.h>
+#import <Foundation/Foundation.h>
+#import "CloudantSyncTests.h"
+#import "CDTURLSessionTask.h"
+#import <OCMock/OCMock.h>
+
+@interface CDTURLSessionTaskTests : CloudantSyncTests
+
+@end
+
+@implementation CDTURLSessionTaskTests
+
+- (void)testTaskCorrectlyProxiesCalls
+{
+    NSURLSessionDataTask *task = [[NSURLSessionDataTask alloc]init];
+    id mockedTask = OCMPartialMock(task);
+    OCMStub([mockedTask state]).andReturn(NSURLSessionTaskStateSuspended);
+    OCMStub([(NSURLSessionDataTask *)mockedTask resume]).andDo(nil);
+    OCMStub([mockedTask cancel]).andDo(nil);
+    
+    CDTURLSessionTask * cdtTask  = [[CDTURLSessionTask alloc]initWithTask:mockedTask];
+    
+    //call void methods methods
+    [cdtTask resume];
+    [cdtTask cancel];
+    
+    //verify that object state is as expected
+    XCTAssertEqual(NSURLSessionTaskStateSuspended, cdtTask.state);
+    XCTAssertEqual(mockedTask, cdtTask.task);
+    
+    //verify mock methods called
+    OCMVerify([(NSURLSessionDataTask *)mockedTask resume]);
+    OCMVerify([mockedTask cancel]);
+    OCMVerify([mockedTask state]);
+}
+
+@end


### PR DESCRIPTION
## What

Lay the ground work to enable replaying HTTP requests in the CDTURLSession class.

## How

Replace NSURLSessionDataTask references with CDTURLSessionTask references.

## Why

Replaying requests requires the ability to transparently replay requests before calling the completion handler. In order to this, the caller must not be aware of the underling http requests, CDTURLSessionTask enables this wrapping a NSURLSessionTask in preparation for the work to enable retries.

## Reviewers

reviewer @tomblench 
reviewer @mikerhodes 