### PR TITLE
Use CocoaLumberjack v2.0.0 since 2.0.1 cannot build as a framework

### DIFF
--- a/CDTDatastore.podspec
+++ b/CDTDatastore.podspec
@@ -103,7 +103,7 @@ Pod::Spec.new do |s|
     sp.frameworks = 'SystemConfiguration'
 
     sp.dependency 'CDTDatastore/no-arc'
-    sp.dependency 'CocoaLumberjack', '~> 2.0'
+    sp.dependency 'CocoaLumberjack', '= 2.0.0'
   end
 
   s.subspec 'no-arc' do |sp|


### PR DESCRIPTION
See https://github.com/CocoaLumberjack/CocoaLumberjack/issues/544

and also the same issue affecting this project itself: #194 