### PR TITLE
Upgrade FMDB to 2.6

### DIFF
--- a/CDTDatastore.podspec
+++ b/CDTDatastore.podspec
@@ -59,7 +59,7 @@ Pod::Spec.new do |s|
 
     sp.library = 'sqlite3', 'z'
 
-    sp.dependency 'FMDB', '= 2.3'
+    sp.dependency 'FMDB', '= 2.6'
   end
 
   s.subspec 'SQLCipher' do |sp|
@@ -89,7 +89,7 @@ Pod::Spec.new do |s|
 
     sp.library = 'z'
 
-    sp.dependency 'FMDB/SQLCipher', '= 2.3'
+    sp.dependency 'FMDB/SQLCipher', '= 2.6'
 
     # Some CDTDatastore classes use SQLite functions, therefore we have
     # to include 'SQLCipher' although 'FMDB/SQLCipher' also depends on it

--- a/Classes/common/Encryption/FMDatabase+EncryptionKey.m
+++ b/Classes/common/Encryption/FMDatabase+EncryptionKey.m
@@ -15,6 +15,7 @@
 //
 
 #import "FMDatabase+EncryptionKey.h"
+#import <sqlite3.h>
 
 #import "TDMisc.h"
 #import "CDTLogging.h"

--- a/Classes/common/touchdb/TD_Database+Insertion.m
+++ b/Classes/common/touchdb/TD_Database+Insertion.m
@@ -17,6 +17,7 @@
 //
 //  Modifications for this distribution by Cloudant, Inc., Copyright (c) 2014 Cloudant, Inc.
 
+#import <sqlite3.h>
 #import "TD_Database+Insertion.h"
 #import "TD_Database+Attachments.h"
 #import "TD_Revision.h"

--- a/Classes/common/touchdb/TD_Database.m
+++ b/Classes/common/touchdb/TD_Database.m
@@ -18,6 +18,7 @@
 //
 //  Modifications for this distribution by Cloudant, Inc., Copyright (c) 2014 Cloudant, Inc.
 
+#import <sqlite3.h>
 #import "TD_Database.h"
 #import "TD_Database+Attachments.h"
 #import "TD_Database+BlobFilenames.h"

--- a/EncryptionTests/EncryptionTests.xcodeproj/project.pbxproj
+++ b/EncryptionTests/EncryptionTests.xcodeproj/project.pbxproj
@@ -205,6 +205,7 @@
 				CD033AFD1A9BA2F600825DA9 /* Frameworks */,
 				CD033AFE1A9BA2F600825DA9 /* Resources */,
 				D6EDF3F8494B32D1818D2352 /* Copy Pods Resources */,
+				63834D71F7F4F13976360AE6 /* Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -224,6 +225,7 @@
 				CD033B0B1A9BA30400825DA9 /* Frameworks */,
 				CD033B0C1A9BA30400825DA9 /* Resources */,
 				8DC801F6E57A17E5CC9B74AE /* Copy Pods Resources */,
+				98941AE2A6C3945CA69C7B67 /* Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -290,6 +292,21 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		63834D71F7F4F13976360AE6 /* Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ios/Pods-ios-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		8BBF044129B9EE453ADF202E /* Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -333,6 +350,21 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		98941AE2A6C3945CA69C7B67 /* Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-osx/Pods-osx-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		D6EDF3F8494B32D1818D2352 /* Copy Pods Resources */ = {

--- a/Project/Project.xcodeproj/project.pbxproj
+++ b/Project/Project.xcodeproj/project.pbxproj
@@ -200,6 +200,7 @@
 				27C1CDC0184E2D9C000604EF /* Frameworks */,
 				27C1CDC1184E2D9C000604EF /* Resources */,
 				06339AAA143043BE90F2CA14 /* Copy Pods Resources */,
+				01D6DDE3A059F0A342F166B5 /* Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -284,6 +285,21 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		01D6DDE3A059F0A342F166B5 /* Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ios/Pods-ios-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		06339AAA143043BE90F2CA14 /* Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;

--- a/ReplicationAcceptance/ReplicationAcceptance.xcodeproj/project.pbxproj
+++ b/ReplicationAcceptance/ReplicationAcceptance.xcodeproj/project.pbxproj
@@ -45,8 +45,8 @@
 		984775061AB886790024B64C /* ReplicationSettings.m in Sources */ = {isa = PBXBuildFile; fileRef = 984775041AB886790024B64C /* ReplicationSettings.m */; };
 		984775081AB888F40024B64C /* ReplicationSettings.plist in Resources */ = {isa = PBXBuildFile; fileRef = 984775071AB888F40024B64C /* ReplicationSettings.plist */; };
 		984775091AB888F40024B64C /* ReplicationSettings.plist in Resources */ = {isa = PBXBuildFile; fileRef = 984775071AB888F40024B64C /* ReplicationSettings.plist */; };
-		989242BC1BA033F800FEE788 /* CDTRATestContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 989242BB1BA033F800FEE788 /* CDTRATestContext.m */; settings = {ASSET_TAGS = (); }; };
-		989242BD1BA033F800FEE788 /* CDTRATestContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 989242BB1BA033F800FEE788 /* CDTRATestContext.m */; settings = {ASSET_TAGS = (); }; };
+		989242BC1BA033F800FEE788 /* CDTRATestContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 989242BB1BA033F800FEE788 /* CDTRATestContext.m */; };
+		989242BD1BA033F800FEE788 /* CDTRATestContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 989242BB1BA033F800FEE788 /* CDTRATestContext.m */; };
 		9F8CA2C71A639AB000A0E91C /* ChangeTrackerNSURLProtocolTimedOut.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F8CA2C61A639AB000A0E91C /* ChangeTrackerNSURLProtocolTimedOut.m */; };
 		9F8CA2C81A639AB000A0E91C /* ChangeTrackerNSURLProtocolTimedOut.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F8CA2C61A639AB000A0E91C /* ChangeTrackerNSURLProtocolTimedOut.m */; };
 		9F8CA2C91A639AB000A0E91C /* ChangeTrackerNSURLProtocolTimedOut.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F8CA2C61A639AB000A0E91C /* ChangeTrackerNSURLProtocolTimedOut.m */; };
@@ -362,6 +362,7 @@
 				27A7E68718997412007FAF1C /* Resources */,
 				DA7978ED7F6244DC8D4D91B8 /* Copy Pods Resources */,
 				982BBD681ADD31FA00D2F9F1 /* Set Replication Settings */,
+				2D305AB58A79BD9C237DFF7F /* Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -382,6 +383,7 @@
 				BB7BC6BD2CC743AAAAC21269 /* Copy Pods Resources */,
 				27A7E69B1899741C007FAF1C /* Resources */,
 				9847750B1AB9CDE50024B64C /* Set replication settings */,
+				C596BD6DDB86D2C4EC48DA71 /* Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -418,6 +420,7 @@
 				27ED1093192CF8DB00F75E95 /* Frameworks */,
 				27ED1094192CF8DB00F75E95 /* Resources */,
 				4204E69A031642919A587BB0 /* Copy Pods Resources */,
+				F03629E239D182AFB450F7E3 /* Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -522,6 +525,21 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
+		2D305AB58A79BD9C237DFF7F /* Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ios/Pods-ios-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		4204E69A031642919A587BB0 /* Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -611,6 +629,21 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-osx/Pods-osx-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
+		C596BD6DDB86D2C4EC48DA71 /* Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-osx/Pods-osx-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		DA7978ED7F6244DC8D4D91B8 /* Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -624,6 +657,21 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ios/Pods-ios-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		F03629E239D182AFB450F7E3 /* Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ios/Pods-ios-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/Tests/Tests.xcodeproj/project.pbxproj
+++ b/Tests/Tests.xcodeproj/project.pbxproj
@@ -32,8 +32,8 @@
 		8E82CAB11A83C3700046DA9D /* schema6to7upgrade.touchdb in Resources */ = {isa = PBXBuildFile; fileRef = 8E82CAB01A83C3670046DA9D /* schema6to7upgrade.touchdb */; };
 		8E82CAB21A83C3700046DA9D /* schema6to7upgrade.touchdb in Resources */ = {isa = PBXBuildFile; fileRef = 8E82CAB01A83C3670046DA9D /* schema6to7upgrade.touchdb */; };
 		9823C84B1B8B1ECD00154EC5 /* CDTURLSessionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9823C84A1B8B1ECD00154EC5 /* CDTURLSessionTests.m */; };
-		985849EE1BA07741009475C9 /* CDTSessionCookieInterceptorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 985849ED1BA07741009475C9 /* CDTSessionCookieInterceptorTests.m */; settings = {ASSET_TAGS = (); }; };
-		985849EF1BA07741009475C9 /* CDTSessionCookieInterceptorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 985849ED1BA07741009475C9 /* CDTSessionCookieInterceptorTests.m */; settings = {ASSET_TAGS = (); }; };
+		985849EE1BA07741009475C9 /* CDTSessionCookieInterceptorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 985849ED1BA07741009475C9 /* CDTSessionCookieInterceptorTests.m */; };
+		985849EF1BA07741009475C9 /* CDTSessionCookieInterceptorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 985849ED1BA07741009475C9 /* CDTSessionCookieInterceptorTests.m */; };
 		985A188719D2CC54000283E9 /* CDTDatastoreEvents.m in Sources */ = {isa = PBXBuildFile; fileRef = 985A188619D2CC54000283E9 /* CDTDatastoreEvents.m */; };
 		985A188819D2CC54000283E9 /* CDTDatastoreEvents.m in Sources */ = {isa = PBXBuildFile; fileRef = 985A188619D2CC54000283E9 /* CDTDatastoreEvents.m */; };
 		985A188A19D2CCEB000283E9 /* DatastoreConflicts.m in Sources */ = {isa = PBXBuildFile; fileRef = 985A188919D2CCEB000283E9 /* DatastoreConflicts.m */; };
@@ -606,6 +606,7 @@
 				27389E09185345FD0027A404 /* Frameworks */,
 				27389E0A185345FD0027A404 /* Resources */,
 				08B95EDB86F54BC99DEF0C13 /* Copy Pods Resources */,
+				E116515A7F29B065FB7EA2BD /* Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -625,6 +626,7 @@
 				27CCEDC3187AD64F006F3C66 /* Frameworks */,
 				27CCEDC4187AD64F006F3C66 /* Resources */,
 				E63BC4B0310E42E0AC6C6072 /* Copy Pods Resources */,
+				24372F24AC89AACDD67B1172 /* Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -729,6 +731,21 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
+		24372F24AC89AACDD67B1172 /* Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-osx/Pods-osx-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		708AFFBE12E945969103B2AF /* Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -742,6 +759,21 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		E116515A7F29B065FB7EA2BD /* Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ios/Pods-ios-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		E63BC4B0310E42E0AC6C6072 /* Copy Pods Resources */ = {

--- a/Tests/Tests/DBQueryUtils.m
+++ b/Tests/Tests/DBQueryUtils.m
@@ -13,6 +13,9 @@
 //  and limitations under the License.
 
 #import "DBQueryUtils.h"
+
+#import <sqlite3.h>
+
 #import "FMResultSet.h"
 #import "FMDatabaseQueue.h"
 #import "FMDatabase.h"

--- a/Tests/Tests/DatastoreCRUD.m
+++ b/Tests/Tests/DatastoreCRUD.m
@@ -1490,15 +1490,13 @@
         XCTAssertTrue([result boolForColumn:@"current"], @"%@", [result stringForColumn:@"current"]);
         XCTAssertTrue([result boolForColumn:@"deleted"], @"%@", [result stringForColumn:@"current"]);
         XCTAssertTrue([result intForColumn:@"parent"] == 1, @"Found %@", [result intForColumn:@"parent"]);
-        
-        //TD_Database+Insertion inserts an empty NSData object instead of NSNull on delete
-        XCTAssertEqualObjects([result objectForColumnName:@"json"], [NSData data], @"Found %@", [result objectForColumnName:@"json"]);
-        error = nil;
-        jsonDoc = [TDJSON JSONObjectWithData: [result dataForColumn:@"json"]
-                                     options: TDJSONReadingMutableContainers
-                                       error: NULL];
-        XCTAssertNil(jsonDoc, @"Expected revs.json to be nil: %@",jsonDoc);
-        
+
+        // Although TD_Database+Insertion inserts an empty NSData object instead of NSNull on
+        // delete,
+        // FMDB 2.4+ returns NSNull for empty NSData when reading from the database.
+        XCTAssertEqual([result objectForColumnName:@"json"], [NSNull null], @"Found %@",
+                       [result objectForColumnName:@"json"]);
+
         //shouldn't be any more rows.
         XCTAssertFalse([result next], @"There are too many rows in revs");
         XCTAssertNil([result stringForColumn:@"doc_id"], @"after [result next], doc_id is %@", [result stringForColumn:@"doc_id"]);
@@ -1618,16 +1616,13 @@
         XCTAssertTrue([result boolForColumn:@"current"], @"%@", [result stringForColumn:@"current"]);
         XCTAssertTrue([result boolForColumn:@"deleted"], @"%@", [result stringForColumn:@"current"]);
         XCTAssertTrue([result intForColumn:@"parent"] == 2, @"Found %d", [result intForColumn:@"parent"]);
-        
-        //TD_Database+Insertion inserts an empty NSData object instead of NSNull
-        XCTAssertEqualObjects([result objectForColumnName:@"json"], [NSData data], @"Found %@", [result objectForColumnName:@"json"]);
-        
-        error = nil;
-        jsonDoc = [TDJSON JSONObjectWithData: [result dataForColumn:@"json"]
-                                     options: TDJSONReadingMutableContainers
-                                       error: &error];
-        XCTAssertNil(jsonDoc, @"Expected json dictionary to be nil: %@. Error %@",jsonDoc, error);
-        
+
+        // Although TD_Database+Insertion inserts an empty NSData object instead of NSNull on
+        // delete,
+        // FMDB 2.4+ returns NSNull for empty NSData when reading from the database.
+        XCTAssertEqual([result objectForColumnName:@"json"], [NSNull null], @"Found %@",
+                       [result objectForColumnName:@"json"]);
+
         //should be done
         XCTAssertFalse([result next], @"There are too many rows in revs");
         XCTAssertNil([result stringForColumn:@"doc_id"], @"after [result next], doc_id is %@", [result stringForColumn:@"doc_id"]);


### PR DESCRIPTION
## What
Upgrade FMDB version to 2.6

## How
- Upgrade FMDB version in podspec to 2.6
- Add Sqlite3 header to files which require it
- Fix test expectations for deleted documents in line with
  FMDB returning NSNull for Blobs of length zero.

## Reviewers
reviewer @ricellis
## Issues

FB #58943