### PR TITLE
Set HTTP Method for `_session` requests

### DIFF
--- a/Classes/common/HTTP/CDTSessionCookieInterceptor.m
+++ b/Classes/common/HTTP/CDTSessionCookieInterceptor.m
@@ -105,6 +105,7 @@ static const NSInteger CDTSessionCookieRequestTimeout = 600;
     components.path = @"/_session";
 
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:components.URL];
+    request.HTTPMethod = @"POST";
     request.HTTPBody = self.sessionRequestBody;
 
     dispatch_semaphore_t sema = dispatch_semaphore_create(0);

--- a/Tests/Tests/CDTSessionCookieInterceptorTests.m
+++ b/Tests/Tests/CDTSessionCookieInterceptorTests.m
@@ -49,18 +49,29 @@ static const NSString *testCookieHeaderValue =
       return [[request.URL host] isEqualToString:@"username.cloudant.com"];
     }
         withStubResponse:^OHHTTPStubsResponse *__nonnull(NSURLRequest *__nonnull request) {
-          return [OHHTTPStubsResponse
-              responseWithJSONObject:@{
-                  @"ok" : @(YES),
-                  @"name" : @"username",
-                  @"roles" : @[ @"_admin" ]
-              }
-                          statusCode:200
-                             headers:@{
-                                 @"Set-Cookie" :
-                                     [NSString stringWithFormat:@"%@; Version=1; Path=/; HttpOnly",
-                                                                testCookieHeaderValue]
-                             }];
+
+          if ([request.HTTPMethod isEqualToString:@"POST"]) {
+              return [OHHTTPStubsResponse
+                  responseWithJSONObject:@{
+                      @"ok" : @(YES),
+                      @"name" : @"username",
+                      @"roles" : @[ @"_admin" ]
+                  }
+                              statusCode:200
+                                 headers:@{
+                                     @"Set-Cookie" : [NSString
+                                         stringWithFormat:@"%@; Version=1; Path=/; HttpOnly",
+                                                          testCookieHeaderValue]
+                                 }];
+          } else if ([request.HTTPMethod isEqualToString:@"GET"]) {
+              return [OHHTTPStubsResponse responseWithJSONObject:@{} statusCode:200 headers:@{}];
+          } else if ([request.HTTPMethod isEqualToString:@"DELETE"]) {
+              return [OHHTTPStubsResponse responseWithJSONObject:@{} statusCode:200 headers:@{}];
+          } else {
+              XCTFail(@"Unexpected HTTP Method");
+              return [OHHTTPStubsResponse responseWithJSONObject:@{} statusCode:400 headers:@{}];
+          }
+
         }];
 }
 


### PR DESCRIPTION
## What
Fix issue where session authentication would fail.

## How

Set the HTTP method for `_session` requests made by the `CDTSessionCookieInterceptor` 

## Testing

The OHHTTPStub now checks for the correct HTTP method and delivers a response based on it. For `GET` requests it will return 200 with an empty body, and no headers, for `POST` the cookie header will be set and a 200 response returned.

## Reviewers

reviewer @tomblench 
reviewer @mikerhodes 
