### PR TITLE
50707 replacpt sample

### DIFF
--- a/Project/Project/CDTTodo.h
+++ b/Project/Project/CDTTodo.h
@@ -16,8 +16,10 @@
 
 #import <Foundation/Foundation.h>
 
+@class CDTDocumentRevision;
+
 /**
- A simple class that maps from a JSON document to a Todo task, to
+ A simple class that maps from a document revision to a Todo task, to
  prevent typos in keys and hold the type information in one place.
  */
 @interface CDTTodo : NSObject
@@ -25,9 +27,19 @@
 @property (nonatomic,strong) NSString *taskDescription;
 @property (nonatomic) BOOL completed;
 
+/**
+ Uptodate version of the CDTDocumentRevision associated with this task.
+ */
+@property (nonatomic, strong, readonly) CDTDocumentRevision *rev;
+
+/**
+ Create a new task
+ */
 -(instancetype)initWithDescription:(NSString*)description completed:(BOOL)completed;
 
-+(instancetype)fromDict:(NSDictionary*)dict;
--(NSDictionary*)toDict;
+/**
+ Initialise an existing task from a document revision.
+ */
+- (instancetype)initWithDocumentRevision:(CDTDocumentRevision *)rev;
 
 @end

--- a/Project/Project/CDTTodo.m
+++ b/Project/Project/CDTTodo.m
@@ -16,32 +16,42 @@
 
 #import "CDTTodo.h"
 
+#import <CloudantSync.h>
+
 @implementation CDTTodo
 
 -(instancetype)initWithDescription:(NSString*)description completed:(BOOL)completed
 {
     self = [super init];
     if (self) {
-        _taskDescription = description;
-        _completed = completed;
+        _rev = [CDTDocumentRevision revision];
+        _rev.body = [@{
+            @"description" : description,
+            @"completed" : @(completed),
+            @"type" : @"com.cloudant.sync.example.task"
+        } mutableCopy];
     }
     return self;
 }
 
-+(instancetype)fromDict:(NSDictionary*)dict
+- (instancetype)initWithDocumentRevision:(CDTDocumentRevision *)rev
 {
-    return [[[self class] alloc] initWithDescription:[dict objectForKey:@"description"]
-                                      completed:[[dict objectForKey:@"completed"] boolValue]];
+    self = [super init];
+    if (self) {
+        _rev = rev;
+    }
+    return self;
 }
 
--(NSDictionary*)toDict
+- (NSString *)taskDescription { return self.rev.body[@"description"]; }
+
+- (void)setTaskDescription:(NSString *)taskDescription
 {
-    NSDictionary *dict = @{
-                          @"description": self.taskDescription,
-                          @"completed": @(self.completed),
-                          @"type": @"com.cloudant.sync.example.task"
-                          };
-    return dict;
+    self.rev.body[@"description"] = taskDescription;
 }
+
+- (BOOL)completed { return [self.rev.body[@"completed"] boolValue]; }
+
+- (void)setCompleted:(BOOL)completed { self.rev.body[@"completed"] = @(completed); }
 
 @end

--- a/ReplicationAcceptance/ReplicationAcceptance/Attachments.m
+++ b/ReplicationAcceptance/ReplicationAcceptance/Attachments.m
@@ -126,10 +126,9 @@
     NSError *error;
     
     NSString *docId = @"document1";
-    CDTMutableDocumentRevision *mrev = [CDTMutableDocumentRevision revision];
-    mrev.docId = docId;
-    mrev.body =@{@"hello": @12};
-    
+    CDTDocumentRevision *rev = [CDTDocumentRevision revisionWithDocId:docId];
+    rev.body = [@{ @"hello" : @12 } mutableCopy];
+
     NSMutableDictionary *attachments = [NSMutableDictionary dictionary];
     NSString *content = @"blahblah";
     NSData *data = [content dataUsingEncoding:NSUTF8StringEncoding];
@@ -141,20 +140,18 @@
     
     [originalAttachments setObject:data forKey:name];
 
-    
-    mrev.attachments = attachments;
-    CDTDocumentRevision *rev = [self.datastore createDocumentFromRevision:mrev error:&error];
-    
+    rev.attachments = attachments;
+    rev = [self.datastore createDocumentFromRevision:rev error:&error];
+
     XCTAssertNotNil(rev, @"Unable to add attachments to document");
     XCTAssertTrue([self isNumberOfAttachmentsForRevision:rev equalTo:1],
                   @"Incorrect number of attachments");
     
     [self pushTo:remoteDbURL from:self.datastore];
-    
-    CDTMutableDocumentRevision *mRev = [rev mutableCopy];
-    mRev.attachments = [@{} mutableCopy];
-    CDTDocumentRevision *rev2 = [self.datastore updateDocumentFromRevision:mRev error:&error];
-    
+
+    rev.attachments = [@{} mutableCopy];
+    CDTDocumentRevision *rev2 = [self.datastore updateDocumentFromRevision:rev error:&error];
+
     XCTAssertNotNil(rev2, @"Unable to add attachments to document");
     XCTAssertTrue([self isNumberOfAttachmentsForRevision:rev2 equalTo:0],
                   @"Incorrect number of attachments");
@@ -313,10 +310,9 @@
     NSError *error;
     
     NSString *docId = @"document1";
-    CDTMutableDocumentRevision *mrev = [CDTMutableDocumentRevision revision];
-    mrev.docId = docId;
-    mrev.body =@{@"hello": @12};
-    
+    CDTDocumentRevision *rev = [CDTDocumentRevision revisionWithDocId:docId];
+    rev.body = [@{ @"hello" : @12 } mutableCopy];
+
     NSMutableDictionary *attachments = [NSMutableDictionary dictionary];
     for (NSInteger i = 1; i <= nAttachments; i++) {
         NSString *content = [NSString stringWithFormat:@"blahblah-%li", (long)i];
@@ -329,10 +325,9 @@
         
         [originalAttachments setObject:data forKey:name];
     }
-    
-    mrev.attachments = attachments;
-    CDTDocumentRevision *rev = [self.datastore createDocumentFromRevision:mrev error:&error];
 
+    rev.attachments = attachments;
+    rev = [self.datastore createDocumentFromRevision:rev error:&error];
 
     XCTAssertNotNil(rev, @"Unable to add attachments to document");
     XCTAssertTrue([self isNumberOfAttachmentsForRevision:rev equalTo:nAttachments],
@@ -394,10 +389,9 @@
     NSString *docId = @"document1";
     
     NSError *error;
-    CDTMutableDocumentRevision *mrev = [CDTMutableDocumentRevision revision];
-    mrev.docId = docId;
-    mrev.body =@{@"hello": @12};
-    
+    CDTDocumentRevision *rev = [CDTDocumentRevision revisionWithDocId:docId];
+    rev.body = [@{ @"hello" : @12 } mutableCopy];
+
     NSMutableDictionary *attachments = [NSMutableDictionary dictionary];
     for (NSInteger i = 1; i <= nAttachments; i++) {
         NSString *content = [NSString stringWithFormat:@"blahblah-%li", (long)i];
@@ -410,9 +404,9 @@
         
         [originalAttachments setObject:data forKey:name];
     }
-    
-    mrev.attachments = attachments;
-    CDTDocumentRevision *rev = [self.datastore createDocumentFromRevision:mrev error:&error];
+
+    rev.attachments = attachments;
+    rev = [self.datastore createDocumentFromRevision:rev error:&error];
 
     XCTAssertNotNil(rev, @"Unable to add attachments to document");
     XCTAssertTrue([self isNumberOfAttachmentsForRevision:rev equalTo:nAttachments],
@@ -433,11 +427,10 @@
         NSString *name = [NSString stringWithFormat:@"attachment-%li", (long)i];
         [attachments removeObjectForKey:name];
     }
-    mrev.attachments = attachments;
-    mrev.sourceRevId = rev.revId;
-    
-    rev = [self.datastore updateDocumentFromRevision:mrev error:nil];
-    
+    rev.attachments = attachments;
+
+    rev = [self.datastore updateDocumentFromRevision:rev error:nil];
+
     XCTAssertNotNil(rev, @"Attachments are not deleted.");
     XCTAssertTrue([self isNumberOfAttachmentsForRevision:rev equalTo:nAttachments/2],
                  @"Incorrect number of attachments");
@@ -494,10 +487,9 @@
     NSString *docId = @"document1";
     
     NSError *error;
-    CDTMutableDocumentRevision *mrev = [CDTMutableDocumentRevision revision];
-    mrev.docId = docId;
-    mrev.body =@{@"hello": @12};
-    
+    CDTDocumentRevision *rev = [CDTDocumentRevision revisionWithDocId:docId];
+    rev.body = [@{ @"hello" : @12 } mutableCopy];
+
     NSMutableDictionary *attachments = [NSMutableDictionary dictionary];
     for (NSInteger i = 1; i <= nAttachments; i++) {
         NSString *content = [NSString stringWithFormat:@"blahblah-%li", (long)i];
@@ -510,10 +502,10 @@
         
         [originalAttachments setObject:data forKey:name];
     }
-    
-    mrev.attachments = attachments;
-    CDTDocumentRevision *rev = [self.datastore createDocumentFromRevision:mrev error:&error];
-    
+
+    rev.attachments = attachments;
+    rev = [self.datastore createDocumentFromRevision:rev error:&error];
+
     XCTAssertNotNil(rev, @"Unable to add attachments to document");
     XCTAssertTrue([self isNumberOfAttachmentsForRevision:rev equalTo:nAttachments],
                  @"Incorrect number of attachments");
@@ -533,11 +525,10 @@
         NSString *name = [NSString stringWithFormat:@"attachment-%li", (long)i];
         [attachments removeObjectForKey:name];
     }
-    mrev.attachments = attachments;
-    mrev.sourceRevId = rev.revId;
-    
-    rev = [self.datastore updateDocumentFromRevision:mrev error:nil];
-    
+    rev.attachments = attachments;
+
+    rev = [self.datastore updateDocumentFromRevision:rev error:nil];
+
     XCTAssertNotNil(rev, @"Attachments are not deleted.");
     XCTAssertTrue([self isNumberOfAttachmentsForRevision:rev equalTo:nAttachments/2],
                  @"Incorrect number of attachments");
@@ -703,9 +694,8 @@
                                                                           name:attachmentName
                                                                           type:@"text/plain"];    
     NSError *error = nil;
-    CDTMutableDocumentRevision *mrev = [rev mutableCopy];
-    [mrev.attachments setObject:attachment forKey:attachmentName];
-    rev = [self.datastore updateDocumentFromRevision:mrev error:&error];
+    [rev.attachments setObject:attachment forKey:attachmentName];
+    rev = [self.datastore updateDocumentFromRevision:rev error:&error];
 
     XCTAssertNotNil(rev, @"Unable to add attachments to document");
     
@@ -774,9 +764,8 @@
     
     CDTDocumentRevision *rev = [self.datastore getDocumentWithId:docId
                                                            error:nil];
-    CDTMutableDocumentRevision *mrev = [rev mutableCopy];
-    [mrev.attachments removeObjectForKey:attachmentName];
-    rev = [self.datastore updateDocumentFromRevision:mrev error:nil];
+    [rev.attachments removeObjectForKey:attachmentName];
+    rev = [self.datastore updateDocumentFromRevision:rev error:nil];
 
     XCTAssertNotNil(rev, @"Unable to add attachments to document");
     XCTAssertTrue([self isNumberOfAttachmentsForRevision:rev equalTo:(NSUInteger)0],


### PR DESCRIPTION
_What_

Update the Replication Acceptance and Sample projects to use the new CDTDocumentRevision classes.

_Why_

So we can still run the sample and acceptance tests.

_How_

* d5a3fe1cb3c85519ed022cc8232738629d31798b adds real model classes to the Todo project, wrapping the document interaction. These classes handle modifying documents as required, and providing revisions to be saved.
* 56d9847b17345f12bd6766260714a292c0166c34 basically rewrites any `mutableCopy` calls to no-ops. It also calls `[CDTDocumentRevision revisionWithDocId:blah]` instead of `[CDTMutableDocumentRevision revision]; revision.docId = blah;` as `docId` is a readonly property of CDTDocumentRevision, and that can't be changed.

reviewer @rhyshort 
reviewer @tomblench 