### PR TITLE
Audit Query APIs for Nullability and add annotations as required

### DIFF
--- a/CDTDatastore/CDTDocumentRevision.h
+++ b/CDTDatastore/CDTDocumentRevision.h
@@ -20,6 +20,8 @@
 
 @class TD_RevisionList;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  * Represents a single revision of a document in a datastore.
  */
@@ -35,8 +37,8 @@
 
 @property (nonatomic, readonly) SequenceNumber sequence;
 
-@property (nonnull, nonatomic, strong) NSMutableDictionary *body;
-@property (nonnull, nonatomic, strong) NSMutableDictionary *attachments;
+@property (nonatomic, strong) NSMutableDictionary *body;
+@property (nonatomic, strong) NSMutableDictionary *attachments;
 
 @property (nonatomic, getter=isChanged) bool changed;
 
@@ -49,17 +51,17 @@
  */
 - (BOOL)isFullRevision;
 
-- (nullable instancetype)initWithDocId:(nullable NSString *)docId
-         revisionId:(nullable NSString *)revId
-               body:(nullable NSDictionary *)body
-        attachments:(nullable NSDictionary *)attachments;
+- (instancetype)initWithDocId:(nullable NSString *)docId
+                   revisionId:(nullable NSString *)revId
+                         body:(nullable NSDictionary *)body
+                  attachments:(nullable NSDictionary *)attachments;
 
-- (nullable instancetype)initWithDocId:(nullable NSString *)docId
-         revisionId:(nullable NSString *)revId
-               body:(nullable NSDictionary *)body
-            deleted:(BOOL)deleted
-        attachments:(nullable NSDictionary *)attachments
-           sequence:(SequenceNumber)sequence;
+- (instancetype)initWithDocId:(nullable NSString *)docId
+                   revisionId:(nullable NSString *)revId
+                         body:(nullable NSDictionary *)body
+                      deleted:(BOOL)deleted
+                  attachments:(nullable NSDictionary *)attachments
+                     sequence:(SequenceNumber)sequence;
 
 /**
  Creates an CDTDocumentRevision from JSON Data
@@ -75,19 +77,18 @@
 
  @return new CDTDocumentRevision instance
 */
-+ (nullable CDTDocumentRevision *)createRevisionFromJson:(nonnull NSDictionary *)jsonDict
-                                    forDocument:(nonnull NSURL *)documentURL
-                                          error:(NSError *__autoreleasing __nullable * __nullable)error __attribute__((deprecated));;
-
++ (nullable CDTDocumentRevision *)createRevisionFromJson:(NSDictionary *)jsonDict
+                                             forDocument:(NSURL *)documentURL
+                                                   error:(NSError *__autoreleasing __nullable * __nullable)error __attribute__((deprecated));
 /**
  Create a new, blank revision which will have an ID generated on saving.
  */
-+ (nullable CDTDocumentRevision *)revision;
++ (CDTDocumentRevision *)revision;
 
 /**
  Create a new, blank revision with an assigned ID.
  */
-+ (nullable CDTDocumentRevision *)revisionWithDocId:(nonnull NSString *)docId;
++ (CDTDocumentRevision *)revisionWithDocId:(NSString *)docId;
 
 /**
  Create a blank revision with a rev ID, which will be treated as an update when saving.
@@ -98,7 +99,7 @@
  Useful during testing and when it's not necessary to start with an existing revision's
  content.
  */
-+ (nullable CDTDocumentRevision *)revisionWithDocId:(nonnull NSString *)docId revId:(nonnull NSString *)revId;
++ (CDTDocumentRevision *)revisionWithDocId:(NSString *)docId revId:(NSString *)revId;
 
 /**
  Return document content as an NSData object.
@@ -120,6 +121,8 @@
 
  @return copy of this document
  */
-- (nullable CDTDocumentRevision *)copy;
+- (CDTDocumentRevision *)copy;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/CDTDatastore/query/CDTDatastore+Query.h
+++ b/CDTDatastore/query/CDTDatastore+Query.h
@@ -17,6 +17,8 @@
 #import "CDTDatastore.h"
 #import "CDTQIndexManager.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  This category adds query capabilities to CDTDatastore.
  
@@ -44,7 +46,7 @@
        ...
      }
  */
-- (NSDictionary * /* NSString -> NSArray[NSString]*/)listIndexes;
+- (NSDictionary<NSString *, NSArray<NSString *> *> *)listIndexes;
 
 /**
  Create a new index over a set of fields.
@@ -63,17 +65,17 @@
  
  @return The name of the index if it's created successfully.
  */
-- (NSString *)ensureIndexed:(NSArray * /* NSString */)fieldNames
-                   withName:(NSString *)indexName;
+- (nullable NSString *)ensureIndexed:(NSArray<NSString *> *)fieldNames
+                            withName:(NSString *)indexName;
 /**
  Create a new index based on an index type over a set of fields.
  
  Index type can be either "json" or "text".  A TEXT index provides
  the ability to perform text searches.
  */
-- (NSString *)ensureIndexed:(NSArray * /* NSString */)fieldNames
-                   withName:(NSString *)indexName
-                       type:(NSString *)type;
+- (nullable NSString *)ensureIndexed:(NSArray<NSString *> *)fieldNames
+                            withName:(NSString *)indexName
+                                type:(NSString *)type;
 
 /**
  Create a new index based on an index type with specific index 
@@ -94,10 +96,10 @@
  default tokenizer used to construct the TEXT index with the
  "porter" algorithm tokenizer.
  */
-- (NSString *)ensureIndexed:(NSArray * /* NSString */)fieldNames
-                   withName:(NSString *)indexName
-                       type:(NSString *)type
-                   settings:(NSDictionary *)indexSettings;
+- (nullable NSString *)ensureIndexed:(NSArray<NSString *> *)fieldNames
+                            withName:(NSString *)indexName
+                                type:(NSString *)type
+                            settings:(NSDictionary *)indexSettings;
 
 /**
  Delete an index.
@@ -124,7 +126,7 @@
  
  @return Set of documents, or `nil` if there was an error.
  */
-- (CDTQResultSet *)find:(NSDictionary *)query;
+- (nullable CDTQResultSet *)find:(NSDictionary *)query;
 
 /**
  Find document matching a query.
@@ -137,10 +139,12 @@
  
  @return Set of documents, or `nil` if there was an error.
  */
-- (CDTQResultSet *)find:(NSDictionary *)query
-                   skip:(NSUInteger)skip
-                  limit:(NSUInteger)limit
-                 fields:(NSArray *)fields
-                   sort:(NSArray *)sortDocument;
+- (nullable CDTQResultSet *)find:(NSDictionary *)query
+                            skip:(NSUInteger)skip
+                           limit:(NSUInteger)limit
+                          fields:(nullable NSArray *)fields
+                            sort:(nullable NSArray *)sortDocument;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/CDTDatastore/query/CDTQIndex.h
+++ b/CDTDatastore/query/CDTQIndex.h
@@ -14,6 +14,8 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 extern NSString *const kCDTQJsonType;
 extern NSString *const kCDTQTextType;
 
@@ -22,10 +24,10 @@ extern NSString *const kCDTQTextType;
  */
 @interface CDTQIndex : NSObject
 
-@property (nonatomic, strong) NSArray *fieldNames;
+@property (nullable, nonatomic, strong) NSArray<NSString *> *fieldNames;
 @property (nonatomic, strong) NSString *indexName;
 @property (nonatomic, strong) NSString *indexType;
-@property (nonatomic, strong) NSDictionary *indexSettings;
+@property (nullable, nonatomic, strong) NSDictionary *indexSettings;
 
 /**
  * This function sets the index type to the default setting of "json"
@@ -34,11 +36,11 @@ extern NSString *const kCDTQTextType;
  * @param fieldNames the field names in the index
  * @return the Index object or nil if arguments passed in were invalid.
  */
-+ (instancetype)index:(NSString *)indexName withFields:(NSArray *)fieldNames;
++ (nullable instancetype)index:(NSString *)indexName withFields:(NSArray<NSString *> *)fieldNames;
 
-+ (instancetype)index:(NSString *)indexName
-           withFields:(NSArray *)fieldNames
-               ofType:(NSString *)indexType;
++ (nullable instancetype)index:(NSString *)indexName
+                    withFields:(NSArray<NSString *> *)fieldNames
+                        ofType:(NSString *)indexType;
 
 /**
  * This function handles index specific validation and ensures that the constructed
@@ -51,10 +53,10 @@ extern NSString *const kCDTQTextType;
  *                      Only supported parameter is 'tokenize' for text indexes only.
  * @return the Index object or nil if arguments passed in were invalid.
  */
-+ (instancetype)index:(NSString *)indexName
-           withFields:(NSArray *)fieldNames
-               ofType:(NSString *)indexType
-         withSettings:(NSDictionary *)indexSettings;
++ (nullable instancetype)index:(NSString *)indexName
+                    withFields:(NSArray<NSString *> *)fieldNames
+                        ofType:(NSString *)indexType
+                  withSettings:(nullable NSDictionary<NSString *, NSString *> *)indexSettings;
 
 /**
  * Compares the index type and accompanying settings with the passed in arguments.
@@ -73,3 +75,5 @@ extern NSString *const kCDTQTextType;
 - (NSString *)settingsAsJSON;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/CDTDatastore/query/CDTQIndexCreator.h
+++ b/CDTDatastore/query/CDTQIndexCreator.h
@@ -19,6 +19,8 @@
 @class CDTDatastore;
 @class CDTQSqlParts;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface CDTQIndexCreator : NSObject
 
 /**
@@ -28,28 +30,32 @@
  @param indexName Name of index to create.
  @returns name of created index
  */
-+ (NSString *)ensureIndexed:(CDTQIndex *)index
-                 inDatabase:(FMDatabaseQueue *)database
-              fromDatastore:(CDTDatastore *)datastore;
++ (nullable NSString *)ensureIndexed:(CDTQIndex *)index
+                          inDatabase:(FMDatabaseQueue *)database
+                       fromDatastore:(CDTDatastore *)datastore;
 
 + (NSArray /*NSDictionary or NSString*/ *)removeDirectionsFromFields:(NSArray *)fieldNames;
 
 + (BOOL)validFieldName:(NSString *)fieldName;
 
-+ (NSArray /*CDTQSqlParts*/ *)insertMetadataStatementsForIndexName:(NSString *)indexName
-                                                              type:(NSString *)indexType
-                                                          settings:(NSString *)indexSettings
-                                                        fieldNames:
-                                                            (NSArray /*NSString*/ *)fieldNames;
++ (nullable NSArray<CDTQSqlParts *> *)
+insertMetadataStatementsForIndexName:(NSString *)indexName
+                                type:(NSString *)indexType
+                            settings:(nullable NSString *)indexSettings
+                          fieldNames:(NSArray<NSString *> *)fieldNames;
 
-+ (CDTQSqlParts *)createIndexTableStatementForIndexName:(NSString *)indexName
-                                             fieldNames:(NSArray /*NSString*/ *)fieldNames;
++ (nullable CDTQSqlParts *)createIndexTableStatementForIndexName:(NSString *)indexName
+                                                      fieldNames:(NSArray<NSString *> *)fieldNames;
 
-+ (CDTQSqlParts *)createIndexIndexStatementForIndexName:(NSString *)indexName
-                                             fieldNames:(NSArray /*NSString*/ *)fieldNames;
++ (nullable CDTQSqlParts *)createIndexIndexStatementForIndexName:(NSString *)indexName
+                                                      fieldNames:(NSArray<NSString *> *)fieldNames;
 
-+ (CDTQSqlParts *)createVirtualTableStatementForIndexName:(NSString *)indexName
-                                               fieldNames:(NSArray /*NSString*/ *)fieldNames
-                                                 settings:(NSDictionary *)indexSettings;
++ (nullable CDTQSqlParts *)
+createVirtualTableStatementForIndexName:(NSString *)indexName
+                             fieldNames:(NSArray<NSString *> *)fieldNames
+                               settings:
+                                   (nullable NSDictionary<NSString *, NSString *> *)indexSettings;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/CDTDatastore/query/CDTQIndexManager.h
+++ b/CDTDatastore/query/CDTQIndexManager.h
@@ -14,6 +14,8 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 extern NSString *const CDTQIndexManagerErrorDomain;
 extern NSString *const kCDTQIndexTablePrefix;
 extern NSString *const kCDTQIndexMetadataTableName;
@@ -75,42 +77,43 @@ typedef NS_ENUM(NSInteger, CDTQQueryError) {
 /**
  Constructs a new CDTQIndexManager which indexes documents in `datastore`
  */
-+ (CDTQIndexManager *)managerUsingDatastore:(CDTDatastore *)datastore
-                                      error:(NSError *__autoreleasing *)error;
++ (nullable CDTQIndexManager *)
+managerUsingDatastore:(CDTDatastore *)datastore
+                error:(NSError *__autoreleasing __nullable *__nullable)error;
 
-- (instancetype)initUsingDatastore:(CDTDatastore *)datastore
-                             error:(NSError *__autoreleasing *)error;
+- (nullable instancetype)initUsingDatastore:(CDTDatastore *)datastore
+                                      error:(NSError *__autoreleasing __nullable *__nullable)error;
 
-- (NSDictionary * /* NSString -> NSArray[NSString]*/)listIndexes;
+- (NSDictionary<NSString *, NSArray<NSString *> *> *)listIndexes;
 
 /** Internal */
-+ (NSDictionary /* NSString -> NSArray[NSString]*/ *)listIndexesInDatabaseQueue:
-        (FMDatabaseQueue *)db;
++ (NSDictionary<NSString *, NSArray<NSString *> *> *)listIndexesInDatabaseQueue:
+    (FMDatabaseQueue *)db;
 /** Internal */
-+ (NSDictionary /* NSString -> NSArray[NSString]*/ *)listIndexesInDatabase:(FMDatabase *)db;
++ (NSDictionary<NSString *, NSArray<NSString *> *> *)listIndexesInDatabase:(FMDatabase *)db;
 
-- (NSString *)ensureIndexed:(NSArray * /* NSString */)fieldNames withName:(NSString *)indexName;
+- (nullable NSString *)ensureIndexed:(NSArray<NSString *> *)fieldNames withName:(NSString *)indexName;
 
-- (NSString *)ensureIndexed:(NSArray * /* NSString */)fieldNames
-                   withName:(NSString *)indexName
-                       type:(NSString *)type;
+- (nullable NSString *)ensureIndexed:(NSArray<NSString *> *)fieldNames
+                            withName:(NSString *)indexName
+                                type:(NSString *)type;
 
-- (NSString *)ensureIndexed:(NSArray * /* NSString */)fieldNames
-                   withName:(NSString *)indexName
-                       type:(NSString *)type
-                   settings:(NSDictionary *)indexSettings;
+- (nullable NSString *)ensureIndexed:(NSArray<NSString *> *)fieldNames
+                            withName:(NSString *)indexName
+                                type:(NSString *)type
+                            settings:(nullable NSDictionary *)indexSettings;
 
 - (BOOL)deleteIndexNamed:(NSString *)indexName;
 
 - (BOOL)updateAllIndexes;
 
-- (CDTQResultSet *)find:(NSDictionary *)query;
+- (nullable CDTQResultSet *)find:(NSDictionary *)query;
 
-- (CDTQResultSet *)find:(NSDictionary *)query
-                   skip:(NSUInteger)skip
-                  limit:(NSUInteger)limit
-                 fields:(NSArray *)fields
-                   sort:(NSArray *)sortDocument;
+- (nullable CDTQResultSet *)find:(NSDictionary *)query
+                            skip:(NSUInteger)skip
+                           limit:(NSUInteger)limit
+                          fields:(nullable NSArray *)fields
+                            sort:(nullable NSArray *)sortDocument;
 
 /** Internal */
 + (NSString *)tableNameForIndex:(NSString *)indexName;
@@ -119,3 +122,4 @@ typedef NS_ENUM(NSInteger, CDTQQueryError) {
 + (BOOL)ftsAvailableInDatabase:(FMDatabaseQueue *)db;
 
 @end
+NS_ASSUME_NONNULL_END

--- a/CDTDatastore/query/CDTQIndexUpdater.h
+++ b/CDTDatastore/query/CDTQIndexUpdater.h
@@ -16,6 +16,8 @@
 
 #import "CDTDefines.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class CDTDocumentRevision;
 @class CDTDatastore;
 
@@ -32,7 +34,7 @@
 
  The indexes are assumed to already exist.
  */
-+ (BOOL)updateAllIndexes:(NSDictionary /*NSString -> NSArray[NSString]*/ *)indexes
++ (BOOL)updateAllIndexes:(NSDictionary<NSString *, NSArray<NSString *> *> *)indexes
               inDatabase:(FMDatabaseQueue *)database
            fromDatastore:(CDTDatastore *)datastore;
 
@@ -42,23 +44,24 @@
  The index is assumed to already exist.
  */
 + (BOOL)updateIndex:(NSString *)indexName
-         withFields:(NSArray /* NSString */ *)fieldNames
+         withFields:(NSArray<NSString *> *)fieldNames
          inDatabase:(FMDatabaseQueue *)database
       fromDatastore:(CDTDatastore *)datastore
-              error:(NSError *__autoreleasing *)error;
+              error:(NSError *__nullable __autoreleasing *__nullable)error;
 
 /**
  Constructs a new CDTQQueryExecutor using the indexes in `database` to index documents from
  `datastore`.
  */
-- (instancetype)initWithDatabase:(FMDatabaseQueue *)database datastore:(CDTDatastore *)datastore;
+- (instancetype)initWithDatabase:(FMDatabaseQueue *)database
+                       datastore:(CDTDatastore *)datastore;
 
 /**
  Update all the indexes in a set.
 
  The indexes are assumed to already exist.
  */
-- (BOOL)updateAllIndexes:(NSDictionary /*NSString -> NSArray[NSString]*/ *)indexes;
+- (BOOL)updateAllIndexes:(NSDictionary<NSString *, NSArray<NSString *> *> *)indexes;
 
 /**
  Update a single index.
@@ -66,8 +69,8 @@
  The index is assumed to already exist.
  */
 - (BOOL)updateIndex:(NSString *)indexName
-         withFields:(NSArray /* NSString */ *)fieldNames
-              error:(NSError *__autoreleasing *)error;
+         withFields:(NSArray<NSString *> *)fieldNames
+              error:(NSError *__autoreleasing __nullable *__nullable)error;
 
 /**
  Generate the DELETE statement to remove a documents entries from an index.
@@ -78,9 +81,9 @@
 /**
  Generate the INSERT statement to add a document to an index.
  */
-+ (NSArray /*CDTQSqlParts*/ *)partsToIndexRevision:(CDTDocumentRevision *)rev
-                                           inIndex:(NSString *)indexName
-                                    withFieldNames:(NSArray *)fieldNames;
++ (NSArray<CDTQSqlParts *> *)partsToIndexRevision:(CDTDocumentRevision *)rev
+                                          inIndex:(NSString *)indexName
+                                   withFieldNames:(NSArray<NSString *> *)fieldNames;
 
 /**
  Return the sequence number for the given index
@@ -91,3 +94,4 @@
 - (SequenceNumber)sequenceNumberForIndex:(NSString *)indexName;
 
 @end
+NS_ASSUME_NONNULL_END

--- a/CDTDatastore/query/CDTQProjectedDocumentRevision.h
+++ b/CDTDatastore/query/CDTQProjectedDocumentRevision.h
@@ -14,6 +14,8 @@
 
 #import "CDTDocumentRevision.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class CDTDatastore;
 
 /**
@@ -28,12 +30,14 @@
 /**
  Initialise with a datastore so mutableCopy can return a full document.
  */
-- (id)initWithDocId:(NSString *)docId
-         revisionId:(NSString *)revId
-               body:(NSDictionary *)body
-            deleted:(BOOL)deleted
-        attachments:(NSDictionary *)attachments
-           sequence:(SequenceNumber)sequence
-          datastore:(CDTDatastore *)datastore;
+- (instancetype)initWithDocId:(NSString *)docId
+                   revisionId:(NSString *)revId
+                         body:(NSDictionary *)body
+                      deleted:(BOOL)deleted
+                  attachments:(NSDictionary *)attachments
+                     sequence:(SequenceNumber)sequence
+                    datastore:(CDTDatastore *)datastore;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/CDTDatastore/query/CDTQQueryConstants.h
+++ b/CDTDatastore/query/CDTQQueryConstants.h
@@ -14,6 +14,8 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 extern NSString *const AND;
 
 extern NSString *const OR;
@@ -45,3 +47,5 @@ extern NSString *const SEARCH;
 extern NSString *const MOD;
 
 extern NSString *const SIZE;
+
+NS_ASSUME_NONNULL_END

--- a/CDTDatastore/query/CDTQQueryExecutor.h
+++ b/CDTDatastore/query/CDTQQueryExecutor.h
@@ -14,6 +14,8 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class CDTDatastore;
 @class CDTQResultSet;
 @class CDTQSqlParts;
@@ -28,7 +30,8 @@
  Constructs a new CDTQQueryExecutor using the indexes in `database` to find documents from
  `datastore`.
  */
-- (instancetype)initWithDatabase:(FMDatabaseQueue *)database datastore:(CDTDatastore *)datastore;
+- (instancetype)initWithDatabase:(FMDatabaseQueue *)database
+                       datastore:(CDTDatastore *)datastore;
 
 /**
  Execute the query passed using the selection of index definition provided.
@@ -43,12 +46,13 @@
  @param fields fields to project from the result documents
  @param sortDocument document specifying the order to return results, nil to have no sorting
  */
-- (CDTQResultSet *)find:(NSDictionary *)query
-           usingIndexes:(NSDictionary *)indexes
-                   skip:(NSUInteger)skip
-                  limit:(NSUInteger)limit
-                 fields:(NSArray *)fields
-                   sort:(NSArray *)sortDocument;
+- (nullable CDTQResultSet *)find:(NSDictionary<NSString *, NSObject *> *)query
+                    usingIndexes:(NSDictionary *)indexes
+                            skip:(NSUInteger)skip
+                           limit:(NSUInteger)limit
+                          fields:(NSArray<NSString *> *)fields
+                            sort:(nullable NSArray<NSDictionary<NSString *, NSString *> *> *)
+                                     sortDocument;
 
 /**
  Return SQL to get ordered list of docIds.
@@ -57,8 +61,11 @@
  @"asc"} ]`
  @param indexes dictionary of indexes
  */
-+ (CDTQSqlParts *)sqlToSortIds:(NSSet /*NSString*/ *)docIdSet
-                    usingOrder:(NSArray /*NSDictionary*/ *)sortDocument
-                       indexes:(NSDictionary *)indexes;
++ (nullable CDTQSqlParts *)sqlToSortIds:(NSSet<NSString *> *)docIdSet
+                             usingOrder:
+                                 (NSArray<NSDictionary<NSString *, NSString *> *> *)sortDocument
+                                indexes:(NSDictionary<NSString *, NSString *> *)indexes;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/CDTDatastore/query/CDTQQuerySqlTranslator.h
+++ b/CDTDatastore/query/CDTQQuerySqlTranslator.h
@@ -14,6 +14,8 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class CDTQSqlParts;
 
 @interface CDTQQueryNode : NSObject
@@ -110,9 +112,9 @@
  */
 @interface CDTQQuerySqlTranslator : NSObject
 
-+ (CDTQQueryNode *)translateQuery:(NSDictionary *)query
-                     toUseIndexes:(NSDictionary *)indexes
-                indexesCoverQuery:(BOOL *)indexesCoverQuery;
++ (nullable CDTQQueryNode *)translateQuery:(NSDictionary *)query
+                              toUseIndexes:(NSDictionary *)indexes
+                         indexesCoverQuery:(BOOL *)indexesCoverQuery;
 
 /**
  Expand implicit operators in a query.
@@ -128,12 +130,12 @@
  @[@{@"fieldName": @"mike"}, ...]
  ```
  */
-+ (NSArray *)fieldsForAndClause:(NSArray *)clause;
++ (nullable NSArray *)fieldsForAndClause:(NSArray *)clause;
 
 /**
  Checks for the existence of an operator in a query clause array
 */
-+ (BOOL)isOperator:(NSString *)operator inClause:(NSArray *)clause;
++ (BOOL)isOperator:(NSString *) operator inClause:(NSArray *)clause;
 
 /**
  Selects an index to use for a given query from the set provided.
@@ -144,17 +146,20 @@
  @param indexes index list of the form @{indexName: @[fieldName1, fieldName2]}
  @return name of index from `indexes` to ues for `query`, or `nil` if none found.
  */
-+ (NSString *)chooseIndexForAndClause:(NSArray *)clause fromIndexes:(NSDictionary *)indexes;
++ (nullable NSString *)chooseIndexForAndClause:(NSArray *)clause
+                                   fromIndexes:(NSDictionary *)indexes;
 
 /**
  Selects an index to use for a set of fields.
  */
-+ (NSString *)chooseIndexForFields:(NSSet *)neededFields fromIndexes:(NSDictionary *)indexes;
++ (nullable NSString *)chooseIndexForFields:(NSSet *)neededFields
+                                fromIndexes:(NSDictionary *)indexes;
 
 /**
  Returns the SQL WHERE clause for a query.
  */
-+ (CDTQSqlParts *)wherePartsForAndClause:(NSArray *)clause usingIndex:(NSString *)indexName;
++ (nullable CDTQSqlParts *)wherePartsForAndClause:(NSArray *)clause
+                                       usingIndex:(NSString *)indexName;
 
 /**
  Returns the SQL statement to find document IDs matching query.
@@ -162,6 +167,9 @@
  @param query the query being executed.
  @param indexName the index selected for use in this query
  */
-+ (CDTQSqlParts *)selectStatementForAndClause:(NSArray *)clause usingIndex:(NSString *)indexName;
++ (nullable CDTQSqlParts *)selectStatementForAndClause:(NSArray *)clause
+                                            usingIndex:(NSString *)indexName;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/CDTDatastore/query/CDTQQueryValidator.h
+++ b/CDTDatastore/query/CDTQQueryValidator.h
@@ -21,6 +21,6 @@
 /**
  Expand implicit operators in a query, and validate
  */
-+ (NSDictionary *)normaliseAndValidateQuery:(NSDictionary *)query;
++ (nullable NSDictionary *)normaliseAndValidateQuery:(nonnull NSDictionary *)query;
 
 @end

--- a/CDTDatastore/query/CDTQResultSet.h
+++ b/CDTDatastore/query/CDTQResultSet.h
@@ -14,6 +14,8 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class CDTDatastore;
 @class CDTQResultSetBuilder;
 @class CDTDocumentRevision;
@@ -26,12 +28,12 @@ typedef void (^CDTQResultSetBuilderBlock)(CDTQResultSetBuilder *configuration);
  */
 @interface CDTQResultSetBuilder : NSObject
 
-@property (nonatomic, strong) NSArray *docIds;
-@property (nonatomic, strong) CDTDatastore *datastore;
-@property (nonatomic, strong) NSArray *fields;
+@property (nullable, nonatomic, strong) NSArray *docIds;
+@property (nullable, nonatomic, strong) CDTDatastore *datastore;
+@property (nullable, nonatomic, strong) NSArray *fields;
 @property (nonatomic) NSUInteger skip;
 @property (nonatomic) NSUInteger limit;
-@property (nonatomic, strong) CDTQUnindexedMatcher *matcher;
+@property (nullable, nonatomic, strong) CDTQUnindexedMatcher *matcher;
 
 @end
 
@@ -58,6 +60,8 @@ typedef void (^CDTQResultSetBuilderBlock)(CDTQResultSetBuilder *configuration);
 - (void)enumerateObjectsUsingBlock:(void (^)(CDTDocumentRevision *rev, NSUInteger idx,
                                              BOOL *stop))block;
 
-@property (nonatomic, strong, readonly) NSArray *documentIds;  // of type NSString*
+@property (nonatomic, strong, readonly) NSArray<NSString *> *documentIds;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/CDTDatastore/query/CDTQUnindexedMatcher.h
+++ b/CDTDatastore/query/CDTQUnindexedMatcher.h
@@ -17,6 +17,8 @@
 
 #import "CDTQQuerySqlTranslator.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class CDTDocumentRevision;
 
 @interface CDTQOperatorExpressionNode : CDTQQueryNode
@@ -90,7 +92,7 @@
  Assumes selector is valid as we're calling this late in
  the query processing.
  */
-+ (CDTQUnindexedMatcher *)matcherWithSelector:(NSDictionary *)selector;
++ (nullable CDTQUnindexedMatcher *)matcherWithSelector:(NSDictionary *)selector;
 
 /**
  Returns YES if a document matches this matcher's selector.
@@ -98,3 +100,5 @@
 - (BOOL)matches:(CDTDocumentRevision *)rev;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/CDTDatastore/query/CDTQValueExtractor.h
+++ b/CDTDatastore/query/CDTQValueExtractor.h
@@ -14,6 +14,8 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class CDTDocumentRevision;
 
 /**
@@ -21,9 +23,12 @@
  */
 @interface CDTQValueExtractor : NSObject
 
-+ (NSObject *)extractValueForFieldName:(NSString *)possiblyDottedField
-                          fromRevision:(CDTDocumentRevision *)rev;
++ (nullable NSObject *)extractValueForFieldName:(NSString *)possiblyDottedField
+                                   fromRevision:(CDTDocumentRevision *)rev;
 
-+ (NSObject *)extractValueForFieldName:(NSString *)fieldName fromDictionary:(NSDictionary *)body;
++ (nullable NSObject *)extractValueForFieldName:(NSString *)fieldName
+                                 fromDictionary:(NSDictionary *)body;
 
 @end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
## What
Audit the Query APIs (CDTQ prefixed classes) for nullability and add annotations as required.

## How

Go through each header and inspect underlying code to identify which parameters or properties can be 
null and which ones cannot be null.

## Reviewers
reviewer @brynh 
## Notes

Important: Due to the API impact in Swift, it needs to be made sure that the annotations are correct, this is because an incorrect annotation for an API to be `nonnull` but can in fact be null could result in a crash.