### PR TITLE
Avoid assertion in allDocsQuery:options: when a docId isn't found.

### DIFF
--- a/Classes/common/CDTDatastore.m
+++ b/Classes/common/CDTDatastore.m
@@ -350,6 +350,12 @@ NSString *const CDTDatastoreChangeNotification = @"CDTDatastoreChangeNotificatio
         NSString *docId = row[@"id"];
 
         NSString *revId = row[@"value"][@"rev"];
+        
+        // If a document isn't found, docId and revId will be null, and row will
+        // contain an @"error" key.
+        if (docId == nil && revId == nil && [row[@"error"] isEqualToString:@"not_found"]) {
+            continue;
+        }
 
         // deleted field only present in deleted documents, but to be safe we use
         // the fact that (BOOL)[nil -boolValue] is false

--- a/Tests/Tests/CDTDatastoreQueryTests.m
+++ b/Tests/Tests/CDTDatastoreQueryTests.m
@@ -89,6 +89,13 @@ SpecBegin(CDTDatastoreQuery) describe(@"When using datastore query", ^{
         expect(results).toNot.beNil();
         expect([results.documentIds count]).to.equal(3);
     });
+    
+    it(@"can find documents and ignore non-existent documents", ^{
+        NSDictionary *query = @{ @"_id" : @{ @"$in" : @[@"mike12", @"mike34", @"mike72", @"mike-not-found"] } };
+        CDTQResultSet *results = [ds find:query];
+        expect(results).toNot.beNil();
+        expect([results.documentIds count]).to.equal(3);
+    });
 
     it(@" can delete an index", ^{
         [ds ensureIndexed:@[ @"name", @"address" ] withName:@"basic"];


### PR DESCRIPTION
When using `allDocsQuery:options:` with an array of docIds, a missing document will cause an 'Invalid parameter not satisfying: properties' assertion in `[TD_Body initWithProperties:]`.