### PR TITLE
Added end to end tests for HTTPInterceptors

### DIFF
--- a/ReplicationAcceptance/ReplicationAcceptance.xcodeproj/project.pbxproj
+++ b/ReplicationAcceptance/ReplicationAcceptance.xcodeproj/project.pbxproj
@@ -45,6 +45,8 @@
 		984775061AB886790024B64C /* ReplicationSettings.m in Sources */ = {isa = PBXBuildFile; fileRef = 984775041AB886790024B64C /* ReplicationSettings.m */; };
 		984775081AB888F40024B64C /* ReplicationSettings.plist in Resources */ = {isa = PBXBuildFile; fileRef = 984775071AB888F40024B64C /* ReplicationSettings.plist */; };
 		984775091AB888F40024B64C /* ReplicationSettings.plist in Resources */ = {isa = PBXBuildFile; fileRef = 984775071AB888F40024B64C /* ReplicationSettings.plist */; };
+		989242BC1BA033F800FEE788 /* CDTRATestContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 989242BB1BA033F800FEE788 /* CDTRATestContext.m */; settings = {ASSET_TAGS = (); }; };
+		989242BD1BA033F800FEE788 /* CDTRATestContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 989242BB1BA033F800FEE788 /* CDTRATestContext.m */; settings = {ASSET_TAGS = (); }; };
 		9F8CA2C71A639AB000A0E91C /* ChangeTrackerNSURLProtocolTimedOut.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F8CA2C61A639AB000A0E91C /* ChangeTrackerNSURLProtocolTimedOut.m */; };
 		9F8CA2C81A639AB000A0E91C /* ChangeTrackerNSURLProtocolTimedOut.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F8CA2C61A639AB000A0E91C /* ChangeTrackerNSURLProtocolTimedOut.m */; };
 		9F8CA2C91A639AB000A0E91C /* ChangeTrackerNSURLProtocolTimedOut.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F8CA2C61A639AB000A0E91C /* ChangeTrackerNSURLProtocolTimedOut.m */; };
@@ -117,6 +119,8 @@
 		984775031AB886790024B64C /* ReplicationSettings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ReplicationSettings.h; sourceTree = "<group>"; };
 		984775041AB886790024B64C /* ReplicationSettings.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ReplicationSettings.m; sourceTree = "<group>"; };
 		984775071AB888F40024B64C /* ReplicationSettings.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = ReplicationSettings.plist; sourceTree = "<group>"; };
+		989242BA1BA033F800FEE788 /* CDTRATestContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDTRATestContext.h; sourceTree = "<group>"; };
+		989242BB1BA033F800FEE788 /* CDTRATestContext.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTRATestContext.m; sourceTree = "<group>"; };
 		9F8CA2C51A639AB000A0E91C /* ChangeTrackerNSURLProtocolTimedOut.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ChangeTrackerNSURLProtocolTimedOut.h; sourceTree = "<group>"; };
 		9F8CA2C61A639AB000A0E91C /* ChangeTrackerNSURLProtocolTimedOut.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ChangeTrackerNSURLProtocolTimedOut.m; sourceTree = "<group>"; };
 		9F8CA2CA1A64E63F00A0E91C /* CDTRunBlocksForReplicatorDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDTRunBlocksForReplicatorDelegate.h; sourceTree = "<group>"; };
@@ -253,6 +257,8 @@
 				9FC2F13019F72B710032A074 /* ReplicatorURLProtocolTester.m */,
 				984775031AB886790024B64C /* ReplicationSettings.h */,
 				984775041AB886790024B64C /* ReplicationSettings.m */,
+				989242BA1BA033F800FEE788 /* CDTRATestContext.h */,
+				989242BB1BA033F800FEE788 /* CDTRATestContext.m */,
 			);
 			path = ReplicationAcceptance;
 			sourceTree = "<group>";
@@ -635,6 +641,7 @@
 				9F95598F1A5F184000435808 /* ChangeTrackerDelegate.m in Sources */,
 				9FC2F12C19F070710032A074 /* ReplicatorURLProtocol.m in Sources */,
 				27A7E6AF189975B2007FAF1C /* CloudantReplicationBase.m in Sources */,
+				989242BC1BA033F800FEE788 /* CDTRATestContext.m in Sources */,
 				9F8CA2C71A639AB000A0E91C /* ChangeTrackerNSURLProtocolTimedOut.m in Sources */,
 				27DFEEB718DB4A0D0052D487 /* Attachments.m in Sources */,
 				984775051AB886790024B64C /* ReplicationSettings.m in Sources */,
@@ -653,6 +660,7 @@
 				9F9559901A5F184000435808 /* ChangeTrackerDelegate.m in Sources */,
 				9FC2F12D19F070710032A074 /* ReplicatorURLProtocol.m in Sources */,
 				27A7E6B0189975B2007FAF1C /* CloudantReplicationBase.m in Sources */,
+				989242BD1BA033F800FEE788 /* CDTRATestContext.m in Sources */,
 				9F8CA2C81A639AB000A0E91C /* ChangeTrackerNSURLProtocolTimedOut.m in Sources */,
 				27DFEEB818DB4A0D0052D487 /* Attachments.m in Sources */,
 				984775061AB886790024B64C /* ReplicationSettings.m in Sources */,

--- a/ReplicationAcceptance/ReplicationAcceptance/CDTRATestContext.h
+++ b/ReplicationAcceptance/ReplicationAcceptance/CDTRATestContext.h
@@ -1,0 +1,42 @@
+//
+//  CDTRATestContext.h
+//  ReplicationAcceptance
+//
+//  Created by Rhys Short on 09/09/2015.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+#import "CDTHTTPInterceptorContext.h"
+#import "CDTHTTPInterceptor.h"
+
+@interface CDTRATestContext : CDTHTTPInterceptorContext
+
+@property (nonatomic) int modifyCount;
+
+- (instancetype)initWithContext:(CDTHTTPInterceptorContext *)context NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithRequest:(NSMutableURLRequest *)request UNAVAILABLE_ATTRIBUTE;
+
+@end
+
+@interface TestRequestPiplineInterceptor1 : NSObject <CDTHTTPInterceptor>
+
+@end
+
+@interface TestRequestPiplineInterceptor2 : NSObject <CDTHTTPInterceptor>
+@property (nonatomic) BOOL expectedContextFound;
+
+@end
+
+@interface TestResponsePiplineInterceptor1 : NSObject <CDTHTTPInterceptor>
+
+@end
+
+@interface TestResponsePiplineInterceptor2 : NSObject <CDTHTTPInterceptor>
+@property (nonatomic) BOOL expectedContextFound;
+@end

--- a/ReplicationAcceptance/ReplicationAcceptance/CDTRATestContext.m
+++ b/ReplicationAcceptance/ReplicationAcceptance/CDTRATestContext.m
@@ -1,0 +1,67 @@
+//
+//  CDTRATestContext.m
+//  ReplicationAcceptance
+//
+//  Created by Rhys Short on 09/09/2015.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+#import "CDTRATestContext.h"
+#import "XCTest/XCTest.h"
+
+@implementation CDTRATestContext
+
+- (instancetype)initWithContext:(CDTHTTPInterceptorContext *)context
+{
+    self = [super initWithRequest:context.request];
+    if (self) {
+        self.response = context.response;
+    }
+    return self;
+}
+
+@end
+
+@implementation TestRequestPiplineInterceptor1
+
+- (CDTHTTPInterceptorContext *)interceptRequestInContext:(CDTHTTPInterceptorContext *)context
+{
+    return [[CDTRATestContext alloc] initWithContext:context];
+}
+
+@end
+
+@implementation TestRequestPiplineInterceptor2
+
+- (CDTHTTPInterceptorContext *)interceptRequestInContext:(CDTHTTPInterceptorContext *)context
+{
+    self.expectedContextFound = [context class] == [CDTRATestContext class];
+    return context;
+}
+
+@end
+
+@implementation TestResponsePiplineInterceptor1
+
+- (CDTHTTPInterceptorContext *)interceptResponseInContext:(CDTHTTPInterceptorContext *)context
+{
+    return [[CDTRATestContext alloc] initWithContext:context];
+}
+
+@end
+
+@implementation TestResponsePiplineInterceptor2
+
+- (CDTHTTPInterceptorContext *)interceptResponseInContext:(CDTHTTPInterceptorContext *)context
+{
+    self.expectedContextFound = [context class] == [CDTRATestContext class];
+    return context;
+}
+
+@end


### PR DESCRIPTION
Added end to end tests for HTTPInterceptors

- test the pipeline passes the same context object to the response
interceptor as the request interceptor

- test that the interceptor API on CDTAbstractReplication successfully
passes down the correct configuration.

reviewer @tomblench 
reviewer @mikerhodes 