### PR TITLE
50707 - Use mutable dictionaries in CDTDocumentRevision

### DIFF
--- a/CDTDatastore.xcworkspace/contents.xcworkspacedata
+++ b/CDTDatastore.xcworkspace/contents.xcworkspacedata
@@ -583,6 +583,25 @@
          <FileRef
             location = "group:CDTMacros.h">
          </FileRef>
+         <Group
+            location = "container:"
+            name = "Utils">
+            <FileRef
+               location = "group:Classes/common/Utils/CDTChangedDictionary.h">
+            </FileRef>
+            <FileRef
+               location = "group:Classes/common/Utils/CDTChangedDictionary.m">
+            </FileRef>
+            <FileRef
+               location = "group:Classes/common/Utils/CDTChangedArray.h">
+            </FileRef>
+            <FileRef
+               location = "group:Classes/common/Utils/CDTChangedArray.m">
+            </FileRef>
+            <FileRef
+               location = "group:Classes/common/Utils/CDTChangedObserver.h">
+            </FileRef>
+         </Group>
       </Group>
       <Group
          location = "group:Classes/ios"

--- a/Classes/common/CDTDatastore+Conflicts.m
+++ b/Classes/common/CDTDatastore+Conflicts.m
@@ -58,7 +58,7 @@
     NSMutableArray *downloadedAttachments = [NSMutableArray array];
     NSMutableArray *attachmentsToCopy = [NSMutableArray array];
 
-    BOOL isNewRevision = YES;  // TODO work out whether we can more easily tell if a rev is `dirty'
+    BOOL isNewRevision = resolvedRev.isChanged;
 
     if (resolvedRev == nil) {  // do nothing
         return kTDStatusOK;

--- a/Classes/common/CDTDocumentRevision.h
+++ b/Classes/common/CDTDocumentRevision.h
@@ -16,6 +16,7 @@
 #import <Foundation/Foundation.h>
 
 #import "TD_Revision.h"
+#import "CDTChangedObserver.h"
 
 @class TD_RevisionList;
 @class CDTDocumentRevision;
@@ -23,7 +24,7 @@
 /**
  * Represents a single revision of a document in a datastore.
  */
-@interface CDTDocumentRevision : NSObject
+@interface CDTDocumentRevision : NSObject <CDTChangedObserver>
 
 /** Document ID for this document revision. */
 @property (nonatomic, strong, readonly) NSString *docId;
@@ -35,10 +36,10 @@
 
 @property (nonatomic, readonly) SequenceNumber sequence;
 
-@property (nonatomic, strong) NSDictionary *body;
-@property (nonatomic, strong) NSDictionary *attachments;
+@property (nonatomic, strong) NSMutableDictionary *body;
+@property (nonatomic, strong) NSMutableDictionary *attachments;
 
-@property (nonatomic) bool isChanged;
+@property (nonatomic, getter=isChanged) bool changed;
 
 - (id)initWithDocId:(NSString *)docId
          revisionId:(NSString *)revId

--- a/Classes/common/CDTDocumentRevision.h
+++ b/Classes/common/CDTDocumentRevision.h
@@ -38,6 +38,8 @@
 @property (nonatomic, strong) NSDictionary *body;
 @property (nonatomic, strong) NSDictionary *attachments;
 
+@property (nonatomic) bool isChanged;
+
 - (id)initWithDocId:(NSString *)docId
          revisionId:(NSString *)revId
                body:(NSDictionary *)body

--- a/Classes/common/CDTDocumentRevision.m
+++ b/Classes/common/CDTDocumentRevision.m
@@ -168,8 +168,11 @@
 
             [mutableCopy removeObjectsForKeys:keysToRemove];
             _body = [NSDictionary dictionaryWithDictionary:mutableCopy];
-        } else
+        } else {
             _body = [NSDictionary dictionary];
+        }
+
+        _isChanged = NO;
     }
     return self;
 }
@@ -201,10 +204,15 @@
     return mutableCopy;
 }
 
-- (void)setBody:(NSDictionary *)body { _body = body; }
+- (void)setBody:(NSDictionary *)body
+{
+    self.isChanged = YES;
+    _body = body;
+}
 
 - (void)setAttachments:(NSMutableDictionary *)attachments
 {
+    self.isChanged = YES;
     _attachments = attachments;
 }
 

--- a/Classes/common/CDTDocumentRevision.m
+++ b/Classes/common/CDTDocumentRevision.m
@@ -21,6 +21,8 @@
 #import "TD_Database.h"
 #import "CDTLogging.h"
 
+#import "CDTChangedDictionary.h"
+
 @interface CDTDocumentRevision ()
 
 @property (nonatomic, strong, readonly) TD_RevisionList *revs;
@@ -156,7 +158,7 @@
         _docId = docId;
         _revId = revId;
         _deleted = deleted;
-        _attachments = [NSDictionary dictionaryWithDictionary:attachments];
+        _attachments = [CDTChangedDictionary dictionaryWrappingContents:attachments];
         _sequence = sequence;
         if (!deleted && body) {
             NSMutableDictionary *mutableCopy = [body mutableCopy];
@@ -167,12 +169,14 @@
             NSArray *keysToRemove = [[body allKeys] filteredArrayUsingPredicate:_prefixPredicate];
 
             [mutableCopy removeObjectsForKeys:keysToRemove];
-            _body = [NSDictionary dictionaryWithDictionary:mutableCopy];
+            _body = [CDTChangedDictionary dictionaryWrappingContents:mutableCopy];
         } else {
-            _body = [NSDictionary dictionary];
+            _body = [CDTChangedDictionary dictionaryWrappingContents:@{}];
         }
 
-        _isChanged = NO;
+        _changed = NO;
+        ((CDTChangedDictionary *)_body).delegate = self;
+        ((CDTChangedDictionary *)_attachments).delegate = self;
     }
     return self;
 }
@@ -204,16 +208,24 @@
     return mutableCopy;
 }
 
+- (void)contentOfObjectDidChange:(NSObject *)object { self.changed = YES; }
+
 - (void)setBody:(NSDictionary *)body
 {
-    self.isChanged = YES;
-    _body = body;
+    self.changed = YES;
+
+    // No need to wrap the dictionary with a CDTChangedDictionary
+    // because we've already marked ourselves as changed.
+    _body = [body mutableCopy];
 }
 
 - (void)setAttachments:(NSMutableDictionary *)attachments
 {
-    self.isChanged = YES;
-    _attachments = attachments;
+    self.changed = YES;
+
+    // No need to wrap the dictionary with a CDTChangedDictionary
+    // because we've already marked ourselves as changed.
+    _attachments = [attachments mutableCopy];
 }
 
 @end

--- a/Classes/common/Utils/CDTChangedArray.h
+++ b/Classes/common/Utils/CDTChangedArray.h
@@ -1,0 +1,68 @@
+//
+//  CDTChangedArray.h
+//
+//
+//  Created by Michael Rhodes on 17/08/2015.
+//  Copyright (c) 2015 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "CDTChangedObserver.h"
+
+/**
+ A wrapper around NSMutableArray which has a changed flag that's
+ set when the content is changed.
+
+ Changes are tracked very simply, isChanged is set to true when any of the
+ following are called:
+
+  - insertObject:atIndex:
+  - removeObjectAtIndex:
+  - addObject:
+  - removeLastObject
+  - replaceObjectAtIndex:withObject:
+
+ The changed flag will only be set for modifications through this class, not
+ when the underlying array changes itself, therefore it's important
+ not to let the contained array "escape" from this class if all changes
+ need to be tracked.
+
+ This class implements `CDTChangedObserver` so that it can bubble changes up
+ through to its parent containers within a deep structure that has been
+ wrapped with CDTChangedDictionary's `dictionaryWrappingContents:`. That
+ method copies the contents of all containers within the passed dictionary
+ into new CDTChanged* containers, assigning each wrapped container its parent
+ container as delegate.
+ */
+@interface CDTChangedArray : NSMutableArray <CDTChangedObserver>
+
+/**
+ Create an empty array.
+ */
++ (CDTChangedArray *)emptyArray;
+
+/**
+ Will be notified if this object is changed.
+ */
+@property (nonatomic, weak) NSObject<CDTChangedObserver> *delegate;
+
+/**
+ Init with array. This constructor must be used.
+ */
+- (instancetype)initWithMutableArray:(nonnull NSMutableArray *)array;
+
+/**
+ Set to YES if this dictionary has been modified.
+ */
+@property (nonatomic, getter=isChanged) bool changed;
+
+@end

--- a/Classes/common/Utils/CDTChangedArray.m
+++ b/Classes/common/Utils/CDTChangedArray.m
@@ -1,0 +1,92 @@
+//
+//  CDTChangedArray.m
+//
+//
+//  Created by Michael Rhodes on 17/08/2015.
+//  Copyright (c) 2015 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#import "CDTChangedArray.h"
+
+#import "CDTChangedDictionary.h"
+
+@interface CDTChangedArray ()
+
+@property (nonatomic, strong) NSMutableArray *wrappedArray;
+
+@end
+
+@implementation CDTChangedArray
+
++ (CDTChangedArray *)emptyArray
+{
+    return [[CDTChangedArray alloc] initWithMutableArray:[@[] mutableCopy]];
+}
+
+- (instancetype)initWithMutableArray:(nonnull NSMutableArray *)array
+{
+    self = [self init];
+    if (self) {
+        _wrappedArray = array;
+    }
+    return self;
+}
+
+- (void)setChanged:(bool)changed
+{
+    _changed = changed;
+
+    if (_changed && self.delegate) {
+        [self.delegate contentOfObjectDidChange:self];
+    }
+}
+
+- (void)contentOfObjectDidChange:(NSObject *)object { self.changed = YES; }
+
+#pragma mark NSMutableArray primitives
+
+- (void)insertObject:(id)anObject atIndex:(NSUInteger)index
+{
+    self.changed = YES;
+    [self.wrappedArray insertObject:anObject atIndex:index];
+}
+
+- (void)removeObjectAtIndex:(NSUInteger)index
+{
+    self.changed = YES;
+    [self.wrappedArray removeObjectAtIndex:index];
+}
+
+- (void)addObject:(id)anObject
+{
+    self.changed = YES;
+    [self.wrappedArray addObject:anObject];
+}
+
+- (void)removeLastObject
+{
+    self.changed = YES;
+    [self.wrappedArray removeLastObject];
+}
+
+- (void)replaceObjectAtIndex:(NSUInteger)index withObject:(id)anObject
+{
+    self.changed = YES;
+    [self.wrappedArray replaceObjectAtIndex:index withObject:anObject];
+}
+
+#pragma mark NSArray primitives
+
+- (NSUInteger)count { return self.wrappedArray.count; }
+
+- (id)objectAtIndex:(NSUInteger)index { return [self.wrappedArray objectAtIndex:index]; }
+
+@end

--- a/Classes/common/Utils/CDTChangedDictionary.h
+++ b/Classes/common/Utils/CDTChangedDictionary.h
@@ -1,0 +1,67 @@
+//
+//  CDTChangedDictionary.h
+//
+//
+//  Created by Michael Rhodes on 17/08/2015.
+//  Copyright (c) 2015 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "CDTChangedObserver.h"
+
+/**
+ A wrapper around NSMutableDictionary which has a changed flag that's
+ set when the content is changed.
+
+ Changes are tracked very simply, isChanged is set to true when either of
+ removeObjectForKey: or setObject:forKey: is called.
+
+ The changed flag will only be set for modifications through this class, not
+ when the underlying dictionary changes itself, therefore it's important
+ not to let the contained dictionary "escape" from this class if all changes
+ need to be tracked.
+
+ This class implements `CDTChangedObserver` so that it can bubble changes up
+ through to its parent containers within a deep structure that has been
+ wrapped with `dictionaryWrappingContents:`. That
+ method copies the contents of all containers within the passed dictionary
+ into new CDTChanged* containers, assigning each wrapped container its parent
+ container as delegate.
+ */
+@interface CDTChangedDictionary : NSMutableDictionary <CDTChangedObserver>
+
+/**
+ Create an empty dictionary.
+ */
++ (CDTChangedDictionary *)emptyDictionary;
+
+/**
+ Will be notified if this object is changed.
+ */
+@property (nonatomic, weak) NSObject<CDTChangedObserver> *delegate;
+
+/**
+ Set to YES if this dictionary has been modified.
+ */
+@property (nonatomic, getter=isChanged) bool changed;
+
+/**
+ Init with dictionary. This constructor must be used.
+ */
+- (instancetype)initWithDictionary:(NSMutableDictionary *)dictionary;
+
+/**
+ Wrap a nested JSON-compatible structure with Changed dictionary and array objects.
+ */
++ (CDTChangedDictionary *)dictionaryWrappingContents:(NSDictionary *)dictionary;
+
+@end

--- a/Classes/common/Utils/CDTChangedDictionary.m
+++ b/Classes/common/Utils/CDTChangedDictionary.m
@@ -1,0 +1,141 @@
+//
+//  CDTChangedDictionary.m
+//
+//
+//  Created by Michael Rhodes on 17/08/2015.
+//  Copyright (c) 2015 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#import "CDTChangedDictionary.h"
+
+#import "CDTChangedArray.h"
+
+@interface CDTChangedDictionary ()
+
+@property (nonatomic, strong, readonly) NSMutableDictionary *wrappedDictionary;
+
+@end
+
+@implementation CDTChangedDictionary
+
++ (CDTChangedDictionary *)emptyDictionary
+{
+    return [[CDTChangedDictionary alloc] initWithDictionary:[@{} mutableCopy]];
+}
+
+- (instancetype)initWithDictionary:(NSMutableDictionary *)dictionary
+{
+    self = [self init];
+    if (self) {
+        _wrappedDictionary = dictionary;
+    }
+    return self;
+}
+
+- (void)setChanged:(bool)changed
+{
+    _changed = changed;
+
+    if (_changed && self.delegate) {
+        [self.delegate contentOfObjectDidChange:self];
+    }
+}
+
+- (void)contentOfObjectDidChange:(NSObject *)object { self.changed = YES; }
+
+#pragma mark NSMutableDictionary primitive methods
+
+- (void)setObject:(id)anObject forKey:(id<NSCopying>)aKey
+{
+    self.changed = YES;
+    [self.wrappedDictionary setObject:anObject forKey:aKey];
+}
+
+- (void)removeObjectForKey:(id)aKey
+{
+    self.changed = YES;
+    [self.wrappedDictionary removeObjectForKey:aKey];
+}
+
+#pragma mark NSDictionary primitive methods
+
+- (id)initWithObjects:(const id[])objects
+              forKeys:(const id<NSCopying> [])keys
+                count:(NSUInteger)count
+{
+    self = [self init];
+    if (self) {
+        _wrappedDictionary =
+            [[NSMutableDictionary alloc] initWithObjects:objects forKeys:keys count:count];
+    }
+    return self;
+}
+
+- (NSUInteger)count { return self.wrappedDictionary.count; }
+
+- (id)objectForKey:(id)aKey { return [self.wrappedDictionary objectForKey:aKey]; }
+
+- (NSEnumerator *)keyEnumerator { return [self.wrappedDictionary keyEnumerator]; }
+
++ (CDTChangedDictionary *)dictionaryWrappingContents:(NSDictionary *)dictionary
+{
+    // We need to create the changed dictionary at the end to avoid setting
+    // isChanged prematurely.
+    CDTChangedDictionary *changedDict = [CDTChangedDictionary emptyDictionary];
+
+    for (NSString *key in dictionary) {
+        NSObject *ob = dictionary[key];
+        if ([ob isKindOfClass:[NSDictionary class]]) {
+            CDTChangedDictionary *tmp =
+                [CDTChangedDictionary dictionaryWrappingContents:(NSDictionary *)ob];
+            tmp.delegate = changedDict;
+            changedDict[key] = tmp;
+        } else if ([ob isKindOfClass:[NSArray class]]) {
+            CDTChangedArray *tmp = [CDTChangedDictionary arrayWrappingContents:(NSArray *)ob];
+            tmp.delegate = changedDict;
+            changedDict[key] = tmp;
+        } else {
+            changedDict[key] = ob;
+        }
+    }
+
+    // Reset changed flag -- it will have been set while we built the dictionary
+    changedDict.changed = NO;
+
+    return changedDict;
+}
+
++ (CDTChangedArray *)arrayWrappingContents:(NSArray *)array
+{
+    CDTChangedArray *changedArray = [CDTChangedArray emptyArray];
+
+    for (NSObject *ob in array) {
+        if ([ob isKindOfClass:[NSDictionary class]]) {
+            CDTChangedDictionary *tmp =
+                [CDTChangedDictionary dictionaryWrappingContents:(NSDictionary *)ob];
+            tmp.delegate = changedArray;
+            [changedArray addObject:tmp];
+        } else if ([ob isKindOfClass:[NSArray class]]) {
+            CDTChangedArray *tmp = [CDTChangedDictionary arrayWrappingContents:(NSArray *)ob];
+            tmp.delegate = changedArray;
+            [changedArray addObject:tmp];
+        } else {
+            [changedArray addObject:ob];
+        }
+    }
+
+    // Reset changed flag -- it will have been set while we built the dictionary
+    changedArray.changed = NO;
+
+    return changedArray;
+}
+
+@end

--- a/Classes/common/Utils/CDTChangedObserver.h
+++ b/Classes/common/Utils/CDTChangedObserver.h
@@ -1,0 +1,23 @@
+//
+//  CDTChangedObserver.h
+//
+//
+//  Created by Michael Rhodes on 18/08/2015.
+//  Copyright (c) 2015 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+
+@protocol CDTChangedObserver <NSObject>
+
+- (void)contentOfObjectDidChange:(NSObject *)object;
+
+@end

--- a/Tests/Tests.xcodeproj/project.pbxproj
+++ b/Tests/Tests.xcodeproj/project.pbxproj
@@ -15,6 +15,12 @@
 		27389E3618534E050027A404 /* DatastoreActions.m in Sources */ = {isa = PBXBuildFile; fileRef = 27389E3018534E050027A404 /* DatastoreActions.m */; };
 		27651C6419001B54006FEF7F /* bonsai-boston.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 27651C6319001B54006FEF7F /* bonsai-boston.jpg */; };
 		27651C6519001B54006FEF7F /* bonsai-boston.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 27651C6319001B54006FEF7F /* bonsai-boston.jpg */; };
+		278EC7BB1B82061500292E02 /* CDTChangedDictionaryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 278EC7BA1B82061500292E02 /* CDTChangedDictionaryTests.m */; };
+		278EC7BC1B82061500292E02 /* CDTChangedDictionaryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 278EC7BA1B82061500292E02 /* CDTChangedDictionaryTests.m */; };
+		278EC7BE1B820F9000292E02 /* CDTChangedArrayTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 278EC7BD1B820F9000292E02 /* CDTChangedArrayTests.m */; };
+		278EC7BF1B820F9000292E02 /* CDTChangedArrayTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 278EC7BD1B820F9000292E02 /* CDTChangedArrayTests.m */; };
+		278EC7C11B821AB000292E02 /* CDTChangedDictionaryJSONWrappingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 278EC7C01B821AB000292E02 /* CDTChangedDictionaryJSONWrappingTests.m */; };
+		278EC7C21B821AB000292E02 /* CDTChangedDictionaryJSONWrappingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 278EC7C01B821AB000292E02 /* CDTChangedDictionaryJSONWrappingTests.m */; };
 		27CCEDCD187AD64F006F3C66 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 27CCEDCB187AD64F006F3C66 /* InfoPlist.strings */; };
 		27CCEDD6187AD70C006F3C66 /* CloudantSyncTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 27389E2E18534E050027A404 /* CloudantSyncTests.m */; };
 		27CCEDD7187AD719006F3C66 /* DatastoreActions.m in Sources */ = {isa = PBXBuildFile; fileRef = 27389E3018534E050027A404 /* DatastoreActions.m */; };
@@ -178,6 +184,9 @@
 		27389E2E18534E050027A404 /* CloudantSyncTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CloudantSyncTests.m; sourceTree = "<group>"; };
 		27389E3018534E050027A404 /* DatastoreActions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DatastoreActions.m; sourceTree = "<group>"; };
 		27651C6319001B54006FEF7F /* bonsai-boston.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; name = "bonsai-boston.jpg"; path = "Assets/bonsai-boston.jpg"; sourceTree = "<group>"; };
+		278EC7BA1B82061500292E02 /* CDTChangedDictionaryTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CDTChangedDictionaryTests.m; path = Utils/CDTChangedDictionaryTests.m; sourceTree = "<group>"; };
+		278EC7BD1B820F9000292E02 /* CDTChangedArrayTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CDTChangedArrayTests.m; path = Utils/CDTChangedArrayTests.m; sourceTree = "<group>"; };
+		278EC7C01B821AB000292E02 /* CDTChangedDictionaryJSONWrappingTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CDTChangedDictionaryJSONWrappingTests.m; path = Utils/CDTChangedDictionaryJSONWrappingTests.m; sourceTree = "<group>"; };
 		27CCEDC6187AD64F006F3C66 /* Tests OSX.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Tests OSX.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		27CCEDCA187AD64F006F3C66 /* Tests OSX-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Tests OSX-Info.plist"; sourceTree = "<group>"; };
 		27CCEDCC187AD64F006F3C66 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -339,6 +348,7 @@
 		27389E15185345FD0027A404 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				278EC7B91B8205D500292E02 /* Utils */,
 				CD2188CF1AE570480036F59F /* Encryption */,
 				CD3FBCA11AB05A170032376E /* Helpers */,
 				CD1C82501B42D7AA00DB7044 /* CDTFetchChangesTests.m */,
@@ -404,6 +414,16 @@
 				27389E1D185345FD0027A404 /* Tests-Prefix.pch */,
 			);
 			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		278EC7B91B8205D500292E02 /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				278EC7BA1B82061500292E02 /* CDTChangedDictionaryTests.m */,
+				278EC7BD1B820F9000292E02 /* CDTChangedArrayTests.m */,
+				278EC7C01B821AB000292E02 /* CDTChangedDictionaryJSONWrappingTests.m */,
+			);
+			name = Utils;
 			sourceTree = "<group>";
 		};
 		27ACD1EC193DDDCC00658EC2 /* Events */ = {
@@ -736,8 +756,10 @@
 				EC0C834C1AB217290051042F /* CDTQQuerySortTests.m in Sources */,
 				9F0D240E188F01DD00D3D04E /* TDMiscTests.m in Sources */,
 				EC0C835E1AB217290051042F /* CDTQSQLOnlyIndexManager.m in Sources */,
+				278EC7C11B821AB000292E02 /* CDTChangedDictionaryJSONWrappingTests.m in Sources */,
 				CD2188E51AE571410036F59F /* CDTEncryptionKeychainUtilsPBKDF2Tests.m in Sources */,
 				CD196E6D1B18CD090039133F /* TD_DatabaseBlobFilenamesTests.m in Sources */,
+				278EC7BB1B82061500292E02 /* CDTChangedDictionaryTests.m in Sources */,
 				EC0C83421AB217290051042F /* CDTQIndexManagerTests.m in Sources */,
 				9F0D23F7188DF30D00D3D04E /* TDMultiStreamWriterTests.m in Sources */,
 				ECA0DC611AFD568D00E174BC /* CDTQTextSearchTests.m in Sources */,
@@ -790,6 +812,7 @@
 				9F0D23F4188B4FFF00D3D04E /* TDMultipartWriterTests.m in Sources */,
 				CD2188DC1AE5711A0036F59F /* DatastoreManagerEncryptionTests.m in Sources */,
 				CD0D10EC1AB09CE8003315B5 /* TD_DatabaseDeletionTests.m in Sources */,
+				278EC7BE1B820F9000292E02 /* CDTChangedArrayTests.m in Sources */,
 				CD3FBCA61AB05A170032376E /* CDTHelperFixedKeyProvider.m in Sources */,
 				CD2188DA1AE5711A0036F59F /* DatastoreEncryptionTests.m in Sources */,
 				CDD0251C1B0F631C007D185D /* TDBlobStoreEncryptionTests.m in Sources */,
@@ -812,8 +835,10 @@
 				9F0D23F2188B4FA900D3D04E /* TDMultipartReaderTests.m in Sources */,
 				EC0C835F1AB217290051042F /* CDTQSQLOnlyIndexManager.m in Sources */,
 				EC0C83431AB217290051042F /* CDTQIndexManagerTests.m in Sources */,
+				278EC7C21B821AB000292E02 /* CDTChangedDictionaryJSONWrappingTests.m in Sources */,
 				CD2188E61AE571410036F59F /* CDTEncryptionKeychainUtilsPBKDF2Tests.m in Sources */,
 				CD196E6E1B18CD090039133F /* TD_DatabaseBlobFilenamesTests.m in Sources */,
+				278EC7BC1B82061500292E02 /* CDTChangedDictionaryTests.m in Sources */,
 				9F0D2400188DF96600D3D04E /* TD_DatabaseManagerTests.m in Sources */,
 				9F0D240F188F01DD00D3D04E /* TDMiscTests.m in Sources */,
 				ECA0DC621AFD568D00E174BC /* CDTQTextSearchTests.m in Sources */,
@@ -866,6 +891,7 @@
 				9F0D23F5188B4FFF00D3D04E /* TDMultipartWriterTests.m in Sources */,
 				CD2188DD1AE5711A0036F59F /* DatastoreManagerEncryptionTests.m in Sources */,
 				CD0D10ED1AB09CE8003315B5 /* TD_DatabaseDeletionTests.m in Sources */,
+				278EC7BF1B820F9000292E02 /* CDTChangedArrayTests.m in Sources */,
 				CD3FBCA71AB05A170032376E /* CDTHelperFixedKeyProvider.m in Sources */,
 				CD2188DB1AE5711A0036F59F /* DatastoreEncryptionTests.m in Sources */,
 				CDD0251D1B0F631C007D185D /* TDBlobStoreEncryptionTests.m in Sources */,

--- a/Tests/Tests/DatastoreConflicts.m
+++ b/Tests/Tests/DatastoreConflicts.m
@@ -565,7 +565,7 @@
                  @"foundSet: %@", foundConflictedDocIds);
 }
 
-- (void)ignore_testResolveConflictWithBiggestRev
+- (void)testResolveConflictWithBiggestRev
 {
     
     [self addConflictingDocumentWithId:@"doc0" toDatastore:self.datastore];
@@ -640,7 +640,7 @@
     }
 }
 
-- (void)ignore_testResolveSubset
+- (void)testResolveSubset
 {
     //add a non-conflicting document
     [self addNonConflictingDocumentWithBody:@{@"conflict":@"no"} toDatastore:self.datastore];
@@ -685,7 +685,7 @@
     }
 }
 
-- (void)ignore_testResolveConflictWithSmallestRev
+- (void)testResolveConflictWithSmallestRev
 {
     
     [self addConflictingDocumentWithId:@"doc0" toDatastore:self.datastore];
@@ -721,7 +721,7 @@
     
 }
 
-- (void)ignore_testResolveConflictWithAttachmentWithBiggestRev
+- (void)testResolveConflictWithAttachmentWithBiggestRev
 {
     //this tests that the conflict resolution retains the revisions association with an attachment
     // before
@@ -800,7 +800,7 @@
     
 }
 
-- (void)ignore_testResolveConflictWithAttachmentForRev2b
+- (void)testResolveConflictWithAttachmentForRev2b
 {
     //this tests that the conflict resolution retains the revision associations with attachments
     // before

--- a/Tests/Tests/Utils/CDTChangedArrayTests.m
+++ b/Tests/Tests/Utils/CDTChangedArrayTests.m
@@ -1,0 +1,105 @@
+//
+//  CDTChangedArrayTests.m
+//  Tests
+//
+//  Created by Michael Rhodes on 17/08/2015.
+//  Copyright (c) 2015 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#import <XCTest/XCTest.h>
+
+#import <CDTChangedArray.h>
+
+@interface CDTChangedArrayTests : XCTestCase
+
+@end
+
+@implementation CDTChangedArrayTests
+
+- (void)testUnchangedNewArray
+{
+    NSMutableArray *base = [@[] mutableCopy];
+    CDTChangedArray *array = [[CDTChangedArray alloc] initWithMutableArray:base];
+    XCTAssertFalse(array.isChanged);
+}
+
+- (void)testUnchangedNonEmptyArray
+{
+    NSMutableArray *base = [@[ @"cat", @"dog" ] mutableCopy];
+    CDTChangedArray *array = [[CDTChangedArray alloc] initWithMutableArray:base];
+    XCTAssertFalse(array.isChanged);
+}
+
+- (void)testUnchangedRead
+{
+    NSMutableArray *base = [@[ @"cat", @"dog" ] mutableCopy];
+    CDTChangedArray *array = [[CDTChangedArray alloc] initWithMutableArray:base];
+    XCTAssertNotNil(array[1]);
+    XCTAssertFalse(array.isChanged);
+}
+
+- (void)testUnchangedCount
+{
+    NSMutableArray *base = [@[ @"cat", @"dog" ] mutableCopy];
+    CDTChangedArray *array = [[CDTChangedArray alloc] initWithMutableArray:base];
+    XCTAssertEqual(2, array.count);
+    XCTAssertFalse(array.isChanged);
+}
+
+- (void)testChangedSubscriptInsert
+{
+    NSMutableArray *base = [@[ @"cat", @"dog" ] mutableCopy];
+    CDTChangedArray *array = [[CDTChangedArray alloc] initWithMutableArray:base];
+    array[1] = @"parrot";
+    XCTAssertTrue(array.isChanged);
+}
+
+- (void)testChangedInsertObjectAtIndex
+{
+    NSMutableArray *base = [@[ @"cat", @"dog" ] mutableCopy];
+    CDTChangedArray *array = [[CDTChangedArray alloc] initWithMutableArray:base];
+    [array insertObject:@"parrot" atIndex:1];
+    XCTAssertTrue(array.isChanged);
+}
+
+- (void)testChangedRemoveObjectAtIndex
+{
+    NSMutableArray *base = [@[ @"cat", @"dog" ] mutableCopy];
+    CDTChangedArray *array = [[CDTChangedArray alloc] initWithMutableArray:base];
+    [array removeObjectAtIndex:1];
+    XCTAssertTrue(array.isChanged);
+}
+
+- (void)testChangedAddObject
+{
+    NSMutableArray *base = [@[ @"cat", @"dog" ] mutableCopy];
+    CDTChangedArray *array = [[CDTChangedArray alloc] initWithMutableArray:base];
+    [array addObject:@"parrot"];
+    XCTAssertTrue(array.isChanged);
+}
+
+- (void)testChangedRemoveLastObject
+{
+    NSMutableArray *base = [@[ @"cat", @"dog" ] mutableCopy];
+    CDTChangedArray *array = [[CDTChangedArray alloc] initWithMutableArray:base];
+    [array removeLastObject];
+    XCTAssertTrue(array.isChanged);
+}
+
+- (void)testChangedReplaceObjectAtIndexWithObject
+{
+    NSMutableArray *base = [@[ @"cat", @"dog" ] mutableCopy];
+    CDTChangedArray *array = [[CDTChangedArray alloc] initWithMutableArray:base];
+    [array replaceObjectAtIndex:1 withObject:@"parrot"];
+    XCTAssertTrue(array.isChanged);
+}
+
+@end

--- a/Tests/Tests/Utils/CDTChangedDictionaryJSONWrappingTests.m
+++ b/Tests/Tests/Utils/CDTChangedDictionaryJSONWrappingTests.m
@@ -1,0 +1,88 @@
+//
+//  CDTChangedDictionaryJSONWrappingTests.m
+//  Tests
+//
+//  Created by Michael Rhodes on 17/08/2015.
+//  Copyright (c) 2015 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#import <XCTest/XCTest.h>
+
+#import <CDTChangedDictionary.h>
+#import <CDTChangedArray.h>
+
+@interface CDTChangedDictionaryJSONWrappingTests : XCTestCase
+
+@property (nonatomic, strong) CDTChangedDictionary *dictionary;
+
+@end
+
+@implementation CDTChangedDictionaryJSONWrappingTests
+
+- (void)setUp
+{
+    [super setUp];
+
+    NSDictionary *dictionary = @{
+        @"dict" :
+            @{@"array" : @[ @"one", @"two" ], @"dict" : @{@"one" : @"two"}, @"hello" : @"world"},
+
+        @"array" : @[ @[ @"foo", @YES ], @{@"foo" : @YES}, @"two" ]
+    };
+
+    self.dictionary = [CDTChangedDictionary dictionaryWrappingContents:dictionary];
+}
+
+- (void)testUnmodified { XCTAssertFalse(self.dictionary.isChanged); }
+
+- (void)testModifyTopLevelField
+{
+    self.dictionary[@"dict"] = @[ @1, @2 ];
+    XCTAssertTrue(self.dictionary.isChanged);
+}
+
+- (void)testModifyNestedArrayFirstLevel
+{
+    self.dictionary[@"array"][1] = @"two_changed";
+    XCTAssertTrue(self.dictionary.isChanged);
+}
+
+- (void)testModifyNestedArraySecondLevel
+{
+    self.dictionary[@"dict"][@"array"] = @"two_changed";
+    XCTAssertTrue(self.dictionary.isChanged);
+}
+
+- (void)testModifyArrayNestedInDictionary
+{
+    self.dictionary[@"dict"][@"array"][1] = @"two_changed";
+    XCTAssertTrue(self.dictionary.isChanged);
+}
+
+- (void)testModifyDictionaryNestedInDictionary
+{
+    self.dictionary[@"dict"][@"dict"][@"one"] = @"two_changed";
+    XCTAssertTrue(self.dictionary.isChanged);
+}
+
+- (void)testModifyArrayNestedInArray
+{
+    self.dictionary[@"array"][0][1] = @"two_changed";
+    XCTAssertTrue(self.dictionary.isChanged);
+}
+
+- (void)testModifyDictionaryNestedInArray
+{
+    self.dictionary[@"array"][1][@"foo"] = @"two_changed";
+    XCTAssertTrue(self.dictionary.isChanged);
+}
+
+@end

--- a/Tests/Tests/Utils/CDTChangedDictionaryTests.m
+++ b/Tests/Tests/Utils/CDTChangedDictionaryTests.m
@@ -1,0 +1,161 @@
+//
+//  CDTChangedDictionaryTests.m
+//  Tests
+//
+//  Created by Michael Rhodes on 17/08/2015.
+//  Copyright (c) 2015 Cloudant. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#import <XCTest/XCTest.h>
+
+#import <CDTChangedDictionary.h>
+
+@interface CDTChangedDictionaryTests : XCTestCase
+
+@end
+
+@implementation CDTChangedDictionaryTests
+
+- (void)testStartUnchanged
+{
+    NSMutableDictionary *base = [@{} mutableCopy];
+    CDTChangedDictionary *dictionary = [[CDTChangedDictionary alloc] initWithDictionary:base];
+
+    XCTAssertFalse(dictionary.isChanged);
+}
+
+- (void)testReadUnchangedNonExistantKey
+{
+    NSMutableDictionary *base = [@{} mutableCopy];
+    CDTChangedDictionary *dictionary = [[CDTChangedDictionary alloc] initWithDictionary:base];
+
+    NSObject *o = dictionary[@"hello"];
+
+    XCTAssertNil(o);
+    XCTAssertFalse(dictionary.isChanged);
+}
+
+- (void)testReadUnchangedExistantKey
+{
+    NSMutableDictionary *base = [@{ @"hello" : @"world" } mutableCopy];
+    CDTChangedDictionary *dictionary = [[CDTChangedDictionary alloc] initWithDictionary:base];
+
+    NSObject *o = dictionary[@"hello"];
+
+    XCTAssertNotNil(o);
+    XCTAssertFalse(dictionary.isChanged);
+}
+
+// initWithObjects:forKeys:count:
+
+- (void)testUnchangedCount
+{
+    NSMutableDictionary *base = [@{ @"hello" : @"world" } mutableCopy];
+    CDTChangedDictionary *dictionary = [[CDTChangedDictionary alloc] initWithDictionary:base];
+
+    NSUInteger count = dictionary.count;
+
+    XCTAssertEqual(count, 1);
+    XCTAssertFalse(dictionary.isChanged);
+}
+
+- (void)testUnchangedKeyEnumerator
+{
+    NSMutableDictionary *base = [@{ @"hello" : @"world" } mutableCopy];
+    CDTChangedDictionary *dictionary = [[CDTChangedDictionary alloc] initWithDictionary:base];
+
+    NSEnumerator *enumerator = [dictionary keyEnumerator];
+
+    XCTAssertNotNil(enumerator);
+    XCTAssertFalse(dictionary.isChanged);
+}
+
+- (void)testUnchangedInitWithObjects
+{
+    id keys[1] = { @"hello" };
+    id objects[1] = { @"world" };
+
+    CDTChangedDictionary *dictionary =
+        [[CDTChangedDictionary alloc] initWithObjects:objects forKeys:keys count:1];
+    XCTAssertEqual(dictionary.count, 1);
+    XCTAssertFalse(dictionary.isChanged);
+}
+
+// Changing with subscript
+
+- (void)testChangedInitWithObjectsSubscript
+{
+    id keys[1] = { @"hello" };
+    id objects[1] = { @"world" };
+
+    CDTChangedDictionary *dictionary =
+        [[CDTChangedDictionary alloc] initWithObjects:objects forKeys:keys count:1];
+    dictionary[@"foo"] = @"bar";
+
+    XCTAssertEqual(dictionary.count, 2);
+    XCTAssertTrue(dictionary.isChanged);
+}
+
+- (void)testChangedInitWithDictionarySubscript
+{
+    NSMutableDictionary *base = [@{} mutableCopy];
+    CDTChangedDictionary *dictionary = [[CDTChangedDictionary alloc] initWithDictionary:base];
+    dictionary[@"foo"] = @"bar";
+    XCTAssertTrue(dictionary.isChanged);
+}
+
+// Changing with setObject:forKey:
+
+- (void)testChangedInitWithObjectsSetObjectForKey
+{
+    id keys[1] = { @"hello" };
+    id objects[1] = { @"world" };
+
+    CDTChangedDictionary *dictionary =
+        [[CDTChangedDictionary alloc] initWithObjects:objects forKeys:keys count:1];
+    [dictionary setObject:@"bar" forKey:@"foo"];
+
+    XCTAssertEqual(dictionary.count, 2);
+    XCTAssertTrue(dictionary.isChanged);
+}
+
+- (void)testChangedInitWithDictionarySetObjectForKey
+{
+    NSMutableDictionary *base = [@{} mutableCopy];
+    CDTChangedDictionary *dictionary = [[CDTChangedDictionary alloc] initWithDictionary:base];
+    [dictionary setObject:@"bar" forKey:@"foo"];
+    XCTAssertTrue(dictionary.isChanged);
+}
+
+// Removing objects
+
+- (void)testChangedInitWithObjectsRemove
+{
+    id keys[1] = { @"hello" };
+    id objects[1] = { @"world" };
+
+    CDTChangedDictionary *dictionary =
+        [[CDTChangedDictionary alloc] initWithObjects:objects forKeys:keys count:1];
+    [dictionary removeObjectForKey:@"hello"];
+
+    XCTAssertEqual(dictionary.count, 0);
+    XCTAssertTrue(dictionary.isChanged);
+}
+
+- (void)testChangedInitWithDictionaryRemove
+{
+    NSMutableDictionary *base = [@{ @"hello" : @"world" } mutableCopy];
+    CDTChangedDictionary *dictionary = [[CDTChangedDictionary alloc] initWithDictionary:base];
+    [dictionary removeObjectForKey:@"hello"];
+    XCTAssertTrue(dictionary.isChanged);
+}
+
+@end


### PR DESCRIPTION
_What_

Change CDTDocumentRevision's `body` and `attachment` properties into mutable dictionaries.

These dictionaries are wrapped with observer classes which report changes to the dictionaries and their deep contents, which allows us to report whether a particular document revision object has been changed since it was read from the database. This allows us to fix the conflict resolver tests, so they are re-enabled.

_Why_

The aim is to simplify the modification of document revisions for developers using the library. The PR allows developers to again modify the body and attachments, as they were able to on `CDTMutableDocumentRevision` objects.

So the previous way was this:

```objc
CDTDocumentRevision *rev = [datastore getDocumentWithId:id error:nil];
CDTMutableDocumentRevision *mutable = [rev mutableCopy];
mutable.body[@"foo"] = @"bar";
[datastore updateDocumentWithRevision:mutable error:nil];
```
with this PR, this is reduced to:
```objc
CDTDocumentRevision *rev = [datastore getDocumentWithId:id error:nil];
rev.body[@"foo"] = @"bar";
[datastore updateDocumentWithRevision:mutable error:nil];
```

_How_

First, the `body` and `attachment` properties are changed to be `NSMutableDictionary` objects. Internally, these are actually wrapped in NSMutableDictionary subclasses to enable the revision to observe changes as the users alters the body or attachments of the revision.

`isChanged` is a new property on `CDTDocumentRevision` and the new classes which wrap dictionaries and arrays to observe changes, `CDTChangedDictionary` and `CDTChangedArray` respectively. 

The class names  `CDTChangedDictionary` and `CDTChangedArray` seem a bit imperfect, but after thinking for a while I couldn't think of something better -- suggestions welcome.

A `CDTDocumentRevision` wraps the body and attachments passed into the `init...` method using a class method on `CDTChangedDictionary` which deep copies the contents of any dictionaries and attachments into new mutable dictionaries -- this helps prevent changes happening to the underlying containers which wouldn't be observed by the wrappers.

The `Changed*` classes report their changed status via both a property and a delegate. Parent containers register themselves as delegate on their children. The document revision object registers itself as delegate on the top level body and attachments dictionary. This way, changes to nested containers will cascade up to the document revision.

_Suggestions_

I think the easiest way to follow this PR -- if you'd rather I can break it up -- is:

1. CDTChangedArray -- this implements the primitive methods of NS(Mutable)Array, and fires off a message to its delegate.
1. CDTChangedDictionary -- similarly implements the primitive methods of NS(Mutable)Dictionary.
1. CDTChangedDictionary -- check the class methods for deep-wrapping dictionaries.
1. CDTDocumentRevision -- check the logic of isChanged, particularly whether it's always guaranteed to be set correctly on any change to body/attachments. The main hole here is non-wrapped objects, but I think for JSON, we only have primitive types which can't change without being replaced within the dict/array structure. I could be wrong.

For info on _primitive methods_, see https://mikeash.com/pyblog/friday-qa-2010-03-12-subclassing-class-clusters.html.

reviewer @rhyshort 
reviewer @tomblench 