### PR TITLE
Add iOS replication policies

### DIFF
--- a/Classes/common/CDTReplicator/CDTNSURLSessionConfigurationDelegate.h
+++ b/Classes/common/CDTReplicator/CDTNSURLSessionConfigurationDelegate.h
@@ -1,5 +1,5 @@
 //
-//  NSURLSessionConfigurationDelegate.h
+//  CDTNSURLSessionConfigurationDelegate.h
 //
 //
 //  Created by Bryn Harding.
@@ -21,7 +21,7 @@
  E.g. to enable replication only over wifi, the user could set the allowsCellularAccess attribute
  to NO.
  */
-@protocol NSURLSessionConfigurationDelegate
+@protocol CDTNSURLSessionConfigurationDelegate
 @optional
 - (nonnull NSURLSessionConfiguration*)customiseNSURLSessionConfiguration:(nonnull NSURLSessionConfiguration *)config;
 @end

--- a/Classes/common/CDTReplicator/CDTReplicator.h
+++ b/Classes/common/CDTReplicator/CDTReplicator.h
@@ -16,7 +16,7 @@
 #import <Foundation/Foundation.h>
 
 #import "CDTReplicatorDelegate.h"
-#import "NSURLSessionConfigurationDelegate.h"
+#import "CDTNSURLSessionConfigurationDelegate.h"
 
 @class CDTDatastore;
 @class TDReplicatorManager;
@@ -137,9 +137,9 @@ typedef NS_ENUM(NSInteger, CDTReplicatorState) {
  * achieved by setting the NSURLSessionConfiguration's allowsCellularAccess
  * attribute to 'NO'.
  *
- * @see NSURLSessionConfigurationDelegate
+ * @see CDTNSURLSessionConfigurationDelegate
  */
-@property (nonatomic, weak) NSObject<NSURLSessionConfigurationDelegate> *sessionConfigDelegate;
+@property (nonatomic, weak) NSObject<CDTNSURLSessionConfigurationDelegate> *sessionConfigDelegate;
 
 /**
  Returns true if the state is `CDTReplicatorStatePending`, `CDTReplicatorStateStarted` or

--- a/Classes/common/CDTReplicator/CDTReplicator.h
+++ b/Classes/common/CDTReplicator/CDTReplicator.h
@@ -161,6 +161,7 @@ typedef NS_ENUM(NSInteger, CDTReplicatorState) {
  */
 -(id)initWithTDReplicatorManager:(TDReplicatorManager*)replicatorManager
                      replication:(CDTAbstractReplication*)replication
+           sessionConfigDelegate:(NSObject<CDTNSURLSessionConfigurationDelegate> *)delegate
                            error:(NSError * __autoreleasing*)error;
 
 /*

--- a/Classes/common/CDTReplicator/CDTReplicator.h
+++ b/Classes/common/CDTReplicator/CDTReplicator.h
@@ -16,6 +16,7 @@
 #import <Foundation/Foundation.h>
 
 #import "CDTReplicatorDelegate.h"
+#import "NSURLSessionConfigurationDelegate.h"
 
 @class CDTDatastore;
 @class TDReplicatorManager;
@@ -80,6 +81,7 @@ typedef NS_ENUM(NSInteger, CDTReplicatorState) {
     CDTReplicatorStateError
 };
 
+
 /**
  A CDTReplicator instance represents a replication job.
 
@@ -125,6 +127,19 @@ typedef NS_ENUM(NSInteger, CDTReplicatorState) {
  * @see CDTReplicatorDelegate
  */
 @property (nonatomic, weak) NSObject<CDTReplicatorDelegate> *delegate;
+
+/**
+ * Set the delegate for handling customisation of the NSURLSession
+ * used during replication.
+ *
+ * This allows the setting of specific options on the NSURLSessionConfiguration
+ * to control the replication - e.g. replication only when on Wifi would be
+ * achieved by setting the NSURLSessionConfiguration's allowsCellularAccess
+ * attribute to 'NO'.
+ *
+ * @see NSURLSessionConfigurationDelegate
+ */
+@property (nonatomic, weak) NSObject<NSURLSessionConfigurationDelegate> *sessionConfigDelegate;
 
 /**
  Returns true if the state is `CDTReplicatorStatePending`, `CDTReplicatorStateStarted` or
@@ -178,9 +193,20 @@ typedef NS_ENUM(NSInteger, CDTReplicatorState) {
  * return NO. Only when in `CDTReplicatorStatePending` will replication.
  *
  * @param error the error describing a failure.
+ * @param taskGroup an optional dispatch_group_t allowing clients to wait for the completion
+ *                  of all replication tasks in the taskGroup before proceeding.
  * @return YES or NO depending on success.
  *
  * @see CDTReplicatorState
+ */
+- (BOOL)startWithError:(NSError *__autoreleasing *)error taskGroup:(nullable dispatch_group_t)taskGroup;
+
+/**
+ * Starts a replication.
+ *
+ * Calling this is the same as calling startWithError:taskGroup: with a nil taskGroup.
+ *
+ * @see startWithError:taskGroup:
  */
 - (BOOL)startWithError:(NSError *__autoreleasing *)error;
 

--- a/Classes/common/CDTReplicator/CDTReplicator.h
+++ b/Classes/common/CDTReplicator/CDTReplicator.h
@@ -185,28 +185,28 @@ typedef NS_ENUM(NSInteger, CDTReplicatorState) {
  * The replication will continue until the replication is caught up with the source database;
  * that is, until there are no current changes to replicate.
  *
- * -startWithError can be called from any thread and will immediately return. It queues its work
- * on a separate replication thread. The methods on the CDTReplicatorDelegate
+ * -startWithTaskGroup:error: can be called from any thread and will immediately return. It queues 
+ * its work on a separate replication thread. The methods on the CDTReplicatorDelegate
  * may be called from the background threads.
  *
  * A given CDTReplicator instance cannot be reused. Calling this method more than once will
  * return NO. Only when in `CDTReplicatorStatePending` will replication.
  *
- * @param error the error describing a failure.
  * @param taskGroup an optional dispatch_group_t allowing clients to wait for the completion
  *                  of all replication tasks in the taskGroup before proceeding.
+ * @param error the error describing a failure.
  * @return YES or NO depending on success.
  *
  * @see CDTReplicatorState
  */
-- (BOOL)startWithError:(NSError *__autoreleasing *)error taskGroup:(nullable dispatch_group_t)taskGroup;
+- (BOOL)startWithTaskGroup:(nullable dispatch_group_t)taskGroup error:(NSError *__autoreleasing *)error;
 
 /**
  * Starts a replication.
  *
- * Calling this is the same as calling startWithError:taskGroup: with a nil taskGroup.
+ * Calling this is the same as calling startWithTaskGroup:error: with a nil taskGroup.
  *
- * @see startWithError:taskGroup:
+ * @see startWithTaskGroup:error:
  */
 - (BOOL)startWithError:(NSError *__autoreleasing *)error;
 
@@ -239,7 +239,7 @@ typedef NS_ENUM(NSInteger, CDTReplicatorState) {
  * to stop the replication before it starts. If it cannot stop the replication, this method
  * will return NO and replication will start and progress as normal.
  *
- * If -startWithError was never called, this method will move the state from
+ * If -startWithTaskGroup:error: was never called, this method will move the state from
  * CDTRelicatorStatePending to CDTReplicatorStateStopped, inform the delegate and return YES.
  *
  *

--- a/Classes/common/CDTReplicator/CDTReplicator.m
+++ b/Classes/common/CDTReplicator/CDTReplicator.m
@@ -193,7 +193,7 @@ static NSString *const CDTReplicatorErrorDomain = @"CDTReplicatorErrorDomain";
         self.tdReplicator = [self.replicatorManager createReplicatorWithProperties:self.replConfig
                                                                              error:&localError];
 
-        // Pass the NSURLSessionConfigurationDelegate onto the TDReplicator so that the
+        // Pass the CDTNSURLSessionConfigurationDelegate onto the TDReplicator so that the
         // NSURLSession can be custom configured.
         self.tdReplicator.sessionConfigDelegate = self.sessionConfigDelegate;
 

--- a/Classes/common/CDTReplicator/CDTReplicator.m
+++ b/Classes/common/CDTReplicator/CDTReplicator.m
@@ -74,6 +74,7 @@ static NSString *const CDTReplicatorErrorDomain = @"CDTReplicatorErrorDomain";
 
 - (id)initWithTDReplicatorManager:(TDReplicatorManager *)replicatorManager
                       replication:(CDTAbstractReplication *)replication
+            sessionConfigDelegate:(NSObject<CDTNSURLSessionConfigurationDelegate> *)delegate
                             error:(NSError *__autoreleasing *)error
 {
     if (replicatorManager == nil || replication == nil) {
@@ -94,6 +95,7 @@ static NSString *const CDTReplicatorErrorDomain = @"CDTReplicatorErrorDomain";
 
         _state = CDTReplicatorStatePending;
         _started = NO;
+        _sessionConfigDelegate = delegate;
     }
     return self;
 }

--- a/Classes/common/CDTReplicator/CDTReplicator.m
+++ b/Classes/common/CDTReplicator/CDTReplicator.m
@@ -154,19 +154,20 @@ static NSString *const CDTReplicatorErrorDomain = @"CDTReplicatorErrorDomain";
 
 #pragma mark Lifecycle
 - (BOOL)startWithError:(NSError *__autoreleasing *)error {
-    return [self startWithError:error taskGroup:nil];
+    return [self startWithTaskGroup:nil error:error];
 }
 
-- (BOOL)startWithError:(NSError *__autoreleasing *)error taskGroup:(dispatch_group_t)taskGroup;
+- (BOOL)startWithTaskGroup:(dispatch_group_t)taskGroup error:(NSError *__autoreleasing *)error;
 {
     @synchronized(self)
     {
         // check both self.started and self.state. While unlikely, it is possible for -stop to
-        // be called before -startWithError. If -stop is called first on a particular instance,
-        // the resulting state will 'stopped' and the object can no longer be started at that point.
+        // be called before -startWithTaskGroup:error:. If -stop is called first on a particular
+        // instance, the resulting state will 'stopped' and the object can no longer be started at
+        // that point.
         if (self.started || self.state != CDTReplicatorStatePending) {
             CDTLogInfo(CDTREPLICATION_LOG_CONTEXT,
-                       @"-startWithError: CDTReplicator can only be started "
+                       @"-startWithTaskGroup:error: CDTReplicator can only be started "
                        @"once and only from its initial state, CDTReplicatorStatePending. "
                        @"Current State: %@",
                        [CDTReplicator stringForReplicatorState:self.state]);
@@ -180,7 +181,7 @@ static NSString *const CDTReplicatorErrorDomain = @"CDTReplicatorErrorDomain";
                                          userInfo:userInfo];
             }
             // do not change self.state or set self.error here. This is a non-fatal error since
-            // the caller has previously called -startWithError.
+            // the caller has previously called -startWithTaskGroup:error:.
 
             return NO;
         }
@@ -278,7 +279,7 @@ static NSString *const CDTReplicatorErrorDomain = @"CDTReplicatorErrorDomain";
             case CDTReplicatorStatePending:
 
                 if (self.started) {
-                    //-startWithError was called and self.tdReplicator was successfully
+                    //-startWithTaskGroup:error: was called and self.tdReplicator was successfully
                     //instantiated (otherwise state == 'error')
                     if ([self.tdReplicator cancelIfNotStarted]) {
                         self.state = CDTReplicatorStateStopped;

--- a/Classes/common/CDTReplicator/CDTReplicatorFactory.h
+++ b/Classes/common/CDTReplicator/CDTReplicatorFactory.h
@@ -71,6 +71,12 @@
 /**
  * Create a CDTReplicator object. This is the equivalent of calling
  * oneWay:sessionConfigDelegate:error: with a nil sessionConfigDelegate.
+ *
+ * @param replication a CDTPullReplication or CDTPushReplication
+ * @param error report error information
+ *
+ * @return a CDTReplicator instance which can be used to start and
+ *  stop the replication itself.
  */
 - (CDTReplicator *)oneWay:(CDTAbstractReplication *)replication
                     error:(NSError *__autoreleasing *)error;

--- a/Classes/common/CDTReplicator/CDTReplicatorFactory.h
+++ b/Classes/common/CDTReplicator/CDTReplicatorFactory.h
@@ -14,6 +14,7 @@
 //  and limitations under the License.
 
 #import <Foundation/Foundation.h>
+#import "CDTNSURLSessionConfigurationDelegate.h"
 
 @class CDTDatastore;
 @class CDTReplicator;
@@ -68,6 +69,13 @@
  */
 
 /**
+ * Create a CDTReplicator object. This is the equivalent of calling
+ * oneWay:sessionConfigDelegate:error: with a nil sessionConfigDelegate.
+ */
+- (CDTReplicator *)oneWay:(CDTAbstractReplication *)replication
+                    error:(NSError *__autoreleasing *)error;
+
+/**
  * Create a CDTReplicator object set up to replicate changes from the
  * local datastore to a remote database.
  *
@@ -76,12 +84,16 @@
  *
  * @param replication a CDTPullReplication or CDTPushReplication
  * @param error report error information
+ * @param delegate the delegate for handling customisation of the NSURLSession used during
+ *        replication.
  *
  * @return a CDTReplicator instance which can be used to start and
  *  stop the replication itself.
  */
 - (CDTReplicator *)oneWay:(CDTAbstractReplication *)replication
+    sessionConfigDelegate:(NSObject<CDTNSURLSessionConfigurationDelegate> *)delegate
                     error:(NSError *__autoreleasing *)error;
+
 
 /**
  @name Deprecated

--- a/Classes/common/CDTReplicator/CDTReplicatorFactory.m
+++ b/Classes/common/CDTReplicator/CDTReplicatorFactory.m
@@ -78,10 +78,18 @@ static NSString *const CDTReplicatorFactoryErrorDomain = @"CDTReplicatorFactoryE
 - (CDTReplicator *)oneWay:(CDTAbstractReplication *)replication
                     error:(NSError *__autoreleasing *)error
 {
+    return [self oneWay:replication sessionConfigDelegate:nil error:error];
+}
+
+- (CDTReplicator *)oneWay:(CDTAbstractReplication *)replication
+    sessionConfigDelegate:(NSObject<CDTNSURLSessionConfigurationDelegate> *)delegate
+                    error:(NSError *__autoreleasing *)error
+{
     NSError *localError;
     CDTReplicator *replicator =
         [[CDTReplicator alloc] initWithTDReplicatorManager:self.replicatorManager
                                                replication:replication
+                                     sessionConfigDelegate:delegate
                                                      error:&localError];
 
     if (replicator == nil) {

--- a/Classes/common/CDTReplicator/NSURLSessionConfigurationDelegate.h
+++ b/Classes/common/CDTReplicator/NSURLSessionConfigurationDelegate.h
@@ -1,0 +1,29 @@
+//
+//  NSURLSessionConfigurationDelegate.h
+//
+//
+//  Created by Bryn Harding.
+//  Copyright (c) 2016 IBM Corp.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+/**
+ This protocol is used to enable the customisation of the NSURLSessionConfiguration by the user.
+ This allows particular configuration options to be customised based on the client's requirements.
+ E.g. to enable replication only over wifi, the user could set the allowsCellularAccess attribute
+ to NO.
+ */
+@protocol NSURLSessionConfigurationDelegate
+@optional
+- (nonnull NSURLSessionConfiguration*)customiseNSURLSessionConfiguration:(nonnull NSURLSessionConfiguration *)config;
+@end
+
+

--- a/Classes/common/HTTP/CDTURLSession.h
+++ b/Classes/common/HTTP/CDTURLSession.h
@@ -39,9 +39,9 @@
  * @param requestInterceptors array of interceptors that should be run before each request is made.
  * @param sessionConfigDelegate the delegate used to customise the NSURLSessionConfiguration.
  **/
-- (nonnull instancetype)initWithCallbackThread:(nonnull NSThread *)thread
-                           requestInterceptors:(nullable NSArray *)requestInterceptors
-                         sessionConfigDelegate:(nullable NSObject<NSURLSessionConfigurationDelegate> *)sessionConfigDelegate  NS_DESIGNATED_INITIALIZER;
+- (nullable instancetype)initWithCallbackThread:(nonnull NSThread *)thread
+                            requestInterceptors:(nullable NSArray *)requestInterceptors
+                          sessionConfigDelegate:(nullable NSObject<NSURLSessionConfigurationDelegate> *)sessionConfigDelegate  NS_DESIGNATED_INITIALIZER;
 
 /**
  * Performs a data task for a request.

--- a/Classes/common/HTTP/CDTURLSession.h
+++ b/Classes/common/HTTP/CDTURLSession.h
@@ -70,7 +70,9 @@
 /**
  * Disassociates an NSURLSessionDataTask from any CDTURLSessionTask it was previously associated
  * with via a call to NSURLSessionDataTask:createDataTaskWithRequest:associatedWithTask:
-  *
+ * The given task is also cancelled since once it is disassociated from the CDTURLSessionTask any
+ * response will not be processed.
+ *
  * @param task The NSURLSessionDataTask to be disassociated from any CDTURLSessionTask.
  */
 - (void) disassociateTask:(nonnull NSURLSessionDataTask *)task;

--- a/Classes/common/HTTP/CDTURLSession.h
+++ b/Classes/common/HTTP/CDTURLSession.h
@@ -15,7 +15,7 @@
 #import <Foundation/Foundation.h>
 #import "CDTURLSessionTask.h"
 #import "CDTMacros.h"
-#import "NSURLSessionConfigurationDelegate.h"
+#import "CDTNSURLSessionConfigurationDelegate.h"
 
 @class CDTHTTPInterceptorContext;
 
@@ -41,7 +41,7 @@
  **/
 - (nullable instancetype)initWithCallbackThread:(nonnull NSThread *)thread
                             requestInterceptors:(nullable NSArray *)requestInterceptors
-                          sessionConfigDelegate:(nullable NSObject<NSURLSessionConfigurationDelegate> *)sessionConfigDelegate  NS_DESIGNATED_INITIALIZER;
+                          sessionConfigDelegate:(nullable NSObject<CDTNSURLSessionConfigurationDelegate> *)sessionConfigDelegate  NS_DESIGNATED_INITIALIZER;
 
 /**
  * Performs a data task for a request.

--- a/Classes/common/HTTP/CDTURLSession.h
+++ b/Classes/common/HTTP/CDTURLSession.h
@@ -15,43 +15,64 @@
 #import <Foundation/Foundation.h>
 #import "CDTURLSessionTask.h"
 #import "CDTMacros.h"
+#import "NSURLSessionConfigurationDelegate.h"
 
 @class CDTHTTPInterceptorContext;
 
-/** 
+/**
  Façade class to NSURLSession, makes completion handlers run on
  the thread which created the object.
  */
 
-@interface CDTURLSession : NSObject
+@interface CDTURLSession : NSObject <NSURLSessionDataDelegate>
 
 /**
  * Initalises a CDTURLSession without a delegate and an empty array of interceptors. Calling this 
  * method will result in completionHandlers being called on the thread which called this method.
  **/
-- (instancetype)init;
+- (nonnull instancetype)init;
 
 /**
  * Initalise a CDTURLSession.
  *
- * @param delegate an object that implements NSURLSessionDelegate protocol
- * @param thread the thread which callbacks should be run on
- * @param reuqestInterceptors array of interceptors that should be run before each request is made.
+ * @param thread the thread which callbacks should be run on.
+ * @param requestInterceptors array of interceptors that should be run before each request is made.
+ * @param sessionConfigDelegate the delegate used to customise the NSURLSessionConfiguration.
  **/
-- (instancetype)initWithDelegate:(NSObject<NSURLSessionDelegate> *)delegate
-                  callbackThread:(NSThread *)thread
-             requestInterceptors:(NSArray *)requestInterceptors NS_DESIGNATED_INITIALIZER;
+- (nonnull instancetype)initWithCallbackThread:(nonnull NSThread *)thread
+                           requestInterceptors:(nullable NSArray *)requestInterceptors
+                         sessionConfigDelegate:(nullable NSObject<NSURLSessionConfigurationDelegate> *)sessionConfigDelegate  NS_DESIGNATED_INITIALIZER;
 
 /**
  * Performs a data task for a request.
  * 
  * @param request The request to make
- * @param completionHandler A block to call when the request completes
+ * @param taskDelegate The CDTURLSessionTaskDelegate to invoke to handle responses to the request.
  *
  * @return returns a task to used the make the request. `resume` needs to be called
  * in order for the task to start making the request.
  */
-- (CDTURLSessionTask *)dataTaskWithRequest:(NSURLRequest *)request
-                         completionHandler:(void (^)(NSData *data, NSURLResponse *response, NSError *error))completionHandler;
+- (nonnull CDTURLSessionTask *)dataTaskWithRequest:(nonnull NSURLRequest *)request
+                                      taskDelegate:(nullable NSObject<CDTURLSessionTaskDelegate> *)taskDelegate;
+
+/**
+ * Creates a NSURLSessionDataTask for the given request and associates the given CDTURLSessionTask
+ * with it.
+ *
+ * @param request The request to make
+ * @param task The CDTURLSessionTask to be associated with the returned NSURLSessionDataTask.
+ *
+ * @return returns an NSURLSessionDataTask.
+ */
+- (nonnull NSURLSessionDataTask *)createDataTaskWithRequest:(nonnull NSURLRequest *)request
+                                         associatedWithTask:(nonnull CDTURLSessionTask *)task;
+
+/**
+ * Disassociates an NSURLSessionDataTask from any CDTURLSessionTask it was previously associated
+ * with via a call to NSURLSessionDataTask:createDataTaskWithRequest:associatedWithTask:
+  *
+ * @param task The NSURLSessionDataTask to be disassociated from any CDTURLSessionTask.
+ */
+- (void) disassociateTask:(nonnull NSURLSessionDataTask *)task;
 
 @end

--- a/Classes/common/HTTP/CDTURLSession.m
+++ b/Classes/common/HTTP/CDTURLSession.m
@@ -52,6 +52,9 @@
         // Create a unique session id using the address of self.
         NSString *sessionId = [NSString stringWithFormat:@"com.cloudant.sync.sessionid.%p", self];
 
+// Only compile this for iOS8.0 and above or OSX 10.10 and above
+#if (defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 80000) \
+ || (defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && __MAC_OS_X_VERSION_MAX_ALLOWED >= 101000)
         // NSURLSessionConfiguration:backgroundSessionConfigurationWithIdentifier was introduced in iOS 8.0
         // to replace backgroundSessionConfiguration which was deprecated in iOS 8.0, so use the new version if
         // available.
@@ -60,6 +63,10 @@
         } else {
             config = [NSURLSessionConfiguration backgroundSessionConfiguration:sessionId];
         }
+#else
+        config = [NSURLSessionConfiguration backgroundSessionConfiguration:sessionId];
+#endif
+
         config = [sessionConfigDelegate customiseNSURLSessionConfiguration:config];
 
         _session = [NSURLSession sessionWithConfiguration:config

--- a/Classes/common/HTTP/CDTURLSession.m
+++ b/Classes/common/HTTP/CDTURLSession.m
@@ -51,6 +51,10 @@
         NSURLSessionConfiguration *config;
         // Create a unique session id using the address of self.
         NSString *sessionId = [NSString stringWithFormat:@"com.cloudant.sync.sessionid.%p", self];
+
+        // NSURLSessionConfiguration:backgroundSessionConfigurationWithIdentifier was introduced in iOS 8.0
+        // to replace backgroundSessionConfiguration which was deprecated in iOS 8.0, so use the new version if
+        // available.
         if ([[NSURLSessionConfiguration class] respondsToSelector:@selector(backgroundSessionConfigurationWithIdentifier:)]) {
             config = [NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:sessionId];
         } else {

--- a/Classes/common/HTTP/CDTURLSession.m
+++ b/Classes/common/HTTP/CDTURLSession.m
@@ -66,6 +66,9 @@
                                                  delegate:self
                                             delegateQueue:nil];
 
+        // Configure taskMap to hold weak references to the underlying NSURLSessionDataTask objects
+        // so we don't unnecessarily hold on to objects and that values are removed from
+        // the taskMap when the NSURLSessionDataTasks are deallocated.
         _taskMap = [NSMapTable strongToWeakObjectsMapTable];
     }
     return self;

--- a/Classes/common/HTTP/CDTURLSession.m
+++ b/Classes/common/HTTP/CDTURLSession.m
@@ -84,7 +84,7 @@
 
 {
     NSURLSessionDataTask *nsURLSessionTask = [self.session dataTaskWithRequest:request];
-    [_taskMap setObject:task forKey:[NSNumber numberWithInteger:nsURLSessionTask.taskIdentifier]];
+    [self.taskMap setObject:task forKey:[NSNumber numberWithInteger:nsURLSessionTask.taskIdentifier]];
     return nsURLSessionTask;
 }
 
@@ -117,12 +117,12 @@
 
 - (CDTURLSessionTask *)getSessionTaskForId:(NSUInteger)identifier
 {
-    return [_taskMap objectForKey:[NSNumber numberWithInteger:identifier]];
+    return [self.taskMap objectForKey:[NSNumber numberWithInteger:identifier]];
 }
 
 - (void) disassociateTask:(nonnull NSURLSessionDataTask *)task
 {
-    [_taskMap removeObjectForKey:[NSNumber numberWithInteger:task.taskIdentifier]];
+    [self.taskMap removeObjectForKey:[NSNumber numberWithInteger:task.taskIdentifier]];
 }
 
 @end

--- a/Classes/common/HTTP/CDTURLSession.m
+++ b/Classes/common/HTTP/CDTURLSession.m
@@ -123,6 +123,7 @@
 - (void) disassociateTask:(nonnull NSURLSessionDataTask *)task
 {
     [self.taskMap removeObjectForKey:[NSNumber numberWithInteger:task.taskIdentifier]];
+    [task cancel];
 }
 
 @end

--- a/Classes/common/HTTP/CDTURLSession.m
+++ b/Classes/common/HTTP/CDTURLSession.m
@@ -93,7 +93,7 @@
     CDTURLSessionTask *cdtURLSessionTask = [self getSessionTaskForId:dataTask.taskIdentifier];
     data = [NSData dataWithData:data];
     MYOnThread(self.thread, ^{
-        [cdtURLSessionTask.delegate handleData:data];
+        [cdtURLSessionTask.delegate receivedData:data];
     });
 
 }

--- a/Classes/common/HTTP/CDTURLSession.m
+++ b/Classes/common/HTTP/CDTURLSession.m
@@ -40,7 +40,7 @@
 
 - (instancetype)initWithCallbackThread:(NSThread *)thread
                    requestInterceptors:(NSArray *)requestInterceptors
-                 sessionConfigDelegate:(NSObject<NSURLSessionConfigurationDelegate> *)sessionConfigDelegate
+                 sessionConfigDelegate:(NSObject<CDTNSURLSessionConfigurationDelegate> *)sessionConfigDelegate
 {
     NSParameterAssert(thread);
     self = [super init];

--- a/Classes/common/HTTP/CDTURLSession.m
+++ b/Classes/common/HTTP/CDTURLSession.m
@@ -90,7 +90,7 @@
 
 - (void)URLSession:(NSURLSession *)session dataTask:(NSURLSessionDataTask *)dataTask didReceiveData:(NSData *)data
 {
-    __strong CDTURLSessionTask *cdtURLSessionTask = [self getSessionTaskForId:dataTask.taskIdentifier];
+    CDTURLSessionTask *cdtURLSessionTask = [self getSessionTaskForId:dataTask.taskIdentifier];
     data = [NSData dataWithData:data];
     MYOnThread(self.thread, ^{
         [cdtURLSessionTask.delegate handleData:data];
@@ -100,7 +100,7 @@
 
 - (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didCompleteWithError:(NSError *)error
 {
-    __strong CDTURLSessionTask *cdtURLSessionTask = [self getSessionTaskForId:task.taskIdentifier];
+    CDTURLSessionTask *cdtURLSessionTask = [self getSessionTaskForId:task.taskIdentifier];
     if (error && cdtURLSessionTask) {
         [cdtURLSessionTask processError:error onThread:self.thread];
     }
@@ -108,7 +108,7 @@
 
 - (void)URLSession:(NSURLSession *)session dataTask:(NSURLSessionDataTask *)dataTask didReceiveResponse:(NSURLResponse *)response completionHandler:(void (^)(NSURLSessionResponseDisposition))completionHandler
 {
-    __strong CDTURLSessionTask *cdtURLSessionTask = [self getSessionTaskForId:dataTask.taskIdentifier];
+    CDTURLSessionTask *cdtURLSessionTask = [self getSessionTaskForId:dataTask.taskIdentifier];
     if (cdtURLSessionTask) {
         [cdtURLSessionTask processResponse:response onThread:self.thread];
     }

--- a/Classes/common/HTTP/CDTURLSessionTask.h
+++ b/Classes/common/HTTP/CDTURLSessionTask.h
@@ -20,9 +20,9 @@
 @class CDTURLSession;
 
 @protocol CDTURLSessionTaskDelegate
-- (void)handleData:(nullable NSData *)data;
-- (void)handleResponse:(nullable NSURLResponse *)response;
-- (void)handleError:(nullable NSError *)error;
+- (void)receivedData:(nullable NSData *)data;
+- (void)receivedResponse:(nullable NSURLResponse *)response;
+- (void)requestDidError:(nullable NSError *)error;
 @end
 
 @interface CDTURLSessionTask : NSObject

--- a/Classes/common/HTTP/CDTURLSessionTask.h
+++ b/Classes/common/HTTP/CDTURLSessionTask.h
@@ -26,11 +26,8 @@
 @end
 
 @interface CDTURLSessionTask : NSObject
-{
-    id <CDTURLSessionTaskDelegate> _delegate;
-}
 
-@property (nullable, nonatomic, strong) id delegate;
+@property (nullable, nonatomic, weak) NSObject<CDTURLSessionTaskDelegate> *delegate;
 
 /*
  * The current state of the task within the session.

--- a/Classes/common/HTTP/CDTURLSessionTask.m
+++ b/Classes/common/HTTP/CDTURLSessionTask.m
@@ -44,7 +44,7 @@
 
 @property (nonatomic) int remainingRetries;
 
-@property BOOL finished;
+@property (atomic) BOOL finished;
 
 @end
 

--- a/Classes/common/HTTP/CDTURLSessionTask.m
+++ b/Classes/common/HTTP/CDTURLSessionTask.m
@@ -92,15 +92,15 @@
     if (t) {
         [t cancel];
     }
-    _finished = YES;
+    self.finished = YES;
 }
 
 - (NSURLSessionTaskState)state
 {
     NSURLSessionTask *t = self.inProgressTask;
-    // Check _finished as we use that to guard against returning the
+    // Check finished as we use that to guard against returning the
     // NSURLSessionTask's state if we're about to retry the request.
-    if (_finished && t) {
+    if (self.finished && t) {
         return t.state;
     } else {
         return NSURLSessionTaskStateSuspended;  // essentially we're in this state until resumed.
@@ -111,7 +111,7 @@
 
 - (nonnull NSURLSessionDataTask *)makeRequest
 {
-    _finished = NO;
+    self.finished = NO;
     __block CDTHTTPInterceptorContext *ctx =
         [[CDTHTTPInterceptorContext alloc] initWithRequest:[self.request mutableCopy]];
 
@@ -181,7 +181,7 @@
         MYOnThread(thread, ^{
             [self.delegate receivedResponse:response];
         });
-        _finished = YES;
+        self.finished = YES;
     }
 }
 
@@ -203,7 +203,7 @@
         MYOnThread(thread, ^{
             [self.delegate requestDidError:error];
         });
-        _finished = YES;
+        self.finished = YES;
     }
 }
 

--- a/Classes/common/HTTP/CDTURLSessionTask.m
+++ b/Classes/common/HTTP/CDTURLSessionTask.m
@@ -179,7 +179,7 @@
         [self.inProgressTask resume];
     } else {
         MYOnThread(thread, ^{
-            [self.delegate handleResponse:response];
+            [self.delegate receivedResponse:response];
         });
         _finished = YES;
     }
@@ -201,7 +201,7 @@
         [self.inProgressTask resume];
     } else {
         MYOnThread(thread, ^{
-            [self.delegate handleError:error];
+            [self.delegate requestDidError:error];
         });
         _finished = YES;
     }

--- a/Classes/common/HTTP/CDTURLSessionTask.m
+++ b/Classes/common/HTTP/CDTURLSessionTask.m
@@ -18,6 +18,8 @@
 #import "CDTHTTPInterceptorContext.h"
 #import "CDTHTTPInterceptor.h"
 #import "CDTLogging.h"
+#import "CDTURLSession.h"
+#import "MYBlockUtils.h"
 
 @interface CDTURLSessionTask ()
 
@@ -31,7 +33,7 @@
  */
 @property (nonnull, nonatomic, strong) NSURLSessionDataTask *inProgressTask;
 
-@property NSURLSession *session;
+@property CDTURLSession *session;
 
 /**
  Request interceptors. -init... filters to only valid request interceptors
@@ -41,6 +43,8 @@
 @property (nonnull, nonatomic, strong) NSArray *responseInterceptors;
 
 @property (nonatomic) int remainingRetries;
+
+@property BOOL finished;
 
 @end
 
@@ -52,9 +56,13 @@
     return nil;
 }
 
-- (nullable instancetype)initWithSession:(NSURLSession *)session
-                                 request:(NSURLRequest *)request
-                            interceptors:(NSArray *)interceptors
+- (void) dealloc {
+    [self.session disassociateTask:self.inProgressTask];
+}
+
+- (instancetype)initWithSession:(CDTURLSession *)session
+                        request:(NSURLRequest *)request
+                   interceptors:(NSArray *)interceptors
 {
     NSParameterAssert(session);
     NSParameterAssert(request);
@@ -84,12 +92,15 @@
     if (t) {
         [t cancel];
     }
+    _finished = YES;
 }
 
 - (NSURLSessionTaskState)state
 {
     NSURLSessionTask *t = self.inProgressTask;
-    if (t) {
+    // Check _finished as we use that to guard against returning the
+    // NSURLSessionTask's state if we're about to retry the request.
+    if (_finished && t) {
         return t.state;
     } else {
         return NSURLSessionTaskStateSuspended;  // essentially we're in this state until resumed.
@@ -100,6 +111,7 @@
 
 - (nonnull NSURLSessionDataTask *)makeRequest
 {
+    _finished = NO;
     __block CDTHTTPInterceptorContext *ctx =
         [[CDTHTTPInterceptorContext alloc] initWithRequest:[self.request mutableCopy]];
 
@@ -108,27 +120,8 @@
         ctx = [obj interceptRequestInContext:ctx];
     }
 
-    __weak CDTURLSessionTask *weakSelf = self;
-    return [self.session
-        dataTaskWithRequest:ctx.request
-          completionHandler:^void(NSData *data, NSURLResponse *response, NSError *error) {
-            __strong CDTURLSessionTask *strongSelf = weakSelf;
-            if (strongSelf) {
-                ctx.response = (NSHTTPURLResponse*)response;
-                for (NSObject<CDTHTTPInterceptor> *obj in strongSelf.responseInterceptors) {
-                    ctx = [obj interceptResponseInContext:ctx];
-                }
-
-                if (ctx.shouldRetry && strongSelf.remainingRetries > 0) {
-                    // retry
-                    strongSelf.remainingRetries--;
-                    strongSelf.inProgressTask = [strongSelf makeRequest];
-                    [strongSelf.inProgressTask resume];
-                } else if (strongSelf.completionHandler) {
-                    strongSelf.completionHandler(data, response, error);
-                }
-            }
-          }];
+    return [self.session createDataTaskWithRequest:ctx.request
+                                associatedWithTask:self];
 }
 
 /**
@@ -167,6 +160,51 @@
     }
 
     return [NSArray arrayWithArray:responseInterceptors];
+}
+
+- (void)processResponse:(NSURLResponse *)response onThread:(NSThread *)thread
+{
+    __block CDTHTTPInterceptorContext *ctx =
+    [[CDTHTTPInterceptorContext alloc] initWithRequest:[self.request mutableCopy]];
+
+    ctx.response = (NSHTTPURLResponse*)response;
+    for (NSObject<CDTHTTPInterceptor> *obj in self.responseInterceptors) {
+        ctx = [obj interceptResponseInContext:ctx];
+    }
+
+    if (ctx.shouldRetry && self.remainingRetries > 0) {
+        // retry
+        self.remainingRetries--;
+        self.inProgressTask = [self makeRequest];
+        [self.inProgressTask resume];
+    } else {
+        MYOnThread(thread, ^{
+            [self.delegate handleResponse:response];
+        });
+        _finished = YES;
+    }
+}
+
+- (void)processError:(NSError *)error onThread:(NSThread *)thread
+{
+    __block CDTHTTPInterceptorContext *ctx =
+    [[CDTHTTPInterceptorContext alloc] initWithRequest:[self.request mutableCopy]];
+
+    for (NSObject<CDTHTTPInterceptor> *obj in self.responseInterceptors) {
+        ctx = [obj interceptResponseInContext:ctx];
+    }
+
+    if (ctx.shouldRetry && self.remainingRetries > 0) {
+        // retry
+        self.remainingRetries--;
+        self.inProgressTask = [self makeRequest];
+        [self.inProgressTask resume];
+    } else {
+        MYOnThread(thread, ^{
+            [self.delegate handleError:error];
+        });
+        _finished = YES;
+    }
 }
 
 @end

--- a/Classes/common/touchdb/ChangeTracker/TDURLConnectionChangeTracker.h
+++ b/Classes/common/touchdb/ChangeTracker/TDURLConnectionChangeTracker.h
@@ -8,7 +8,7 @@
 
 #import "TDChangeTracker.h"
 
-@interface TDURLConnectionChangeTracker : TDChangeTracker <NSURLSessionTaskDelegate>
+@interface TDURLConnectionChangeTracker : TDChangeTracker <NSURLSessionTaskDelegate, CDTURLSessionTaskDelegate>
 
 // used only for testing and debugging. counts the total number of retry attempts and
 // is not reset to zero with each separate request (unlike TDChangeTracker retryCount).

--- a/Classes/common/touchdb/ChangeTracker/TDURLConnectionChangeTracker.m
+++ b/Classes/common/touchdb/ChangeTracker/TDURLConnectionChangeTracker.m
@@ -229,7 +229,10 @@ didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
         //otherwise, retryOrError will set the error and stop.
         [self retryOrError:TDStatusToNSErrorWithInfo(status, self.changesFeedURL, errorInfo)];
     }
-    
+
+    if (TDStatusIsError(((NSHTTPURLResponse *)response).statusCode)) {
+        [self finishedLoading];
+    }
 }
 
 -(void)receivedData:(NSData *)data
@@ -238,6 +241,7 @@ didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
                   [self class], (unsigned long)[data length]);
     
     [self.inputBuffer appendData:data];
+    [self finishedLoading];
 }
 
 -(void) finishedLoading
@@ -286,7 +290,7 @@ didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
     
 }
 
--(void) failedWithError:(NSError *)error
+-(void) requestDidError:(NSError *)error
 {
     [self retryOrError:error];
 }
@@ -325,22 +329,6 @@ didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
     }
     
     return match;
-}
-
-- (void)handleData:(NSData *)data {
-    [self receivedData:data];
-    [self finishedLoading];
-}
-
-- (void)handleResponse:(NSURLResponse *)response {
-    [self receivedResponse:response];
-    if (TDStatusIsError(((NSHTTPURLResponse *)response).statusCode)) {
-        [self finishedLoading];
-    }
-}
-
-- (void)handleError:(NSError *)error {
-    [self failedWithError:error];
 }
 
 @end

--- a/Classes/common/touchdb/ChangeTracker/TDURLConnectionChangeTracker.m
+++ b/Classes/common/touchdb/ChangeTracker/TDURLConnectionChangeTracker.m
@@ -95,18 +95,7 @@
         }
     }
     
-    __weak TDURLConnectionChangeTracker *weakSelf = self;
-    self.task = [self.session dataTaskWithRequest:self.request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-        TDURLConnectionChangeTracker *strongSelf = weakSelf;
-        if(error){
-            [strongSelf failedWithError:error];
-            return;
-        } else {
-            [strongSelf receivedResponse:response];
-            [strongSelf receivedData:data];
-            [strongSelf finishedLoading];
-        }
-    }];
+    self.task = [self.session dataTaskWithRequest:self.request taskDelegate:self];
 
     [self.task resume];
     
@@ -336,6 +325,22 @@ didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
     }
     
     return match;
+}
+
+- (void)handleData:(NSData *)data {
+    [self receivedData:data];
+    [self finishedLoading];
+}
+
+- (void)handleResponse:(NSURLResponse *)response {
+    [self receivedResponse:response];
+    if (TDStatusIsError(((NSHTTPURLResponse *)response).statusCode)) {
+        [self finishedLoading];
+    }
+}
+
+- (void)handleError:(NSError *)error {
+    [self failedWithError:error];
 }
 
 @end

--- a/Classes/common/touchdb/TDRemoteRequest.h
+++ b/Classes/common/touchdb/TDRemoteRequest.h
@@ -18,7 +18,7 @@ typedef void (^TDRemoteRequestCompletionBlock)(id result, NSError* error);
 
 /** Asynchronous HTTP request; a fairly simple wrapper around NSURLConnection that calls a
  * completion block when ready. */
-@interface TDRemoteRequest : NSObject {
+@interface TDRemoteRequest : NSObject <CDTURLSessionTaskDelegate> {
    @protected
     NSMutableURLRequest* _request;
     id<TDAuthorizer> _authorizer;

--- a/Classes/common/touchdb/TDRemoteRequest.h
+++ b/Classes/common/touchdb/TDRemoteRequest.h
@@ -16,7 +16,7 @@
     @param error  The error, if any, else nil. */
 typedef void (^TDRemoteRequestCompletionBlock)(id result, NSError* error);
 
-/** Asynchronous HTTP request; a fairly simple wrapper around NSURLConnection that calls a
+/** Asynchronous HTTP request; a fairly simple wrapper around NSURLSession that calls a
  * completion block when ready. */
 @interface TDRemoteRequest : NSObject <CDTURLSessionTaskDelegate> {
    @protected

--- a/Classes/common/touchdb/TDRemoteRequest.m
+++ b/Classes/common/touchdb/TDRemoteRequest.m
@@ -219,7 +219,7 @@
         return NO;
     }
 }
-- (void) receivedResponse:(NSURLResponse *)response
+- (void)receivedResponse:(NSURLResponse *)response
 {
     //if we hit an error we shouldn't retry, the Http interceptors should deal with retries.
     _status = (int)((NSHTTPURLResponse *)response).statusCode;
@@ -228,7 +228,7 @@
     if (TDStatusIsError(_status)) [self cancelWithStatus:_status];
 }
 
--(void) receivedData:(NSData *)data
+- (void)receivedData:(NSData *)data
 {
     CDTLogVerbose(CDTTD_REMOTE_REQUEST_CONTEXT, @"%@: Got %lu bytes", self, (unsigned long)data.length);
 }
@@ -251,18 +251,6 @@
     CDTLogVerbose(CDTTD_REMOTE_REQUEST_CONTEXT, @"%@: Finished loading", self);
     [self clearSession];
     [self respondWithResult:self error:nil];
-}
-
-- (void)handleData:(NSData *)data {
-    [self receivedData:data];
-}
-
-- (void)handleResponse:(NSURLResponse *)response {
-    [self receivedResponse:response];
-}
-
-- (void)handleError:(NSError *)error {
-    [self requestDidError:error];
 }
 
 @end

--- a/Classes/common/touchdb/TDReplicator.h
+++ b/Classes/common/touchdb/TDReplicator.h
@@ -71,7 +71,7 @@ extern NSString* TDReplicatorStoppedNotification;
 @property (copy) NSArray* docIDs;
 @property (copy) NSDictionary* options;
 @property (nonatomic, strong,readonly) CDTURLSession *session;
-@property (nonatomic, weak) NSObject<NSURLSessionConfigurationDelegate> *sessionConfigDelegate;
+@property (nonatomic, weak) NSObject<CDTNSURLSessionConfigurationDelegate> *sessionConfigDelegate;
 
 /** Access to the replicator's NSThread execution state.*/
 /** NSThread.executing*/

--- a/Classes/common/touchdb/TDReplicator.h
+++ b/Classes/common/touchdb/TDReplicator.h
@@ -71,6 +71,7 @@ extern NSString* TDReplicatorStoppedNotification;
 @property (copy) NSArray* docIDs;
 @property (copy) NSDictionary* options;
 @property (nonatomic, strong,readonly) CDTURLSession *session;
+@property (nonatomic, weak) NSObject<NSURLSessionConfigurationDelegate> *sessionConfigDelegate;
 
 /** Access to the replicator's NSThread execution state.*/
 /** NSThread.executing*/
@@ -90,8 +91,11 @@ extern NSString* TDReplicatorStoppedNotification;
 
 /** Starts the replicator.
     Replicators run asynchronously so nothing will happen until later.
-    A replicator can only be started once; don't reuse it after it stops. */
-- (void)start;
+    A replicator can only be started once; don't reuse it after it stops.
+
+    @param taskGroup The dispatch_group_t to make the replicators part of.
+ */
+- (void)startWithTaskGroup:(dispatch_group_t)taskGroup;
 
 /** Request to stop the replicator.
     Any pending asynchronous operations will be canceled.

--- a/Classes/common/touchdb/TDReplicator.m
+++ b/Classes/common/touchdb/TDReplicator.m
@@ -215,7 +215,7 @@ NSString* TDReplicatorStartedNotification = @"TDReplicatorStarted";
     }
 }
 
-- (void) start {
+- (void) startWithTaskGroup:(dispatch_group_t)taskGroup {
     
     if(_replicatorThread){
         return;
@@ -223,9 +223,12 @@ NSString* TDReplicatorStartedNotification = @"TDReplicatorStarted";
     
     self.running = YES;
     
+    if (taskGroup) {
+        dispatch_group_enter(taskGroup);
+    }
     _replicatorThread = [[NSThread alloc] initWithTarget: self
-                                            selector: @selector(runReplicatorThread)
-                                              object: nil];
+                                                selector: @selector(runReplicatorThread:)
+                                                  object: taskGroup];
     CDTLogInfo(CDTREPLICATION_LOG_CONTEXT, @"Starting TDReplicator thread %@ ...", _replicatorThread);
     [_replicatorThread start];
     
@@ -268,10 +271,10 @@ NSString* TDReplicatorStartedNotification = @"TDReplicatorStarted";
  * Start a thread for each replicator
  * Taken from TDServer.m.
  */
-- (void) runReplicatorThread {
-    self.session = [[CDTURLSession alloc] initWithDelegate:nil
-                                            callbackThread:_replicatorThread
-                                       requestInterceptors:self.interceptors];
+- (void) runReplicatorThread:(dispatch_group_t)taskGroup {
+    self.session = [[CDTURLSession alloc] initWithCallbackThread:_replicatorThread
+                                             requestInterceptors:self.interceptors
+                                           sessionConfigDelegate:self.sessionConfigDelegate];
     @autoreleasepool {
         CDTLogInfo(CDTREPLICATION_LOG_CONTEXT, @"TDReplicator thread starting...");
         
@@ -296,6 +299,10 @@ NSString* TDReplicatorStartedNotification = @"TDReplicatorStarted";
         _db = nil;
         
         CDTLogInfo(CDTREPLICATION_LOG_CONTEXT, @"TDReplicator thread exiting");
+
+        if (taskGroup) {
+            dispatch_group_leave(taskGroup);
+        }
     }
 }
 

--- a/EncryptionTests/EncryptionTests.xcodeproj/project.pbxproj
+++ b/EncryptionTests/EncryptionTests.xcodeproj/project.pbxproj
@@ -205,7 +205,6 @@
 				CD033AFD1A9BA2F600825DA9 /* Frameworks */,
 				CD033AFE1A9BA2F600825DA9 /* Resources */,
 				D6EDF3F8494B32D1818D2352 /* Copy Pods Resources */,
-				63834D71F7F4F13976360AE6 /* Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -225,7 +224,6 @@
 				CD033B0B1A9BA30400825DA9 /* Frameworks */,
 				CD033B0C1A9BA30400825DA9 /* Resources */,
 				8DC801F6E57A17E5CC9B74AE /* Copy Pods Resources */,
-				98941AE2A6C3945CA69C7B67 /* Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -292,21 +290,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		63834D71F7F4F13976360AE6 /* Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ios/Pods-ios-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		8BBF044129B9EE453ADF202E /* Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -350,21 +333,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		98941AE2A6C3945CA69C7B67 /* Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-osx/Pods-osx-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		D6EDF3F8494B32D1818D2352 /* Copy Pods Resources */ = {

--- a/Project/Project.xcodeproj/project.pbxproj
+++ b/Project/Project.xcodeproj/project.pbxproj
@@ -200,7 +200,6 @@
 				27C1CDC0184E2D9C000604EF /* Frameworks */,
 				27C1CDC1184E2D9C000604EF /* Resources */,
 				06339AAA143043BE90F2CA14 /* Copy Pods Resources */,
-				01D6DDE3A059F0A342F166B5 /* Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -285,21 +284,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		01D6DDE3A059F0A342F166B5 /* Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ios/Pods-ios-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		06339AAA143043BE90F2CA14 /* Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;

--- a/Tests/Tests.xcodeproj/project.pbxproj
+++ b/Tests/Tests.xcodeproj/project.pbxproj
@@ -606,7 +606,6 @@
 				27389E09185345FD0027A404 /* Frameworks */,
 				27389E0A185345FD0027A404 /* Resources */,
 				08B95EDB86F54BC99DEF0C13 /* Copy Pods Resources */,
-				E116515A7F29B065FB7EA2BD /* Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -626,7 +625,6 @@
 				27CCEDC3187AD64F006F3C66 /* Frameworks */,
 				27CCEDC4187AD64F006F3C66 /* Resources */,
 				E63BC4B0310E42E0AC6C6072 /* Copy Pods Resources */,
-				24372F24AC89AACDD67B1172 /* Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -731,21 +729,6 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		24372F24AC89AACDD67B1172 /* Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-osx/Pods-osx-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		708AFFBE12E945969103B2AF /* Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -759,21 +742,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		E116515A7F29B065FB7EA2BD /* Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ios/Pods-ios-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		E63BC4B0310E42E0AC6C6072 /* Copy Pods Resources */ = {

--- a/Tests/Tests/CDTReplicationTests.m
+++ b/Tests/Tests/CDTReplicationTests.m
@@ -61,7 +61,7 @@
 
 @end
 
-@interface CDTReplicationTests : CloudantSyncTests <NSURLSessionConfigurationDelegate>
+@interface CDTReplicationTests : CloudantSyncTests <CDTNSURLSessionConfigurationDelegate>
 
 @end
 

--- a/Tests/Tests/CDTReplicationTests.m
+++ b/Tests/Tests/CDTReplicationTests.m
@@ -98,7 +98,7 @@
     OCMStub([mockedReplicator sessionConfigDelegate]).andReturn(self);
 
     dispatch_group_t taskGroup = dispatch_group_create();
-    [replicator startWithError:&error taskGroup:taskGroup];
+    [replicator startWithTaskGroup:taskGroup error:&error];
 
     dispatch_group_wait(taskGroup, DISPATCH_TIME_FOREVER);
 

--- a/Tests/Tests/CDTReplicationTests.m
+++ b/Tests/Tests/CDTReplicationTests.m
@@ -28,6 +28,8 @@
 #import "TDPusher.h"
 #import <OHHTTPStubs/OHHTTPStubs.h>
 #import <OHHTTPStubs/OHHTTPStubsResponse+JSON.h>
+#import <OCMock/OCMock.h>
+
 @interface ChangesFeedRequestCheckInterceptor : NSObject <CDTHTTPInterceptor>
 
 @property (nonatomic) BOOL changesFeedRequestMade;
@@ -59,7 +61,7 @@
 
 @end
 
-@interface CDTReplicationTests : CloudantSyncTests
+@interface CDTReplicationTests : CloudantSyncTests <NSURLSessionConfigurationDelegate>
 
 @end
 
@@ -68,11 +70,11 @@
 - (void)testFiltersWithChangesFeed
 {
     [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *__nonnull request) {
-      return YES;
+        return YES;
     }
-        withStubResponse:^OHHTTPStubsResponse *__nonnull(NSURLRequest *__nonnull request) {
-          return [OHHTTPStubsResponse responseWithJSONObject:@{} statusCode:404 headers:@{}];
-        }];
+    withStubResponse:^OHHTTPStubsResponse *__nonnull(NSURLRequest *__nonnull request) {
+        return [OHHTTPStubsResponse responseWithJSONObject:@{} statusCode:404 headers:@{}];
+    }];
 
     NSError *error;
     // we need a real live remote here, so the reachability test before the replication starts
@@ -90,13 +92,15 @@
 
     CDTReplicator *replicator = [replicatorFactory oneWay:pull error:&error];
 
-    [replicator startWithError:&error];
+    // OHHTTPStubs doesn't work with background sessions, so for the purposes
+    // of this test we'll make this a foreground session.
+    id mockedReplicator = OCMPartialMock(replicator);
+    OCMStub([mockedReplicator sessionConfigDelegate]).andReturn(self);
 
-    while (replicator.state != CDTReplicatorStateComplete &&
-           replicator.state != CDTReplicatorStateError) {
-        NSLog(@"Replicating......");
-        [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate distantFuture]];
-    }
+    dispatch_group_t taskGroup = dispatch_group_create();
+    [replicator startWithError:&error taskGroup:taskGroup];
+
+    dispatch_group_wait(taskGroup, DISPATCH_TIME_FOREVER);
 
     XCTAssertTrue(interceptor.changesFeedRequestMade);
     [OHHTTPStubs removeAllStubs];
@@ -433,6 +437,12 @@
         XCTAssertEqual(error.code, CDTReplicationErrorProhibitedOptionalHttpHeader,
                        @"Wrote error code: %@", error.code);
     }
+}
+
+- (NSURLSessionConfiguration*) customiseNSURLSessionConfiguration:(NSURLSessionConfiguration *)config
+{
+    config = [NSURLSessionConfiguration defaultSessionConfiguration];
+    return config;
 }
 
 @end

--- a/Tests/Tests/CDTURLSessionTaskTests.m
+++ b/Tests/Tests/CDTURLSessionTaskTests.m
@@ -17,6 +17,7 @@
 #import <XCTest/XCTest.h>
 #import <Foundation/Foundation.h>
 #import "CloudantSyncTests.h"
+#import "CDTURLSession.h"
 #import "CDTURLSessionTask.h"
 #import <OCMock/OCMock.h>
 
@@ -34,11 +35,14 @@
     OCMStub([(NSURLSessionDataTask *)mockedTask resume]).andDo(nil);
     OCMStub([mockedTask cancel]).andDo(nil);
 
-    NSURLSession *session = [NSURLSession
-        sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]];
+    NSThread *thread = [[NSThread alloc] init];
+    CDTURLSession *session = [[CDTURLSession alloc] initWithCallbackThread:thread
+                                                       requestInterceptors:nil
+                                                     sessionConfigDelegate:nil];
     id mockedSession = OCMPartialMock(session);
-    OCMStub([mockedSession dataTaskWithRequest:[OCMArg any] completionHandler:[OCMArg any]])
+    OCMStub([mockedSession createDataTaskWithRequest:[OCMArg any] associatedWithTask:[OCMArg any]])
         .andReturn(mockedTask);
+    OCMStub([mockedSession disassociateTask:[OCMArg any]]).andDo(nil);
 
     NSURLRequest *r = [NSURLRequest requestWithURL:[NSURL URLWithString:@"http://localhost"]];
 

--- a/Tests/Tests/CDTURLSessionTests.m
+++ b/Tests/Tests/CDTURLSessionTests.m
@@ -98,7 +98,7 @@
 
 @end
 
-@interface CDTURLSessionTests : CloudantSyncTests <NSURLSessionConfigurationDelegate>
+@interface CDTURLSessionTests : CloudantSyncTests <CDTNSURLSessionConfigurationDelegate>
 
 @end
 

--- a/Tests/Tests/CDTURLSessionTests.m
+++ b/Tests/Tests/CDTURLSessionTests.m
@@ -73,9 +73,9 @@
 
 - (instancetype)init
 {
-    return [self initWithNumberOfRetires:1];
+    return [self initWithNumberOfRetries:1];
 }
-- (instancetype)initWithNumberOfRetires:(int)retries
+- (instancetype)initWithNumberOfRetries:(int)retries
 {
     self = [super init];
     if (self) {
@@ -98,7 +98,7 @@
 
 @end
 
-@interface CDTURLSessionTests : CloudantSyncTests
+@interface CDTURLSessionTests : CloudantSyncTests <NSURLSessionConfigurationDelegate>
 
 @end
 
@@ -126,14 +126,14 @@
 {
     CDTCountingHTTPRequestInterceptor *countingInterceptor =
         [[CDTCountingHTTPRequestInterceptor alloc] init];
-    CDTURLSession *session = [[CDTURLSession alloc] initWithDelegate:nil
-                                                      callbackThread:[NSThread currentThread]
-                                                 requestInterceptors:@[ countingInterceptor ]];
+    CDTURLSession *session = [[CDTURLSession alloc] initWithCallbackThread:[NSThread currentThread]
+                                                       requestInterceptors:@[ countingInterceptor ]
+                                                     sessionConfigDelegate:self];
 
     NSURLRequest *request =
         [NSURLRequest requestWithURL:[NSURL URLWithString:@"http://localhost:5984"]];
 
-    CDTURLSessionTask *task = [session dataTaskWithRequest:request completionHandler:nil];
+    CDTURLSessionTask *task = [session dataTaskWithRequest:request taskDelegate:nil];
 
     XCTAssertEqual(task.requestInterceptors.count, 1);
     XCTAssertEqual(task.requestInterceptors[0], countingInterceptor);
@@ -146,14 +146,14 @@
 {
     CDTCountingHTTPRequestInterceptor *countingInterceptor =
         [[CDTCountingHTTPRequestInterceptor alloc] init];
-    CDTURLSession *session = [[CDTURLSession alloc] initWithDelegate:nil
-                                                      callbackThread:[NSThread currentThread]
-                                                 requestInterceptors:@[ countingInterceptor ]];
+    CDTURLSession *session = [[CDTURLSession alloc] initWithCallbackThread:[NSThread currentThread]
+                                                       requestInterceptors:@[ countingInterceptor ]
+                                                     sessionConfigDelegate:self];
 
     NSURLRequest *request =
         [NSURLRequest requestWithURL:[NSURL URLWithString:@"http://localhost:5984"]];
 
-    CDTURLSessionTask *task = [session dataTaskWithRequest:request completionHandler:nil];
+    CDTURLSessionTask *task = [session dataTaskWithRequest:request taskDelegate:nil];
 
     [task resume];
 
@@ -168,14 +168,14 @@
 - (void)testInterceptorsCanRetryRequests
 {
     CDTRetryingHTTPInterceptor *replayingInterceptor = [[CDTRetryingHTTPInterceptor alloc] init];
-    CDTURLSession *session = [[CDTURLSession alloc] initWithDelegate:nil
-                                                      callbackThread:[NSThread currentThread]
-                                                 requestInterceptors:@[ replayingInterceptor ]];
+    CDTURLSession *session = [[CDTURLSession alloc] initWithCallbackThread:[NSThread currentThread]
+                                                       requestInterceptors:@[ replayingInterceptor ]
+                                                     sessionConfigDelegate:self];
 
     NSURLRequest *request =
         [NSURLRequest requestWithURL:[NSURL URLWithString:@"http://localhost:5984"]];
 
-    CDTURLSessionTask *task = [session dataTaskWithRequest:request completionHandler:nil];
+    CDTURLSessionTask *task = [session dataTaskWithRequest:request taskDelegate:nil];
 
     XCTAssertEqual(task.responseInterceptors.count, 1);
     XCTAssertEqual(task.responseInterceptors[0], replayingInterceptor);
@@ -191,15 +191,15 @@
 - (void)testMaxNumberOfRetriesEnforced
 {
     CDTRetryingHTTPInterceptor *replayingInterceptor =
-        [[CDTRetryingHTTPInterceptor alloc] initWithNumberOfRetires:1000000];
-    CDTURLSession *session = [[CDTURLSession alloc] initWithDelegate:nil
-                                                      callbackThread:[NSThread currentThread]
-                                                 requestInterceptors:@[ replayingInterceptor ]];
+        [[CDTRetryingHTTPInterceptor alloc] initWithNumberOfRetries:1000000];
+    CDTURLSession *session = [[CDTURLSession alloc] initWithCallbackThread:[NSThread currentThread]
+                                                       requestInterceptors:@[ replayingInterceptor ]
+                                                     sessionConfigDelegate:self];
 
     NSURLRequest *request =
         [NSURLRequest requestWithURL:[NSURL URLWithString:@"http://localhost:5984"]];
 
-    CDTURLSessionTask *task = [session dataTaskWithRequest:request completionHandler:nil];
+    CDTURLSessionTask *task = [session dataTaskWithRequest:request taskDelegate:nil];
 
     XCTAssertEqual(task.responseInterceptors.count, 1);
     XCTAssertEqual(task.responseInterceptors[0], replayingInterceptor);
@@ -211,6 +211,12 @@
     }
     // it should be called 11 times because we retry a request 10 times making 11 reqests in total
     XCTAssertEqual(replayingInterceptor.timesCalled, 11);
+}
+
+- (NSURLSessionConfiguration*)customiseNSURLSessionConfiguration:(nonnull NSURLSessionConfiguration *)config
+{
+    config.timeoutIntervalForResource=1.0;
+    return config;
 }
 
 @end


### PR DESCRIPTION
This is part 1 of a 3 part change to implement replication policies. Each of the 3 parts of the implementation of replication policies is in a separate branch.

_The following text is common to all 3 PRs._

The 3 branches include:
1. _replication-policies-1_: The main code changes implementing replication policies on iOS.
2. _replication-policies-2-doc_: Documentation updates.
3. _replication-policies-3-sample-project_: Updates to the sample project to add periodic replication when on WiFi.

_What?_
Add mechanism to enable users to more easily specify the circumstances under which they want replication to occur. This allows relatively simple definition of policies within the constraints of [iOS background execution](https://developer.apple.com/library/ios/documentation/iPhone/Conceptual/iPhoneOSProgrammingGuide/BackgroundExecution/BackgroundExecution.html) - e.g.:
* Do a pull replication every 2 hours;
* Do a full sync every hour, but only when we have a Wifi connection;

_Why?_
Prior to this PR, it was more complicated to implement such policies and replication when the app was suspended was not supported. This aims to update the code to allow it to support the relatively simple configuration of policies by the user.

_How?_
We need the replication policy management to work within the strict constraints of iOS and to allow background transfers while the app is suspended. This requires that data transfers between the device and server are performed using background sessions.

The code has therefore been modified to configure the `NSURLSession` using a background session configuration. Background session configurations must use delegates to process responses rather than completion handlers and corresponding changes have therefore been made in the code, making `CDTURLSession` the delegate handling the responses.

`CDTURLSession` stores a mapping of the unique identifiers of `NSURLSessionTask` objects to their corresponding `CDTURLSessionTask` objects so that processing of the responses can be further delegated to the `CDTURLSessionTask` that sent the corresponding request.

The new `NSURLSessionConfigurationDelegate` allows a delegate to be set that enables the user to configure aspects of the `NSURLSessionConfiguration` - e.g. setting the `allowsCellularAccess` property to enable/disable use of the cellular data connection.

See the [Replication Policies User Guide](https://github.com/cloudant/CDTDatastore/blob/replication-policies-2-doc/doc/replication-policies.md) for further information on how replication policies are implemented.

reviewer @rhyshort
reviewer @tomblench