### PR TITLE
Merge CDTQLogging.h into CDTLogging.h

### DIFF
--- a/Classes/common/CDTLogging.h
+++ b/Classes/common/CDTLogging.h
@@ -37,9 +37,10 @@
 #define CDTTD_REMOTE_REQUEST_CONTEXT 14
 #define CDTTD_JSON_CONTEXT 15
 #define CDTTD_VIEW_CONTEXT 16
+#define CDTQ_LOG_CONTEXT 17
 
 #define CDTSTART_CONTEXT CDTINDEX_LOG_CONTEXT
-#define CDTEND_CONTEXT CDTTD_VIEW_CONTEXT
+#define CDTEND_CONTEXT CDTQ_LOG_CONTEXT
 
 #ifdef DEBUG
 
@@ -77,5 +78,12 @@ extern DDLogLevel CDTLoggingLevels[];
     LOG_MAYBE(CDTLogAsync, CDTLoggingLevels[context - CDTSTART_CONTEXT], DDLogFlagVerbose, context, nil, \
               __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
 #define CDTChangeLogLevel(context, logLevel) CDTLoggingLevels[context - CDTSTART_CONTEXT] = logLevel
+
+// These macros were previously in the CDTQLogging.h header file, they are here
+// to maintain compatbility with users changing the log level or check the log context
+
+#define CDTQ_LOGGING_CONTEXT CDTQ_LOG_CONTEXT
+
+#define CDTQChangeLogLevel(level) CDTChangeLogLevel(CDTQ_LOG_CONTEXT, level)
 
 #endif

--- a/Classes/common/query/CDTQIndex.m
+++ b/Classes/common/query/CDTQIndex.m
@@ -14,7 +14,7 @@
 
 #import "CDTQIndex.h"
 
-#import "CDTQLogging.h"
+#import "CDTLogging.h"
 
 NSString *const kCDTQJsonType = @"json";
 NSString *const kCDTQTextType = @"text";
@@ -83,37 +83,39 @@ static NSString *const kCDTQTextDefaultTokenizer = @"simple";
          withSettings:(NSDictionary *)indexSettings
 {
     if (fieldNames.count == 0) {
-        LogError(@"No field names provided.");
+        CDTLogError(CDTQ_LOG_CONTEXT, @"No field names provided.");
         return nil;
     }
     
     if (indexName.length == 0) {
-        LogError(@"No index name provided.");
+        CDTLogError(CDTQ_LOG_CONTEXT, @"No index name provided.");
         return nil;
     }
     
     if (indexType.length == 0) {
-        LogError(@"No index type provided.");
+        CDTLogError(CDTQ_LOG_CONTEXT, @"No index type provided.");
         return nil;
     }
     
     if (![[CDTQIndex validTypes] containsObject:indexType.lowercaseString]) {
-        LogError(@"Invalid index type %@.", indexType);
+        CDTLogError(CDTQ_LOG_CONTEXT, @"Invalid index type %@.", indexType);
         return nil;
     }
     
     if ([indexType.lowercaseString isEqualToString:kCDTQJsonType] && indexSettings) {
-        LogWarn(@"Index type is %@, index settings %@ ignored.", indexType, indexSettings);
+        CDTLogWarn(CDTQ_LOG_CONTEXT, @"Index type is %@, index settings %@ ignored.", indexType,
+                   indexSettings);
         indexSettings = nil;
     } else if ([indexType.lowercaseString isEqualToString:kCDTQTextType]) {
         if (!indexSettings) {
             indexSettings = @{ kCDTQTextTokenize: kCDTQTextDefaultTokenizer };
-            LogDebug(@"Index type is %@, defaulting settings to %@.", indexType, indexSettings);
+            CDTLogDebug(CDTQ_LOG_CONTEXT, @"Index type is %@, defaulting settings to %@.",
+                        indexType, indexSettings);
         } else {
             for (NSString *parameter in [indexSettings allKeys]) {
                 if (![[CDTQIndex validSettings] containsObject:parameter.lowercaseString]) {
-                    LogError(@"Invalid parameter %@ in index settings %@.", parameter,
-                                                                            indexSettings);
+                    CDTLogError(CDTQ_LOG_CONTEXT, @"Invalid parameter %@ in index settings %@.",
+                                parameter, indexSettings);
                     return nil;
                 }
             }
@@ -144,7 +146,7 @@ static NSString *const kCDTQTextDefaultTokenizer = @"simple";
                                                                  options:kNilOptions
                                                                    error:&error];
     if (!settingsDict) {
-        LogError(@"Error processing index settings %@", indexSettings);
+        CDTLogError(CDTQ_LOG_CONTEXT, @"Error processing index settings %@", indexSettings);
         return NO;
     }
     
@@ -153,7 +155,7 @@ static NSString *const kCDTQTextDefaultTokenizer = @"simple";
 
 -(NSString *) settingsAsJSON {
     if (!self.indexSettings) {
-        LogWarn(@"Index settings are nil.  Nothing to return.");
+        CDTLogWarn(CDTQ_LOG_CONTEXT, @"Index settings are nil.  Nothing to return.");
         return nil;
     }
     NSError *error;
@@ -161,7 +163,7 @@ static NSString *const kCDTQTextDefaultTokenizer = @"simple";
                                                            options:kNilOptions
                                                              error:&error];
     if (!settingsData) {
-        LogError(@"Error processing index settings %@", self.indexSettings);
+        CDTLogError(CDTQ_LOG_CONTEXT, @"Error processing index settings %@", self.indexSettings);
         return nil;
     }
     

--- a/Classes/common/query/CDTQIndexCreator.m
+++ b/Classes/common/query/CDTQIndexCreator.m
@@ -16,7 +16,7 @@
 
 #import "CDTQIndexManager.h"
 #import "CDTQIndexUpdater.h"
-#import "CDTQLogging.h"
+#import "CDTLogging.h"
 
 #import "CloudantSync.h"
 #import <FMDB/FMDB.h>
@@ -69,8 +69,8 @@
     
     if ([index.indexType.lowercaseString isEqualToString:@"text"]) {
         if (![CDTQIndexManager ftsAvailableInDatabase:self.database]) {
-            LogError(@"Text search not supported.  To add support for text "
-                     @"search, enable FTS compile options in SQLite.");
+            CDTLogError(CDTQ_LOG_CONTEXT, @"Text search not supported.  To add support for text "
+                                          @"search, enable FTS compile options in SQLite.");
             return nil;
         }
     }
@@ -86,7 +86,8 @@
     // Check there are no duplicate field names in the array
     NSSet *uniqueNames = [NSSet setWithArray:fieldNames];
     if (uniqueNames.count != fieldNames.count) {
-        LogError(@"Cannot create index with duplicated field names %@", fieldNames);
+        CDTLogError(CDTQ_LOG_CONTEXT, @"Cannot create index with duplicated field names %@",
+                    fieldNames);
         return nil;
     }
 
@@ -108,7 +109,8 @@
     // else fail.
     NSDictionary *existingIndexes = [CDTQIndexManager listIndexesInDatabaseQueue:self.database];
     if ([CDTQIndexCreator indexLimitReached:index basedOnIndexes:existingIndexes]) {
-        LogError(@"Index limit reached.  Cannot create index %@.", index.indexName);
+        CDTLogError(CDTQ_LOG_CONTEXT, @"Index limit reached.  Cannot create index %@.",
+                    index.indexName);
         return nil;
     }
     if (existingIndexes[index.indexName] != nil) {
@@ -202,7 +204,8 @@
     NSArray *parts = [fieldName componentsSeparatedByString:@"."];
     for (NSString *part in parts) {
         if ([part hasPrefix:@"$"]) {
-            LogError(@"Field names cannot start with a $ in field %@", fieldName);
+            CDTLogError(CDTQ_LOG_CONTEXT, @"Field names cannot start with a $ in field %@",
+                        fieldName);
             return NO;
         }
     }
@@ -249,9 +252,10 @@
             NSString *type = existingIndex[@"type"];
             if ([type.lowercaseString isEqualToString:kCDTQTextType] &&
                 ![name.lowercaseString isEqualToString:index.indexName.lowercaseString]) {
-                LogError(@"The text index %@ already exists.  "
-                          "One text index per datastore permitted.  "
-                          "Delete %@ and recreate %@", name, name, index.indexName);
+                CDTLogError(CDTQ_LOG_CONTEXT, @"The text index %@ already exists.  "
+                                               "One text index per datastore permitted.  "
+                                               "Delete %@ and recreate %@",
+                            name, name, index.indexName);
                 return YES;
             }
         }

--- a/Classes/common/query/CDTQIndexManager.m
+++ b/Classes/common/query/CDTQIndexManager.m
@@ -44,7 +44,7 @@
 #import "CDTQIndexUpdater.h"
 #import "CDTQQueryExecutor.h"
 #import "CDTQIndexCreator.h"
-#import "CDTQLogging.h"
+#import "CDTLogging.h"
 
 #import "CDTEncryptionKeyProvider.h"
 #import "CDTDatastore+EncryptionKey.h"
@@ -214,7 +214,7 @@ static const int VERSION = 2;
  */
 - (NSString *)ensureIndexed:(NSArray * /* NSString */)fieldNames
 {
-    LogError(@"-ensureIndexed: not implemented");
+    CDTLogError(CDTQ_LOG_CONTEXT, @"-ensureIndexed: not implemented");
     return nil;
 }
 
@@ -291,7 +291,7 @@ static const int VERSION = 2;
         success = success && [db executeUpdate:sql withArgumentsInArray:@[ indexName ]];
 
         if (!success) {
-            LogError(@"Failed to delete index: %@", indexName);
+            CDTLogError(CDTQ_LOG_CONTEXT, @"Failed to delete index: %@", indexName);
             *rollback = YES;
         }
     }];
@@ -326,7 +326,7 @@ static const int VERSION = 2;
                    sort:(NSArray *)sortDocument
 {
     if (!query) {
-        LogError(@"-find called with nil selector; bailing.");
+        CDTLogError(CDTQ_LOG_CONTEXT, @"-find called with nil selector; bailing.");
         return nil;
     }
 
@@ -375,10 +375,10 @@ static const int VERSION = 2;
 - (BOOL)isTextSearchEnabled
 {
     if (!_textSearchEnabled) {
-        LogInfo(@"Based on SQLite compile options, "
-                @"text search is currently not supported.  "
-                @"To enable text search recompile SQLite with "
-                @"the full text saerch compile options turned on.");
+        CDTLogInfo(CDTQ_LOG_CONTEXT, @"Based on SQLite compile options, "
+                                     @"text search is currently not supported.  "
+                                     @"To enable text search recompile SQLite with "
+                                     @"the full text saerch compile options turned on.");
     }
     return _textSearchEnabled;
 }
@@ -456,7 +456,8 @@ static const int VERSION = 2;
       NSError *thisError = nil;
       success = [db setKeyWithProvider:provider error:&thisError];
       if (!success) {
-          LogError(@"Problem configuring database with encryption key: %@", thisError);
+          CDTLogError(CDTQ_LOG_CONTEXT, @"Problem configuring database with encryption key: %@",
+                      thisError);
       }
     }];
 
@@ -502,7 +503,7 @@ static const int VERSION = 2;
         success = success && [db executeUpdate:sql];
 
         if (!success) {
-            LogError(@"Failed to update schema");
+            CDTLogError(CDTQ_LOG_CONTEXT, @"Failed to update schema");
             *rollback = YES;
         }
     }];

--- a/Classes/common/query/CDTQLogging.h
+++ b/Classes/common/query/CDTQLogging.h
@@ -11,31 +11,4 @@
 //  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
 //  either express or implied. See the License for the specific language governing permissions
 //  and limitations under the License.
-
-#ifndef Pods_CDTQueryLogging_h
-#define Pods_CDTQueryLogging_h
-
-#import <CocoaLumberjack/CocoaLumberjack.h>
-
-#define CDTQ_LOGGING_CONTEXT 17  // one level higher than CDT logger myabe should be 20?
-static DDLogLevel CDTQLogLevel = DDLogLevelWarning;
-
-#define LogError(frmt, ...)                                                                     \
-    LOG_MAYBE(NO, CDTQLogLevel, DDLogFlagError, CDTQ_LOGGING_CONTEXT, nil, __PRETTY_FUNCTION__, \
-              frmt, ##__VA_ARGS__)
-#define LogWarn(frmt, ...)                                                                         \
-    LOG_MAYBE(YES, CDTQLogLevel, DDLogFlagWarning, CDTQ_LOGGING_CONTEXT, nil, __PRETTY_FUNCTION__, \
-              frmt, ##__VA_ARGS__)
-#define LogInfo(frmt, ...)                                                                      \
-    LOG_MAYBE(YES, CDTQLogLevel, DDLogFlagInfo, CDTQ_LOGGING_CONTEXT, nil, __PRETTY_FUNCTION__, \
-              frmt, ##__VA_ARGS__)
-#define LogDebug(frmt, ...)                                                                      \
-    LOG_MAYBE(YES, CDTQLogLevel, DDLogFlagDebug, CDTQ_LOGGING_CONTEXT, nil, __PRETTY_FUNCTION__, \
-              frmt, ##__VA_ARGS__)
-#define LogVerbose(frmt, ...)                                                                      \
-    LOG_MAYBE(YES, CDTQLogLevel, DDLogFlagVerbose, CDTQ_LOGGING_CONTEXT, nil, __PRETTY_FUNCTION__, \
-              frmt, ##__VA_ARGS__)
-
-#define CDTQChangeLogLevel(level) CDTQLogLevel = level
-
-#endif
+#import "CDTLogging.h"

--- a/Classes/common/query/CDTQQueryValidator.m
+++ b/Classes/common/query/CDTQQueryValidator.m
@@ -15,7 +15,7 @@
 #import "CDTQQueryValidator.h"
 #import "CDTQQueryConstants.h"
 
-#import "CDTQLogging.h"
+#import "CDTLogging.h"
 
 @implementation CDTQQueryValidator
 
@@ -379,13 +379,15 @@
     for (id obj in clauses) {
         valid = NO;
         if (![obj isKindOfClass:[NSDictionary class]]) {
-            LogError(@"Operator argument must be a dictionary %@", [clauses description]);
+            CDTLogError(CDTQ_LOG_CONTEXT, @"Operator argument must be a dictionary %@",
+                        [clauses description]);
             break;
         }
         NSDictionary *clause = (NSDictionary *)obj;
         if ([clause count] != 1) {
-            LogError(@"Operator argument clause should only have one key value pair: %@",
-                     [clauses description]);
+            CDTLogError(CDTQ_LOG_CONTEXT,
+                        @"Operator argument clause should only have one key value pair: %@",
+                        [clauses description]);
             break;
         }
 
@@ -409,7 +411,7 @@
             valid = [CDTQQueryValidator validateTextClause:clause[key]
                                        withTextClauseLimit:textClauseLimitReached];
         } else {
-            LogError(@"%@ operator cannot be a top level operator", key);
+            CDTLogError(CDTQ_LOG_CONTEXT, @"%@ operator cannot be a top level operator", key);
             break;
         }
 
@@ -467,25 +469,26 @@
 + (BOOL)validateTextClause:(NSObject *)clause withTextClauseLimit:(BOOL *)textClauseLimitReached
 {
     if (![clause isKindOfClass:[NSDictionary class]]) {
-        LogError(@"Text search expects an NSDictionary, found %@ instead.", clause);
+        CDTLogError(CDTQ_LOG_CONTEXT, @"Text search expects an NSDictionary, found %@ instead.",
+                    clause);
         return NO;
     }
     
     NSDictionary *textClause = (NSDictionary *) clause;
     if ([textClause count] != 1) {
-        LogError(@"Unexpected content %@ in text search.", textClause);
+        CDTLogError(CDTQ_LOG_CONTEXT, @"Unexpected content %@ in text search.", textClause);
         return NO;
     }
     
     NSString *operator = [textClause allKeys][0];
     if (![operator isEqualToString:SEARCH]) {
-        LogError(@"Invalid operator %@ in text search.", operator);
+        CDTLogError(CDTQ_LOG_CONTEXT, @"Invalid operator %@ in text search.", operator);
         return NO;
     }
     
     if (*textClauseLimitReached) {
-        LogError(@"Multiple text search clauses not allowed in a query.  "
-                  "Rewrite query to contain at most one text search clause.");
+        CDTLogError(CDTQ_LOG_CONTEXT, @"Multiple text search clauses not allowed in a query.  "
+                                       "Rewrite query to contain at most one text search clause.");
         return NO;
     }
     
@@ -536,9 +539,10 @@
        ![((NSArray *) modulus)[1] isKindOfClass:[NSNumber class]] ||
        [((NSArray *) modulus)[0] integerValue] == 0) {
         valid = NO;
-        LogError(@"$mod operator requires a two element NSArray containing NSNumbers "
-                 @"where the first number, the divisor, is not zero.  As in: "
-                 @"{ \"$mod\" : [ 2, 1 ] }.  Where 2 is the divisor and 1 is the remainder.");
+        CDTLogError(CDTQ_LOG_CONTEXT,
+                    @"$mod operator requires a two element NSArray containing NSNumbers "
+                    @"where the first number, the divisor, is not zero.  As in: "
+                    @"{ \"$mod\" : [ 2, 1 ] }.  Where 2 is the divisor and 1 is the remainder.");
     }
     
     return valid;
@@ -550,7 +554,7 @@
     
     if(![textSearch isKindOfClass:[NSString class]]){
         valid = NO;
-        LogError(@"$search operator requires an NSString");
+        CDTLogError(CDTQ_LOG_CONTEXT, @"$search operator requires an NSString");
     }
     
     return valid;
@@ -562,7 +566,7 @@
 
     if (![exists isKindOfClass:[NSNumber class]]) {
         valid = NO;
-        LogError(@"$exists operator expects YES or NO");
+        CDTLogError(CDTQ_LOG_CONTEXT, @"$exists operator expects YES or NO");
     }
 
     return valid;
@@ -571,7 +575,8 @@
 + (BOOL)validateCompoundOperatorOperand:(NSObject *)operand
 {
     if (![operand isKindOfClass:[NSArray class]]) {
-        LogError(@"Argument to compound operator is not an NSArray: %@", [operand description]);
+        CDTLogError(CDTQ_LOG_CONTEXT, @"Argument to compound operator is not an NSArray: %@",
+                    [operand description]);
         return NO;
     }
     return YES;

--- a/Classes/common/query/CDTQResultSet.m
+++ b/Classes/common/query/CDTQResultSet.m
@@ -13,7 +13,7 @@
 //  and limitations under the License.
 
 #import "CDTQResultSet.h"
-#import "CDTQLogging.h"
+#import "CDTLogging.h"
 #import "CDTQProjectedDocumentRevision.h"
 #import "CDTQUnindexedMatcher.h"
 

--- a/Classes/common/query/CDTQUnindexedMatcher.m
+++ b/Classes/common/query/CDTQUnindexedMatcher.m
@@ -17,7 +17,7 @@
 #import "CDTQQueryConstants.h"
 
 #import "CDTQQuerySqlTranslator.h"
-#import "CDTQLogging.h"
+#import "CDTLogging.h"
 #import "CDTQValueExtractor.h"
 #import "CDTQQueryValidator.h"
 
@@ -221,7 +221,7 @@
         return invertResult ? !passed : passed;
     } else {
         // We constructed the tree, so shouldn't end up here; error if we do.
-        LogError(@"Found unexpected selector execution tree: %@", node);
+        CDTLogError(CDTQ_LOG_CONTEXT, @"Found unexpected selector execution tree: %@", node);
         return NO;
     }
 }
@@ -259,7 +259,7 @@
         passed = (exists == expectedBool);
 
     } else {
-        LogWarn(@"Found unexpected operator in selector: %@", operator);
+        CDTLogWarn(CDTQ_LOG_CONTEXT, @"Found unexpected operator in selector: %@", operator);
         passed = NO;  // didn't understand
     }
 
@@ -282,7 +282,7 @@
         return NO;  // NSNull fails all lt/gt/lte/gte tests
 
     } else if (!([l isKindOfClass:[NSString class]] || [l isKindOfClass:[NSNumber class]])) {
-        LogWarn(@"Value in document not NSNumber or NSString: %@", l);
+        CDTLogWarn(CDTQ_LOG_CONTEXT, @"Value in document not NSNumber or NSString: %@", l);
         return NO;  // Not sure how to compare values that are not numbers or strings
 
     } else if ([l isKindOfClass:[NSString class]]) {
@@ -319,7 +319,7 @@
     }
 
     if (!([l isKindOfClass:[NSString class]] || [l isKindOfClass:[NSNumber class]])) {
-        LogWarn(@"Value in document not NSNumber or NSString: %@", l);
+        CDTLogWarn(CDTQ_LOG_CONTEXT, @"Value in document not NSNumber or NSString: %@", l);
         return NO;  // Not sure how to compare values that are not numbers or strings
     }
 
@@ -333,7 +333,7 @@
     }
 
     if (!([l isKindOfClass:[NSString class]] || [l isKindOfClass:[NSNumber class]])) {
-        LogWarn(@"Value in document not NSNumber or NSString: %@", l);
+        CDTLogWarn(CDTQ_LOG_CONTEXT, @"Value in document not NSNumber or NSString: %@", l);
         return NO;  // Not sure how to compare values that are not numbers or strings
     }
 
@@ -347,7 +347,7 @@
     }
 
     if (!([l isKindOfClass:[NSString class]] || [l isKindOfClass:[NSNumber class]])) {
-        LogWarn(@"Value in document not NSNumber or NSString: %@", l);
+        CDTLogWarn(CDTQ_LOG_CONTEXT, @"Value in document not NSNumber or NSString: %@", l);
         return NO;  // Not sure how to compare values that are not numbers or strings
     }
 

--- a/Classes/common/query/CDTQValueExtractor.m
+++ b/Classes/common/query/CDTQValueExtractor.m
@@ -13,7 +13,7 @@
 //  and limitations under the License.
 
 #import "CDTQValueExtractor.h"
-#import "CDTQLogging.h"
+#import "CDTLogging.h"
 
 #import <CDTDocumentRevision.h>
 
@@ -56,7 +56,8 @@
     for (NSString *field in path) {
         currentLevel = currentLevel[field];
         if (currentLevel == nil || ![currentLevel isKindOfClass:[NSDictionary class]]) {
-            LogVerbose(@"Could not extract field %@ from document %@", possiblyDottedField, body);
+            CDTLogVerbose(CDTQ_LOG_CONTEXT, @"Could not extract field %@ from document %@",
+                          possiblyDottedField, body);
             return nil;  // we ran out of stuff before we reached the full path length
         }
     }


### PR DESCRIPTION
Since CDTQ* classes have been part of CDTDatastore, there have been two
header files for controlling logging. Now CDTQLogging macros map onto
CDTLogging macros and have been moved to CDTLogging.h.

CDTQLogging.h has been left for compatibility with existing library users.

reviewer @tomblench 
reviewer @mikerhodes 