### PR TITLE
Use Cookie Authentication

### DIFF
--- a/CDTDatastore.xcodeproj/project.pbxproj
+++ b/CDTDatastore.xcodeproj/project.pbxproj
@@ -29,7 +29,6 @@
 		980F227B1CB818260075A843 /* CDTQTextSearchTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98F77E151C44044000515CC3 /* CDTQTextSearchTests.m */; };
 		980F227C1CB818260075A843 /* CDTQUnindexedMatcherTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98F77E161C44044000515CC3 /* CDTQUnindexedMatcherTests.m */; };
 		980F227D1CB818260075A843 /* CDTQValueExtractorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98F77E171C44044000515CC3 /* CDTQValueExtractorTests.m */; };
-		980F227E1CB818260075A843 /* CDTReplicationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98F77E181C44044000515CC3 /* CDTReplicationTests.m */; };
 		980F227F1CB818260075A843 /* CDTSessionCookieInterceptorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98F77E191C44044000515CC3 /* CDTSessionCookieInterceptorTests.m */; };
 		980F22801CB818260075A843 /* CDTURLSessionTaskTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98F77E1A1C44044000515CC3 /* CDTURLSessionTaskTests.m */; };
 		980F22811CB818260075A843 /* CDTURLSessionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98F77E1B1C44044000515CC3 /* CDTURLSessionTests.m */; };
@@ -635,6 +634,9 @@
 		9891D10B1C511A820068FD1A /* CDTDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 9891D1091C511A820068FD1A /* CDTDefines.h */; };
 		9891D10C1C511A820068FD1A /* CDTDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 9891D1091C511A820068FD1A /* CDTDefines.h */; };
 		9891D10D1C511A820068FD1A /* CDTDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 9891D1091C511A820068FD1A /* CDTDefines.h */; };
+		98C367E91C91B51100C4059D /* CDTReplicationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98F77E181C44044000515CC3 /* CDTReplicationTests.m */; };
+		98C367EA1C91B51300C4059D /* CDTReplicationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98F77E181C44044000515CC3 /* CDTReplicationTests.m */; };
+		98C367EC1C91B51900C4059D /* CDTReplicationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98F77E181C44044000515CC3 /* CDTReplicationTests.m */; };
 		98F005461C46A0F900A5FB8C /* CDTDatastoreEncryption.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 98F786BE1C456B1300515CC3 /* CDTDatastoreEncryption.framework */; };
 		98F77B3A1C43FC9F00515CC3 /* CDTDatastore.h in Headers */ = {isa = PBXBuildFile; fileRef = 98F77B391C43FC9F00515CC3 /* CDTDatastore.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		98F77B411C43FC9F00515CC3 /* CDTDatastore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 98F77B361C43FC9F00515CC3 /* CDTDatastore.framework */; };
@@ -4257,6 +4259,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				98C367EC1C91B51900C4059D /* CDTReplicationTests.m in Sources */,
 				987384DF1C47B45100937212 /* DatastoreManagerEncryptionTests.m in Sources */,
 				987384E01C47B45100937212 /* CDTEncryptionKeychainUtilsPBKDF2Tests.m in Sources */,
 				987384E11C47B45100937212 /* TDBlobStoreEncryptionTests.m in Sources */,
@@ -4527,7 +4530,6 @@
 				980F227B1CB818260075A843 /* CDTQTextSearchTests.m in Sources */,
 				980F227C1CB818260075A843 /* CDTQUnindexedMatcherTests.m in Sources */,
 				980F227D1CB818260075A843 /* CDTQValueExtractorTests.m in Sources */,
-				980F227E1CB818260075A843 /* CDTReplicationTests.m in Sources */,
 				980F227F1CB818260075A843 /* CDTSessionCookieInterceptorTests.m in Sources */,
 				980F22801CB818260075A843 /* CDTURLSessionTaskTests.m in Sources */,
 				980F22811CB818260075A843 /* CDTURLSessionTests.m in Sources */,
@@ -4543,6 +4545,7 @@
 				987382FF1C47B1DD00937212 /* CDTHelperFixedKeyProvider.m in Sources */,
 				98F77E8C1C44044000515CC3 /* CloudantTests.m in Sources */,
 				98F77EA91C44044000515CC3 /* CDTQMatcherIndexManager.m in Sources */,
+				98C367E91C91B51100C4059D /* CDTReplicationTests.m in Sources */,
 				98F77EB91C44044000515CC3 /* TDMultipartWriterTests.m in Sources */,
 				98F77EB11C44044000515CC3 /* TD_DatabaseManagerTests.m in Sources */,
 				98F77EB51C44044000515CC3 /* TDCollateJSONTests.m in Sources */,
@@ -4600,6 +4603,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				98C367EA1C91B51300C4059D /* CDTReplicationTests.m in Sources */,
 				98F77F071C4404B700515CC3 /* DatastoreManagerEncryptionTests.m in Sources */,
 				98F786DE1C456C5500515CC3 /* CDTEncryptionKeychainUtilsPBKDF2Tests.m in Sources */,
 				98F786DF1C456C5500515CC3 /* TDBlobStoreEncryptionTests.m in Sources */,

--- a/CDTDatastore/CDTReplicator/CDTAbstractReplication.h
+++ b/CDTDatastore/CDTReplicator/CDTAbstractReplication.h
@@ -130,10 +130,28 @@ typedef NS_ENUM(NSInteger, CDTReplicationErrors) {
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+ The interceptors that will be executed for this replication.
+ */
 @property (nonnull, nonatomic, readonly, strong) NSArray<NSObject<CDTHTTPInterceptor>*> * httpInterceptors;
+ 
 
+/**
+  Adds an interceptor to the interceptors array.
+ @param interceptor the interceptor to append to the interceptors array.
+ */
 - (void)addInterceptor:(nonnull NSObject<CDTHTTPInterceptor>*)interceptor;
-- (void)addInterceptors:(nonnull NSArray*)interceptors;
+/**
+  Appends the contents of the array to the interceptors array.
+ @param interceptors to append to the interceptors array.
+ */
+- (void)addInterceptors:(nonnull NSArray<NSObject<CDTHTTPInterceptor>*>*)interceptors;
+/**
+ Clears the interceptor array.
+ 
+ Note: Calling this when a URL with user info has been specified will result in the 
+ CDTSessionCookie interceptor being removed from the interceptors array causing replications to fail.
+ */
 - (void)clearInterceptors;
 
 NS_ASSUME_NONNULL_END

--- a/CDTDatastore/CDTReplicator/CDTPullReplication.h
+++ b/CDTDatastore/CDTReplicator/CDTPullReplication.h
@@ -48,7 +48,8 @@
 
 /** All CDTPullReplication objects must have a source and target.
 
- @param source the remote server URL from which the data is replicated.
+ @param source the remote server URL from which the data is replicated, if this contains user info
+        it will be removed from the URL and replaced with CDTSessionCookieInterceptor
  @param target the local datastore to which the data is replicated.
  @return a CDTPullReplication object.
 
@@ -65,7 +66,7 @@
 
 /** The NSURL for the remote datastore:
 
-     protocol://[user:password@]host[:port]/remoteDatabaseName
+     protocol://host[:port]/remoteDatabaseName
 
  Only _http_ and _https_ are valid protocols.
 

--- a/CDTDatastore/CDTReplicator/CDTPullReplication.m
+++ b/CDTDatastore/CDTReplicator/CDTPullReplication.m
@@ -14,6 +14,7 @@
 //  and limitations under the License.
 
 #import "CDTPullReplication.h"
+#import "CDTSessionCookieInterceptor.h"
 #import "CDTDatastore.h"
 #import "CDTLogging.h"
 #import "TDMisc.h"
@@ -33,7 +34,16 @@
 - (instancetype)initWithSource:(NSURL *)source target:(CDTDatastore *)target
 {
     if (self = [super init]) {
-        _source = source;
+        
+        NSURLComponents * sourceComponents = [NSURLComponents componentsWithURL:source resolvingAgainstBaseURL:NO];
+        if(sourceComponents.user && sourceComponents.password){
+            CDTSessionCookieInterceptor * cookieInterceptor = [[CDTSessionCookieInterceptor alloc] initWithUsername:sourceComponents.user password:sourceComponents.password];
+            sourceComponents.user = nil;
+            sourceComponents.password = nil;
+            [self addInterceptor:cookieInterceptor];
+        }
+        
+        _source = sourceComponents.URL;
         _target = target;
     }
     return self;

--- a/CDTDatastore/CDTReplicator/CDTPushReplication.h
+++ b/CDTDatastore/CDTReplicator/CDTPushReplication.h
@@ -53,7 +53,8 @@ typedef BOOL (^CDTFilterBlock)(CDTDocumentRevision *revision, NSDictionary *para
 /** All CDTPushReplication objects must have a source and target.
 
  @param source the local datastore from which the data is replicated.
- @param target the remote server URL to which the data is replicated.
+ @param target the remote server URL to which the data is replicated, if this contains user info
+        it will be removed from the URL and replaced with CDTSessionCookieInterceptor
  @return a CDTPushReplication object.
 
  */
@@ -65,7 +66,7 @@ typedef BOOL (^CDTFilterBlock)(CDTDocumentRevision *revision, NSDictionary *para
 
 /** The NSURL for the target remote datastore
 
-     protocol://[user:password@]host[:port]/remoteDatabaseName
+     protocol://host[:port]/remoteDatabaseName
 
  Only _http_ and _https_ are valid protocols.
 

--- a/CDTDatastore/CDTReplicator/CDTPushReplication.m
+++ b/CDTDatastore/CDTReplicator/CDTPushReplication.m
@@ -15,6 +15,7 @@
 
 #import "CDTPushReplication.h"
 #import "CDTDatastore.h"
+#import "CDTSessionCookieInterceptor.h"
 #import "TDMisc.h"
 #import "CDTLogging.h"
 
@@ -33,8 +34,17 @@
 - (instancetype)initWithSource:(CDTDatastore *)source target:(NSURL *)target
 {
     if (self = [super init]) {
+        
+        NSURLComponents * targetComponents = [NSURLComponents componentsWithURL:target resolvingAgainstBaseURL:NO];
+        if(targetComponents.user && targetComponents.password){
+            CDTSessionCookieInterceptor * cookieInterceptor = [[CDTSessionCookieInterceptor alloc] initWithUsername:targetComponents.user password:targetComponents.password];
+            targetComponents.user = nil;
+            targetComponents.password = nil;
+            [self addInterceptor:cookieInterceptor];
+        }
+        
         _source = source;
-        _target = target;
+        _target = targetComponents.URL;
     }
     return self;
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - [NEW] Added replication policies, allowing users to easily create policies such as "Replicate
    every 2 hours, only when on Wifi". See the [Replication Policies User Guide](doc/replication-policies.md).
+- [IMPROVED] Replications will use session cookies to authenticate rather than
+   using Basic Auth for every request.
 
 ## 1.0.0 (2015-11-6)
 

--- a/PodFile
+++ b/PodFile
@@ -26,6 +26,7 @@ def import_RA_pods
 end
 
 def import_encrypted_test_pods
+    import_test_pods
     pod 'OCMock'
 end
 


### PR DESCRIPTION
## What
Use cookie authentication instead of basic auth for replications
## How
Strip out user info from the url when creating a CDT*Replication class instance.
## Testing
New tests added to CDTReplicationTests.

## Reviewers
reviewer @tomblench 
reviewer @ricellis
