### PR TITLE
Add Nullability annotations to public API

### DIFF
--- a/CDTDatastore/Attachments/CDTAttachment.h
+++ b/CDTDatastore/Attachments/CDTAttachment.h
@@ -43,19 +43,19 @@
 @interface CDTAttachment : NSObject
 
 // common
-@property (nonatomic, strong, readonly) NSString *name;
+@property (nonnull, nonatomic, strong, readonly) NSString *name;
 
 /** Mimetype string */
-@property (nonatomic, strong, readonly) NSString *type;
+@property (nonnull, nonatomic, strong, readonly) NSString *type;
 
 /* Size in bytes, may be -1 if not known (e.g., HTTP URL for new attachment) */
 @property (nonatomic, readonly) NSInteger size;
 
 /** Subclasses should call this to initialise instance vars */
-- (instancetype)initWithName:(NSString *)name type:(NSString *)type size:(NSInteger)size;
+- (nullable instancetype)initWithName:(nonnull NSString *)name type:(nonnull NSString *)type size:(NSInteger)size;
 
 /** Get unopened input stream for this attachment */
-- (NSData *)dataFromAttachmentContent;
+- (nullable NSData *)dataFromAttachmentContent;
 
 @end
 
@@ -72,15 +72,15 @@
 @property (nonatomic, readonly) TDAttachmentEncoding encoding;
 
 /** sha of file, used for file path on disk. */
-@property (nonatomic, readonly) NSData *key;
+@property (nonnull, nonatomic, readonly) NSData *key;
 
-- (instancetype)initWithBlob:(id<CDTBlobReader>)blob
-                        name:(NSString *)name
-                        type:(NSString *)type
+- (nullable instancetype)initWithBlob:(nonnull id<CDTBlobReader>)blob
+                        name:(nonnull NSString *)name
+                        type:(nonnull NSString *)type
                         size:(NSInteger)size
                       revpos:(NSInteger)revpos
                     sequence:(SequenceNumber)sequence
-                         key:(NSData *)keyData
+                         key:(nonnull NSData *)keyData
                     encoding:(TDAttachmentEncoding)encoding;
 
 @end
@@ -95,7 +95,7 @@
  Create a new unsaved attachment using an NSData instance
  as the source of attachment data.
  */
-- (instancetype)initWithData:(NSData *)data name:(NSString *)name type:(NSString *)type;
+- (nullable instancetype)initWithData:(nonnull NSData *)data name:(nonnull NSString *)name type:(nonnull NSString *)type;
 
 @end
 
@@ -105,7 +105,7 @@
  */
 @interface CDTUnsavedFileAttachment : CDTAttachment
 
-- (instancetype)initWithPath:(NSString *)filePath name:(NSString *)name type:(NSString *)type;
+- (nullable instancetype)initWithPath:(nonnull NSString *)filePath name:(nonnull NSString *)name type:(nonnull NSString *)type;
 
 @end
 
@@ -122,10 +122,10 @@
  @param error will point to an NSError object in case of error
 
  */
-+ (CDTSavedHTTPAttachment *)createAttachmentWithName:(NSString *)name
-                                            JSONData:(NSDictionary *)jsonData
-                                       attachmentURL:(NSURL *)attachmentURL
-                                               error:(NSError *__autoreleasing *)error;
++ (nullable CDTSavedHTTPAttachment *)createAttachmentWithName:(nonnull NSString *)name
+                                            JSONData:(nonnull NSDictionary *)jsonData
+                                       attachmentURL:(nonnull NSURL *)attachmentURL
+                                               error:(NSError *__autoreleasing __nullable  * __nullable )error;
 /**
 
  Creates an attachment that represents a remote HTTP accessed attachment
@@ -137,11 +137,11 @@
  @param data attschment data if it has already been downloaded
 
  */
-- (id)initWithDocumentURL:(NSURL *)attachmentURL
-                     name:(NSString *)name
-                     type:(NSString *)type
+- (nullable instancetype)initWithDocumentURL:(nonnull NSURL *)attachmentURL
+                     name:(nonnull NSString *)name
+                     type:(nonnull NSString *)type
                      size:(NSInteger)size
-                     data:(NSData *)data;
+                     data:(nullable NSData *)data;
 
 /**
 
@@ -153,5 +153,5 @@
  @return the attachments data
 
  */
-- (NSData *)dataFromAttachmentContent;
+- (nullable NSData *)dataFromAttachmentContent;
 @end

--- a/CDTDatastore/CDTConflictResolver.h
+++ b/CDTDatastore/CDTConflictResolver.h
@@ -61,6 +61,6 @@
  + *         currently is (i.e., leave the database unchanged).
  *
  */
-- (CDTDocumentRevision *)resolve:(NSString *)docId conflicts:(NSArray *)conflicts;
+- (nullable CDTDocumentRevision *)resolve:(nonnull NSString *)docId conflicts:(nonnull NSArray<CDTDocumentRevision*> *)conflicts;
 
 @end

--- a/CDTDatastore/CDTDatastore+Conflicts.h
+++ b/CDTDatastore/CDTDatastore+Conflicts.h
@@ -23,7 +23,7 @@
  *
  * @return an array of NSString* document ids.
  */
-- (NSArray *)getConflictedDocumentIds;
+- (nonnull NSArray *)getConflictedDocumentIds;
 
 /**
  Resolve conflicts for a specific document using an object that conforms to the
@@ -57,8 +57,8 @@
 
  @see CDTConflictResolver
  */
-- (BOOL)resolveConflictsForDocument:(NSString *)docId
-                           resolver:(NSObject<CDTConflictResolver> *)resolver
-                              error:(NSError *__autoreleasing *)error;
+- (BOOL)resolveConflictsForDocument:(nonnull NSString *)docId
+                           resolver:(nonnull NSObject<CDTConflictResolver> *)resolver
+                              error:(NSError *__autoreleasing __nullable * __nullable)error;
 
 @end

--- a/CDTDatastore/CDTDatastore.h
+++ b/CDTDatastore/CDTDatastore.h
@@ -26,7 +26,7 @@
   - @"source": NSURL of remote db pulled from,
   - @"winner": new winning CDTDocumentRevision, _if_ it changed (often same as rev).
  */
-extern NSString *const CDTDatastoreChangeNotification;
+extern NSString * __nonnull const CDTDatastoreChangeNotification;
 
 @class TD_Database;
 
@@ -66,9 +66,9 @@ extern NSString *const CDTDatastoreChangeNotification;
  */
 @interface CDTDatastore : NSObject
 
-@property (nonatomic, strong, readonly) TD_Database *database;
+@property (nonnull, nonatomic, strong, readonly) TD_Database *database;
 
-+ (NSString *)versionString;
++ (nonnull NSString *)versionString;
 
 /**
  *
@@ -78,7 +78,7 @@ extern NSString *const CDTDatastoreChangeNotification;
  * @param database the database where this datastore should save documents
  *
  */
-- (instancetype)initWithManager:(CDTDatastoreManager *)manager database:(TD_Database *)database;
+- (nullable instancetype)initWithManager:(nonnull CDTDatastoreManager *)manager database:(nonnull TD_Database *)database;
 
 /**
  * The number of document in the datastore.
@@ -88,12 +88,12 @@ extern NSString *const CDTDatastoreChangeNotification;
 /**
  * The name of the datastore.
  */
-@property (readonly) NSString *name;
+@property (nonnull, readonly) NSString *name;
 
 /**
  * The name of the datastore.
  */
-@property (readonly) NSString *extensionsDir;
+@property (nonnull, readonly) NSString *extensionsDir;
 
 /**
  * Returns a document's current winning revision.
@@ -103,8 +103,8 @@ extern NSString *const CDTDatastoreChangeNotification;
  *
  * @return current revision as CDTDocumentRevision of given document
  */
-- (CDTDocumentRevision *)getDocumentWithId:(NSString *)docId
-                                     error:(NSError *__autoreleasing *)error;
+- (nullable CDTDocumentRevision *)getDocumentWithId:(nonnull NSString *)docId
+                                     error:(NSError *__autoreleasing __nullable * __nullable)error;
 
 /**
  * Return a specific revision of a document.
@@ -120,9 +120,9 @@ extern NSString *const CDTDatastoreChangeNotification;
  * @return specified CDTDocumentRevision of the document for given
  *     document id or nil if it doesn't exist
  */
-- (CDTDocumentRevision *)getDocumentWithId:(NSString *)docId
-                                       rev:(NSString *)rev
-                                     error:(NSError *__autoreleasing *)error;
+- (nullable CDTDocumentRevision *)getDocumentWithId:(nonnull NSString *)docId
+                                       rev:(nullable NSString *)rev
+                                     error:(NSError *__autoreleasing __nullable *  __nullable)error;
 
 /**
  * Unpaginated read of all documents.
@@ -133,7 +133,7 @@ extern NSString *const CDTDatastoreChangeNotification;
  *
  * @return NSArray of CDTDocumentRevisions
  */
-- (NSArray *)getAllDocuments;
+- (nonnull NSArray<CDTDocumentRevision*> *)getAllDocuments;
 
 /**
  * Enumerates the current winning revision for all documents in the
@@ -141,7 +141,7 @@ extern NSString *const CDTDatastoreChangeNotification;
  *
  * @return NSArray of NSStrings
  */
-- (NSArray *)getAllDocumentIds;
+- (nonnull NSArray<NSString*> *)getAllDocumentIds;
 
 /**
  * Enumerate the current winning revisions for all documents in the
@@ -160,7 +160,7 @@ extern NSString *const CDTDatastoreChangeNotification;
  * @param descending ordered descending if true, otherwise ascendingly
  * @return NSArray containing CDTDocumentRevision objects
  */
-- (NSArray *)getAllDocumentsOffset:(NSUInteger)offset
+- (nonnull NSArray<CDTDocumentRevision*> *)getAllDocumentsOffset:(NSUInteger)offset
                              limit:(NSUInteger)limit
                         descending:(BOOL)descending;
 
@@ -171,7 +171,7 @@ extern NSString *const CDTDatastoreChangeNotification;
  *
  * @return NSArray containing CDTDocumentRevision objects
  */
-- (NSArray *)getDocumentsWithIds:(NSArray *)docIds;
+- (nonnull NSArray<CDTDocumentRevision*> *)getDocumentsWithIds:(nonnull NSArray *)docIds;
 
 /**
  * Returns the history of revisions for the passed revision.
@@ -182,7 +182,7 @@ extern NSString *const CDTDatastoreChangeNotification;
  * Older revisions will not contain the document data as it will have
  * been compacted away.
  */
-- (NSArray *)getRevisionHistory:(CDTDocumentRevision *)revision;
+- (nonnull NSArray<CDTDocumentRevision*> *)getRevisionHistory:(nonnull CDTDocumentRevision *)revision;
 
 /**
  * Return a directory for an extension to store its data for this CDTDatastore.
@@ -191,7 +191,7 @@ extern NSString *const CDTDatastoreChangeNotification;
  *
  * @return the directory for specified extensionName
  */
-- (NSString *)extensionDataFolder:(NSString *)extensionName;
+- (nonnull NSString *)extensionDataFolder:(nonnull NSString *)extensionName;
 
 #pragma mark API V2
 /**
@@ -202,8 +202,8 @@ extern NSString *const CDTDatastoreChangeNotification;
  *
  * @return document revision created
  */
-- (CDTDocumentRevision *)createDocumentFromRevision:(CDTDocumentRevision *)revision
-                                              error:(NSError *__autoreleasing *)error;
+- (nullable CDTDocumentRevision *)createDocumentFromRevision:(nonnull CDTDocumentRevision *)revision
+                                                       error:(NSError *__autoreleasing __nullable * __nullable )error;
 
 /**
  * Updates a document in the datastore with a new revision
@@ -214,8 +214,8 @@ extern NSString *const CDTDatastoreChangeNotification;
  *  @return the updated document
  *
  */
-- (CDTDocumentRevision *)updateDocumentFromRevision:(CDTDocumentRevision *)revision
-                                              error:(NSError *__autoreleasing *)error;
+- (nullable CDTDocumentRevision *)updateDocumentFromRevision:(nonnull CDTDocumentRevision *)revision
+                                              error:(NSError *__autoreleasing __nullable  * __nullable )error;
 /**
  * Deletes a document from the datastore.
  *
@@ -224,8 +224,8 @@ extern NSString *const CDTDatastoreChangeNotification;
  *
  * @return the deleted document
  */
-- (CDTDocumentRevision *)deleteDocumentFromRevision:(CDTDocumentRevision *)revision
-                                              error:(NSError *__autoreleasing *)error;
+- (nullable CDTDocumentRevision *)deleteDocumentFromRevision:(nonnull CDTDocumentRevision *)revision
+                                              error:(NSError *__autoreleasing __nullable * __nullable)error;
 
 /**
  *
@@ -237,7 +237,7 @@ extern NSString *const CDTDatastoreChangeNotification;
  * @return an array of deleted documents
  *
  */
-- (NSArray *)deleteDocumentWithId:(NSString *)docId error:(NSError *__autoreleasing *)error;
+- (nullable NSArray *)deleteDocumentWithId:(nonnull NSString *)docId error:(NSError *__autoreleasing __nullable * __nullable)error;
 
 /**
  *
@@ -246,5 +246,5 @@ extern NSString *const CDTDatastoreChangeNotification;
  *
  * @param error will point to an NSError object in the case of an error
  */
-- (BOOL)compactWithError:(NSError *__autoreleasing *)error;
+- (BOOL)compactWithError:(NSError *__autoreleasing __nullable * __nullable)error;
 @end

--- a/CDTDatastore/CDTDatastoreManager.h
+++ b/CDTDatastore/CDTDatastoreManager.h
@@ -29,7 +29,7 @@ extern NSString *const CDTDatastoreErrorDomain;
  */
 @interface CDTDatastoreManager : NSObject
 
-@property (nonatomic, strong, readonly) TD_DatabaseManager *manager;
+@property (nonnull, nonatomic, strong, readonly) TD_DatabaseManager *manager;
 
 /**
  Initialises the datastore manager with a directory where the files
@@ -38,7 +38,7 @@ extern NSString *const CDTDatastoreErrorDomain;
  @param directoryPath  directory for files. This must exist.
  @param outError will point to an NSError object in case of error.
  */
-- (id)initWithDirectory:(NSString *)directoryPath error:(NSError **)outError;
+- (nullable instancetype)initWithDirectory:(nonnull NSString *)directoryPath error:(NSError * __autoreleasing __nullable * __nullable)outError;
 
 /**
  Returns a datastore for the given name.
@@ -48,7 +48,7 @@ extern NSString *const CDTDatastoreErrorDomain;
 
  @see CDTDatastore
  */
-- (CDTDatastore *)datastoreNamed:(NSString *)name error:(NSError *__autoreleasing *)error;
+- (nullable CDTDatastore *)datastoreNamed:(nonnull NSString *)name error:(NSError *__autoreleasing __nullable * __nullable)error;
 
 /**
  Deletes a datastore for the given name.
@@ -62,13 +62,13 @@ extern NSString *const CDTDatastoreErrorDomain;
  @param error will point to an NSError object in case of error.
 
  */
-- (BOOL)deleteDatastoreNamed:(NSString *)name error:(NSError *__autoreleasing *)error;
+- (BOOL)deleteDatastoreNamed:(nonnull NSString *)name error:(NSError *__autoreleasing __nullable * __nullable)error;
 
 /**
  
  Returns an array of datastore names (NSString) that are managed by this CDTDatastoreManager.
  
  */
-- (NSArray* /* NSString */)allDatastores;
+- (nonnull NSArray<NSString*>*)allDatastores;
 
 @end

--- a/CDTDatastore/CDTDocumentRevision.h
+++ b/CDTDatastore/CDTDocumentRevision.h
@@ -26,17 +26,17 @@
 @interface CDTDocumentRevision : NSObject <CDTChangedObserver>
 
 /** Document ID for this document revision. */
-@property (nonatomic, strong, readonly) NSString *docId;
+@property (nullable, nonatomic, strong, readonly) NSString *docId;
 /** Revision ID for this document revision. */
-@property (nonatomic, strong, readonly) NSString *revId;
+@property (nullable, nonatomic, strong, readonly) NSString *revId;
 
 /** `YES` if this document revision is deleted. */
 @property (nonatomic, readonly) BOOL deleted;
 
 @property (nonatomic, readonly) SequenceNumber sequence;
 
-@property (nonatomic, strong) NSMutableDictionary *body;
-@property (nonatomic, strong) NSMutableDictionary *attachments;
+@property (nonnull, nonatomic, strong) NSMutableDictionary *body;
+@property (nonnull, nonatomic, strong) NSMutableDictionary *attachments;
 
 @property (nonatomic, getter=isChanged) bool changed;
 
@@ -49,16 +49,16 @@
  */
 - (BOOL)isFullRevision;
 
-- (id)initWithDocId:(NSString *)docId
-         revisionId:(NSString *)revId
-               body:(NSDictionary *)body
-        attachments:(NSDictionary *)attachments;
+- (nullable instancetype)initWithDocId:(nullable NSString *)docId
+         revisionId:(nullable NSString *)revId
+               body:(nullable NSDictionary *)body
+        attachments:(nullable NSDictionary *)attachments;
 
-- (id)initWithDocId:(NSString *)docId
-         revisionId:(NSString *)revId
-               body:(NSDictionary *)body
+- (nullable instancetype)initWithDocId:(nullable NSString *)docId
+         revisionId:(nullable NSString *)revId
+               body:(nullable NSDictionary *)body
             deleted:(BOOL)deleted
-        attachments:(NSDictionary *)attachments
+        attachments:(nullable NSDictionary *)attachments
            sequence:(SequenceNumber)sequence;
 
 /**
@@ -72,19 +72,19 @@
 
  @return new CDTDocumentRevision instance
 */
-+ (CDTDocumentRevision *)createRevisionFromJson:(NSDictionary *)jsonDict
-                                    forDocument:(NSURL *)documentURL
-                                          error:(NSError *__autoreleasing *)error;
++ (nullable CDTDocumentRevision *)createRevisionFromJson:(nonnull NSDictionary *)jsonDict
+                                    forDocument:(nonnull NSURL *)documentURL
+                                          error:(NSError *__autoreleasing __nullable * __nullable)error;
 
 /**
  Create a new, blank revision which will have an ID generated on saving.
  */
-+ (CDTDocumentRevision *)revision;
++ (nullable CDTDocumentRevision *)revision;
 
 /**
  Create a new, blank revision with an assigned ID.
  */
-+ (CDTDocumentRevision *)revisionWithDocId:(NSString *)docId;
++ (nullable CDTDocumentRevision *)revisionWithDocId:(nonnull NSString *)docId;
 
 /**
  Create a blank revision with a rev ID, which will be treated as an update when saving.
@@ -95,7 +95,7 @@
  Useful during testing and when it's not necessary to start with an existing revision's
  content.
  */
-+ (CDTDocumentRevision *)revisionWithDocId:(NSString *)docId revId:(NSString *)revId;
++ (nullable CDTDocumentRevision *)revisionWithDocId:(nonnull NSString *)docId revId:(nonnull NSString *)revId;
 
 /**
  Return document content as an NSData object.
@@ -106,7 +106,7 @@
 
  @return document content as an NSData object.
  */
-- (NSData *)documentAsDataError:(NSError *__autoreleasing *)error;
+- (nullable NSData *)documentAsDataError:(NSError *__autoreleasing __nullable * __nullable)error;
 
 /**
  Return a copy of this document.
@@ -117,6 +117,6 @@
 
  @return copy of this document
  */
-- (CDTDocumentRevision *)copy;
+- (nullable CDTDocumentRevision *)copy;
 
 @end

--- a/CDTDatastore/CDTFetchChanges.h
+++ b/CDTDatastore/CDTFetchChanges.h
@@ -51,7 +51,7 @@
 
  Typically this is set with the initialiser.
  */
-@property (nonatomic, strong) CDTDatastore *datastore;
+@property (nonnull, nonatomic, strong) CDTDatastore *datastore;
 
 /**
  The sequence value identifying the starting point for reading changes.
@@ -65,7 +65,7 @@
 
  Typically this is set with the initialiser.
  */
-@property (nonatomic, copy) NSString *startSequenceValue;
+@property (nullable, nonatomic, copy) NSString *startSequenceValue;
 
 /**
  Use this property to limit the total number of results you want to get.
@@ -109,7 +109,7 @@
  If you intend to use this block to process results, set it before executing the
  operation or submitting it to a queue.
  */
-@property (nonatomic, copy) void (^documentChangedBlock)(CDTDocumentRevision *revision);
+@property (nullable, nonatomic, copy) void (^documentChangedBlock)(CDTDocumentRevision * __nonnull revision);
 
 /**
  The block to execute for each deleted document.
@@ -129,7 +129,7 @@
  If you intend to use this block to process results, set it before executing the
  operation or submitting it to a queue.
  */
-@property (nonatomic, copy) void (^documentWithIDWasDeletedBlock)(NSString *docId);
+@property (nullable, nonatomic, copy) void (^documentWithIDWasDeletedBlock)(NSString * __nonnull docId);
 
 /**
  The block to execute when all changes have been reported.
@@ -158,8 +158,8 @@
  If you intend to use this block to process results, set it before executing the operation or
  submitting the operation object to a queue.
  */
-@property (nonatomic, copy) void (^fetchRecordChangesCompletionBlock)
-    (NSString *newSequenceValue, NSString *startSequenceValue, NSError *fetchError);
+@property (nullable, nonatomic, copy) void (^fetchRecordChangesCompletionBlock)
+    (NSString * __nonnull newSequenceValue, NSString * __nonnull startSequenceValue, NSError * __nullable fetchError);
 
 #pragma mark Initialisers
 
@@ -180,8 +180,8 @@
 
  @return An initialised fetch operation.
  */
-- (instancetype)initWithDatastore:(CDTDatastore *)datastore
-               startSequenceValue:(NSString *)startSequenceValue;
+- (nullable instancetype)initWithDatastore:(nonnull CDTDatastore *)datastore
+               startSequenceValue:(nullable NSString *)startSequenceValue;
 
 
 @end

--- a/CDTDatastore/CDTReplicator/CDTAbstractReplication.h
+++ b/CDTDatastore/CDTReplicator/CDTAbstractReplication.h
@@ -18,7 +18,7 @@
 
 @class CDTDatastore;
 
-extern NSString* const CDTReplicationErrorDomain;
+extern NSString* __nonnull const CDTReplicationErrorDomain;
 
 /**
  * Replication errors.
@@ -126,11 +126,11 @@ typedef NS_ENUM(NSInteger, CDTReplicationErrors) {
 
 
 */
-@property (nonatomic, copy) NSDictionary* optionalHeaders;
+@property (nullable, nonatomic, copy) NSDictionary<NSString*,NSString*>* optionalHeaders;
 
 NS_ASSUME_NONNULL_BEGIN
 
-@property (nonnull, nonatomic, readonly, strong) NSArray* httpInterceptors;
+@property (nonnull, nonatomic, readonly, strong) NSArray<NSObject<CDTHTTPInterceptor>*> * httpInterceptors;
 
 - (void)addInterceptor:(nonnull NSObject<CDTHTTPInterceptor>*)interceptor;
 - (void)addInterceptors:(nonnull NSArray*)interceptors;
@@ -141,7 +141,7 @@ NS_ASSUME_NONNULL_END
 /**
  Returns the default "User-Agent" header value used in HTTP requests made during replication.
 */
-+ (NSString*)defaultUserAgentHTTPHeader;
++ (nonnull NSString*)defaultUserAgentHTTPHeader;
 
 /*
  ---------------------------------------------------------------------------------------
@@ -162,7 +162,7 @@ NS_ASSUME_NONNULL_END
      classes override this method.
 
  */
-- (NSDictionary*)dictionaryForReplicatorDocument:(NSError* __autoreleasing*)error;
+- (nullable NSDictionary*)dictionaryForReplicatorDocument:(NSError* __autoreleasing __nullable * __nullable)error;
 
 /** Checks the content and format of the remoteDatastore URL to ensure that it uses a proper
  protocol (http or https) and has both a username and password (or neither).
@@ -173,6 +173,6 @@ NS_ASSUME_NONNULL_END
  @return YES on valid URL.
 
  */
-- (BOOL)validateRemoteDatastoreURL:(NSURL*)url error:(NSError* __autoreleasing*)error;
+- (BOOL)validateRemoteDatastoreURL:(nonnull NSURL*)url error:(NSError* __autoreleasing __nullable * __nullable)error;
 
 @end

--- a/CDTDatastore/CDTReplicator/CDTPullReplication.h
+++ b/CDTDatastore/CDTReplicator/CDTPullReplication.h
@@ -53,7 +53,7 @@
  @return a CDTPullReplication object.
 
  */
-+ (instancetype)replicationWithSource:(NSURL *)source target:(CDTDatastore *)target;
++ (nullable instancetype)replicationWithSource:(nonnull NSURL *)source target:(nonnull CDTDatastore *)target;
 
 /**
  @name Accessing the replication source and target
@@ -61,7 +61,7 @@
 
 /** The CDTDatastore to which the data is replicated.
  */
-@property (nonatomic, strong, readonly) CDTDatastore *target;
+@property (nonnull, nonatomic, strong, readonly) CDTDatastore *target;
 
 /** The NSURL for the remote datastore:
 
@@ -73,7 +73,7 @@
 
  @see CDTAbstractReplication.
  */
-@property (nonatomic, strong, readonly) NSURL *source;
+@property (nonnull, nonatomic, strong, readonly) NSURL *source;
 
 /**
  @name Filtered pull replication
@@ -143,12 +143,12 @@
 
 
  */
-@property (nonatomic, copy) NSString *filter;
+@property (nullable, nonatomic, copy) NSString *filter;
 
 /** The filter function query parameters
 
  @see -filter
  */
-@property (nonatomic, copy) NSDictionary *filterParams;
+@property (nullable, nonatomic, copy) NSDictionary *filterParams;
 
 @end

--- a/CDTDatastore/CDTReplicator/CDTPushReplication.h
+++ b/CDTDatastore/CDTReplicator/CDTPushReplication.h
@@ -57,7 +57,7 @@ typedef BOOL (^CDTFilterBlock)(CDTDocumentRevision *revision, NSDictionary *para
  @return a CDTPushReplication object.
 
  */
-+ (instancetype)replicationWithSource:(CDTDatastore *)source target:(NSURL *)target;
++ (nullable instancetype)replicationWithSource:(nonnull CDTDatastore *)source target:(nonnull NSURL *)target;
 
 /**
  @name Accessing the replication source and target
@@ -73,12 +73,12 @@ typedef BOOL (^CDTFilterBlock)(CDTDocumentRevision *revision, NSDictionary *para
 
  @see CDTAbstractReplication.
  */
-@property (nonatomic, strong, readonly) NSURL *target;
+@property (nonnull, nonatomic, strong, readonly) NSURL *target;
 
 /**
  The CDTDatastore from which the data is replicated.
  */
-@property (nonatomic, strong, readonly) CDTDatastore *source;
+@property (nonnull, nonatomic, strong, readonly) CDTDatastore *source;
 
 /**
  @name Filtered push replication
@@ -135,12 +135,12 @@ typedef BOOL (^CDTFilterBlock)(CDTDocumentRevision *revision, NSDictionary *para
     [myrep start];
 
  */
-@property (nonatomic, copy) CDTFilterBlock filter;
+@property (nullable, nonatomic, copy) CDTFilterBlock filter;
 
 /** The filter function query parameters
 
  @see -filter
  */
-@property (nonatomic, copy) NSDictionary *filterParams;
+@property (nullable, nonatomic, copy) NSDictionary *filterParams;
 
 @end

--- a/CDTDatastore/CDTReplicator/CDTReplicator.h
+++ b/CDTDatastore/CDTReplicator/CDTReplicator.h
@@ -126,7 +126,7 @@ typedef NS_ENUM(NSInteger, CDTReplicatorState) {
  *
  * @see CDTReplicatorDelegate
  */
-@property (nonatomic, weak) NSObject<CDTReplicatorDelegate> *delegate;
+@property (nullable, nonatomic, weak) NSObject<CDTReplicatorDelegate> *delegate;
 
 /**
  * Set the delegate for handling customisation of the NSURLSession
@@ -139,7 +139,7 @@ typedef NS_ENUM(NSInteger, CDTReplicatorState) {
  *
  * @see CDTNSURLSessionConfigurationDelegate
  */
-@property (nonatomic, weak) NSObject<CDTNSURLSessionConfigurationDelegate> *sessionConfigDelegate;
+@property (nullable, nonatomic, weak) NSObject<CDTNSURLSessionConfigurationDelegate> *sessionConfigDelegate;
 
 /**
  Returns true if the state is `CDTReplicatorStatePending`, `CDTReplicatorStateStarted` or
@@ -154,15 +154,15 @@ typedef NS_ENUM(NSInteger, CDTReplicatorState) {
 
  @param state state to return string representation
  */
-+ (NSString *)stringForReplicatorState:(CDTReplicatorState)state;
++ (nonnull NSString *)stringForReplicatorState:(CDTReplicatorState)state;
 
 /*
  Private so no docs
  */
--(id)initWithTDReplicatorManager:(TDReplicatorManager*)replicatorManager
-                     replication:(CDTAbstractReplication*)replication
-           sessionConfigDelegate:(NSObject<CDTNSURLSessionConfigurationDelegate> *)delegate
-                           error:(NSError * __autoreleasing*)error;
+-(instancetype)initWithTDReplicatorManager:(nonnull TDReplicatorManager*)replicatorManager
+                     replication:(nonnull CDTAbstractReplication*)replication
+           sessionConfigDelegate:(nullable NSObject<CDTNSURLSessionConfigurationDelegate> *)delegate
+                           error:(NSError * __autoreleasing __nullable * __nullable )error;
 
 /*
  Access the underlying NSThread execution state.
@@ -200,7 +200,7 @@ typedef NS_ENUM(NSInteger, CDTReplicatorState) {
  *
  * @see CDTReplicatorState
  */
-- (BOOL)startWithTaskGroup:(nullable dispatch_group_t)taskGroup error:(NSError *__autoreleasing *)error;
+- (BOOL)startWithTaskGroup:(nullable dispatch_group_t)taskGroup error:(NSError *__autoreleasing __nullable * __nullable)error;
 
 /**
  * Starts a replication.
@@ -209,7 +209,7 @@ typedef NS_ENUM(NSInteger, CDTReplicatorState) {
  *
  * @see startWithTaskGroup:error:
  */
-- (BOOL)startWithError:(NSError *__autoreleasing *)error;
+- (BOOL)startWithError:(NSError *__autoreleasing __nullable * __nullable)error;
 
 /**
  * Stop an in-progress replication or attempt to stop a replication that has not yet started.
@@ -255,6 +255,6 @@ typedef NS_ENUM(NSInteger, CDTReplicatorState) {
  If -state is equal to CDTReplicatorStateError, this will contain the error message.
  This error information is also sent to the delegate object.
  */
-@property (nonatomic, readonly) NSError *error;
+@property (nullable, nonatomic, readonly) NSError *error;
 
 @end

--- a/CDTDatastore/CDTReplicator/CDTReplicatorDelegate.h
+++ b/CDTDatastore/CDTReplicator/CDTReplicatorDelegate.h
@@ -34,7 +34,7 @@
  *
  * @param replicator the replicator issuing the event.
  */
-- (void)replicatorDidChangeState:(CDTReplicator *)replicator;
+- (void)replicatorDidChangeState:(nonnull CDTReplicator *)replicator;
 
 /**
  * <p>Called whenever the replicator changes progress</p>
@@ -43,7 +43,7 @@
  *
  * @param replicator the replicator issuing the event.
  */
-- (void)replicatorDidChangeProgress:(CDTReplicator *)replicator;
+- (void)replicatorDidChangeProgress:(nonnull CDTReplicator *)replicator;
 
 /**
  * <p>Called when a state transition to COMPLETE or STOPPED is
@@ -55,7 +55,7 @@
  *
  * @param replicator the replicator issuing the event.
  */
-- (void)replicatorDidComplete:(CDTReplicator *)replicator;
+- (void)replicatorDidComplete:(nonnull CDTReplicator *)replicator;
 
 /**
  * <p>Called when a state transition to ERROR is completed.</p>
@@ -73,6 +73,6 @@
  * @param replicator the replicator issuing the event.
  * @param info information about the error that occurred.
  */
-- (void)replicatorDidError:(CDTReplicator *)replicator info:(NSError *)info;
+- (void)replicatorDidError:(nonnull CDTReplicator *)replicator info:(nonnull NSError *)info;
 
 @end

--- a/CDTDatastore/CDTReplicator/CDTReplicatorFactory.h
+++ b/CDTDatastore/CDTReplicator/CDTReplicatorFactory.h
@@ -60,7 +60,7 @@
 
  @param dsManager the manager of the datastores that this factory will replicate to and from.
  */
-- (id)initWithDatastoreManager:(CDTDatastoreManager *)dsManager;
+- (nullable instancetype)initWithDatastoreManager:(nonnull CDTDatastoreManager *)dsManager;
 
 
 /**---------------------------------------------------------------------------------------
@@ -78,8 +78,8 @@
  * @return a CDTReplicator instance which can be used to start and
  *  stop the replication itself.
  */
-- (CDTReplicator *)oneWay:(CDTAbstractReplication *)replication
-                    error:(NSError *__autoreleasing *)error;
+- (nullable CDTReplicator *)oneWay:(nonnull CDTAbstractReplication *)replication
+                    error:(NSError *__autoreleasing __nullable * __nullable)error;
 
 /**
  * Create a CDTReplicator object set up to replicate changes from the
@@ -96,9 +96,9 @@
  * @return a CDTReplicator instance which can be used to start and
  *  stop the replication itself.
  */
-- (CDTReplicator *)oneWay:(CDTAbstractReplication *)replication
-    sessionConfigDelegate:(NSObject<CDTNSURLSessionConfigurationDelegate> *)delegate
-                    error:(NSError *__autoreleasing *)error;
+- (nullable CDTReplicator *)oneWay:(nonnull CDTAbstractReplication *)replication
+    sessionConfigDelegate:(nullable NSObject<CDTNSURLSessionConfigurationDelegate> *)delegate
+                    error:(NSError *__autoreleasing __nullable * __nullable)error;
 
 
 /**
@@ -116,7 +116,7 @@
  *  stop the replication itself.
  * @warning This will soon be deprecated. Use -oneWay:error:.
  */
-- (CDTReplicator *)onewaySourceDatastore:(CDTDatastore *)source targetURI:(NSURL *)target;
+- (nullable CDTReplicator *)onewaySourceDatastore:(nonnull CDTDatastore *)source targetURI:(nonnull NSURL *)target;
 
 /**
  * Create a CDTReplicator object set up to replicate changes from a
@@ -129,6 +129,6 @@
  *  stop the replication itself.
  * @warning This will soon be deprecated. Use -oneWay:error:.
  */
-- (CDTReplicator *)onewaySourceURI:(NSURL *)source targetDatastore:(CDTDatastore *)target;
+- (nullable CDTReplicator *)onewaySourceURI:(nonnull NSURL *)source targetDatastore:(nonnull CDTDatastore *)target;
 
 @end

--- a/CDTDatastore/Encryption/CDTDatastore+EncryptionKey.h
+++ b/CDTDatastore/Encryption/CDTDatastore+EncryptionKey.h
@@ -29,13 +29,13 @@
  *
  * @return an initialized datastore, or nil if an object could not be created
  */
-- (instancetype)initWithManager:(CDTDatastoreManager *)manager
-                       database:(TD_Database *)database
-          encryptionKeyProvider:(id<CDTEncryptionKeyProvider>)provider;
+- (nullable instancetype)initWithManager:(nonnull CDTDatastoreManager *)manager
+                       database:(nonnull TD_Database *)database
+          encryptionKeyProvider:(nullable id<CDTEncryptionKeyProvider>)provider;
 
 /**
  * Return the key provider used to encrypt the datastore
  */
-- (id<CDTEncryptionKeyProvider>)encryptionKeyProvider;
+- (nullable id<CDTEncryptionKeyProvider>)encryptionKeyProvider;
 
 @end

--- a/CDTDatastore/Encryption/CDTEncryptionKey.h
+++ b/CDTDatastore/Encryption/CDTEncryptionKey.h
@@ -43,10 +43,10 @@
  
  @warning If data.length is not CDTENCRYPTIONKEY_KEYSIZE, init will return nil
  */
-- (instancetype)initWithData:(NSData *)data NS_DESIGNATED_INITIALIZER;
+- (nullable instancetype)initWithData:(nonnull NSData *)data NS_DESIGNATED_INITIALIZER;
 
-- (BOOL)isEqualToEncryptionKey:(CDTEncryptionKey *)encryptionKey;
+- (BOOL)isEqualToEncryptionKey:(nonnull CDTEncryptionKey *)encryptionKey;
 
-+ (instancetype)encryptionKeyWithData:(NSData *)data;
++ (nullable instancetype)encryptionKeyWithData:(nonnull NSData *)data;
 
 @end

--- a/CDTDatastore/Encryption/CDTEncryptionKeyNilProvider.h
+++ b/CDTDatastore/Encryption/CDTEncryptionKeyNilProvider.h
@@ -32,6 +32,6 @@
  *
  * @return A key provider
  */
-+ (instancetype)provider;
++ (nullable instancetype)provider;
 
 @end

--- a/CDTDatastore/Encryption/CDTEncryptionKeyProvider.h
+++ b/CDTDatastore/Encryption/CDTEncryptionKeyProvider.h
@@ -29,6 +29,6 @@
  * @warning *Warning:* Encryption will not work unless subspec 'CDTDatastore/SQLCipher' is used.
  * However, data will not be encrypted if this method returns nil (regardless of the subspec).
  */
-- (CDTEncryptionKey *)encryptionKey;
+- (nullable CDTEncryptionKey *)encryptionKey;
 
 @end

--- a/CDTDatastore/Encryption/CDTEncryptionKeySimpleProvider.h
+++ b/CDTDatastore/Encryption/CDTEncryptionKeySimpleProvider.h
@@ -29,10 +29,10 @@
  */
 @interface CDTEncryptionKeySimpleProvider : NSObject <CDTEncryptionKeyProvider>
 
-- (instancetype)init UNAVAILABLE_ATTRIBUTE;
+- (nullable instancetype)init UNAVAILABLE_ATTRIBUTE;
 
-- (instancetype)initWithKey:(NSData *)key NS_DESIGNATED_INITIALIZER;
+- (nullable instancetype)initWithKey:(nonnull NSData *)key NS_DESIGNATED_INITIALIZER;
 
-+ (instancetype)providerWithKey:(NSData *)key;
++ (nullable instancetype)providerWithKey:(nonnull NSData *)key;
 
 @end


### PR DESCRIPTION
## What
Add Nullability annotation to public API to improve interoperability
with swift.

## How
Add nullability specifiers to classes which users are expected to interact with. 
In addition to this, collections have been made generic if required and possible to do  #so.

## Reviewers
reviewer @alfinkel  
## Issues

bugzId: 48965