### PR TITLE
Clean up Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -63,19 +63,11 @@ task :testencryptionosx do
 end
 
 desc "Run tests for all platforms"
-task :test do
-  sh "rake testios"
-  sh "rake testosx"
-  sh "rake testencryptionios"
-  sh "rake testencryptionosx"
+task :test => [:testosx, :testios, :testencryptionosx, :testencryptionios] do
 end
 
 desc "Task for travis"
-task :travis do
-  sh "rake testios"
-  sh "rake testosx"
-  sh "rake testencryptionios"
-  sh "rake testencryptionosx"
+task :travis => [:test] do
   sh "pod lib lint --allow-warnings"
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -108,17 +108,12 @@ end
 # Runs `build` target for workspace/scheme/destination
 def run_build(workspace, scheme, destination)
   # build using xcpretty as otherwise it's very verbose when running tests
-  $ios_success = system("xcodebuild -workspace #{workspace} -scheme '#{scheme}' -destination '#{destination}' build | xcpretty; exit ${PIPESTATUS[0]}")
-  return $ios_success
+  return system("xcodebuild -workspace #{workspace} -scheme '#{scheme}' -destination '#{destination}' build | xcpretty; exit ${PIPESTATUS[0]}")
 end
 
 # Runs `test` target for workspace/scheme/destination
 def run_tests(workspace, scheme, destination)
-  $ios_success = system("xcodebuild -workspace #{workspace} -scheme '#{scheme}' -destination '#{destination}' test")
-  unless $ios_success
-    puts "\033[0;31m! Unit tests failed with status code #{$?}"
-  end
-  return $ios_success
+  return system("xcodebuild -workspace #{workspace} -scheme '#{scheme}' -destination '#{destination}' test")
 end
 
 def test(workspace, scheme, destination)

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,27 @@
 #
+#  The various workspaces, schemes and destinations we test using
+#
+
+# Workspaces
+CDTDATASTORE_WS = 'CDTDatastore.xcworkspace'
+ENCRYPTION_WS = 'EncryptionTests/EncryptionTests.xcworkspace'
+REPLICATION_ACCEPTANCE_WS = './ReplicationAcceptance/ReplicationAcceptance.xcworkspace'
+
+# Schemes
+TESTS_IOS = 'Tests iOS'
+TESTS_OSX = 'Tests OSX'
+ENCRYPTION_IOS = 'Encryption Tests'
+ENCRYPTION_OSX = 'Encryption Tests OSX'
+REPLICATION_ACCEPTANCE_IOS = 'RA_Tests'
+REPLICATION_ACCEPTANCE_OSX = 'RA_Tests_OSX'
+REPLICATION_ACCEPTANCE_ENCRYPTED_IOS = 'RA_EncryptionTests'
+REPLICATION_ACCEPTANCE_ENCRYPTED_OSX = 'RA_EncryptionTests_OSX'
+
+# Destinations
+IPHONE_DEST = 'platform=iOS Simulator,OS=latest,name=iPhone 4S'
+OSX_DEST = 'platform=OS X'
+
+#
 #  Primary tasks
 #
 
@@ -79,27 +102,8 @@ task :docs do
 end
 
 #
-#  Helper methods and defines
+#  Helper methods
 #
-
-# Workspaces
-CDTDATASTORE_WS = 'CDTDatastore.xcworkspace'
-ENCRYPTION_WS = 'EncryptionTests/EncryptionTests.xcworkspace'
-REPLICATION_ACCEPTANCE_WS = './ReplicationAcceptance/ReplicationAcceptance.xcworkspace'
-
-# Schemes
-TESTS_IOS = 'Tests iOS'
-TESTS_OSX = 'Tests OSX'
-ENCRYPTION_IOS = 'Encryption Tests'
-ENCRYPTION_OSX = 'Encryption Tests OSX'
-REPLICATION_ACCEPTANCE_IOS = 'RA_Tests'
-REPLICATION_ACCEPTANCE_OSX = 'RA_Tests_OSX'
-REPLICATION_ACCEPTANCE_ENCRYPTED_IOS = 'RA_EncryptionTests'
-REPLICATION_ACCEPTANCE_ENCRYPTED_OSX = 'RA_EncryptionTests_OSX'
-
-# Destinations
-IPHONE_DEST = 'platform=iOS Simulator,OS=latest,name=iPhone 4S'
-OSX_DEST = 'platform=OS X'
 
 # Runs `build` target for workspace/scheme/destination
 def run_build(workspace, scheme, destination)


### PR DESCRIPTION
_What_

Firstly, adding methods to the Rakefile to avoid code duplication.

Secondly, making the dependents of the `:travis` task into true dependents rather than running a sub-process with another rake instance inside. In addition, OS X tests are run first rather than iOS. This is a fail-fast philosophy.

_Why_

Rakefile was becoming unwieldy. Many tasks had almost the same code, meaning any changes that affected many tasks were error prone (e.g., change iPhone model that tests run on).

The changes to the `travis` task are to make failures in the build cause failures on travis more quickly. Using true dependents means that the rake task will fail after the first XCTest run fails. In combination with running the OS X tests before the iOS tests, this reduces failing test runs to 6 minutes rather than 20 minutes.

My thought here was that if we fail on OS X, we're likely to fail iOS and the encryption tests. So lets run heavier tests only if the faster test runs work out.

BugzID: 52223

reviewer @tomblench 