### PR TITLE
Add documentation for the removal of CDTMutableDocumentRevision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,15 @@
 
 ## Unreleased
 
+- [BREAKING] CDTMutableDocumentRevision removed. CDTDocumentRevision objects
+  are now mutable -- you can change them and pass to
+  `updateDocumentFromRevision:error:` to make document updates.
 - [NEW] Added query support for the `$size` operator.
-- [FIX] Fixed issue where at least one index had to be created before a query would execute.  You can now query for documents without the existence of any indexes.
-- [REMOVED] Removed deprecated method `start` on CDTReplicator, use `startWithError` instead.
+- [FIX] Fixed issue where at least one index had to be created before a query
+  would execute.  You can now query for documents without the existence of any
+  indexes.
+- [REMOVED] Removed deprecated method `start` on CDTReplicator, use
+  `startWithError` instead.
 
 ## 0.17.1 (2015-06-24)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 - [BREAKING] CDTMutableDocumentRevision removed. CDTDocumentRevision objects
   are now mutable -- you can change them and pass to
-  `updateDocumentFromRevision:error:` to make document updates.
+  `updateDocumentFromRevision:error:` to make document updates. See
+  [doc/api-migration.md](doc/api-migration.md).
 - [NEW] Added query support for the `$size` operator.
 - [FIX] Fixed issue where at least one index had to be created before a query
   would execute.  You can now query for documents without the existence of any

--- a/Classes/common/CDTDocumentRevision.h
+++ b/Classes/common/CDTDocumentRevision.h
@@ -76,10 +76,25 @@
                                     forDocument:(NSURL *)documentURL
                                           error:(NSError *__autoreleasing *)error;
 
+/**
+ Create a new, blank revision which will have an ID generated on saving.
+ */
 + (CDTDocumentRevision *)revision;
 
+/**
+ Create a new, blank revision with an assigned ID.
+ */
 + (CDTDocumentRevision *)revisionWithDocId:(NSString *)docId;
 
+/**
+ Create a blank revision with a rev ID, which will be treated as an update when saving.
+
+ In general, not that useful in day-to-day life, where updates will be made to document
+ revisions retrieved from a datastore.
+
+ Useful during testing and when it's not necessary to start with an existing revision's
+ content.
+ */
 + (CDTDocumentRevision *)revisionWithDocId:(NSString *)docId revId:(NSString *)revId;
 
 /**

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ CDTUnsavedFileAttachment *att1 = [[CDTUnsavedFileAttachment alloc]
                           initWithPath:@"/path/to/image.jpg"
                           name:@"cute_cat.jpg"
                           type:@"image/jpeg"];
-rev.attachments = @[@{ att1.name:att1 } mutableCopy];
+rev.attachments[att1.name] = att;
 
 // Save the document to the database
 CDTDocumentRevision *revision = [datastore createDocumentFromRevision:rev

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ CDTDatastore *datastore = [manager datastoreNamed:@"my_datastore"
 // Create a document
 CDTDocumentRevision *rev = [CDTDocumentRevision revisionWithDocId:@"doc1"];
 // Use [CDTDocumentRevision revision] to get an ID generated for you on saving
-rev.body = @[@{
+rev.body = [@{
     @"description": @"Buy milk",
     @"completed": @NO,
     @"type": @"com.cloudant.sync.example.task"

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ pod "CDTDatastore"
 
 ### Using in a Swift app
 
-CDTDatastore is useable from Swift out of the box with a few small quirks. Install as per the 
+CDTDatastore is useable from Swift out of the box with a few small quirks. Install as per the
 instructions above, and import CloudantSync.h into your [bridging header](https://developer.apple.com/library/ios/documentation/swift/conceptual/buildingcocoaapps/MixandMatch.html). If you need to iterate
 over the CDTQueryResult class, you need to create a small extension before you can do so in Swift:
 
@@ -87,7 +87,7 @@ CDTDatastore gets regularly tested on the following platforms:
 - iPhone 6 (Simulator), iOS 8.1
 - iPad 2 (Simulator), iOS 8.1 and 7.1
 - iPad Air (Simulator), iOS 8.1 and 7.1
-- iPad Retina (Simulator), iOS 8.1 and 7.1  
+- iPad Retina (Simulator), iOS 8.1 and 7.1
 
 ## <a name="overview"></a>Overview of the library
 
@@ -114,31 +114,34 @@ CDTDatastore *datastore = [manager datastoreNamed:@"my_datastore"
                                             error:&outError];
 
 // Create a document
-CDTMutableDocumentRevision *rev = [CDTMutableDocumentRevision revision];
-rev.docId = @"doc1";  // Or don't and get an ID generated for you
-rev.body = @{
+CDTDocumentRevision *rev = [CDTDocumentRevision revisionWithDocId:@"doc1"];
+// Use [CDTDocumentRevision revision] to get an ID generated for you on saving
+rev.body = @[@{
     @"description": @"Buy milk",
     @"completed": @NO,
     @"type": @"com.cloudant.sync.example.task"
-};
+} mutableCopy];
 
 // Add an attachment -- binary data like a JPEG
 CDTUnsavedFileAttachment *att1 = [[CDTUnsavedFileAttachment alloc]
                           initWithPath:@"/path/to/image.jpg"
                           name:@"cute_cat.jpg"
                           type:@"image/jpeg"];
-rev.attachments = @{ att1.name:att1 };
+rev.attachments = @[@{ att1.name:att1 } mutableCopy];
 
 // Save the document to the database
 CDTDocumentRevision *revision = [datastore createDocumentFromRevision:rev
                                                                 error:&error];
+// `revision` will be `nil` on failures.
 
 // Read a document
 NSString *docId = revision.docId;
 CDTDocumentRevision *retrieved = [datastore getDocumentWithId:docId
                                                         error:&error];
 ```
-If you are using Swift, install the libraries as per the instructions above, and configure a bridging header for your project. Pull in the CloudantSync.h header into the bridging header, and you should be good to go:
+If you are using Swift, install the libraries as per the instructions above,
+and configure a bridging header for your project. Pull in the CloudantSync.h
+header into the bridging header, and you should be good to go:
 
 ```objc
 #import <CloudantSync.h>
@@ -168,8 +171,7 @@ if let err = error {
 }
 
 // Create a document
-var rev = CDTMutableDocumentRevision()
-rev.docId = "doc1"  // Or don't and get an ID generated for you
+var rev = CDTDocumentRevision(docId:"doc1")
 var body = [
     "description": "Buy milk",
     "completed": false,
@@ -194,8 +196,8 @@ if let err = error {
 Read more in [the CRUD document](https://github.com/cloudant/CDTDatastore/blob/master/doc/crud.md).
 
 You can subscribe for notifications of changes in the database, which
-is described in 
-[the events documentation](https://github.com/cloudant/cdtdatastore/blob/master/doc/events.md). 
+is described in
+[the events documentation](https://github.com/cloudant/cdtdatastore/blob/master/doc/events.md).
 It's still a bit raw right now:
 
 - You receive a notification for all new revisions in replication (which can be more

--- a/doc/api-migration.md
+++ b/doc/api-migration.md
@@ -1,5 +1,16 @@
 # Migrating to new APIs
 
+This document covers migrating your code when a CDTDatastore release has 
+breaking API changes. Each section covers migrating from one particular 
+version to another. The section titles state the specific versions between 
+which the change was made; often one can migrate from earlier versions than 
+the one specified on the left of the title to the new version specified
+on the right.
+
+Feel free to file bugs if the instructions don't work for you; we'll use
+these to improve the documentation and we'll obviously also try to help
+you through the process.
+
 ## 0.17.1 → 0.18.0
 
 This change removes `CDTMutableDocumentRevision`. In a sense, it's the next

--- a/doc/api-migration.md
+++ b/doc/api-migration.md
@@ -1,4 +1,85 @@
-## Migrating to the new API
+# Migrating to new APIs
+
+## 0.17.1 &rarr; 0.18.0
+
+This change removes `CDTMutableDocumentRevision`. In a sense, it's the next
+logical step from the `0.8` transition, further streamlining document create,
+read, update and delete operations. It also makes the operation of the
+revision objects more similar to other systems, like CoreData.
+
+The key changes are:
+
+- Remove `CDTMutableDocumentRevision` class.
+- Instead, `CDTDocumentRevision` is now a mutable class which can be used to
+  update documents.
+
+### Update process
+
+1. Remove use of `mutableCopy` to create `CDTMutableDocumentRevision` objects.
+1. If required, use `copy` on `CDTDocumentRevision` to create copies of
+   revisions (say if you are relying on the original object not changing for
+   use in UIs etc.).
+1. Update code to use `CDTDocumentRevision` objects everywhere.
+   - In particular, where assigning `NSDictionary` objects to either
+     `body` or `attachments`, you now must use `NSMutableDictionary` objects.
+   - For most CRUD operations this is hopefully simple; the API for
+     `CDTDocumentRevision` and `CDTMutableDocumentRevision` is similar and
+     the same methods on `CDTDatastore` objects are used.
+   - For conflict resolution, use of the `copy` method may be useful.
+1. Hopefully, see a simplification in your codebase.
+
+Below are examples of using the new API.
+
+#### Creating a document
+
+Instead of using an `CDTMutableDocumentRevision` object, just create a
+`CDTDocumentRevision`, make your changes and ask the datastore to create a
+document from the revision:
+
+```objc
+// `rev` is created without a revision ID.
+CDTDocumentRevision *rev = [CDTDocumentRevision revisionWithDocId:@"docId"];
+rev.body = [@{@"key":@"value"} mutableCopy];
+
+rev1 = [datastore createDocumentFromRevision:rev
+                                      error:&error];
+// `rev1` will now have a revision ID. Note `rev1` is a different object to rev
+```
+
+A key change is that the `body` and `attachment` attributes on
+`CDTDocumentRevision` classes now must be a mutable dictionary. Previously,
+it could be either. This change was made to enable use of `body` as a real
+property, which makes interacting with the datastore in Swift easier.
+
+#### Updating a document
+
+Instead of creating a `CDTMutableDocumentRevision` from a retrieved revision,
+just make changes on the retrieved revision and update it:
+
+```objc
+rev1 = [datastore createDocumentFromRevision:rev
+                                      error:&error];
+rev1[@"newKey"] = @"newValue";
+
+CDTDocumentRevision * newRev = [datastore updateDocumentFromRevision:rev1
+                                                               error:&error];
+```
+
+#### Deleting a document
+
+This hasn't changed, just call delete with an existing revision:
+
+```objc
+rev1 = [datastore createDocumentFromRevision:rev
+                                      error:&error];
+[datastore deleteDocumentFromRevision:rev1 error:&error];
+```
+
+## 0.7 &rarr; 0.8
+
+This change introduces `CDTMutableDocumentRevision` to fix problems when
+creating, updating and removing documents. For example, you can now modify
+both document content and attachments in a single update.
 
 With the release of 0.7 some methods were deprecated, and then in another release 0.8.0,
 they were removed this will guide you through the differences and how to migrate to the new API.
@@ -19,7 +100,7 @@ they were removed this will guide you through the differences and how to migrate
 * `updateDocumentWithId:prevRev:body:error:`
 * `deleteDocumentWithId:rev:error:`
 
-### Deprecated Classes 
+### Deprecated Classes
 
 * `CDTDocumentBody`
 
@@ -34,7 +115,7 @@ CDTMutableDocumentRevision * mutable = [CDTMutableDocumentRevision revision];
 mutableRevision.body = @{@"key":@"value"};
 mutableRevision.docId = @"docID"
 
-CDTDocumentRevision * rev = [datastore createDocumentFromRevision:rev 
+CDTDocumentRevision * rev = [datastore createDocumentFromRevision:rev
 															error:&error];
 ```
 
@@ -42,16 +123,16 @@ CDTDocumentRevision * rev = [datastore createDocumentFromRevision:rev
 
 Previously updating a document required the creation of a new `CDTDocumentBody` and passing
 directly the revision of which it is replacing and its doc id. This information is extracted from
-the `CDTDocumentRevision` object. 
+the `CDTDocumentRevision` object.
 
 The updates to the API mean you no longer extract this information from a `CDTDocumentRevision`
 instead call ```mutableCopy``` and update the properties on the returned object.
 
-```objc	
+```objc
 CDTMutableDocumentRevision * mutable = [rev mutableCopy];
 [mutable.body setObject:@"newValue" forKey:@"newKey"];
 
-CDTDocumentRevision * newRev = [datastore updateDocumentFromRevision:mutable 
+CDTDocumentRevision * newRev = [datastore updateDocumentFromRevision:mutable
 															   error:&error];
 
 ```
@@ -68,11 +149,11 @@ CDTRevision * deleted = [datastore deleteDocumentFromRevision:rev error:&error];
 
 ### Adding attachments
 
-Adding attachments in the old API created new revision for a document. 
+Adding attachments in the old API created new revision for a document.
 With the new API it is possible to add the  body
 and attachments for the document in the same revision
 
-```objc 
+```objc
 CDTAttachment * attachment = [[CDTUnsavedDataAttachment alloc] initWithData:data
                                                                           name:attachmentName
                                                                           type:@"image/jpg"];

--- a/doc/api-migration.md
+++ b/doc/api-migration.md
@@ -1,6 +1,6 @@
 # Migrating to new APIs
 
-## 0.17.1 &rarr; 0.18.0
+## 0.17.1 → 0.18.0
 
 This change removes `CDTMutableDocumentRevision`. In a sense, it's the next
 logical step from the `0.8` transition, further streamlining document create,
@@ -75,7 +75,7 @@ rev1 = [datastore createDocumentFromRevision:rev
 [datastore deleteDocumentFromRevision:rev1 error:&error];
 ```
 
-## 0.7 &rarr; 0.8
+## 0.7 → 0.8
 
 This change introduces `CDTMutableDocumentRevision` to fix problems when
 creating, updating and removing documents. For example, you can now modify

--- a/doc/crud.md
+++ b/doc/crud.md
@@ -473,7 +473,7 @@ CDTDocumentRevision *saved = [datastore createDocumentFromRevision:rev];
 It should be possible to create a new document by copying data from another
 document:
 
-1. Copy a document with attachments
+1. Copy a document with attachments, adding or modifying one attachment
     ```objc
     CDTDocumentRevision *rev = [CDTDocumentRevision revisionWithDocId:@"doc2"];
     rev.body = [saved.body mutableCopy];
@@ -486,7 +486,8 @@ document:
                                                                    error:&error];
     ```
 
-1. Add a document from a `mutableCopy`, without attachments
+1. Copy a document's body to a new document, adding or changing a value, 
+   without also copying attachments
     ```objc
     CDTDocumentRevision *rev = [CDTDocumentRevision revisionWithDocId:@"doc2"];
     rev.body = [saved.body mutableCopy];

--- a/doc/crud.md
+++ b/doc/crud.md
@@ -70,7 +70,7 @@ delete documents.
 Documents are represented as a set of revisions. To create a document, you
 set up the initial revision of the document and save that to the datastore.
 
-Create a mutable document revision object, set its body, ID and attachments
+Create a document revision object with an ID, set its body and attachments
 and then call `-createDocumentFromRevision:error:` to add it to the datastore:
 
 ```objc
@@ -79,13 +79,12 @@ CDTDatastore *datastore = [manager datastoreNamed:@"my_datastore"
 NSError *error;
 
 // Create a document
-CDTMutableDocumentRevision *rev = [CDTMutableDocumentRevision revision];
-rev.docId = @"doc1";  // Or don't assign the docId property, we'll generate one
-rev.body = @{
+CDTDocumentRevision *rev = [CDTDocumentRevision revisionWithDocId:@"doc1"];
+rev.body = [@{
     @"description": @"Buy milk",
     @"completed": @NO,
     @"type": @"com.cloudant.sync.example.task"
-};
+} mutableCopy];
 CDTDocumentRevision *revision = [datastore createDocumentFromRevision:rev
                                                                 error:&error];
 ```
@@ -104,19 +103,17 @@ CDTDocumentRevision *retrieved = [datastore getDocumentWithId:docId
                                                         error:&error];
 ```
 
-You get an immutable revision back from this method call. To make changes to
-the document, you need to call `-mutableCopy` on the revision and save it
-back to the datastore, as shown below.
+You can make updates to `retrieved` which can then be saved to the datastore
+as an update.
 
 ### Update
 
-To update a document, call `mutableCopy` on the original document revision,
-make your changes and save the document:
+To update a document, just make your changes to the revision and save the
+document:
 
 ```objc
-CDTMutableDocumentRevision *update = [retrieved mutableCopy];
-update.body[@"completed"] = @YES;  // Or assign a new NSDictionary
-CDTDocumentRevision *updated = [datastore updateDocumentFromRevision:update
+retrieved.body[@"completed"] = @YES;  // Or assign a new NSMutableDictionary
+CDTDocumentRevision *updated = [datastore updateDocumentFromRevision:retrieved
                                                                error:&error];
 ```
 
@@ -125,7 +122,7 @@ CDTDocumentRevision *updated = [datastore updateDocumentFromRevision:update
 To delete a document, you need the current revision:
 
 ```objc
-BOOL deleted = [datastore deleteDocumentFromRevision:saved
+BOOL deleted = [datastore deleteDocumentFromRevision:updated
                                                error:&error];
 ```
 
@@ -173,21 +170,20 @@ To add an attachment to a document, just add (or overwrite) the attachment
 in the `attachments` dictionary:
 
 ```objc
-// Create a new document
-CDTMutableDocumentRevision *rev = [CDTMutableDocumentRevision revision];
-// or get an existing one and create a mutable copy
-CDTDocumentRevision *retrieved = [datastore getDocumentWithId:@"mydoc"
-                                                        error:&error];
-CDTMutableDocumentRevision *rev = [retrieved mutableCopy];
+// Create a new document:
+CDTDocumentRevision *rev = [CDTDocumentRevision revision];
+// or get an existing one:
+CDTDocumentRevision *rev = [datastore getDocumentWithId:@"mydoc"
+                                                  error:&error];
 
-rev.body = @{ ... };
+rev.body = [@{ ... } mutableCopy];
 CDTUnsavedFileAttachment *att1 = [[CDTUnsavedFileAttachment alloc]
                   initWithPath:@"/path/to/image.jpg"
                           name:@"cute_cat.jpg"
                           type:@"image/jpeg"]];
 
 // As with the document body, you can replace all attachments:
-rev.attachments = @{ att1.name: att1 };
+rev.attachments = [@{ att1.name: att1 } mutableCopy];
 
 // Or just add or update a single one:
 rev.attachments[att1.name] = att1;
@@ -212,8 +208,8 @@ CDTUnsavedDataAttachment *att2 = [[CDTUnsavedDataAttachment alloc]
                           name:@"cute_cat.jpg"
                           type:@"image/jpeg"]];
 
-CDTMutableDocumentRevision *rev = [CDTMutableDocumentRevision revision];
-rev.attachments = @{ att1.name: att1, att2.name: att2 };
+CDTDocumentRevision *rev = [CDTDocumentRevision revision];
+rev.attachments = [@{ att1.name: att1, att2.name: att2 } mutableCopy];
 CDTDocumentRevision *saved = [datastore createDocumentFromRevision:rev
                                                              error:&error];
 ```
@@ -233,9 +229,8 @@ To remove an attachment, remove it from the `attachments` dictionary:
 ```objc
 CDTDocumentRevision *retrieved = [datastore getDocumentWithId:@"mydoc"
                                                         error:&error];
-CDTMutableDocumentRevision *update = [retrieved mutableCopy];
-[update.attachments removeObjectForKey:@"cute_cat.jpg"];
-CDTDocumentRevision *updated = [datastore updateDocumentFromRevision:update
+[retrieved.attachments removeObjectForKey:@"cute_cat.jpg"];
+CDTDocumentRevision *updated = [datastore updateDocumentFromRevision:retrieved
                                                                error:&error];
 
 ```
@@ -259,17 +254,16 @@ This is the simplest case as we don't need to worry about previous revisions.
 1. Add a document with body, but not attachments or ID. You'll get an
    autogenerated ID.
     ```objc
-    CDTMutableDocumentRevision *rev = [CDTMutableDocumentRevision revision];
-    rev.body = @{ ... };
+    CDTDocumentRevision *rev = [CDTDocumentRevision revision];
+    rev.body = [@{ ... } mutableCopy];
 
     CDTDocumentRevision *saved = [datastore createDocumentFromRevision:rev];
     ```
 
 1. Add a new document to the store with a body and ID, but without attachments.
     ```objc
-    CDTMutableDocumentRevision *rev = [CDTMutableDocumentRevision revision];
-    rev.docId = @"doc1";
-    rev.body = @{ ... };
+    CDTDocumentRevision *rev = [CDTDocumentRevision revisionWithDocId:@"doc1"];
+    rev.body = [@{ ... } mutableCopy];
 
     CDTDocumentRevision *saved = [datastore createDocumentFromRevision:rev
                                                                  error:&error];
@@ -277,15 +271,14 @@ This is the simplest case as we don't need to worry about previous revisions.
 
 1. Add a new document to the store with attachments.
     ```objc
-    CDTMutableDocumentRevision *rev = [CDTMutableDocumentRevision revision];
-    rev.docId = @"doc1";
-    rev.body = @{ ... };
+    CDTDocumentRevision *rev = [CDTDocumentRevision revisionWithDocId:@"doc1"];
+    rev.body = [@{ ... } mutableCopy];
 
     CDTUnsavedFileAttachment *att1 = [[CDTUnsavedFileAttachment alloc]
                       initWithPath:@"path"
                               name:@"filename"
                               type:@"image/jpeg"]]
-    rev.attachments = @{ att1.name:att1 };
+    rev.attachments = [@{ att1.name:att1 } mutableCopy];
 
     CDTDocumentRevision *saved = [datastore createDocumentFromRevision:rev];
     ```
@@ -293,21 +286,21 @@ This is the simplest case as we don't need to worry about previous revisions.
 1. Add a document with body and attachments, but no ID. You'll get an
    autogenerated ID.
     ```objc
-    CDTMutableDocumentRevision *rev = [CDTMutableDocumentRevision revision];
-    rev.body = @{ ... };
+    CDTDocumentRevision *rev = [CDTDocumentRevision revision];
+    rev.body = [@{ ... } mutableCopy];
 
     CDTUnsavedFileAttachment *att1 = [[CDTUnsavedFileAttachment alloc]
                       initWithPath:@"path"
                               name:@"filename"
                               type:@"image/jpeg"]]
-    rev.attachments = @{ att1.name:att1 };
+    rev.attachments = [@{ att1.name:att1 } mutableCopy];
 
     CDTDocumentRevision *saved = [datastore createDocumentFromRevision:rev];
     ```
 
 1. You can't create a document without a body (body is the only required property).
     ```objc
-    CDTMutableDocumentRevision *rev = [CDTMutableDocumentRevision revision];
+    CDTDocumentRevision *rev = [CDTDocumentRevision revision];
     rev.docId = @"doc1";
 
     CDTDocumentRevision *saved = [datastore createDocumentFromRevision:rev];
@@ -323,9 +316,8 @@ For the first set of examples the original document is set up with a body
 and no attachments:
 
 ```objc
-CDTMutableDocumentRevision *rev = [CDTMutableDocumentRevision revision];
-rev.docId = @"doc1";
-rev.body = @{ ... };
+CDTDocumentRevision *rev = [CDTDocumentRevision revisionWithDocId:@"doc1"];
+rev.body = [@{ ... } mutableCopy];
 
 CDTDocumentRevision *saved = [datastore createDocumentFromRevision:rev];
 ```
@@ -342,9 +334,8 @@ CDTUnsavedFileAttachment *att1 = [[CDTUnsavedFileAttachment alloc]
 
 1. Update body for doc that has no attachments, keeping no attachments
     ```objc
-    CDTMutableDocumentRevision *update = [saved mutableCopy];
-    update.body = @{ ... };
-    CDTDocumentRevision *updated = [datastore updateDocumentFromRevision:update
+    saved.body = [@{ ... } mutableCopy];
+    CDTDocumentRevision *updated = [datastore updateDocumentFromRevision:saved
                                                                    error:&error];
     ```
 
@@ -352,55 +343,50 @@ CDTUnsavedFileAttachment *att1 = [[CDTUnsavedFileAttachment alloc]
    that a mutableCopy of a document with no attachments has an
    `NSMutableDictionary` set for its `attachments` property.
     ```objc
-    CDTMutableDocumentRevision *update = [saved mutableCopy];
-    update.body[@"hello"] = @"world";
-    update.attachments[@att1.name] = att1;
+    saved.body[@"hello"] = @"world";
+    saved.attachments[@att1.name] = att1;
 
-    CDTDocumentRevision *updated = [datastore updateDocumentFromRevision:update
+    CDTDocumentRevision *updated = [datastore updateDocumentFromRevision:saved
                                                                    error:&error];
     ```
 
 1. Update body for doc with no attachments, removing attachments dictionary
    entirely.
     ```objc
-    CDTMutableDocumentRevision *update = [saved mutableCopy];
-    update.body[@"hello"] = @"world";
-    update.attachments = nil;
+    saved.body[@"hello"] = @"world";
+    saved.attachments = nil;
 
-    CDTDocumentRevision *updated = [datastore updateDocumentFromRevision:update
+    CDTDocumentRevision *updated = [datastore updateDocumentFromRevision:saved
                                                                    error:&error];
     ```
 
 1. Update the attachments without changing the body, add attachments to a doc
    that had none.
     ```objc
-    CDTMutableDocumentRevision *update = [saved mutableCopy];
-    update.attachments[@att1.name] = att1;
+    saved.attachments[@att1.name] = att1;
 
-    CDTDocumentRevision *updated = [datastore updateDocumentFromRevision:update
+    CDTDocumentRevision *updated = [datastore updateDocumentFromRevision:saved
                                                                    error:&error];
     ```
 
 1. Update attachments by copying from another revision.
     ```objc
     CDTMutableDocumentRevision *anotherDoc = [datastore getDocumentForId:@"anotherId"];
-    CDTMutableDocumentRevision *update = [saved mutableCopy];
-    update.attachments = anotherDoc.attachments;
+    saved.attachments = anotherDoc.attachments;
 
-    CDTDocumentRevision *updated = [datastore updateDocumentFromRevision:update
+    CDTDocumentRevision *updated = [datastore updateDocumentFromRevision:saved
                                                                    error:&error];
     ```
 
 1. Updating a document using an outdated source revision causes a conflict
     ```objc
-    CDTMutableDocumentRevision *update = [saved mutableCopy];
-    update.body = @{ ... };
-    [datastore updateDocumentFromRevision:update];
+    saved.body = [@{ ... } mutableCopy];
+    [datastore updateDocumentFromRevision:saved];
 
-    CDTMutableDocumentRevision *update2 = [saved mutableCopy];
-    update2.body = @{ ... ... };
+    // Note this is the old revision!
+    saved.body = @{ ... ... };
 
-    CDTDocumentRevision *updated = [datastore updateDocumentFromRevision:update
+    CDTDocumentRevision *updated = [datastore updateDocumentFromRevision:saved
                                                                    error:&error];
     // Updated should be nil, and error should be set/exception thrown
     ```
@@ -410,108 +396,101 @@ For the second set of examples the original document is set up with a body and
 several attachments:
 
 ```objc
-CDTMutableDocumentRevision *rev = [CDTMutableDocumentRevision revision];
-rev.docId = @"doc1";
-rev.body = @{ ... };
+CDTDocumentRevision *rev = [CDTDocumentRevision revisionWithDocId:@"doc1"];
+rev.body = [@{ ... } mutableCopy];
 
 CDTUnsavedFileAttachment *att1 = /* blah */
 /* set up more attachments */
-rev.attachments = @{ att1.name:att1, att2.name:att2, att3.name:att3 };
+rev.attachments = [@{ att1.name:att1, att2.name:att2, att3.name:att3 } mutableCopy];
 
 CDTDocumentRevision *saved = [datastore createDocumentFromRevision:rev];
 ```
 
 1. Update body without changing attachments
     ```objc
-    CDTMutableDocumentRevision *update = [saved mutableCopy];
-    update.body[@"hello"] = @"world";
+    saved.body[@"hello"] = @"world";
 
-    CDTDocumentRevision *updated = [datastore updateDocumentFromRevision:update];
+    CDTDocumentRevision *updated = [datastore updateDocumentFromRevision:saved
+                                                                   error:&error];
     // Should have the same attachments
     ```
 
 1. Update the attachments without changing the body, remove attachments
     ```objc
-    CDTMutableDocumentRevision *update = [saved mutableCopy];
-    [update.attachments removeObjectForKey:att1.name];
+    [saved.attachments removeObjectForKey:att1.name];
 
-    CDTDocumentRevision *updated = [datastore updateDocumentFromRevision:update
+    CDTDocumentRevision *updated = [datastore updateDocumentFromRevision:saved
                                                                    error:&error];
     ```
 
 1. Update the attachments without changing the body, add attachments
     ```objc
-    CDTMutableDocumentRevision *update = [saved mutableCopy];
     // Create att100 attachment
-    update.attachments[att100.name] = att100;
+    saved.attachments[att100.name] = att100;
 
-    CDTDocumentRevision *updated = [datastore updateDocumentFromRevision:update
+    CDTDocumentRevision *updated = [datastore updateDocumentFromRevision:saved
                                                                    error:&error];
     ```
 
 1. Update the attachments without changing the body, remove all attachments
    by setting `nil` for attachments dictionary.
     ```objc
-    CDTMutableDocumentRevision *update = [saved mutableCopy];
-    update.attachments = nil;
+    saved.attachments = nil;
 
-    CDTDocumentRevision *updated = [datastore updateDocumentFromRevision:update
+    CDTDocumentRevision *updated = [datastore updateDocumentFromRevision:saved
                                                                    error:&error];
     ```
 
 1. Update the attachments without changing the body, remove all attachments
    by setting an empty dictionary.
     ```objc
-    CDTMutableDocumentRevision *update = [saved mutableCopy];
-    update.attachments = @{};
+    saved.attachments = [@{} mutableCopy];
 
-    CDTDocumentRevision *updated = [datastore updateDocumentFromRevision:update
+    CDTDocumentRevision *updated = [datastore updateDocumentFromRevision:saved
                                                                    error:&error];
     ```
 
 1. Copy an attachment from one document to another.
     ```objc
     // Create a revision with attachments
-    CDTMutableDocumentRevision *rev = [CDTMutableDocumentRevision revision];
-    rev.docId = @"doc1";
-    rev.body = @{ ... };
+    CDTDocumentRevision *rev = [CDTDocumentRevision revisionWithDocId:@"doc1"];
+    rev.body = [@{ ... } mutableCopy];
     CDTUnsavedFileAttachment *att1 = /* blah */
-    rev.attachments = @{ att1.name: att1 };
+    rev.attachments = [@{ att1.name: att1 } mutableCopy];
     CDTDocumentRevision *revWithAttachments = [datastore createDocumentFromRevision:rev
                                                                               error:&error];
 
     // Add attachment to "saved" from "revWithAttachments"
-    CDTMutableDocumentRevision *update = [saved mutableCopy];
     CDTAttachment *savedAttachment = revWithAttachments.attachments[@"nameOfAttachment"];
-    update.attachments = @{savedAttachment.name: savedAttachment};
+    saved.attachments = @{savedAttachment.name: savedAttachment};
 
-    CDTDocumentRevision *updated = [datastore updateDocumentFromRevision:update
+    CDTDocumentRevision *updated = [datastore updateDocumentFromRevision:saved
                                                                    error:&error];
     ```
 
-### Creating a document from a `mutableCopy`
+### Creating a document by copying data
 
-It should be possible to create a new document from a `mutableCopy` of an existing document.
+It should be possible to create a new document by copying data from another
+document:
 
-
-1. Add a document from a `mutableCopy`, with attachments
+1. Copy a document with attachments
     ```objc
-    CDTMutableDocumentRevision *update = [saved mutableCopy];
-    update.docId = @"doc2";
-    update.body[@"hello"] = @"world";
+    CDTDocumentRevision *rev = [CDTDocumentRevision revisionWithDocId:@"doc2"];
+    rev.body = [saved.body mutableCopy];
+    rev.body[@"hello"] = @"world";
     // Create att100 attachment
-    update.attachments[att100.name] = att100;
+    rev.attachments = [saved.attachments mutableCopy];
+    rev.attachments[att100.name] = att100;
 
-    CDTDocumentRevision *updated = [datastore createDocumentFromRevision:update
+    CDTDocumentRevision *updated = [datastore createDocumentFromRevision:rev
                                                                    error:&error];
     ```
 
 1. Add a document from a `mutableCopy`, without attachments
     ```objc
-    CDTMutableDocumentRevision *update = [saved mutableCopy];
-    update.docId = @"doc2";
-    update.body = @{ ... };
-    update.attachments = nil;
+    CDTDocumentRevision *rev = [CDTDocumentRevision revisionWithDocId:@"doc2"];
+    rev.body = [saved.body mutableCopy];
+    rev.body[@"hello"] = @"world";
 
     CDTDocumentRevision *updated = [datastore createDocumentFromRevision:update
                                                                    error:&error];
@@ -520,14 +499,15 @@ It should be possible to create a new document from a `mutableCopy` of an existi
 1. Fail if the document ID is present in the datastore. Note this shouldn't
    fail if the document is being added to a different datastore.
     ```objc
-    CDTMutableDocumentRevision *update = [saved mutableCopy];
-    update.body[@"hello"] = @"world";
+    // Doc ID same as `saved`:
+    CDTDocumentRevision *rev = [CDTDocumentRevision revisionWithDocId:@"doc1"];
+    rev.body[@"hello"] = @"world";
 
-    CDTDocumentRevision *updated = [datastore createDocumentFromRevision:update
+    CDTDocumentRevision *updated = [datastore createDocumentFromRevision:rev
                                                                    error:&error];
     // Fails, saved is nil
 
-    CDTDocumentRevision *updated = [other_datastore createDocumentFromRevision:update
+    CDTDocumentRevision *updated = [other_datastore createDocumentFromRevision:rev
                                                                          error:&error];
     // Succeeds
     ```


### PR DESCRIPTION
_What_

The documentation is updated for the removal of the `CDTMutableDocumentRevision` class.

https://github.com/cloudant/CDTDatastore/commit/e4275d0e0734863421739f358f7a31184c547347

Covers migrating to the new API.

https://github.com/cloudant/CDTDatastore/commit/8b56dc8647026df0b293a5dd82bd1e1802fef193

Updates the CRUD documentation..

BugzID: 51929