### PR TITLE
Deprecate cloudant toolkit integration points

### DIFF
--- a/CDTDatastore/Attachments/CDTAttachment.h
+++ b/CDTDatastore/Attachments/CDTAttachment.h
@@ -109,6 +109,11 @@
 
 @end
 
+__attribute__((deprecated))
+/**
+ * @deprecated Class wasn't designed for use outside specific internal use-case, it is now 
+               deprecated and will be removed in the next major version.
+ */
 @interface CDTSavedHTTPAttachment : CDTAttachment
 
 /**

--- a/CDTDatastore/CDTDocumentRevision.h
+++ b/CDTDatastore/CDTDocumentRevision.h
@@ -65,6 +65,9 @@
  Creates an CDTDocumentRevision from JSON Data
  The json data is expected to come from
  Cloudant or a CouchDB instance.
+ 
+ @deprecated Method is deprecated and will be removed in 2.0, method was designed for a specific 
+             internal usecase.
 
  @param json JSON data to create an object from
  @param documentURL the url of the document
@@ -74,7 +77,7 @@
 */
 + (nullable CDTDocumentRevision *)createRevisionFromJson:(nonnull NSDictionary *)jsonDict
                                     forDocument:(nonnull NSURL *)documentURL
-                                          error:(NSError *__autoreleasing __nullable * __nullable)error;
+                                          error:(NSError *__autoreleasing __nullable * __nullable)error __attribute__((deprecated));;
 
 /**
  Create a new, blank revision which will have an ID generated on saving.


### PR DESCRIPTION
## What
Deprecate the integration points for Cloudant ToolKit.

## Why
Cloudant ToolKit is deprecated so the integration points are no longer required, and since we are following [semver](semvar.org) this has be to deprecated rather than removed.

## Reviewers

reviewer @mikerhodes

## Issues

Fixes #235