### PR TITLE
62326 ra tests failing

### DIFF
--- a/CDTDatastore/HTTP/CDTURLSessionTask.h
+++ b/CDTDatastore/HTTP/CDTURLSessionTask.h
@@ -83,4 +83,8 @@
 - (void)processError:(nonnull NSError *)error
             onThread:(nonnull NSThread *)thread;
 
+- (void) completedThread:(nonnull NSThread *)thread;
+
+- (void)processData:(nullable NSData*)data;
+
 @end


### PR DESCRIPTION
# What
Fix issue were request were incorrectly marked as completed when only a portion of the data had be received. 
## How
Manually buffer the data before passing it back to task, when the completed delegate is called.

## Testing
Run Replication Acceptance test suite to verify it all passes. 

Note there is a issue with the bad credentials url change tracker test is due to how the creds are generated.

## Reviewers
reviewer @alfinkel 
## Issues

BugzId: 62326