### PR TITLE
Expose HTTP interceptors in public API

### DIFF
--- a/Classes/common/CDTReplicator/CDTAbstractReplication.h
+++ b/Classes/common/CDTReplicator/CDTAbstractReplication.h
@@ -14,6 +14,7 @@
 //  and limitations under the License.
 
 #import <Foundation/Foundation.h>
+#import "CDTHTTPInterceptor.h"
 
 @class CDTDatastore;
 
@@ -126,6 +127,16 @@ typedef NS_ENUM(NSInteger, CDTReplicationErrors) {
 
 */
 @property (nonatomic, copy) NSDictionary* optionalHeaders;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@property (nonnull, nonatomic, readonly, strong) NSArray* httpInterceptors;
+
+- (void)addInterceptor:(nonnull NSObject<CDTHTTPInterceptor>*)interceptor;
+- (void)addInterceptors:(nonnull NSArray*)interceptors;
+- (void)clearInterceptors;
+
+NS_ASSUME_NONNULL_END
 
 /**
  Returns the default "User-Agent" header value used in HTTP requests made during replication.

--- a/Classes/common/touchdb/ChangeTracker/TDChangeTracker.h
+++ b/Classes/common/touchdb/ChangeTracker/TDChangeTracker.h
@@ -14,6 +14,7 @@
 //  and limitations under the License.
 
 #import <Foundation/Foundation.h>
+#import "CDTURLSession.h"
 @class TDChangeTracker;
 @protocol TDAuthorizer;
 
@@ -49,7 +50,8 @@ typedef enum TDChangeTrackerMode { kOneShot, kLongPoll, kContinuous } TDChangeTr
                      mode:(TDChangeTrackerMode)mode
                 conflicts:(BOOL)includeConflicts
              lastSequence:(id)lastSequenceID
-                   client:(id<TDChangeTrackerClient>)client;
+                   client:(id<TDChangeTrackerClient>)client
+                  session:(CDTURLSession*)session;
 
 @property (readonly, nonatomic) NSURL* databaseURL;
 @property (readonly, nonatomic) NSString* databaseName;

--- a/Classes/common/touchdb/ChangeTracker/TDChangeTracker.m
+++ b/Classes/common/touchdb/ChangeTracker/TDChangeTracker.m
@@ -48,6 +48,7 @@
                 conflicts:(BOOL)includeConflicts
              lastSequence:(id)lastSequenceID
                    client:(id<TDChangeTrackerClient>)client
+                  session:(CDTURLSession*)session
 {
     NSParameterAssert(databaseURL);
     NSParameterAssert(client);
@@ -59,7 +60,8 @@
                                                                         mode:mode
                                                                    conflicts:includeConflicts
                                                                 lastSequence:lastSequenceID
-                                                                      client:client];
+                                                                      client:client
+                                                                     session:session];
         }
         _databaseURL = databaseURL;
         _client = client;

--- a/Classes/common/touchdb/ChangeTracker/TDURLConnectionChangeTracker.m
+++ b/Classes/common/touchdb/ChangeTracker/TDURLConnectionChangeTracker.m
@@ -43,15 +43,23 @@
 
 @implementation TDURLConnectionChangeTracker
 
-
--(instancetype) initWithDatabaseURL:(NSURL *)databaseURL mode:(TDChangeTrackerMode)mode conflicts:(BOOL)includeConflicts lastSequence:(id)lastSequenceID client:(id<TDChangeTrackerClient>)client
+- (instancetype)initWithDatabaseURL:(NSURL *)databaseURL
+                               mode:(TDChangeTrackerMode)mode
+                          conflicts:(BOOL)includeConflicts
+                       lastSequence:(id)lastSequenceID
+                             client:(id<TDChangeTrackerClient>)client
+                            session:(CDTURLSession *)session
 {
-    self = [super initWithDatabaseURL:databaseURL mode:mode conflicts:includeConflicts lastSequence:lastSequenceID client:client];
-    
+    NSParameterAssert(session);
+    self = [super initWithDatabaseURL:databaseURL
+                                 mode:mode
+                            conflicts:includeConflicts
+                         lastSequence:lastSequenceID
+                               client:client
+                              session:session];
+
     if(self){
-        _session = [[CDTURLSession alloc] initWithDelegate:self
-                                            callbackThread:[NSThread currentThread]
-                                       requestInterceptors:@[]];
+        _session = session;
     }
     return self;
 }

--- a/Classes/common/touchdb/TDPuller.m
+++ b/Classes/common/touchdb/TDPuller.m
@@ -94,7 +94,8 @@ static NSString* joinQuotedEscaped(NSArray* strings);
                                                              mode:mode
                                                         conflicts:YES
                                                      lastSequence:_lastSequence
-                                                           client:self];
+                                                           client:self
+                                                          session:self.session];
     // Limit the number of changes to return, so we can parse the feed in parts:
     _changeTracker.limit = kChangesFeedLimit;
     _changeTracker.filterName = _filterName;

--- a/Classes/common/touchdb/TDReplicator.h
+++ b/Classes/common/touchdb/TDReplicator.h
@@ -56,7 +56,11 @@ extern NSString* TDReplicatorStoppedNotification;
 + (NSString*)progressChangedNotification;
 + (NSString*)stoppedNotification;
 
-- (id)initWithDB:(TD_Database*)db remote:(NSURL*)remote push:(BOOL)push continuous:(BOOL)continuous;
+- (instancetype)initWithDB:(TD_Database*)db
+                    remote:(NSURL*)remote
+                      push:(BOOL)push
+                continuous:(BOOL)continuous
+              interceptors:(NSArray*)interceptors;
 
 @property (weak, readonly) TD_Database* db;
 @property (readonly) NSURL* remote;

--- a/ReplicationAcceptance/ReplicationAcceptance/ReplicationAcceptance.m
+++ b/ReplicationAcceptance/ReplicationAcceptance/ReplicationAcceptance.m
@@ -38,6 +38,7 @@
 #import "ChangeTrackerDelegate.h"
 #import "ChangeTrackerNSURLProtocolTimedOut.h"
 #import "TDInternal.h"
+#import "CDTHTTPInterceptor.h"
 
 @interface ReplicationAcceptance () 
 
@@ -113,7 +114,7 @@ static NSUInteger largeRevTreeSize = 1500;
     
     pull.filter = filterName;
     pull.filterParams = params;
-    
+
     NSError *error;
     CDTReplicator *replicator =  [self.replicatorFactory oneWay:pull error:&error];
     XCTAssertNil(error, @"%@",error);
@@ -128,10 +129,9 @@ static NSUInteger largeRevTreeSize = 1500;
         [NSThread sleepForTimeInterval:1.0f];
         NSLog(@" -> %@", [CDTReplicator stringForReplicatorState:replicator.state]);
     }
-    
+
     return replicator;
 }
-
 
 /**
  Create a new replicator, and wait for replication from the local database to complete.
@@ -1424,12 +1424,16 @@ static NSUInteger largeRevTreeSize = 1500;
     delegate.changeBlock = ^(NSDictionary *change) {
         XCTFail(@"Should not be called");
     };
-    
-    TDChangeTracker *changeTracker = [[TDChangeTracker alloc] initWithDatabaseURL:self.primaryRemoteDatabaseURL
-                                                                             mode:kOneShot
-                                                                        conflicts:YES
-                                                                     lastSequence:nil
-                                                                           client:delegate];
+
+    CDTURLSession *session = [[CDTURLSession alloc] init];
+
+    TDChangeTracker *changeTracker =
+        [[TDChangeTracker alloc] initWithDatabaseURL:self.primaryRemoteDatabaseURL
+                                                mode:kOneShot
+                                           conflicts:YES
+                                        lastSequence:nil
+                                              client:delegate
+                                             session:session];
     changeTracker.limit = limitSize;
     
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
@@ -1507,11 +1511,13 @@ static NSUInteger largeRevTreeSize = 1500;
     };
     
     NSURL *url = [self sharedDemoURL];
+    CDTURLSession *session = [[CDTURLSession alloc] init];
     TDChangeTracker *changeTracker = [[TDChangeTracker alloc] initWithDatabaseURL:url
                                                                              mode:kOneShot
                                                                         conflicts:YES
                                                                      lastSequence:nil
-                                                                           client:delegate];
+                                                                           client:delegate
+                                                                          session:session];
     changeTracker.limit = limitSize;
     
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
@@ -1562,11 +1568,13 @@ static NSUInteger largeRevTreeSize = 1500;
     };
     
     NSURL *url = [NSURL URLWithString:@"https://mikerhodescloudant.cloudant.com/shared_todo_sample"];
+    CDTURLSession *session = [[CDTURLSession alloc] init];
     TDChangeTracker *changeTracker = [[TDChangeTracker alloc] initWithDatabaseURL:url
                                                                              mode:kOneShot
                                                                         conflicts:YES
                                                                      lastSequence:nil
-                                                                           client:delegate];
+                                                                           client:delegate
+                                                                          session:session];
     changeTracker.limit = limitSize;
     
     NSURLCredential *cred = [NSURLCredential credentialWithUser: [[self sharedDemoURL] user]
@@ -1614,12 +1622,14 @@ static NSUInteger largeRevTreeSize = 1500;
     };
     
     NSURL *url = [self badCredentialsDemoURL];
-    
+
+    CDTURLSession *session = [[CDTURLSession alloc] init];
     TDChangeTracker *changeTracker = [[TDChangeTracker alloc] initWithDatabaseURL:url
                                                                              mode:kOneShot
                                                                         conflicts:YES
                                                                      lastSequence:nil
-                                                                           client:delegate];
+                                                                           client:delegate
+                                                                          session:session];
     changeTracker.limit = limitSize;
 
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{

--- a/Tests/Tests/CDTReplicationTests.m
+++ b/Tests/Tests/CDTReplicationTests.m
@@ -26,6 +26,38 @@
 #import "TD_Revision.h"
 #import "TDPuller.h"
 #import "TDPusher.h"
+#import "AllNullResponseURLProtocol.h"
+
+@interface ChangesFeedRequestCheckInterceptor : NSObject <CDTHTTPInterceptor>
+
+@property (nonatomic) BOOL changesFeedRequestMade;
+
+@end
+
+@implementation ChangesFeedRequestCheckInterceptor
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        _changesFeedRequestMade = NO;
+    }
+    return self;
+}
+
+- (CDTHTTPInterceptorContext *)interceptRequestInContext:(CDTHTTPInterceptorContext *)context
+{
+    // determines if the interceptor was run before request
+    NSURL *url = context.request.URL;
+
+    if ([[url path] containsString:@"/_changes"]) {
+        self.changesFeedRequestMade = YES;
+    }
+
+    return context;
+}
+
+@end
 
 @interface CDTReplicationTests : CloudantSyncTests
 
@@ -33,6 +65,37 @@
 
 @implementation CDTReplicationTests
 
+- (void)testFiltersWithChangesFeed
+{
+    NSError *error;
+    // we need a real live remote here, so the reachability test before the replication starts
+    // passes, it doesn't need a couch server, since the NSURLProtocol will 404 any request.
+    NSString *remoteUrl = @"https://example.com";
+
+    [NSURLProtocol registerClass:[AllNullResponseURLProtocol class]];
+
+    CDTDatastore *tmp = [self.factory datastoreNamed:@"test_database" error:&error];
+    CDTPullReplication *pull =
+        [CDTPullReplication replicationWithSource:[NSURL URLWithString:remoteUrl] target:tmp];
+    ChangesFeedRequestCheckInterceptor *interceptor =
+        [[ChangesFeedRequestCheckInterceptor alloc] init];
+    [pull addInterceptor:interceptor];
+    CDTReplicatorFactory *replicatorFactory =
+        [[CDTReplicatorFactory alloc] initWithDatastoreManager:self.factory];
+
+    CDTReplicator *replicator = [replicatorFactory oneWay:pull error:&error];
+
+    [replicator startWithError:&error];
+
+    while (replicator.state != CDTReplicatorStateComplete &&
+           replicator.state != CDTReplicatorStateError) {
+        NSLog(@"Replicating......");
+        [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate distantFuture]];
+    }
+
+    XCTAssertTrue(interceptor.changesFeedRequestMade);
+    [NSURLProtocol unregisterClass:[AllNullResponseURLProtocol class]];
+}
 
 -(void)testReplicatorIsNilForNilDatastoreManager {
     
@@ -43,12 +106,14 @@
 -(void)testDictionaryForPullReplicationDocument
 {
     NSString *remoteUrl = @"https://adam:cox@myaccount.cloudant.com/mydb";
-    NSDictionary *expectedDictionary = @{@"target":@"test_database",
-                                         @"source": remoteUrl,
-                                         @"filter": @"myddoc/myfilter",
-                                         @"query_params":@{@"min":@23, @"max":@43}};
+    NSDictionary *expectedDictionary = @{
+        @"target" : @"test_database",
+        @"source" : remoteUrl,
+        @"filter" : @"myddoc/myfilter",
+        @"query_params" : @{@"min" : @23, @"max" : @43},
+        @"interceptors" : @[]
+    };
 
-    
     NSError *error;
     CDTDatastore *tmp = [self.factory datastoreNamed:@"test_database" error:&error];
     CDTPullReplication *pull = [CDTPullReplication replicationWithSource:[NSURL URLWithString:remoteUrl]
@@ -76,9 +141,11 @@
 -(void)testDictionaryForPushReplicationDocument
 {
     NSString *remoteUrl = @"https://adam:cox@myaccount.cloudant.com/mydb";
-    NSDictionary *expectedDictionary = @{@"source":@"test_database",
-                                         @"target": remoteUrl};
-    
+    NSDictionary *expectedDictionary =
+        @{ @"source" : @"test_database",
+           @"target" : remoteUrl,
+           @"interceptors" : @[] };
+
     NSError *error;
     CDTDatastore *tmp = [self.factory datastoreNamed:@"test_database" error:&error];
     

--- a/Tests/Tests/CDTURLSessionTests.m
+++ b/Tests/Tests/CDTURLSessionTests.m
@@ -97,6 +97,18 @@
 
 @implementation CDTURLSessionTests
 
+- (void)setUp
+{
+    [super setUp];
+    [NSURLProtocol registerClass:[AllNullResponseURLProtocol class]];
+}
+
+- (void)tearDown
+{
+    [super tearDown];
+    [NSURLProtocol unregisterClass:[AllNullResponseURLProtocol class]];
+}
+
 - (void)testInterceptorsSetCorrectly
 {
     CDTCountingHTTPRequestInterceptor *countingInterceptor =
@@ -165,8 +177,6 @@
 
 - (void)testMaxNumberOfRetriesEnforced
 {
-    [NSURLProtocol registerClass:[AllNullResponseURLProtocol class]];
-
     CDTRetryingHTTPInterceptor *replayingInterceptor =
         [[CDTRetryingHTTPInterceptor alloc] initWithNumberOfRetires:1000000];
     CDTURLSession *session = [[CDTURLSession alloc] initWithDelegate:nil
@@ -188,8 +198,6 @@
     }
     // it should be called 11 times because we retry a request 10 times making 11 reqests in total
     XCTAssertEqual(replayingInterceptor.timesCalled, 11);
-
-    [NSURLProtocol unregisterClass:[AllNullResponseURLProtocol class]];
 }
 
 @end


### PR DESCRIPTION
## What

Expose HTTP interceptors in the public API via the
`CDTAbstractReplication` object.

## How

The following APIs have been added to the CDTAbstractReplication object:
`-addInterceptor:`
`-addInterceptors:`
`-clearInterceptors:`

## Reviewers

reviewer @tomblench 
reviewer @mikerhodes 