### PR TITLE
Update sample project.

### DIFF
--- a/Project/Project.xcodeproj/project.pbxproj
+++ b/Project/Project.xcodeproj/project.pbxproj
@@ -49,7 +49,7 @@
 		27C1CDCA184E2D9C000604EF /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		27C1CDCE184E2D9C000604EF /* Project-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Project-Info.plist"; sourceTree = "<group>"; };
 		27C1CDD0184E2D9C000604EF /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		27C1CDD2184E2D9C000604EF /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; tabWidth = 5; };
+		27C1CDD2184E2D9C000604EF /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		27C1CDD4184E2D9C000604EF /* Project-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Project-Prefix.pch"; sourceTree = "<group>"; };
 		27C1CDD5184E2D9C000604EF /* CDTAppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CDTAppDelegate.h; sourceTree = "<group>"; };
 		27C1CDD6184E2D9C000604EF /* CDTAppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CDTAppDelegate.m; sourceTree = "<group>"; };

--- a/Project/Project.xcodeproj/project.pbxproj
+++ b/Project/Project.xcodeproj/project.pbxproj
@@ -49,7 +49,7 @@
 		27C1CDCA184E2D9C000604EF /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		27C1CDCE184E2D9C000604EF /* Project-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Project-Info.plist"; sourceTree = "<group>"; };
 		27C1CDD0184E2D9C000604EF /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		27C1CDD2184E2D9C000604EF /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		27C1CDD2184E2D9C000604EF /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; tabWidth = 5; };
 		27C1CDD4184E2D9C000604EF /* Project-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Project-Prefix.pch"; sourceTree = "<group>"; };
 		27C1CDD5184E2D9C000604EF /* CDTAppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CDTAppDelegate.h; sourceTree = "<group>"; };
 		27C1CDD6184E2D9C000604EF /* CDTAppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CDTAppDelegate.m; sourceTree = "<group>"; };
@@ -200,7 +200,6 @@
 				27C1CDC0184E2D9C000604EF /* Frameworks */,
 				27C1CDC1184E2D9C000604EF /* Resources */,
 				06339AAA143043BE90F2CA14 /* Copy Pods Resources */,
-				01D6DDE3A059F0A342F166B5 /* Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -285,21 +284,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		01D6DDE3A059F0A342F166B5 /* Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ios/Pods-ios-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		06339AAA143043BE90F2CA14 /* Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;

--- a/Project/Project/CDTAppDelegate.m
+++ b/Project/Project/CDTAppDelegate.m
@@ -144,9 +144,9 @@
 
 - (void)application:(UIApplication *)application performFetchWithCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler
 {
-    [self.todoReplicator syncInBackgroundWithCompletionHandler:nil];
-
-    completionHandler(UIBackgroundFetchResultNewData);
+    [self.todoReplicator syncInBackgroundWithCompletionHandler:^{
+        completionHandler(UIBackgroundFetchResultNewData);
+    }];
 }
 
 @end

--- a/Project/Project/CDTAppDelegate.m
+++ b/Project/Project/CDTAppDelegate.m
@@ -50,6 +50,9 @@
 
     self.todoReplicator = [[CDTTodoReplicator alloc] init];
     
+    int backgroundInterval24hrs = 24*60*60;
+    [[UIApplication sharedApplication] setMinimumBackgroundFetchInterval:backgroundInterval24hrs];
+
     return YES;
 }
 							
@@ -137,6 +140,13 @@
 
     return datastore;
 
+}
+
+- (void)application:(UIApplication *)application performFetchWithCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler
+{
+    [self.todoReplicator syncInBackgroundWithCompletionHandler:nil];
+
+    completionHandler(UIBackgroundFetchResultNewData);
 }
 
 @end

--- a/Project/Project/CDTTodoReplicator.h
+++ b/Project/Project/CDTTodoReplicator.h
@@ -18,8 +18,8 @@
 
 #import <CloudantSync.h>
 
-@interface CDTTodoReplicator : NSObject<CDTReplicatorDelegate>
+@interface CDTTodoReplicator : NSObject<CDTReplicatorDelegate, NSURLSessionConfigurationDelegate>
 
--(void)sync;
+- (void)syncInBackgroundWithCompletionHandler:(void (^)())completionHandler;
 
 @end

--- a/Project/Project/CDTTodoReplicator.m
+++ b/Project/Project/CDTTodoReplicator.m
@@ -74,7 +74,7 @@
         [self pullReplication:backgroundTasks];
         [self pushReplication:backgroundTasks];
 
-        dispatch_group_wait(backgroundTasks, dispatch_time(DISPATCH_TIME_NOW, 30000000000));
+        dispatch_group_wait(backgroundTasks, dispatch_time(DISPATCH_TIME_NOW, 30 * NSEC_PER_SEC));
         if (completionHandler) {
             completionHandler();
         }

--- a/Project/Project/CDTViewController.m
+++ b/Project/Project/CDTViewController.m
@@ -167,8 +167,10 @@
 -(IBAction)replicateTapped:(id)sender {
     NSLog(@"Replicate");
 
+    __weak CDTViewController *weakSelf = self;
     [self.todoReplicator syncInBackgroundWithCompletionHandler:^{
-        [self toggleCompletedShown:nil];
+        __strong CDTViewController *strongSelf = weakSelf;
+        [strongSelf toggleCompletedShown:nil];
     }];
 }
 
@@ -356,8 +358,10 @@
 
 - (void)periodicReplication:(NSTimer *)timer
 {
+    __weak CDTViewController *weakSelf = self;
     [self.todoReplicator syncInBackgroundWithCompletionHandler:^{
-        [self performSelectorOnMainThread:@selector(refresh) withObject:nil waitUntilDone:false];
+        __strong CDTViewController *strongSelf = weakSelf;
+        [strongSelf performSelectorOnMainThread:@selector(refresh) withObject:nil waitUntilDone:false];
     }];
 }
 

--- a/Project/Project/CDTViewController.m
+++ b/Project/Project/CDTViewController.m
@@ -27,6 +27,7 @@
 @property (readonly) CDTTodoReplicator *todoReplicator;
 @property (nonatomic, strong) NSArray *todoList;
 @property (nonatomic,readonly) BOOL showOnlyCompleted;
+@property (nonatomic, strong) NSTimer *timer;
 
 @property (nonatomic,weak) UISegmentedControl *showCompletedSegmentedControl;
 
@@ -43,6 +44,12 @@
 
     [self reloadTasks];
     [self.tableView reloadData];
+
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(stopTimer:) name:UIApplicationWillResignActiveNotification object:nil];
+
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(startTimer:) name:UIApplicationWillEnterForegroundNotification object:nil];
+
+    [self startTimer:self];
 }
 
 #pragma mark Data managment
@@ -160,13 +167,9 @@
 -(IBAction)replicateTapped:(id)sender {
     NSLog(@"Replicate");
 
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        [self.todoReplicator sync];
-        dispatch_async(dispatch_get_main_queue(), ^{
-            [self reloadTasks];
-            [self.tableView reloadData];
-        });
-    });
+    [self.todoReplicator syncInBackgroundWithCompletionHandler:^{
+        [self toggleCompletedShown:nil];
+    }];
 }
 
 /**
@@ -349,6 +352,31 @@
     }
     
     [self.tableView endUpdates];
+}
+
+- (void)periodicReplication:(NSTimer *)timer
+{
+    [self.todoReplicator syncInBackgroundWithCompletionHandler:^{
+        [self performSelectorOnMainThread:@selector(refresh) withObject:nil waitUntilDone:false];
+    }];
+}
+
+- (void)startTimer:(id)sender {
+    _timer = [NSTimer scheduledTimerWithTimeInterval:5*60
+                                              target:self
+                                            selector:@selector(periodicReplication:)
+                                            userInfo:nil
+                                             repeats:YES];
+}
+
+- (void)stopTimer:(id)sender {
+    [_timer invalidate];
+    _timer = nil;
+}
+
+- (void)refresh {
+    [self reloadTasks];
+    [self.tableView reloadData];
 }
 
 

--- a/Project/Project/Project-Info.plist
+++ b/Project/Project/Project-Info.plist
@@ -40,18 +40,5 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>NSAppTransportSecurity</key>
-	<dict>
-		<key>NSExceptionDomains</key>
-		<dict>
-			<key>cloudant.com</key>
-			<dict>
-				<key>NSIncludesSubdomains</key>
-				<true/>
-				<key>NSExceptionRequiresForwardSecrecy</key>
-				<false/>
-			</dict>
-		</dict>
-	</dict>
 </dict>
 </plist>

--- a/Project/Project/Project-Info.plist
+++ b/Project/Project/Project-Info.plist
@@ -24,6 +24,10 @@
 	<string>1.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>fetch</string>
+	</array>
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
 	<key>UIRequiredDeviceCapabilities</key>
@@ -36,5 +40,18 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>cloudant.com</key>
+			<dict>
+				<key>NSIncludesSubdomains</key>
+				<true/>
+				<key>NSExceptionRequiresForwardSecrecy</key>
+				<false/>
+			</dict>
+		</dict>
+	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
This is part 3 of a 3 part change to implement replication policies. Each of the 3 parts of the implementation of replication policies is in a separate branch.

_The following text is common to all 3 PRs._

The 3 branches include:
1. _replication-policies-1_: The main code changes implementing replication policies on iOS.
2. _replication-policies-2-doc_: Documentation updates.
3. _replication-policies-3-sample-project_: Updates to the sample project to add periodic replication when on WiFi.

_What?_
Add mechanism to enable users to more easily specify the circumstances under which they want replication to occur. This allows relatively simple definition of policies within the constraints of [iOS background execution](https://developer.apple.com/library/ios/documentation/iPhone/Conceptual/iPhoneOSProgrammingGuide/BackgroundExecution/BackgroundExecution.html) - e.g.:
* Do a pull replication every 2 hours;
* Do a full sync every hour, but only when we have a Wifi connection;

_Why?_
Prior to this PR, it was more complicated to implement such policies and replication when the app was suspended was not supported. This aims to update the code to allow it to support the relatively simple configuration of policies by the user.

_How?_
We need the replication policy management to work within the strict constraints of iOS and to allow background transfers while the app is suspended. This requires that data transfers between the device and server are performed using background sessions.

The code has therefore been modified to configure the `NSURLSession` using a background session configuration. Background session configurations must use delegates to process responses rather than completion handlers and corresponding changes have therefore been made in the code, making `CDTURLSession` the delegate handling the responses.

`CDTURLSession` stores a mapping of the unique identifiers of `NSURLSessionTask` objects to their corresponding `CDTURLSessionTask` objects so that processing of the responses can be further delegated to the `CDTURLSessionTask` that sent the corresponding request.

The new `NSURLSessionConfigurationDelegate` allows a delegate to be set that enables the user to configure aspects of the `NSURLSessionConfiguration` - e.g. setting the `allowsCellularAccess` property to enable/disable use of the cellular data connection.

See the [Replication Policies User Guide](https://github.com/cloudant/CDTDatastore/blob/replication-policies-2-doc/doc/replication-policies.md) for further information on how replication policies are implemented.

reviewer @rhyshort
reviewer @tomblench