### PR TITLE
51928 Add isFullRevision property to CDTDocumentRevision and subclasses

### DIFF
--- a/Classes/common/CDTDatastore.m
+++ b/Classes/common/CDTDatastore.m
@@ -599,9 +599,27 @@ NSString *const CDTDatastoreChangeNotification = @"CDTDatastoreChangeNotificatio
 - (CDTDocumentRevision *)updateDocumentFromRevision:(CDTDocumentRevision *)revision
                                               error:(NSError *__autoreleasing *)error
 {
+    if (!revision.isFullRevision) {
+        if (error) {
+            NSString *reason = @"Trying to save revision where isFullVersion is NO";
+            NSString *msg = @"Possibly trying to save projected query result.";
+            NSString *recovery = @"Try calling -copy on projected revisions before saving.";
+            NSDictionary *info = @{
+                NSLocalizedFailureReasonErrorKey : reason,
+                NSLocalizedDescriptionKey : msg,
+                NSLocalizedRecoverySuggestionErrorKey : recovery
+            };
+            *error =
+                [NSError errorWithDomain:TDHTTPErrorDomain code:kTDStatusBadRequest userInfo:info];
+        }
+        return nil;
+    }
+
     if (!revision.body) {
         TDStatus status = kTDStatusBadRequest;
-        *error = TDStatusToNSError(status, nil);
+        if (error) {
+            *error = TDStatusToNSError(status, nil);
+        }
         return nil;
     }
 

--- a/Classes/common/CDTDocumentRevision.h
+++ b/Classes/common/CDTDocumentRevision.h
@@ -19,7 +19,6 @@
 #import "CDTChangedObserver.h"
 
 @class TD_RevisionList;
-@class CDTDocumentRevision;
 
 /**
  * Represents a single revision of a document in a datastore.
@@ -40,6 +39,15 @@
 @property (nonatomic, strong) NSMutableDictionary *attachments;
 
 @property (nonatomic, getter=isChanged) bool changed;
+
+/**
+ Indicates if this document revision contains all fields and attachments. If NO, datastore
+ will refuse to save.
+
+ This allows for document projections to conform to the CDTDocumentRevision API without
+ risking their being saved to the datastore.
+ */
+- (BOOL)isFullRevision;
 
 - (id)initWithDocId:(NSString *)docId
          revisionId:(NSString *)revId

--- a/Classes/common/CDTDocumentRevision.m
+++ b/Classes/common/CDTDocumentRevision.m
@@ -181,6 +181,8 @@
     return self;
 }
 
+- (BOOL)isFullRevision { return YES; }
+
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 - (NSData *)documentAsDataError:(NSError *__autoreleasing *)error

--- a/Classes/common/query/CDTQProjectedDocumentRevision.m
+++ b/Classes/common/query/CDTQProjectedDocumentRevision.m
@@ -44,7 +44,10 @@
     return self;
 }
 
-- (CDTDocumentRevision *)mutableCopy
+/** A projection doesn't contain attachments, nor all fields from a document. */
+- (BOOL)isFullRevision { return NO; }
+
+- (CDTDocumentRevision *)copy
 {
     CDTDocumentRevision *rev = [self.datastore getDocumentWithId:self.docId error:nil];
     if (rev == nil) {

--- a/Tests/Tests/CDTQFilterFieldsTest.m
+++ b/Tests/Tests/CDTQFilterFieldsTest.m
@@ -194,7 +194,7 @@ SpecBegin(CDTQFilterFieldsTest)
 
         context(@"mutableCopy of projected doc", ^{
 
-            xit(@"returns full doc", ^{
+            it(@"returns full doc", ^{
                 NSDictionary *query = @{ @"name" : @"mike", @"age" : @12 };
                 CDTQResultSet *result =
                     [im find:query skip:0 limit:NSUIntegerMax fields:@[ @"name" ] sort:nil];
@@ -213,7 +213,7 @@ SpecBegin(CDTQFilterFieldsTest)
                     }];
             });
 
-            xit(@"returns nil when doc updated", ^{
+            it(@"returns nil when doc updated", ^{
                 NSDictionary *query = @{ @"name" : @"mike", @"age" : @12 };
                 CDTQResultSet *result =
                     [im find:query skip:0 limit:NSUIntegerMax fields:@[ @"name" ] sort:nil];
@@ -235,7 +235,7 @@ SpecBegin(CDTQFilterFieldsTest)
                     }];
             });
 
-            xit(@"returns nil when doc deleted", ^{
+            it(@"returns nil when doc deleted", ^{
                 NSDictionary *query = @{ @"name" : @"mike", @"age" : @12 };
                 CDTQResultSet *result =
                     [im find:query skip:0 limit:NSUIntegerMax fields:@[ @"name" ] sort:nil];


### PR DESCRIPTION
_Why_

Some operations, for example querying with a field filter, produce document revision objects which are not complete representations of the revision. In order to avoid data loss in applications, these revisions should not be allowed to be saved by the datastore.

_How_

https://github.com/cloudant/CDTDatastore/commit/0c722a5eeaa3e1d171284cc5029929e922cfcd87

Adds `isFullRevision` property to `CDTDocumentRevision`. This allows partial revision objects, such as `CDTQProjectedDocumentRevision`, to be recognised when a developer attempts to write one to the database. `-updateDocumentFromRevision:error:` uses `isFullRevision` to reject updates where the property is `NO`.

- `CDTDocumentRevision` sets the property to `YES` so it can be saved.
- `CDTProjectedDocumentRevision` sets the property to `NO` so it cannot be saved.
- `-updateDocumentFromRevision:error:` first checks the property before saving.

https://github.com/cloudant/CDTDatastore/commit/f6c8250797d9dded092f5dabbf486e8d9b9f6044

Re-enables tests which needed this functionality.