### PR TITLE
mdk/Fix multipart replicator hang

### DIFF
--- a/Classes/common/touchdb/TDMultipartUploader.m
+++ b/Classes/common/touchdb/TDMultipartUploader.m
@@ -70,4 +70,11 @@
     [super requestDidError:error];
 }
 
+- (void)receivedData:(NSData *)data
+{
+    [super receivedData:data];
+    [self clearSession];
+    [self respondWithResult:self error:nil];
+}
+
 @end


### PR DESCRIPTION
This PR fixes a problem with multipart uploads that was exposed by CDTIncrementalStore.

The problem was introduced in 0.19.0 and traced down to the conversion from NSURLConnection to NSURLSession.  In a nutshell, the TDMultipartUploader maintains a queue of uploads to be processed and used the connectionDidFinishLoading: delegate method of NSURLConnection to initiate the next upload.  In the conversion to NSURLSession, this delegate method is no longer called and no provision was made to trigger subsequent uploads through another means.

This PR adds a simple receivedData: method to TDMultipartUploader to trigger subsequent uploads.  This is consistent with the change made to TDRemoteJSONRequest which signals that its processing is complete in its receivedData: method.

This PR includes a test case in the ReplicationAcceptance test suite to reproduce the problem (prior to the fix) and verifies the fix.