### PR TITLE
Use an Enum to denote the index type rather than a String

### DIFF
--- a/CDTDatastore.xcodeproj/project.pbxproj
+++ b/CDTDatastore.xcodeproj/project.pbxproj
@@ -16,6 +16,40 @@
 		444F22564A61FE341E679D1E /* Pods_CDTDatastore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 661443AD245B12F70D33C303 /* Pods_CDTDatastore.framework */; };
 		6400126AA8043B4CE33B19DA /* Pods_CDTDatastoreReplicationAcceptanceTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1BEFE677789AF6FA5E2CDCFF /* Pods_CDTDatastoreReplicationAcceptanceTests.framework */; };
 		672DDDA1A88D83963155710B /* Pods_CDTDatastoreEncryptionTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A15735F4EFD5449302A3D38A /* Pods_CDTDatastoreEncryptionTests.framework */; };
+		980F22711CB818260075A843 /* CDTQFilterFieldsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 98F77E0B1C44044000515CC3 /* CDTQFilterFieldsTest.m */; };
+		980F22721CB818260075A843 /* CDTQIndexCreatorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98F77E0C1C44044000515CC3 /* CDTQIndexCreatorTests.m */; };
+		980F22731CB818260075A843 /* CDTQIndexManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98F77E0D1C44044000515CC3 /* CDTQIndexManagerTests.m */; };
+		980F22741CB818260075A843 /* CDTQIndexTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98F77E0E1C44044000515CC3 /* CDTQIndexTests.m */; };
+		980F22751CB818260075A843 /* CDTQIndexUpdaterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98F77E0F1C44044000515CC3 /* CDTQIndexUpdaterTests.m */; };
+		980F22761CB818260075A843 /* CDTQInvalidQuerySyntax.m in Sources */ = {isa = PBXBuildFile; fileRef = 98F77E101C44044000515CC3 /* CDTQInvalidQuerySyntax.m */; };
+		980F22771CB818260075A843 /* CDTQPerformanceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98F77E111C44044000515CC3 /* CDTQPerformanceTests.m */; };
+		980F22781CB818260075A843 /* CDTQQueryExecutorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98F77E121C44044000515CC3 /* CDTQQueryExecutorTests.m */; };
+		980F22791CB818260075A843 /* CDTQQuerySortTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98F77E131C44044000515CC3 /* CDTQQuerySortTests.m */; };
+		980F227A1CB818260075A843 /* CDTQQuerySqlTranslatorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98F77E141C44044000515CC3 /* CDTQQuerySqlTranslatorTests.m */; };
+		980F227B1CB818260075A843 /* CDTQTextSearchTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98F77E151C44044000515CC3 /* CDTQTextSearchTests.m */; };
+		980F227C1CB818260075A843 /* CDTQUnindexedMatcherTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98F77E161C44044000515CC3 /* CDTQUnindexedMatcherTests.m */; };
+		980F227D1CB818260075A843 /* CDTQValueExtractorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98F77E171C44044000515CC3 /* CDTQValueExtractorTests.m */; };
+		980F227E1CB818260075A843 /* CDTReplicationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98F77E181C44044000515CC3 /* CDTReplicationTests.m */; };
+		980F227F1CB818260075A843 /* CDTSessionCookieInterceptorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98F77E191C44044000515CC3 /* CDTSessionCookieInterceptorTests.m */; };
+		980F22801CB818260075A843 /* CDTURLSessionTaskTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98F77E1A1C44044000515CC3 /* CDTURLSessionTaskTests.m */; };
+		980F22811CB818260075A843 /* CDTURLSessionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98F77E1B1C44044000515CC3 /* CDTURLSessionTests.m */; };
+		980F22861CB818530075A843 /* CDTQFilterFieldsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 98F77E0B1C44044000515CC3 /* CDTQFilterFieldsTest.m */; };
+		980F22871CB818530075A843 /* CDTQIndexCreatorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98F77E0C1C44044000515CC3 /* CDTQIndexCreatorTests.m */; };
+		980F22881CB818530075A843 /* CDTQIndexManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98F77E0D1C44044000515CC3 /* CDTQIndexManagerTests.m */; };
+		980F22891CB818530075A843 /* CDTQIndexTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98F77E0E1C44044000515CC3 /* CDTQIndexTests.m */; };
+		980F228A1CB818530075A843 /* CDTQIndexUpdaterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98F77E0F1C44044000515CC3 /* CDTQIndexUpdaterTests.m */; };
+		980F228B1CB818530075A843 /* CDTQInvalidQuerySyntax.m in Sources */ = {isa = PBXBuildFile; fileRef = 98F77E101C44044000515CC3 /* CDTQInvalidQuerySyntax.m */; };
+		980F228C1CB818530075A843 /* CDTQPerformanceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98F77E111C44044000515CC3 /* CDTQPerformanceTests.m */; };
+		980F228D1CB818530075A843 /* CDTQQueryExecutorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98F77E121C44044000515CC3 /* CDTQQueryExecutorTests.m */; };
+		980F228E1CB818530075A843 /* CDTQQuerySortTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98F77E131C44044000515CC3 /* CDTQQuerySortTests.m */; };
+		980F228F1CB818530075A843 /* CDTQQuerySqlTranslatorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98F77E141C44044000515CC3 /* CDTQQuerySqlTranslatorTests.m */; };
+		980F22901CB818530075A843 /* CDTQTextSearchTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98F77E151C44044000515CC3 /* CDTQTextSearchTests.m */; };
+		980F22911CB818530075A843 /* CDTQUnindexedMatcherTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98F77E161C44044000515CC3 /* CDTQUnindexedMatcherTests.m */; };
+		980F22921CB818530075A843 /* CDTQValueExtractorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98F77E171C44044000515CC3 /* CDTQValueExtractorTests.m */; };
+		980F22931CB818530075A843 /* CDTReplicationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98F77E181C44044000515CC3 /* CDTReplicationTests.m */; };
+		980F22941CB818530075A843 /* CDTSessionCookieInterceptorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98F77E191C44044000515CC3 /* CDTSessionCookieInterceptorTests.m */; };
+		980F22951CB818530075A843 /* CDTURLSessionTaskTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98F77E1A1C44044000515CC3 /* CDTURLSessionTaskTests.m */; };
+		980F22961CB818530075A843 /* CDTURLSessionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98F77E1B1C44044000515CC3 /* CDTURLSessionTests.m */; };
 		987344B5C0516C4D1F3EA7CD /* Pods_CDTDatastoreEncryptionTestsOSX.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA5FF88F2E1F1461DA4E6D01 /* Pods_CDTDatastoreEncryptionTestsOSX.framework */; };
 		987382F91C47ADD300937212 /* CDTFetchChanges.m in Sources */ = {isa = PBXBuildFile; fileRef = 98F77B641C43FCEE00515CC3 /* CDTFetchChanges.m */; };
 		987382FF1C47B1DD00937212 /* CDTHelperFixedKeyProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 987382FC1C47B1DD00937212 /* CDTHelperFixedKeyProvider.m */; };
@@ -3040,12 +3074,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 987383EA1C47B38800937212 /* Build configuration list for PBXNativeTarget "CDTDatastoreOSX" */;
 			buildPhases = (
-				C0D80F0611E3B790FA2BA136 /* Check Pods Manifest.lock */,
+				C0D80F0611E3B790FA2BA136 /* 📦 Check Pods Manifest.lock */,
 				987383031C47B38800937212 /* Sources */,
 				987383681C47B38800937212 /* Frameworks */,
 				9873836C1C47B38800937212 /* Headers */,
 				987383E81C47B38800937212 /* Resources */,
-				6F6915B85006D9936EDEE7CC /* Copy Pods Resources */,
+				6F6915B85006D9936EDEE7CC /* 📦 Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -3060,12 +3094,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 987384D71C47B3C400937212 /* Build configuration list for PBXNativeTarget "CDTDatastoreEncryptionOSX" */;
 			buildPhases = (
-				999DADF90202C0C5DBE5F674 /* Check Pods Manifest.lock */,
+				999DADF90202C0C5DBE5F674 /* 📦 Check Pods Manifest.lock */,
 				987383F11C47B3C400937212 /* Sources */,
 				987384561C47B3C400937212 /* Frameworks */,
 				987384591C47B3C400937212 /* Headers */,
 				987384D51C47B3C400937212 /* Resources */,
-				8845812F02DC3725900E289A /* Copy Pods Resources */,
+				8845812F02DC3725900E289A /* 📦 Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -3080,12 +3114,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 987384FD1C47B45100937212 /* Build configuration list for PBXNativeTarget "CDTDatastoreEncryptionTestsOSX" */;
 			buildPhases = (
-				6668299CAC86A2B8C6375F36 /* Check Pods Manifest.lock */,
+				6668299CAC86A2B8C6375F36 /* 📦 Check Pods Manifest.lock */,
 				987384DE1C47B45100937212 /* Sources */,
 				987384F21C47B45100937212 /* Frameworks */,
 				987384F51C47B45100937212 /* Resources */,
-				B4F55BEDD741B55543ECC051 /* Embed Pods Frameworks */,
-				1EDD3B97A6029CAD1A6851B0 /* Copy Pods Resources */,
+				B4F55BEDD741B55543ECC051 /* 📦 Embed Pods Frameworks */,
+				1EDD3B97A6029CAD1A6851B0 /* 📦 Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -3101,12 +3135,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 9873851D1C47B45300937212 /* Build configuration list for PBXNativeTarget "CDTDatastoreReplicationAcceptanceTestsOSX" */;
 			buildPhases = (
-				4AE9FDFB19C9500334A02539 /* Check Pods Manifest.lock */,
+				4AE9FDFB19C9500334A02539 /* 📦 Check Pods Manifest.lock */,
 				987385061C47B45300937212 /* Sources */,
 				987385141C47B45300937212 /* Frameworks */,
 				987385171C47B45300937212 /* Resources */,
-				1C5E1D2A63CE216A3CEFA2B4 /* Embed Pods Frameworks */,
-				E0CE9A04DAC818E15FECD919 /* Copy Pods Resources */,
+				1C5E1D2A63CE216A3CEFA2B4 /* 📦 Embed Pods Frameworks */,
+				E0CE9A04DAC818E15FECD919 /* 📦 Copy Pods Resources */,
 				9888EC061C512CA500E58783 /* Set Replication Settings */,
 			);
 			buildRules = (
@@ -3123,12 +3157,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 987385731C47B45600937212 /* Build configuration list for PBXNativeTarget "CDTDatastoreTestsOSX" */;
 			buildPhases = (
-				49F077EF054ED47F21F7DADF /* Check Pods Manifest.lock */,
+				49F077EF054ED47F21F7DADF /* 📦 Check Pods Manifest.lock */,
 				987385261C47B45600937212 /* Sources */,
 				987385641C47B45600937212 /* Frameworks */,
 				987385681C47B45600937212 /* Resources */,
-				7C202EA6D8C982673E20A305 /* Embed Pods Frameworks */,
-				EBA83FC4C8132BD93CB14457 /* Copy Pods Resources */,
+				7C202EA6D8C982673E20A305 /* 📦 Embed Pods Frameworks */,
+				EBA83FC4C8132BD93CB14457 /* 📦 Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -3143,12 +3177,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 987385B31C47F62500937212 /* Build configuration list for PBXNativeTarget "CDTDatastoreEncryptedReplicationAcceptanceTests" */;
 			buildPhases = (
-				1B18E3E8A1BD209015EE7BA9 /* Check Pods Manifest.lock */,
+				1B18E3E8A1BD209015EE7BA9 /* 📦 Check Pods Manifest.lock */,
 				9873859C1C47F62500937212 /* Sources */,
 				987385AA1C47F62500937212 /* Frameworks */,
 				987385AD1C47F62500937212 /* Resources */,
-				FE64BA780CE34986E46D681B /* Embed Pods Frameworks */,
-				9D682C6D1687193E73985ED1 /* Copy Pods Resources */,
+				FE64BA780CE34986E46D681B /* 📦 Embed Pods Frameworks */,
+				9D682C6D1687193E73985ED1 /* 📦 Copy Pods Resources */,
 				9888EC051C512C7500E58783 /* Set Replication Settings */,
 			);
 			buildRules = (
@@ -3165,12 +3199,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 987385D31C47F63900937212 /* Build configuration list for PBXNativeTarget "CDTDatastoreEncryptedReplicationAcceptanceTestsOSX" */;
 			buildPhases = (
-				4875F2C52560074FC0379BC3 /* Check Pods Manifest.lock */,
+				4875F2C52560074FC0379BC3 /* 📦 Check Pods Manifest.lock */,
 				987385BC1C47F63900937212 /* Sources */,
 				987385CA1C47F63900937212 /* Frameworks */,
 				987385CD1C47F63900937212 /* Resources */,
-				F10202E7AB1A178DC77D31AE /* Embed Pods Frameworks */,
-				25CA8313C5888B984B36B42A /* Copy Pods Resources */,
+				F10202E7AB1A178DC77D31AE /* 📦 Embed Pods Frameworks */,
+				25CA8313C5888B984B36B42A /* 📦 Copy Pods Resources */,
 				9888EC041C512C2200E58783 /* Set Replication Settings */,
 			);
 			buildRules = (
@@ -3187,12 +3221,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 98F77B4A1C43FC9F00515CC3 /* Build configuration list for PBXNativeTarget "CDTDatastore" */;
 			buildPhases = (
-				18010A7AC335A1DC45C59083 /* Check Pods Manifest.lock */,
+				18010A7AC335A1DC45C59083 /* 📦 Check Pods Manifest.lock */,
 				98F77B311C43FC9F00515CC3 /* Sources */,
 				98F77B321C43FC9F00515CC3 /* Frameworks */,
 				98F77B331C43FC9F00515CC3 /* Headers */,
 				98F77B341C43FC9F00515CC3 /* Resources */,
-				2FA89F25B3ED73F39CFA4C97 /* Copy Pods Resources */,
+				2FA89F25B3ED73F39CFA4C97 /* 📦 Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -3207,13 +3241,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 98F77B4D1C43FC9F00515CC3 /* Build configuration list for PBXNativeTarget "CDTDatastoreTests" */;
 			buildPhases = (
-				E6DC9C53535134C73C8857F9 /* Check Pods Manifest.lock */,
+				E6DC9C53535134C73C8857F9 /* 📦 Check Pods Manifest.lock */,
 				98F77B3C1C43FC9F00515CC3 /* Sources */,
 				98F77B3D1C43FC9F00515CC3 /* Frameworks */,
 				98F77B3E1C43FC9F00515CC3 /* Resources */,
 				987385FB1C49657A00937212 /* CopyFiles */,
-				09D5A7639A5BB0EDAE8E8053 /* Embed Pods Frameworks */,
-				282873F5DCB0A93CFFFF523C /* Copy Pods Resources */,
+				09D5A7639A5BB0EDAE8E8053 /* 📦 Embed Pods Frameworks */,
+				282873F5DCB0A93CFFFF523C /* 📦 Copy Pods Resources */,
 			);
 			buildRules = (
 				987385FA1C49655000937212 /* PBXBuildRule */,
@@ -3230,12 +3264,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 98F77D361C44028700515CC3 /* Build configuration list for PBXNativeTarget "CDTDatastoreReplicationAcceptanceTests" */;
 			buildPhases = (
-				457AA11115F42906B2158A90 /* Check Pods Manifest.lock */,
+				457AA11115F42906B2158A90 /* 📦 Check Pods Manifest.lock */,
 				98F77D281C44028700515CC3 /* Sources */,
 				98F77D291C44028700515CC3 /* Frameworks */,
 				98F77D2A1C44028700515CC3 /* Resources */,
-				BAE31094CCE3DB1970125797 /* Embed Pods Frameworks */,
-				041AC5C69D22B9854304F724 /* Copy Pods Resources */,
+				BAE31094CCE3DB1970125797 /* 📦 Embed Pods Frameworks */,
+				041AC5C69D22B9854304F724 /* 📦 Copy Pods Resources */,
 				9888EC091C512CF800E58783 /* Set Replication Settings */,
 			);
 			buildRules = (
@@ -3252,12 +3286,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 98F77EFB1C44047600515CC3 /* Build configuration list for PBXNativeTarget "CDTDatastoreEncryptionTests" */;
 			buildPhases = (
-				0A2F28E6317B33D03BD8E38A /* Check Pods Manifest.lock */,
+				0A2F28E6317B33D03BD8E38A /* 📦 Check Pods Manifest.lock */,
 				98F77EEF1C44047600515CC3 /* Sources */,
 				98F77EF01C44047600515CC3 /* Frameworks */,
 				98F77EF11C44047600515CC3 /* Resources */,
-				8ADFC52EE8715FEFD644EDCE /* Embed Pods Frameworks */,
-				C7F72B7CBA2A186F3CB6A3DC /* Copy Pods Resources */,
+				8ADFC52EE8715FEFD644EDCE /* 📦 Embed Pods Frameworks */,
+				C7F72B7CBA2A186F3CB6A3DC /* 📦 Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -3273,12 +3307,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 98F786BB1C456B1300515CC3 /* Build configuration list for PBXNativeTarget "CDTDatastoreEncryption" */;
 			buildPhases = (
-				2244EB04BB3849FCB4BF009F /* Check Pods Manifest.lock */,
+				2244EB04BB3849FCB4BF009F /* 📦 Check Pods Manifest.lock */,
 				98F785D41C456B1300515CC3 /* Sources */,
 				98F786391C456B1300515CC3 /* Frameworks */,
 				98F7863D1C456B1300515CC3 /* Headers */,
 				98F786B91C456B1300515CC3 /* Resources */,
-				68B26C8A807C3D37B1C8BB19 /* Copy Pods Resources */,
+				68B26C8A807C3D37B1C8BB19 /* 📦 Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -3466,14 +3500,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		041AC5C69D22B9854304F724 /* Copy Pods Resources */ = {
+		041AC5C69D22B9854304F724 /* 📦 Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Copy Pods Resources";
+			name = "📦 Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3481,14 +3515,14 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-CDTDatastoreReplicationAcceptanceTests/Pods-CDTDatastoreReplicationAcceptanceTests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		09D5A7639A5BB0EDAE8E8053 /* Embed Pods Frameworks */ = {
+		09D5A7639A5BB0EDAE8E8053 /* 📦 Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Embed Pods Frameworks";
+			name = "📦 Embed Pods Frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3496,14 +3530,14 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-CDTDatastoreTests/Pods-CDTDatastoreTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		0A2F28E6317B33D03BD8E38A /* Check Pods Manifest.lock */ = {
+		0A2F28E6317B33D03BD8E38A /* 📦 Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Check Pods Manifest.lock";
+			name = "📦 Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3511,14 +3545,14 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		18010A7AC335A1DC45C59083 /* Check Pods Manifest.lock */ = {
+		18010A7AC335A1DC45C59083 /* 📦 Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Check Pods Manifest.lock";
+			name = "📦 Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3526,14 +3560,14 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		1B18E3E8A1BD209015EE7BA9 /* Check Pods Manifest.lock */ = {
+		1B18E3E8A1BD209015EE7BA9 /* 📦 Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Check Pods Manifest.lock";
+			name = "📦 Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3541,14 +3575,14 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		1C5E1D2A63CE216A3CEFA2B4 /* Embed Pods Frameworks */ = {
+		1C5E1D2A63CE216A3CEFA2B4 /* 📦 Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Embed Pods Frameworks";
+			name = "📦 Embed Pods Frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3556,14 +3590,14 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-CDTDatastoreReplicationAcceptanceTestsOSX/Pods-CDTDatastoreReplicationAcceptanceTestsOSX-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		1EDD3B97A6029CAD1A6851B0 /* Copy Pods Resources */ = {
+		1EDD3B97A6029CAD1A6851B0 /* 📦 Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Copy Pods Resources";
+			name = "📦 Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3571,14 +3605,14 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-CDTDatastoreEncryptionTestsOSX/Pods-CDTDatastoreEncryptionTestsOSX-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		2244EB04BB3849FCB4BF009F /* Check Pods Manifest.lock */ = {
+		2244EB04BB3849FCB4BF009F /* 📦 Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Check Pods Manifest.lock";
+			name = "📦 Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3586,14 +3620,14 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		25CA8313C5888B984B36B42A /* Copy Pods Resources */ = {
+		25CA8313C5888B984B36B42A /* 📦 Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Copy Pods Resources";
+			name = "📦 Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3601,14 +3635,14 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-CDTDatastoreEncryptedReplicationAcceptanceTestsOSX/Pods-CDTDatastoreEncryptedReplicationAcceptanceTestsOSX-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		282873F5DCB0A93CFFFF523C /* Copy Pods Resources */ = {
+		282873F5DCB0A93CFFFF523C /* 📦 Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Copy Pods Resources";
+			name = "📦 Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3616,14 +3650,14 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-CDTDatastoreTests/Pods-CDTDatastoreTests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		2FA89F25B3ED73F39CFA4C97 /* Copy Pods Resources */ = {
+		2FA89F25B3ED73F39CFA4C97 /* 📦 Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Copy Pods Resources";
+			name = "📦 Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3631,14 +3665,14 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-CDTDatastore/Pods-CDTDatastore-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		457AA11115F42906B2158A90 /* Check Pods Manifest.lock */ = {
+		457AA11115F42906B2158A90 /* 📦 Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Check Pods Manifest.lock";
+			name = "📦 Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3646,14 +3680,14 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		4875F2C52560074FC0379BC3 /* Check Pods Manifest.lock */ = {
+		4875F2C52560074FC0379BC3 /* 📦 Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Check Pods Manifest.lock";
+			name = "📦 Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3661,14 +3695,14 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		49F077EF054ED47F21F7DADF /* Check Pods Manifest.lock */ = {
+		49F077EF054ED47F21F7DADF /* 📦 Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Check Pods Manifest.lock";
+			name = "📦 Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3676,14 +3710,14 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		4AE9FDFB19C9500334A02539 /* Check Pods Manifest.lock */ = {
+		4AE9FDFB19C9500334A02539 /* 📦 Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Check Pods Manifest.lock";
+			name = "📦 Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3691,14 +3725,14 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		6668299CAC86A2B8C6375F36 /* Check Pods Manifest.lock */ = {
+		6668299CAC86A2B8C6375F36 /* 📦 Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Check Pods Manifest.lock";
+			name = "📦 Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3706,14 +3740,14 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		68B26C8A807C3D37B1C8BB19 /* Copy Pods Resources */ = {
+		68B26C8A807C3D37B1C8BB19 /* 📦 Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Copy Pods Resources";
+			name = "📦 Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3721,14 +3755,14 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-CDTDatastoreEncryption/Pods-CDTDatastoreEncryption-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		6F6915B85006D9936EDEE7CC /* Copy Pods Resources */ = {
+		6F6915B85006D9936EDEE7CC /* 📦 Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Copy Pods Resources";
+			name = "📦 Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3736,14 +3770,14 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-CDTDatastoreOSX/Pods-CDTDatastoreOSX-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		7C202EA6D8C982673E20A305 /* Embed Pods Frameworks */ = {
+		7C202EA6D8C982673E20A305 /* 📦 Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Embed Pods Frameworks";
+			name = "📦 Embed Pods Frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3751,14 +3785,14 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-CDTDatastoreTestsOSX/Pods-CDTDatastoreTestsOSX-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		8845812F02DC3725900E289A /* Copy Pods Resources */ = {
+		8845812F02DC3725900E289A /* 📦 Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Copy Pods Resources";
+			name = "📦 Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3766,14 +3800,14 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-CDTDatastoreEncryptionOSX/Pods-CDTDatastoreEncryptionOSX-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		8ADFC52EE8715FEFD644EDCE /* Embed Pods Frameworks */ = {
+		8ADFC52EE8715FEFD644EDCE /* 📦 Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Embed Pods Frameworks";
+			name = "📦 Embed Pods Frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3837,14 +3871,14 @@
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/buildplist.sh\"";
 		};
-		999DADF90202C0C5DBE5F674 /* Check Pods Manifest.lock */ = {
+		999DADF90202C0C5DBE5F674 /* 📦 Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Check Pods Manifest.lock";
+			name = "📦 Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3852,14 +3886,14 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		9D682C6D1687193E73985ED1 /* Copy Pods Resources */ = {
+		9D682C6D1687193E73985ED1 /* 📦 Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Copy Pods Resources";
+			name = "📦 Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3867,14 +3901,14 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-CDTDatastoreEncryptedReplicationAcceptanceTests/Pods-CDTDatastoreEncryptedReplicationAcceptanceTests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		B4F55BEDD741B55543ECC051 /* Embed Pods Frameworks */ = {
+		B4F55BEDD741B55543ECC051 /* 📦 Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Embed Pods Frameworks";
+			name = "📦 Embed Pods Frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3882,14 +3916,14 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-CDTDatastoreEncryptionTestsOSX/Pods-CDTDatastoreEncryptionTestsOSX-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		BAE31094CCE3DB1970125797 /* Embed Pods Frameworks */ = {
+		BAE31094CCE3DB1970125797 /* 📦 Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Embed Pods Frameworks";
+			name = "📦 Embed Pods Frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3897,14 +3931,14 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-CDTDatastoreReplicationAcceptanceTests/Pods-CDTDatastoreReplicationAcceptanceTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		C0D80F0611E3B790FA2BA136 /* Check Pods Manifest.lock */ = {
+		C0D80F0611E3B790FA2BA136 /* 📦 Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Check Pods Manifest.lock";
+			name = "📦 Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3912,14 +3946,14 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		C7F72B7CBA2A186F3CB6A3DC /* Copy Pods Resources */ = {
+		C7F72B7CBA2A186F3CB6A3DC /* 📦 Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Copy Pods Resources";
+			name = "📦 Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3927,14 +3961,14 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-CDTDatastoreEncryptionTests/Pods-CDTDatastoreEncryptionTests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		E0CE9A04DAC818E15FECD919 /* Copy Pods Resources */ = {
+		E0CE9A04DAC818E15FECD919 /* 📦 Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Copy Pods Resources";
+			name = "📦 Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3942,14 +3976,14 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-CDTDatastoreReplicationAcceptanceTestsOSX/Pods-CDTDatastoreReplicationAcceptanceTestsOSX-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		E6DC9C53535134C73C8857F9 /* Check Pods Manifest.lock */ = {
+		E6DC9C53535134C73C8857F9 /* 📦 Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Check Pods Manifest.lock";
+			name = "📦 Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3957,14 +3991,14 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		EBA83FC4C8132BD93CB14457 /* Copy Pods Resources */ = {
+		EBA83FC4C8132BD93CB14457 /* 📦 Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Copy Pods Resources";
+			name = "📦 Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3972,14 +4006,14 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-CDTDatastoreTestsOSX/Pods-CDTDatastoreTestsOSX-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		F10202E7AB1A178DC77D31AE /* Embed Pods Frameworks */ = {
+		F10202E7AB1A178DC77D31AE /* 📦 Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Embed Pods Frameworks";
+			name = "📦 Embed Pods Frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3987,14 +4021,14 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-CDTDatastoreEncryptedReplicationAcceptanceTestsOSX/Pods-CDTDatastoreEncryptedReplicationAcceptanceTestsOSX-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		FE64BA780CE34986E46D681B /* Embed Pods Frameworks */ = {
+		FE64BA780CE34986E46D681B /* 📦 Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Embed Pods Frameworks";
+			name = "📦 Embed Pods Frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -4268,6 +4302,23 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				980F22861CB818530075A843 /* CDTQFilterFieldsTest.m in Sources */,
+				980F22871CB818530075A843 /* CDTQIndexCreatorTests.m in Sources */,
+				980F22881CB818530075A843 /* CDTQIndexManagerTests.m in Sources */,
+				980F22891CB818530075A843 /* CDTQIndexTests.m in Sources */,
+				980F228A1CB818530075A843 /* CDTQIndexUpdaterTests.m in Sources */,
+				980F228B1CB818530075A843 /* CDTQInvalidQuerySyntax.m in Sources */,
+				980F228C1CB818530075A843 /* CDTQPerformanceTests.m in Sources */,
+				980F228D1CB818530075A843 /* CDTQQueryExecutorTests.m in Sources */,
+				980F228E1CB818530075A843 /* CDTQQuerySortTests.m in Sources */,
+				980F228F1CB818530075A843 /* CDTQQuerySqlTranslatorTests.m in Sources */,
+				980F22901CB818530075A843 /* CDTQTextSearchTests.m in Sources */,
+				980F22911CB818530075A843 /* CDTQUnindexedMatcherTests.m in Sources */,
+				980F22921CB818530075A843 /* CDTQValueExtractorTests.m in Sources */,
+				980F22931CB818530075A843 /* CDTReplicationTests.m in Sources */,
+				980F22941CB818530075A843 /* CDTSessionCookieInterceptorTests.m in Sources */,
+				980F22951CB818530075A843 /* CDTURLSessionTaskTests.m in Sources */,
+				980F22961CB818530075A843 /* CDTURLSessionTests.m in Sources */,
 				987385271C47B45600937212 /* DatastoreActions.m in Sources */,
 				987385291C47B45600937212 /* CDTHelperOneUseKeyProvider.m in Sources */,
 				9873852A1C47B45600937212 /* CDTBlobDataTests.m in Sources */,
@@ -4463,6 +4514,23 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				980F22711CB818260075A843 /* CDTQFilterFieldsTest.m in Sources */,
+				980F22721CB818260075A843 /* CDTQIndexCreatorTests.m in Sources */,
+				980F22731CB818260075A843 /* CDTQIndexManagerTests.m in Sources */,
+				980F22741CB818260075A843 /* CDTQIndexTests.m in Sources */,
+				980F22751CB818260075A843 /* CDTQIndexUpdaterTests.m in Sources */,
+				980F22761CB818260075A843 /* CDTQInvalidQuerySyntax.m in Sources */,
+				980F22771CB818260075A843 /* CDTQPerformanceTests.m in Sources */,
+				980F22781CB818260075A843 /* CDTQQueryExecutorTests.m in Sources */,
+				980F22791CB818260075A843 /* CDTQQuerySortTests.m in Sources */,
+				980F227A1CB818260075A843 /* CDTQQuerySqlTranslatorTests.m in Sources */,
+				980F227B1CB818260075A843 /* CDTQTextSearchTests.m in Sources */,
+				980F227C1CB818260075A843 /* CDTQUnindexedMatcherTests.m in Sources */,
+				980F227D1CB818260075A843 /* CDTQValueExtractorTests.m in Sources */,
+				980F227E1CB818260075A843 /* CDTReplicationTests.m in Sources */,
+				980F227F1CB818260075A843 /* CDTSessionCookieInterceptorTests.m in Sources */,
+				980F22801CB818260075A843 /* CDTURLSessionTaskTests.m in Sources */,
+				980F22811CB818260075A843 /* CDTURLSessionTests.m in Sources */,
 				98F77E8D1C44044000515CC3 /* DatastoreActions.m in Sources */,
 				987383001C47B1DD00937212 /* CDTHelperOneUseKeyProvider.m in Sources */,
 				98F77E771C44044000515CC3 /* CDTBlobDataTests.m in Sources */,

--- a/CDTDatastore/query/CDTDatastore+Query.h
+++ b/CDTDatastore/query/CDTDatastore+Query.h
@@ -69,36 +69,76 @@ NS_ASSUME_NONNULL_BEGIN
                             withName:(NSString *)indexName;
 /**
  Create a new index based on an index type over a set of fields.
- 
+
  Index type can be either "json" or "text".  A TEXT index provides
  the ability to perform text searches.
+
+ @deprecated This method has been deprecated, use -ensureIndexed:withName:ofType instead.
  */
 - (nullable NSString *)ensureIndexed:(NSArray<NSString *> *)fieldNames
                             withName:(NSString *)indexName
-                                type:(NSString *)type;
+                                type:(NSString *)type __attribute__((deprecated));
 
 /**
- Create a new index based on an index type with specific index 
+ Create a new index based on an index type with specific index
  settings over a set of fields.
- 
+
  Index settings currenly only apply to a TEXT index.
- 
+
  An example:
- 
+
  Where ds is your datastore and fields is an array of fieldnames...
- 
- [ds ensureIndexed: fields 
+
+ [ds ensureIndexed: fields
           withName: @"text_idx"
-              type: @"text" 
+              type: @"text"
           settings: @{ @"tokenize": @"porter" }]
- 
+
  This will create a TEXT index named text_idx and override the
  default tokenizer used to construct the TEXT index with the
  "porter" algorithm tokenizer.
+
+ @deprecated This method has been deprecated, use -ensureIndexed:withName:ofType:settings instead.
  */
 - (nullable NSString *)ensureIndexed:(NSArray<NSString *> *)fieldNames
                             withName:(NSString *)indexName
                                 type:(NSString *)type
+                            settings:(NSDictionary *)indexSettings __attribute__((deprecated));
+
+/**
+ Create a new index based on an index type over a set of fields.
+
+ Index type can be either CDTQIndexTypeJSON or CDTQIndexTypeText.  A CDTQIndexTypeText index
+ provides
+ the ability to perform text searches.
+ */
+- (nullable NSString *)ensureIndexed:(NSArray<NSString *> *)fieldNames
+                            withName:(NSString *)indexName
+                              ofType:(CDTQIndexType)type;
+
+/**
+ Create a new index based on an index type with specific index
+ settings over a set of fields.
+
+ Index settings currenly only apply to a TEXT index.
+
+ An example:
+
+ Where ds is your datastore and fields is an array of fieldnames...
+
+ [ds ensureIndexed: fields
+ withName: @"text_idx"
+ ofType: CDTQIndexTypeText
+ settings: @{ @"tokenize": @"porter" }]
+
+ This will create a TEXT index named text_idx and override the
+ default tokenizer used to construct the TEXT index with the
+ "porter" algorithm tokenizer.
+
+ */
+- (nullable NSString *)ensureIndexed:(NSArray<NSString *> *)fieldNames
+                            withName:(NSString *)indexName
+                              ofType:(CDTQIndexType)type
                             settings:(NSDictionary *)indexSettings;
 
 /**

--- a/CDTDatastore/query/CDTDatastore+Query.m
+++ b/CDTDatastore/query/CDTDatastore+Query.m
@@ -20,14 +20,12 @@
 
 - (CDTQIndexManager *)CDTQManager
 {
-    if (objc_getAssociatedObject(self, @selector(CDTQManager)) == nil) {
-        @synchronized(self)
-        {
-            if (objc_getAssociatedObject(self, @selector(CDTQManager)) == nil) {
-                CDTQIndexManager *m = [CDTQIndexManager managerUsingDatastore:self error:nil];
-                objc_setAssociatedObject(self, @selector(CDTQManager), m,
-                                         OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-            }
+    @synchronized(self)
+    {
+        if (objc_getAssociatedObject(self, @selector(CDTQManager)) == nil) {
+            CDTQIndexManager *m = [CDTQIndexManager managerUsingDatastore:self error:nil];
+            objc_setAssociatedObject(self, @selector(CDTQManager), m,
+                                     OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         }
     }
 
@@ -65,6 +63,24 @@
                                   withName:indexName
                                       type:type
                                   settings:indexSettings];
+}
+
+- (NSString *)ensureIndexed:(NSArray<NSString *> *)fieldNames
+                   withName:(NSString *)indexName
+                     ofType:(CDTQIndexType)type
+                   settings:(NSDictionary *)indexSettings
+{
+    return [self.CDTQManager ensureIndexed:fieldNames
+                                  withName:indexName
+                                    ofType:type
+                                  settings:indexSettings];
+}
+
+- (NSString *)ensureIndexed:(NSArray<NSString *> *)fieldNames
+                   withName:(NSString *)indexName
+                     ofType:(CDTQIndexType)type
+{
+    return [self.CDTQManager ensureIndexed:fieldNames withName:indexName ofType:type];
 }
 
 - (CDTQResultSet *)find:(NSDictionary *)query

--- a/CDTDatastore/query/CDTQIndex.h
+++ b/CDTDatastore/query/CDTQIndex.h
@@ -13,11 +13,13 @@
 //  and limitations under the License.
 
 #import <Foundation/Foundation.h>
+#import "CDTQIndexManager.h"
+
 
 NS_ASSUME_NONNULL_BEGIN
 
-extern NSString *const kCDTQJsonType;
-extern NSString *const kCDTQTextType;
+extern NSString *const kCDTQJsonType __deprecated;
+extern NSString *const kCDTQTextType __deprecated;
 
 /**
  * This class provides functionality to manage an index
@@ -26,8 +28,9 @@ extern NSString *const kCDTQTextType;
 
 @property (nullable, nonatomic, strong) NSArray<NSString *> *fieldNames;
 @property (nonatomic, strong) NSString *indexName;
-@property (nonatomic, strong) NSString *indexType;
+@property (nonatomic, strong) NSString *indexType __deprecated;
 @property (nullable, nonatomic, strong) NSDictionary *indexSettings;
+@property (nonatomic) CDTQIndexType type;
 
 /**
  * This function sets the index type to the default setting of "json"
@@ -40,7 +43,37 @@ extern NSString *const kCDTQTextType;
 
 + (nullable instancetype)index:(NSString *)indexName
                     withFields:(NSArray<NSString *> *)fieldNames
-                        ofType:(NSString *)indexType;
+                        ofType:(NSString *)indexType __deprecated;
+
+/**
+ * Creates a CDTIndex object
+ *
+ * @param indexName the index name
+ * @param fieldNames the field names in the index
+ * @param type the index type
+ * @return the Index object or nil if arguments passed in were invalid.
+ */
++ (instancetype)index:(NSString *)indexName
+           withFields:(NSArray<NSString *> *)fieldNames
+                 type:(CDTQIndexType)type;
+
+/**
+ * This function handles index specific validation and ensures that the constructed
+ * Index object is valid.
+ *
+ * @deprecated This has been deprecated use +index:withFields:type:withSettings instead
+ *
+ * @param indexName the index name
+ * @param fieldNames the field names in the index
+ * @param indexType the index type (json or text)
+ * @param indexSettings the optional settings used to configure the index.
+ *                      Only supported parameter is 'tokenize' for text indexes only.
+ * @return the Index object or nil if arguments passed in were invalid.
+ */
++ (nullable instancetype)index:(NSString *)indexName
+                    withFields:(NSArray<NSString *> *)fieldNames
+                        ofType:(NSString *)indexType
+                  withSettings:(nullable NSDictionary<NSString *, NSString *> *)indexSettings __deprecated;
 
 /**
  * This function handles index specific validation and ensures that the constructed
@@ -54,9 +87,21 @@ extern NSString *const kCDTQTextType;
  * @return the Index object or nil if arguments passed in were invalid.
  */
 + (nullable instancetype)index:(NSString *)indexName
-                    withFields:(NSArray<NSString *> *)fieldNames
-                        ofType:(NSString *)indexType
-                  withSettings:(nullable NSDictionary<NSString *, NSString *> *)indexSettings;
+                    withFields:(NSArray *)fieldNames
+                          type:(CDTQIndexType)indexType
+                  withSettings:(NSDictionary *)indexSettings;
+
+/**
+ * Compares the index type and accompanying settings with the passed in arguments.
+ *
+ * @deprecated This has been deprecated use compareToIndexType:withIndexSettings instead
+ *
+ * @param indexType the index type to compare to
+ * @param indexSettings the indexSettings to compare to as an NSString
+ * @return YES/NO - whether there is a match
+ */
+- (BOOL)compareIndexTypeTo:(NSString *)indexType
+         withIndexSettings:(NSString *)indexSettings __deprecated;
 
 /**
  * Compares the index type and accompanying settings with the passed in arguments.
@@ -65,7 +110,7 @@ extern NSString *const kCDTQTextType;
  * @param indexSettings the indexSettings to compare to as an NSString
  * @return YES/NO - whether there is a match
  */
-- (BOOL)compareIndexTypeTo:(NSString *)indexType withIndexSettings:(NSString *)indexSettings;
+- (BOOL)compareToIndexType:(CDTQIndexType)indexType withIndexSettings:(NSString *)indexSettings;
 
 /**
  * Converts the index settings to a JSON string

--- a/CDTDatastore/query/CDTQIndexManager.h
+++ b/CDTDatastore/query/CDTQIndexManager.h
@@ -26,6 +26,21 @@ extern NSString *const kCDTQIndexMetadataTableName;
 @class FMDatabaseQueue;
 @class FMDatabase;
 
+/**
+ * Query Index types
+ */
+typedef NS_ENUM(NSUInteger, CDTQIndexType) {
+    /**
+     * Denotes the index is of type text.
+     */
+    CDTQIndexTypeText,
+    /**
+     * Denotes the index of type JSON.
+     */
+    CDTQIndexTypeJSON,
+
+};
+
 @interface CDTQSqlParts : NSObject
 
 @property (nonatomic, strong) NSString *sqlWithPlaceholders;
@@ -92,16 +107,26 @@ managerUsingDatastore:(CDTDatastore *)datastore
 /** Internal */
 + (NSDictionary<NSString *, NSArray<NSString *> *> *)listIndexesInDatabase:(FMDatabase *)db;
 
-- (nullable NSString *)ensureIndexed:(NSArray<NSString *> *)fieldNames withName:(NSString *)indexName;
+- (nullable NSString *)ensureIndexed:(NSArray<NSString *> *)fieldNames
+                            withName:(NSString *)indexName;
 
 - (nullable NSString *)ensureIndexed:(NSArray<NSString *> *)fieldNames
                             withName:(NSString *)indexName
-                                type:(NSString *)type;
+                                type:(NSString *)type __attribute__((deprecated));
 
 - (nullable NSString *)ensureIndexed:(NSArray<NSString *> *)fieldNames
                             withName:(NSString *)indexName
                                 type:(NSString *)type
-                            settings:(nullable NSDictionary *)indexSettings;
+                            settings:(nullable NSDictionary *)indexSettings __attribute__((deprecated));
+
+- (NSString *)ensureIndexed:(NSArray<NSString *> *)fieldNames
+                   withName:(NSString *)indexName
+                     ofType:(CDTQIndexType)type;
+
+- (NSString *)ensureIndexed:(NSArray<NSString *> *)fieldNames
+                   withName:(NSString *)indexName
+                     ofType:(CDTQIndexType)type
+                   settings:(NSDictionary *)indexSettings;
 
 - (BOOL)deleteIndexNamed:(NSString *)indexName;
 
@@ -117,7 +142,8 @@ managerUsingDatastore:(CDTDatastore *)datastore
 
 /** Internal */
 + (NSString *)tableNameForIndex:(NSString *)indexName;
-
++ (CDTQIndexType)indexTypeForString:(NSString *)string;
++ (NSString *)stringForIndexType:(CDTQIndexType)indexType;
 /** Internal */
 + (BOOL)ftsAvailableInDatabase:(FMDatabaseQueue *)db;
 

--- a/CDTDatastoreTests/CDTDatastoreQueryTests.m
+++ b/CDTDatastoreTests/CDTDatastoreQueryTests.m
@@ -122,20 +122,23 @@ SpecBegin(CDTDatastoreQuery) describe(@"When using datastore query", ^{
         [ds createDocumentFromRevision:rev error:nil];
         expect([ds updateAllIndexes]).to.beTruthy();
     });
-    
+
     it(@"can create a text index", ^{
-        NSString *indexName = [ds ensureIndexed:@[ @"name" ] withName:@"text_idx" type:@"text"];
-        expect(indexName).to.equal(@"text_idx");
+      NSString *indexName =
+          [ds ensureIndexed:@[ @"name" ] withName:@"text_idx" ofType:CDTQIndexTypeText];
+      expect(indexName).to.equal(@"text_idx");
     });
-    
+
     it(@"can create a text index with defined settings", ^{
-        NSString *indexName = [ds ensureIndexed:@[ @"name" ]
-                                       withName:@"text_idx"
-                                           type:@"text"
-                                       settings:@{@"tokenize": @"porter"}];
-        expect(indexName).to.equal(@"text_idx");
+      NSString *indexName = [ds ensureIndexed:@[ @"name" ]
+                                     withName:@"text_idx"
+                                       ofType:CDTQIndexTypeText
+                                     settings:@{
+                                         @"tokenize" : @"porter"
+                                     }];
+      expect(indexName).to.equal(@"text_idx");
     });
-    
+
     it(@"can check if text search is enabled", ^{
         expect([ds isTextSearchEnabled]).to.equal(@YES);
     });

--- a/CDTDatastoreTests/CDTQFilterFieldsTest.m
+++ b/CDTDatastoreTests/CDTQFilterFieldsTest.m
@@ -6,15 +6,15 @@
 //  Copyright (c) 2014 Michael Rhodes. All rights reserved.
 //
 
+#import <CDTDatastore/CDTQIndexCreator.h>
+#import <CDTDatastore/CDTQIndexManager.h>
+#import <CDTDatastore/CDTQIndexUpdater.h>
+#import <CDTDatastore/CDTQQueryExecutor.h>
+#import <CDTDatastore/CDTQResultSet.h>
+#import <CDTDatastore/CloudantSync.h>
 #import <Foundation/Foundation.h>
-#import "Specta.h"
 #import "Expecta.h"
-#import <CloudantSync.h>
-#import <CDTQIndexManager.h>
-#import <CDTQIndexUpdater.h>
-#import <CDTQIndexCreator.h>
-#import <CDTQResultSet.h>
-#import <CDTQQueryExecutor.h>
+#import "Specta.h"
 
 SpecBegin(CDTQFilterFieldsTest)
 

--- a/CDTDatastoreTests/CDTQIndexCreatorTests.m
+++ b/CDTDatastoreTests/CDTQIndexCreatorTests.m
@@ -219,63 +219,68 @@ SpecBegin(CDTQIndexCreator)
             });
 
             it(@"supports using the json type", ^{
-                NSString *name =
-                    [im ensureIndexed:@[ @{ @"name" : @"asc" }, @{
-                        @"age" : @"desc"
-                    } ] withName:@"basic"
-                                 type:@"json"];
-                expect(name).to.equal(@"basic");
+              NSString *name = [im ensureIndexed:@[ @{ @"name" : @"asc" },
+                                                    @{ @"age" : @"desc" } ]
+                                        withName:@"basic"
+                                          ofType:CDTQIndexTypeJSON];
+              expect(name).to.equal(@"basic");
             });
 
             it(@"supports using the text type", ^{
-                NSString *name = [im ensureIndexed:@[ @{ @"name" : @"asc" }, @{ @"age" : @"desc"} ]
-                                          withName:@"basic"
-                                              type:@"text"];
-                expect(name).to.equal(@"basic");
-                NSDictionary *indexes = im.listIndexes;
-                expect(indexes.count).to.equal(1);
-                NSDictionary *index = indexes[@"basic"];
-                expect(index[@"type"]).to.equal(@"text");
-                expect(index[@"settings"]).to.equal(@"{\"tokenize\":\"simple\"}");
+              NSString *name = [im ensureIndexed:@[ @{ @"name" : @"asc" },
+                                                    @{ @"age" : @"desc" } ]
+                                        withName:@"basic"
+                                          ofType:CDTQIndexTypeText];
+              expect(name).to.equal(@"basic");
+              NSDictionary *indexes = im.listIndexes;
+              expect(indexes.count).to.equal(1);
+              NSDictionary *index = indexes[@"basic"];
+              expect(index[@"type"]).to.equal(@"text");
+              expect(index[@"settings"]).to.equal(@"{\"tokenize\":\"simple\"}");
             });
-            
+
             it(@"supports using the text type with a tokenize setting", ^{
-                NSString *name = [im ensureIndexed:@[ @{ @"name" : @"asc" }, @{ @"age" : @"desc"} ]
-                                          withName:@"basic"
-                                              type:@"text"
-                                          settings:@{ @"tokenize" : @"porter" }];
-                expect(name).to.equal(@"basic");
-                NSDictionary *indexes = im.listIndexes;
-                expect(indexes.count).to.equal(1);
-                NSDictionary *index = indexes[@"basic"];
-                expect(index[@"type"]).to.equal(@"text");
-                expect(index[@"settings"]).to.equal(@"{\"tokenize\":\"porter\"}");
+              NSString *name = [im ensureIndexed:@[ @{ @"name" : @"asc" },
+                                                    @{ @"age" : @"desc" } ]
+                                        withName:@"basic"
+                                          ofType:CDTQIndexTypeText
+                                        settings:@{
+                                            @"tokenize" : @"porter"
+                                        }];
+              expect(name).to.equal(@"basic");
+              NSDictionary *indexes = im.listIndexes;
+              expect(indexes.count).to.equal(1);
+              NSDictionary *index = indexes[@"basic"];
+              expect(index[@"type"]).to.equal(@"text");
+              expect(index[@"settings"]).to.equal(@"{\"tokenize\":\"porter\"}");
             });
-            
+
             it(@"supports coexistence of text and json indexes", ^{
-                NSString *name = [im ensureIndexed:@[ @{ @"name" : @"asc" }, @{ @"age" : @"desc"} ]
-                                          withName:@"textIndex"
-                                              type:@"text"];
-                expect(name).to.equal(@"textIndex");
-                name = [im ensureIndexed:@[ @{ @"name" : @"asc" }, @{ @"age" : @"desc"} ]
-                                withName:@"jsonIndex"
-                                    type:@"json"];
-                expect(name).to.equal(@"jsonIndex");
-                expect(im.listIndexes.allKeys).to.containsInAnyOrder(@[ @"textIndex",
-                                                                        @"jsonIndex" ]);
-                
+              NSString *name = [im ensureIndexed:@[ @{ @"name" : @"asc" },
+                                                    @{ @"age" : @"desc" } ]
+                                        withName:@"textIndex"
+                                          ofType:CDTQIndexTypeText];
+              expect(name).to.equal(@"textIndex");
+              name = [im ensureIndexed:@[ @{ @"name" : @"asc" },
+                                          @{ @"age" : @"desc" } ]
+                              withName:@"jsonIndex"
+                                ofType:CDTQIndexTypeJSON];
+              expect(name).to.equal(@"jsonIndex");
+              expect(im.listIndexes.allKeys).to.containsInAnyOrder(@[ @"textIndex", @"jsonIndex" ]);
+
             });
-            
-            
+
             it(@"correctly limits text index creation to one", ^{
-                NSString *name = [im ensureIndexed:@[ @{ @"name" : @"asc" }, @{ @"age" : @"desc"} ]
-                                          withName:@"basic"
-                                              type:@"text"];
-                expect(name).to.equal(@"basic");
-                name = [im ensureIndexed:@[ @{ @"name" : @"asc" }, @{ @"age" : @"desc"} ]
-                                withName:@"anotherTextIndex"
-                                    type:@"text"];
-                expect(name).to.beNil();
+              NSString *name = [im ensureIndexed:@[ @{ @"name" : @"asc" },
+                                                    @{ @"age" : @"desc" } ]
+                                        withName:@"basic"
+                                          ofType:CDTQIndexTypeText];
+              expect(name).to.equal(@"basic");
+              name = [im ensureIndexed:@[ @{ @"name" : @"asc" },
+                                          @{ @"age" : @"desc" } ]
+                              withName:@"anotherTextIndex"
+                                ofType:CDTQIndexTypeText];
+              expect(name).to.beNil();
             });
 
             it(@"doesn't support using the geo type", ^{

--- a/CDTDatastoreTests/CDTQIndexCreatorTests.m
+++ b/CDTDatastoreTests/CDTQIndexCreatorTests.m
@@ -5,13 +5,13 @@
 //  Created by Michael Rhodes on 09/27/2014.
 //  Copyright (c) 2014 Michael Rhodes. All rights reserved.
 //
-
-#import <CloudantSync.h>
-#import <CDTQIndexManager.h>
-#import <CDTQIndexUpdater.h>
-#import <CDTQIndexCreator.h>
-#import <CDTQResultSet.h>
-#import <CDTQQueryExecutor.h>
+#import <CDTDatastore/CDTQIndexCreator.h>
+#import <CDTDatastore/CDTQIndexManager.h>
+#import <CDTDatastore/CDTQIndexUpdater.h>
+#import <CDTDatastore/CDTQQueryExecutor.h>
+#import <CDTDatastore/CDTQResultSet.h>
+#import <CDTDatastore/CloudantSync.h>
+#import <Specta/Specta.h>
 #import "Matchers/CDTQContainsInAnyOrderMatcher.h"
 
 SpecBegin(CDTQIndexCreator)
@@ -279,21 +279,28 @@ SpecBegin(CDTQIndexCreator)
             });
 
             it(@"doesn't support using the geo type", ^{
-                NSString *name =
-                    [im ensureIndexed:@[ @{ @"name" : @"asc" }, @{
-                        @"age" : @"desc"
-                    } ] withName:@"basic"
-                                 type:@"geo"];
-                expect(name).to.beNil();
+
+              @try {
+                  [im ensureIndexed:@[ @{ @"name" : @"asc" },
+                                       @{ @"age" : @"desc" } ]
+                           withName:@"basic"
+                               type:@"geo"];
+                  expect(nil).toNot.beNil();
+              } @catch (NSException *e) {
+                  expect(nil).to.beNil();
+              }
             });
 
             it(@"doesn't support using the unplanned type", ^{
-                NSString *name =
-                    [im ensureIndexed:@[ @{ @"name" : @"asc" }, @{
-                        @"age" : @"desc"
-                    } ] withName:@"basic"
-                                 type:@"frog"];
-                expect(name).to.beNil();
+              @try {
+                  [im ensureIndexed:@[ @{ @"name" : @"asc" },
+                                       @{ @"age" : @"desc" } ]
+                           withName:@"basic"
+                               type:@"frog"];
+                  expect(nil).toNot.beNil();
+              } @catch (NSException *e) {
+                  expect(nil).to.beNil();
+              }
             });
 
         });

--- a/CDTDatastoreTests/CDTQIndexManagerTests.m
+++ b/CDTDatastoreTests/CDTQIndexManagerTests.m
@@ -5,13 +5,14 @@
 //  Created by Michael Rhodes on 09/27/2014.
 //  Copyright (c) 2014 Michael Rhodes. All rights reserved.
 //
-
-#import <CloudantSync.h>
-#import <CDTQIndexManager.h>
-#import <CDTQIndexUpdater.h>
-#import <CDTQIndexCreator.h>
-#import <CDTQResultSet.h>
-#import <CDTQQueryExecutor.h>
+#import <CDTDatastore/CDTQIndexCreator.h>
+#import <CDTDatastore/CDTQIndexManager.h>
+#import <CDTDatastore/CDTQIndexUpdater.h>
+#import <CDTDatastore/CDTQQueryExecutor.h>
+#import <CDTDatastore/CDTQResultSet.h>
+#import <CDTDatastore/CloudantSync.h>
+#import <Expecta/Expecta.h>
+#import <Specta/Specta.h>
 #import "DBQueryUtils.h"
 
 SpecBegin(CDTQIndexManager)

--- a/CDTDatastoreTests/CDTQIndexManagerTests.m
+++ b/CDTDatastoreTests/CDTQIndexManagerTests.m
@@ -192,10 +192,9 @@ SpecBegin(CDTQIndexManager)
                          @"pet" : @{@"species" : @"cat", @"name" : @"mike"}
                          };
             [ds createDocumentFromRevision:rev error:nil];
-            
-            expect([im ensureIndexed:@[ @"name" ]
-                            withName:@"basic"
-                                type:@"text"]).to.equal(@"basic");
+
+            expect([im ensureIndexed:@[ @"name" ] withName:@"basic" ofType:CDTQIndexTypeText])
+                .to.equal(@"basic");
             expect([im listIndexes][@"basic"]).toNot.beNil();
             
             expect([im deleteIndexNamed:@"basic"]).to.equal(@YES);

--- a/CDTDatastoreTests/CDTQIndexTests.m
+++ b/CDTDatastoreTests/CDTQIndexTests.m
@@ -35,19 +35,21 @@ describe(@"When creating an instance of index", ^{
         expect(index.indexName).to.equal(@"basic");
         expect(index.fieldNames).to.containsInAnyOrder(@[ @"name", @"age" ]);
         expect(index.indexType).to.equal(@"json");
+        expect(index.type).to.equal(CDTQIndexTypeJSON);
         expect(index.indexSettings).to.beNil();
     });
-    
-    it(@"constructs an index instance with the TEXT index type and default index settings", ^{
-        CDTQIndex *index = [CDTQIndex index:indexName withFields:fieldNames ofType:@"text"];
 
-        expect(index.indexName).to.equal(@"basic");
-        expect(index.fieldNames).to.containsInAnyOrder(@[ @"name", @"age" ]);
-        expect(index.indexType).to.equal(@"text");
-        expect(index.indexSettings.count).to.equal(1);
-        expect(index.indexSettings[ @"tokenize" ]).to.equal(@"simple");
+    it(@"constructs an index instance with the TEXT index type and default index settings", ^{
+      CDTQIndex *index = [CDTQIndex index:indexName withFields:fieldNames type:CDTQIndexTypeText];
+
+      expect(index.indexName).to.equal(@"basic");
+      expect(index.fieldNames).to.containsInAnyOrder(@[ @"name", @"age" ]);
+      expect(index.indexType).to.equal(@"text");
+      expect(index.type).to.equal(CDTQIndexTypeText);
+      expect(index.indexSettings.count).to.equal(1);
+      expect(index.indexSettings[@"tokenize"]).to.equal(@"simple");
     });
-    
+
     it(@"returns nil when no fields are provided", ^{
         expect([CDTQIndex index:indexName withFields:nil]).to.beNil();
         
@@ -87,22 +89,28 @@ describe(@"When creating an instance of index", ^{
     });
 
     it(@"returns nil when index settings are invalid", ^{
-        expect([CDTQIndex index:indexName
-                     withFields:fieldNames
-                         ofType:@"text"
-                   withSettings:@{ @"foo": @"bar" }]).to.beNil();
+      expect([CDTQIndex index:indexName
+                   withFields:fieldNames
+                         type:CDTQIndexTypeText
+                 withSettings:@{
+                     @"foo" : @"bar"
+                 }])
+          .to.beNil();
     });
-    
+
     it(@"constructs index instance but ignores index settings when appropriate", ^{
         // json indexes do not support index settings.  Index settings will be ignored.
         CDTQIndex *index = [CDTQIndex index:indexName
                                  withFields:fieldNames
-                                     ofType:@"json"
-                               withSettings:@{ @"tokenize": @"porter" }];
+                                       type:CDTQIndexTypeJSON
+                               withSettings:@{
+                                   @"tokenize" : @"porter"
+                               }];
 
         expect(index.indexName).to.equal(@"basic");
         expect(index.fieldNames).to.containsInAnyOrder(@[ @"name", @"age" ]);
         expect(index.indexType).to.equal(@"json");
+        expect(index.type).to.equal(CDTQIndexTypeJSON);
         expect(index.indexSettings).to.beNil();
     });
     
@@ -110,12 +118,15 @@ describe(@"When creating an instance of index", ^{
         // text indexes support the tokenize setting.
         CDTQIndex *index = [CDTQIndex index:indexName
                                  withFields:fieldNames
-                                     ofType:@"text"
-                               withSettings:@{ @"tokenize": @"porter" }];
+                                       type:CDTQIndexTypeText
+                               withSettings:@{
+                                   @"tokenize" : @"porter"
+                               }];
 
         expect(index.indexName).to.equal(@"basic");
         expect(index.fieldNames).to.containsInAnyOrder(@[ @"name", @"age" ]);
         expect(index.indexType).to.equal(@"text");
+        expect(index.type).to.equal(CDTQIndexTypeText);
         expect(index.indexSettings[ @"tokenize" ]).to.equal(@"porter");
     });
     
@@ -134,31 +145,33 @@ describe(@"When comparing index content", ^{
     it(@"correctly compares index type inequality", ^{
         // Construct an index instance of default index type "json"
         CDTQIndex *index = [CDTQIndex index:indexName withFields:fieldNames];
-        
-        expect([index compareIndexTypeTo:@"text" withIndexSettings:nil]).to.equal(NO);
+
+        expect([index compareToIndexType:CDTQIndexTypeText withIndexSettings:nil]).to.equal(NO);
     });
     
     it(@"correctly compares index type equality", ^{
         // Construct an index instance of default index type "json"
         CDTQIndex *index = [CDTQIndex index:indexName withFields:fieldNames];
-        
-        expect([index compareIndexTypeTo:@"json" withIndexSettings:nil]).to.equal(YES);
+
+        expect([index compareToIndexType:CDTQIndexTypeJSON withIndexSettings:nil]).to.equal(YES);
     });
     
     it(@"correctly compares index setting inequality", ^{
         // Construct a "text" index instance with default index settings of { "tokenize": "simple" }
-        CDTQIndex *index = [CDTQIndex index:indexName withFields:fieldNames ofType:@"text"];
-        
-        expect([index compareIndexTypeTo:@"text"
-                       withIndexSettings:@"{\"tokenize\":\"porter\"}"]).to.equal(NO);
+        CDTQIndex *index = [CDTQIndex index:indexName withFields:fieldNames type:CDTQIndexTypeText];
+
+        expect([index compareToIndexType:CDTQIndexTypeText
+                       withIndexSettings:@"{\"tokenize\":\"porter\"}"])
+            .to.equal(NO);
     });
     
     it(@"correctly compares index setting equality", ^{
         // Construct a "text" index instance with default index settings of { "tokenize": "simple" }
-        CDTQIndex *index = [CDTQIndex index:indexName withFields:fieldNames ofType:@"text"];
-        
-        expect([index compareIndexTypeTo:@"text"
-                       withIndexSettings:@"{\"tokenize\":\"simple\"}"]).to.equal(YES);
+        CDTQIndex *index = [CDTQIndex index:indexName withFields:fieldNames type:CDTQIndexTypeText];
+
+        expect([index compareToIndexType:CDTQIndexTypeText
+                       withIndexSettings:@"{\"tokenize\":\"simple\"}"])
+            .to.equal(YES);
     });
     
 });
@@ -172,13 +185,13 @@ describe(@"When retrieving index settings as a String", ^{
         fieldNames = @[ @"name", @"age" ];
         indexName = @"basic";
     });
-    
+
     it(@"returns a String representation of the index settings", ^{
-        CDTQIndex *index = [CDTQIndex index:indexName withFields:fieldNames ofType:@"text"];
-        
-        expect([index settingsAsJSON]).to.equal(@"{\"tokenize\":\"simple\"}");
+      CDTQIndex *index = [CDTQIndex index:indexName withFields:fieldNames type:CDTQIndexTypeText];
+
+      expect([index settingsAsJSON]).to.equal(@"{\"tokenize\":\"simple\"}");
     });
-    
+
     it(@"returns nil when appropriate", ^{
         CDTQIndex *index = [CDTQIndex index:indexName withFields:fieldNames];
         

--- a/CDTDatastoreTests/CDTQIndexTests.m
+++ b/CDTDatastoreTests/CDTQIndexTests.m
@@ -12,9 +12,9 @@
 //  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
 //  either express or implied. See the License for the specific language governing permissions
 //  and limitations under the License.
-
-#import <CloudantSync.h>
-#import <CDTQIndex.h>
+#import <CDTDatastore/CDTQIndex.h>
+#import <CDTDatastore/CloudantSync.h>
+#import <Specta/Specta.h>
 #import "Matchers/CDTQContainsInAnyOrderMatcher.h"
 
 SpecBegin(CDTQIndex)
@@ -59,17 +59,33 @@ describe(@"When creating an instance of index", ^{
         
         expect([CDTQIndex index:@"" withFields:fieldNames]).to.beNil();
     });
-    
+
     it(@"returns nil when index type is specifically nil or blank", ^{
-        expect([CDTQIndex index:indexName withFields:fieldNames ofType:nil]).to.beNil();
-        
-        expect([CDTQIndex index:indexName withFields:fieldNames ofType:@""]).to.beNil();
+      @try {
+          [CDTQIndex index:indexName withFields:fieldNames ofType:nil];
+          expect(nil).toNot.beNil();
+      } @catch (NSException *exception) {
+          expect(nil).to.beNil();
+      }
+
+      @
+      try {
+          [CDTQIndex index:indexName withFields:fieldNames ofType:@""];
+          expect(nil).toNot.beNil();
+      } @catch (NSException *exception) {
+          expect(nil).to.beNil();
+      }
     });
-    
+
     it(@"returns nil when index type is invalid", ^{
-        expect([CDTQIndex index:indexName withFields:fieldNames ofType:@"blah"]).to.beNil();
+      @try {
+          [CDTQIndex index:indexName withFields:fieldNames ofType:@"blah"];
+          expect(nil).toNot.beNil();
+      } @catch (NSException *exception) {
+          expect(nil).to.beNil();
+      }
     });
-    
+
     it(@"returns nil when index settings are invalid", ^{
         expect([CDTQIndex index:indexName
                      withFields:fieldNames

--- a/CDTDatastoreTests/CDTQIndexUpdaterTests.m
+++ b/CDTDatastoreTests/CDTQIndexUpdaterTests.m
@@ -5,13 +5,14 @@
 //  Created by Michael Rhodes on 09/27/2014.
 //  Copyright (c) 2014 Michael Rhodes. All rights reserved.
 //
-
-#import <CloudantSync.h>
-#import <CDTQIndexManager.h>
-#import <CDTQIndexUpdater.h>
-#import <CDTQIndexCreator.h>
-#import <CDTQResultSet.h>
-#import <CDTQQueryExecutor.h>
+#import <CDTDatastore/CDTQIndexCreator.h>
+#import <CDTDatastore/CDTQIndexManager.h>
+#import <CDTDatastore/CDTQIndexUpdater.h>
+#import <CDTDatastore/CDTQQueryExecutor.h>
+#import <CDTDatastore/CDTQResultSet.h>
+#import <CDTDatastore/CloudantSync.h>
+#import <Expecta/Expecta.h>
+#import <Specta/Specta.h>
 
 SpecBegin(CDTQIndexUpdater)
 

--- a/CDTDatastoreTests/CDTQIndexUpdaterTests.m
+++ b/CDTDatastoreTests/CDTQIndexUpdaterTests.m
@@ -374,14 +374,16 @@ SpecBegin(CDTQIndexUpdater)
                 expect([updater sequenceNumberForIndex:@"basic"]).to.equal(7);
 
             });
-            
-            describe(@"when using a text index", ^{
-                it(@"sets correct sequence number", ^{
-                    
+
+            describe(
+                @"when using a text index", ^{
+                  it(@"sets correct sequence number", ^{
+
                     expect([im ensureIndexed:@[ @"pet", @"name" ]
                                     withName:@"basic"
-                                        type:@"text"]).toNot.beNil();
-                    
+                                      ofType:CDTQIndexTypeText])
+                        .toNot.beNil();
+
                     FMDatabaseQueue *queue =
                         (FMDatabaseQueue *)[im performSelector:@selector(database)];
                     
@@ -392,13 +394,14 @@ SpecBegin(CDTQIndexUpdater)
                     expect([updater updateAllIndexes:[im listIndexes]]).to.beTruthy();
                     
                     expect([updater sequenceNumberForIndex:@"basic"]).to.equal(6);
-                    
-                });
-                
-                it(@"sets correct sequence number after update", ^{
+
+                  });
+
+                  it(@"sets correct sequence number after update", ^{
                     expect([im ensureIndexed:@[ @"pet", @"name" ]
                                     withName:@"basic"
-                                        type:@"text"]).toNot.beNil();
+                                      ofType:CDTQIndexTypeText])
+                        .toNot.beNil();
                     FMDatabaseQueue *queue =
                         (FMDatabaseQueue *)[im performSelector:@selector(database)];
                     CDTQIndexUpdater *updater =
@@ -412,9 +415,9 @@ SpecBegin(CDTQIndexUpdater)
                     expect([updater updateAllIndexes:[im listIndexes]]).to.beTruthy();
                     
                     expect([updater sequenceNumberForIndex:@"basic"]).to.equal(7);
-                    
+
+                  });
                 });
-            });
 
         });
     });

--- a/CDTDatastoreTests/CDTQInvalidQuerySyntax.m
+++ b/CDTDatastoreTests/CDTQInvalidQuerySyntax.m
@@ -5,13 +5,14 @@
 //  Created by Rhys Short on 14/10/2014.
 //  Copyright (c) 2014 Michael Rhodes. All rights reserved.
 //
-
-#import <CloudantSync.h>
-#import <CDTQIndexManager.h>
-#import <CDTQIndexUpdater.h>
-#import <CDTQIndexCreator.h>
-#import <CDTQResultSet.h>
-#import <CDTQQueryExecutor.h>
+#import <CDTDatastore/CDTQIndexCreator.h>
+#import <CDTDatastore/CDTQIndexManager.h>
+#import <CDTDatastore/CDTQIndexUpdater.h>
+#import <CDTDatastore/CDTQQueryExecutor.h>
+#import <CDTDatastore/CDTQResultSet.h>
+#import <CDTDatastore/CloudantSync.h>
+#import <Expecta/Expecta.h>
+#import <Specta/Specta.h>
 
 SpecBegin(CDTQQueryExecutorInvalidSyntax) describe(@"cloudant query using invalid syntax", ^{
 

--- a/CDTDatastoreTests/CDTQPerformanceTests.m
+++ b/CDTDatastoreTests/CDTQPerformanceTests.m
@@ -5,15 +5,16 @@
 //  Created by Michael Rhodes on 09/27/2014.
 //  Copyright (c) 2014 Michael Rhodes. All rights reserved.
 //
+#import <CDTDatastore/CDTQIndexCreator.h>
+#import <CDTDatastore/CDTQIndexManager.h>
+#import <CDTDatastore/CDTQIndexUpdater.h>
+#import <CDTDatastore/CDTQQueryExecutor.h>
+#import <CDTDatastore/CDTQResultSet.h>
+#import <CDTDatastore/CloudantSync.h>
+#import <Expecta/Expecta.h>
+#import <Specta/Specta.h>
 
-#import <CloudantSync.h>
-#import <CDTQIndexManager.h>
-#import <CDTQIndexUpdater.h>
-#import <CDTQIndexCreator.h>
-#import <CDTQResultSet.h>
-#import <CDTQQueryExecutor.h>
-
-#import <CocoaLumberjack.h>
+#import <CocoaLumberjack/CocoaLumberjack.h>
 
 SpecBegin(CDTQPerformance)
 

--- a/CDTDatastoreTests/CDTQQueryExecutorTests.m
+++ b/CDTDatastoreTests/CDTQQueryExecutorTests.m
@@ -9,12 +9,15 @@
 #import "CDTQMatcherIndexManager.h"
 #import "CDTQSQLOnlyIndexManager.h"
 
-#import <CloudantSync.h>
-#import <CDTQIndexManager.h>
-#import <CDTQIndexUpdater.h>
-#import <CDTQIndexCreator.h>
-#import <CDTQResultSet.h>
-#import <CDTQQueryExecutor.h>
+#import <Expecta/Expecta.h>
+#import <Specta/Specta.h>
+
+#import <CDTDatastore/CDTQIndexCreator.h>
+#import <CDTDatastore/CDTQIndexManager.h>
+#import <CDTDatastore/CDTQIndexUpdater.h>
+#import <CDTDatastore/CDTQQueryExecutor.h>
+#import <CDTDatastore/CDTQResultSet.h>
+#import <CDTDatastore/CloudantSync.h>
 #import "Matchers/CDTQContainsInAnyOrderMatcher.h"
 #import "Matchers/CDTQEitherMatcher.h"
 

--- a/CDTDatastoreTests/CDTQQuerySortTests.m
+++ b/CDTDatastoreTests/CDTQQuerySortTests.m
@@ -5,13 +5,14 @@
 //  Created by Michael Rhodes on 09/27/2014.
 //  Copyright (c) 2014 Michael Rhodes. All rights reserved.
 //
-
-#import <CloudantSync.h>
-#import <CDTQIndexManager.h>
-#import <CDTQIndexUpdater.h>
-#import <CDTQIndexCreator.h>
-#import <CDTQResultSet.h>
-#import <CDTQQueryExecutor.h>
+#import <CDTDatastore/CDTQIndexCreator.h>
+#import <CDTDatastore/CDTQIndexManager.h>
+#import <CDTDatastore/CDTQIndexUpdater.h>
+#import <CDTDatastore/CDTQQueryExecutor.h>
+#import <CDTDatastore/CDTQResultSet.h>
+#import <CDTDatastore/CloudantSync.h>
+#import <Expecta/Expecta.h>
+#import <Specta/Specta.h>
 
 SpecBegin(CDTQQueryExecutorSorting)
 

--- a/CDTDatastoreTests/CDTQQuerySqlTranslatorTests.m
+++ b/CDTDatastoreTests/CDTQQuerySqlTranslatorTests.m
@@ -5,20 +5,21 @@
 //  Created by Michael Rhodes on 09/27/2014.
 //  Copyright (c) 2014 Michael Rhodes. All rights reserved.
 //
-
-#import <CloudantSync.h>
-#import <CDTQIndexManager.h>
-#import <CDTQIndexUpdater.h>
-#import <CDTQIndexCreator.h>
-#import <CDTQResultSet.h>
-#import <CDTQQueryExecutor.h>
-#import <CDTQQuerySqlTranslator.h>
-#import <CDTQQueryValidator.h>
-#import <Specta.h>
-#import <Expecta.h>
+#import <CDTDatastore/CDTQIndexCreator.h>
+#import <CDTDatastore/CDTQIndexManager.h>
+#import <CDTDatastore/CDTQIndexUpdater.h>
+#import <CDTDatastore/CDTQQueryExecutor.h>
+#import <CDTDatastore/CDTQQuerySqlTranslator.h>
+#import <CDTDatastore/CDTQQueryValidator.h>
+#import <CDTDatastore/CDTQResultSet.h>
+#import <CDTDatastore/CloudantSync.h>
+#import <Expecta/Expecta.h>
+#import <Expecta/Expecta.h>
+#import <Specta/Specta.h>
+#import <Specta/Specta.h>
 #import "Matchers/CDTQContainsInAnyOrderMatcher.h"
-#import "Matchers/CDTQQueryMatcher.h"
 #import "Matchers/CDTQEitherMatcher.h"
+#import "Matchers/CDTQQueryMatcher.h"
 
 SpecBegin(CDTQQuerySqlTranslator) describe(@"cdtq", ^{
 

--- a/CDTDatastoreTests/CDTQQuerySqlTranslatorTests.m
+++ b/CDTDatastoreTests/CDTQQuerySqlTranslatorTests.m
@@ -447,8 +447,8 @@ SpecBegin(CDTQQuerySqlTranslator) describe(@"cdtq", ^{
             im = [CDTQIndexManager managerUsingDatastore:ds error:nil];
             
             [im ensureIndexed:@[ @"name", @"age", @"pet" ] withName:@"basic"];
-            [im ensureIndexed:@[ @"comments" ] withName:@"basic_text" type:@"text"];
-            
+            [im ensureIndexed:@[ @"comments" ] withName:@"basic_text" ofType:CDTQIndexTypeText];
+
             expect([[im listIndexes] count]).to.equal(2);
         });
         

--- a/CDTDatastoreTests/CDTQTextSearchTests.m
+++ b/CDTDatastoreTests/CDTQTextSearchTests.m
@@ -14,9 +14,9 @@
 //  and limitations under the License.
 //
 
-#import <CloudantSync.h>
-#import <Specta.h>
-#import <Expecta.h>
+#import <CDTDatastore/CloudantSync.h>
+#import <Expecta/Expecta.h>
+#import <Specta/Specta.h>
 #import "Matchers/CDTQContainsInAnyOrderMatcher.h"
 
 SpecBegin(CDTQQueryExecutorTextSearch) describe(@"cdtq", ^{

--- a/CDTDatastoreTests/CDTQTextSearchTests.m
+++ b/CDTDatastoreTests/CDTQTextSearchTests.m
@@ -114,54 +114,52 @@ SpecBegin(CDTQQueryExecutorTextSearch) describe(@"cdtq", ^{
         });
 
         it(@"can perform a search consisting of a single text clause", ^{
-            expect([im ensureIndexed:@[ @"comment" ]
-                            withName:@"basic_text"
-                                type:@"text"]).toNot.beNil();
-            
-            NSDictionary* query = @{ @"$text" : @{@"$search" : @"lives in Bristol"} };
-            CDTQResultSet* result = [im find:query];
-            expect(result.documentIds).to.containsInAnyOrder(@[ @"mike12", @"mike34", @"fred12" ]);
+          expect([im ensureIndexed:@[ @"comment" ] withName:@"basic_text" ofType:CDTQIndexTypeText])
+              .toNot.beNil();
+
+          NSDictionary* query = @{ @"$text" : @{@"$search" : @"lives in Bristol"} };
+          CDTQResultSet* result = [im find:query];
+          expect(result.documentIds).to.containsInAnyOrder(@[ @"mike12", @"mike34", @"fred12" ]);
         });
-        
+
         it(@"can perform a phrase search", ^{
-            expect([im ensureIndexed:@[ @"comment" ]
-                            withName:@"basic_text"
-                                type:@"text"]).toNot.beNil();
-            
-            NSDictionary* query = @{ @"$text" : @{@"$search" : @"\"lives in Bristol\""} };
-            CDTQResultSet* result = [im find:query];
-            expect(result.documentIds).to.containsInAnyOrder(@[ @"mike12", @"fred12" ]);
+          expect([im ensureIndexed:@[ @"comment" ] withName:@"basic_text" ofType:CDTQIndexTypeText])
+              .toNot.beNil();
+
+          NSDictionary* query = @{ @"$text" : @{@"$search" : @"\"lives in Bristol\""} };
+          CDTQResultSet* result = [im find:query];
+          expect(result.documentIds).to.containsInAnyOrder(@[ @"mike12", @"fred12" ]);
         });
-        
+
         it(@"can perform a search containing an apostrophe", ^{
-            expect([im ensureIndexed:@[ @"comment" ]
-                            withName:@"basic_text"
-                                type:@"text"]).toNot.beNil();
-            
-            NSDictionary* query = @{ @"$text" : @{@"$search" : @"he's retired"} };
-            CDTQResultSet* result = [im find:query];
-            expect(result.documentIds).to.containsInAnyOrder(@[ @"mike72" ]);
+          expect([im ensureIndexed:@[ @"comment" ] withName:@"basic_text" ofType:CDTQIndexTypeText])
+              .toNot.beNil();
+
+          NSDictionary* query = @{ @"$text" : @{@"$search" : @"he's retired"} };
+          CDTQResultSet* result = [im find:query];
+          expect(result.documentIds).to.containsInAnyOrder(@[ @"mike72" ]);
         });
-        
+
         it(@"can perform a search consisting of a single text clause with a sort", ^{
-            expect([im ensureIndexed:@[ @"name", @"comment" ]
-                            withName:@"basic_text"
-                                type:@"text"]).toNot.beNil();
-            
-            NSDictionary* query = @{ @"$text" : @{@"$search" : @"best friend"} };
-            NSArray *order = @[ @{ @"name" : @"asc" } ];
-            CDTQResultSet* result = [im find:query skip:0 limit:0 fields:nil sort: order];
-            expect(result.documentIds).to.containsInAnyOrder(@[ @"mike12", @"fred12" ]);
-            expect(result.documentIds[0]).to.equal(@"fred12");
-            expect(result.documentIds[1]).to.equal(@"mike12");
+          expect([im ensureIndexed:@[ @"name", @"comment" ]
+                          withName:@"basic_text"
+                            ofType:CDTQIndexTypeText])
+              .toNot.beNil();
+
+          NSDictionary* query = @{ @"$text" : @{@"$search" : @"best friend"} };
+          NSArray* order = @[ @{ @"name" : @"asc" } ];
+          CDTQResultSet* result = [im find:query skip:0 limit:0 fields:nil sort:order];
+          expect(result.documentIds).to.containsInAnyOrder(@[ @"mike12", @"fred12" ]);
+          expect(result.documentIds[0]).to.equal(@"fred12");
+          expect(result.documentIds[1]).to.equal(@"mike12");
         });
-        
+
         it(@"can perform a compound AND query search containing a text clause", ^{
             expect([im ensureIndexed:@[ @"name" ] withName:@"basic"]).toNot.beNil();
-            expect([im ensureIndexed:@[ @"comment" ]
-                            withName:@"basic_text"
-                                type:@"text"]).toNot.beNil();
-            
+            expect(
+                [im ensureIndexed:@[ @"comment" ] withName:@"basic_text" ofType:CDTQIndexTypeText])
+                .toNot.beNil();
+
             NSDictionary* query = @{ @"name" : @"mike",
                                      @"$text" : @{@"$search" : @"best friend"} };
             CDTQResultSet* result = [im find:query];
@@ -170,10 +168,10 @@ SpecBegin(CDTQQueryExecutorTextSearch) describe(@"cdtq", ^{
         
         it(@"can perform a compound OR query search containing a text clause", ^{
             expect([im ensureIndexed:@[ @"name" ] withName:@"basic"]).toNot.beNil();
-            expect([im ensureIndexed:@[ @"comment" ]
-                            withName:@"basic_text"
-                                type:@"text"]).toNot.beNil();
-            
+            expect(
+                [im ensureIndexed:@[ @"comment" ] withName:@"basic_text" ofType:CDTQIndexTypeText])
+                .toNot.beNil();
+
             NSDictionary* query = @{ @"$or" : @[ @{ @"name" : @"mike" },
                                                  @{ @"$text" : @{@"$search" : @"best friend"} } ] };
             CDTQResultSet* result = [im find:query];
@@ -199,202 +197,202 @@ SpecBegin(CDTQQueryExecutorTextSearch) describe(@"cdtq", ^{
             // indexes.
             expect([im ensureIndexed:@[ @"name", @"comment" ]
                             withName:@"basic_text"
-                                type:@"text"]).toNot.beNil();
-            
+                              ofType:CDTQIndexTypeText])
+                .toNot.beNil();
+
             NSDictionary* query = @{ @"$or" : @[ @{ @"name" : @"mike" },
                                                  @{ @"$text" : @{@"$search" : @"best friend"} } ] };
             expect([im find:query]).to.beNil();
         });
-        
+
         it(@"can perform a text search containing non-ascii values", ^{
-            expect([im ensureIndexed:@[ @"comment" ]
-                            withName:@"basic_text"
-                                type:@"text"]).toNot.beNil();
-            
-            NSDictionary* query = @{ @"$text" : @{@"$search" : @"\"صديق له هو\""} };
-            CDTQResultSet* result = [im find:query];
-            expect(result.documentIds).to.containsInAnyOrder(@[ @"john34" ]);
+          expect([im ensureIndexed:@[ @"comment" ] withName:@"basic_text" ofType:CDTQIndexTypeText])
+              .toNot.beNil();
+
+          NSDictionary* query = @{ @"$text" : @{@"$search" : @"\"صديق له هو\""} };
+          CDTQResultSet* result = [im find:query];
+          expect(result.documentIds).to.containsInAnyOrder(@[ @"john34" ]);
         });
-        
+
         it(@"returns empty result set for unmatched phrase search", ^{
-            expect([im ensureIndexed:@[ @"comment" ]
-                            withName:@"basic_text"
-                                type:@"text"]).toNot.beNil();
-            
-            NSDictionary* query = @{ @"$text" : @{@"$search" : @"\"remus romulus\""} };
-            CDTQResultSet* result = [im find:query];
-            expect(result).toNot.beNil();
-            expect(result.documentIds.count).to.equal(0);
+          expect([im ensureIndexed:@[ @"comment" ] withName:@"basic_text" ofType:CDTQIndexTypeText])
+              .toNot.beNil();
+
+          NSDictionary* query = @{ @"$text" : @{@"$search" : @"\"remus romulus\""} };
+          CDTQResultSet* result = [im find:query];
+          expect(result).toNot.beNil();
+          expect(result.documentIds.count).to.equal(0);
         });
-        
+
         it(@"returns correct result set for non-contiguous word search", ^{
-            expect([im ensureIndexed:@[ @"comment" ]
-                            withName:@"basic_text"
-                                type:@"text"]).toNot.beNil();
-            
-            // The search predicate "Remus Romulus" normalizes to "Remus AND Romulus" in SQLite
-            NSDictionary* query = @{ @"$text" : @{@"$search" : @"remus romulus"} };
-            CDTQResultSet* result = [im find:query];
-            expect(result.documentIds).to.containsInAnyOrder(@[ @"fred34" ]);
+          expect([im ensureIndexed:@[ @"comment" ] withName:@"basic_text" ofType:CDTQIndexTypeText])
+              .toNot.beNil();
+
+          // The search predicate "Remus Romulus" normalizes to "Remus AND Romulus" in SQLite
+          NSDictionary* query = @{ @"$text" : @{@"$search" : @"remus romulus"} };
+          CDTQResultSet* result = [im find:query];
+          expect(result.documentIds).to.containsInAnyOrder(@[ @"fred34" ]);
         });
-        
+
         it(@"can perform text search using enhanced query syntax OR operator", ^{
-            expect([im ensureIndexed:@[ @"comment" ]
-                            withName:@"basic_text"
-                                type:@"text"]).toNot.beNil();
-            
-            // Enhanced Query Syntax - logical operators must be uppercase otherwise they will
-            // be treated as a search token
-            NSDictionary* query = @{ @"$text" : @{@"$search" : @"Remus OR Romulus"} };
-            CDTQResultSet* result = [im find:query];
-            expect(result.documentIds).to.containsInAnyOrder(@[ @"fred34", @"mike72" ]);
+          expect([im ensureIndexed:@[ @"comment" ] withName:@"basic_text" ofType:CDTQIndexTypeText])
+              .toNot.beNil();
+
+          // Enhanced Query Syntax - logical operators must be uppercase otherwise they will
+          // be treated as a search token
+          NSDictionary* query = @{ @"$text" : @{@"$search" : @"Remus OR Romulus"} };
+          CDTQResultSet* result = [im find:query];
+          expect(result.documentIds).to.containsInAnyOrder(@[ @"fred34", @"mike72" ]);
         });
-        
+
         it(@"can perform text search using enhanced query syntax NOT operator", ^{
-            expect([im ensureIndexed:@[ @"comment" ]
-                            withName:@"basic_text"
-                                type:@"text"]).toNot.beNil();
-            
-            // Enhanced Query Syntax - logical operators must be uppercase otherwise they will
-            // be treated as a search token
-            // - NOT operator only works between tokens as in (token1 NOT token2)
-            NSDictionary* query = @{ @"$text" : @{@"$search" : @"Remus NOT Romulus"} };
-            CDTQResultSet* result = [im find:query];
-            expect(result.documentIds).to.containsInAnyOrder(@[ @"mike72" ]);
+          expect([im ensureIndexed:@[ @"comment" ] withName:@"basic_text" ofType:CDTQIndexTypeText])
+              .toNot.beNil();
+
+          // Enhanced Query Syntax - logical operators must be uppercase otherwise they will
+          // be treated as a search token
+          // - NOT operator only works between tokens as in (token1 NOT token2)
+          NSDictionary* query = @{ @"$text" : @{@"$search" : @"Remus NOT Romulus"} };
+          CDTQResultSet* result = [im find:query];
+          expect(result.documentIds).to.containsInAnyOrder(@[ @"mike72" ]);
         });
-        
+
         it(@"can perform text search using enhanced query syntax with parentheses", ^{
-            expect([im ensureIndexed:@[ @"comment" ]
-                            withName:@"basic_text"
-                                type:@"text"]).toNot.beNil();
-            
-            // Parentheses are used to override SQLite enhanced query syntax operator precedence
-            // - Operator precedence is NOT -> AND -> OR
-            NSDictionary* query = @{ @"$text" : @{@"$search" : @"(Remus OR Romulus) "
-                                                               @"AND \"lives next door\""} };
-            CDTQResultSet* result = [im find:query];
-            expect(result.documentIds).to.containsInAnyOrder(@[ @"fred34" ]);
+          expect([im ensureIndexed:@[ @"comment" ] withName:@"basic_text" ofType:CDTQIndexTypeText])
+              .toNot.beNil();
+
+          // Parentheses are used to override SQLite enhanced query syntax operator precedence
+          // - Operator precedence is NOT -> AND -> OR
+          NSDictionary* query = @{
+              @"$text" : @{
+                  @"$search" : @"(Remus OR Romulus) "
+                               @"AND \"lives next door\""
+              }
+          };
+          CDTQResultSet* result = [im find:query];
+          expect(result.documentIds).to.containsInAnyOrder(@[ @"fred34" ]);
         });
-        
+
         it(@"can perform text search using NEAR operator", ^{
-            expect([im ensureIndexed:@[ @"comment" ]
-                            withName:@"basic_text"
-                                type:@"text"]).toNot.beNil();
-            
-            // NEAR provides the ability to search for terms/phrases in proximity to each other
-            // - By specifying a value for NEAR as in NEAR/2 you can define the range of proximity.
-            //   If left out it defaults to 10
-            NSDictionary* query = @{ @"$text" : @{@"$search" : @"\"he lives\" NEAR/2 Bristol" } };
-            CDTQResultSet* result = [im find:query];
-            expect(result.documentIds).to.containsInAnyOrder(@[ @"mike12", @"fred12" ]);
+          expect([im ensureIndexed:@[ @"comment" ] withName:@"basic_text" ofType:CDTQIndexTypeText])
+              .toNot.beNil();
+
+          // NEAR provides the ability to search for terms/phrases in proximity to each other
+          // - By specifying a value for NEAR as in NEAR/2 you can define the range of proximity.
+          //   If left out it defaults to 10
+          NSDictionary* query = @{ @"$text" : @{@"$search" : @"\"he lives\" NEAR/2 Bristol"} };
+          CDTQResultSet* result = [im find:query];
+          expect(result.documentIds).to.containsInAnyOrder(@[ @"mike12", @"fred12" ]);
         });
-        
+
         it(@"is case insensitive when using the default tokenizer", ^{
-            expect([im ensureIndexed:@[ @"comment" ]
-                            withName:@"basic_text"
-                                type:@"text"]).toNot.beNil();
-            
-            // Search is generally case-insensitive unless a custom tokenizer is provided
-            NSDictionary* query = @{ @"$text" : @{@"$search" : @"rEmUs RoMuLuS" } };
-            CDTQResultSet* result = [im find:query];
-            expect(result.documentIds).to.containsInAnyOrder(@[ @"fred34" ]);
+          expect([im ensureIndexed:@[ @"comment" ] withName:@"basic_text" ofType:CDTQIndexTypeText])
+              .toNot.beNil();
+
+          // Search is generally case-insensitive unless a custom tokenizer is provided
+          NSDictionary* query = @{ @"$text" : @{@"$search" : @"rEmUs RoMuLuS"} };
+          CDTQResultSet* result = [im find:query];
+          expect(result.documentIds).to.containsInAnyOrder(@[ @"fred34" ]);
         });
-        
+
         it(@"treats non-string field as a string when performing a text search", ^{
-            expect([im ensureIndexed:@[ @"age" ]
-                            withName:@"basic_text"
-                                type:@"text"]).toNot.beNil();
-            
-            NSDictionary* query = @{ @"$text" : @{@"$search" : @"12" } };
-            CDTQResultSet* result = [im find:query];
-            expect(result.documentIds).to.containsInAnyOrder(@[ @"mike12", @"fred12" ]);
+          expect([im ensureIndexed:@[ @"age" ] withName:@"basic_text" ofType:CDTQIndexTypeText])
+              .toNot.beNil();
+
+          NSDictionary* query = @{ @"$text" : @{@"$search" : @"12"} };
+          CDTQResultSet* result = [im find:query];
+          expect(result.documentIds).to.containsInAnyOrder(@[ @"mike12", @"fred12" ]);
         });
-        
+
         it(@"returns nil when text search criteria is not a string", ^{
-            expect([im ensureIndexed:@[ @"age" ]
-                            withName:@"basic_text"
-                                type:@"text"]).toNot.beNil();
-            
-            NSDictionary* query = @{ @"$text" : @{@"$search" : @12 } };
-            expect([im find:query]).to.beNil();
+          expect([im ensureIndexed:@[ @"age" ] withName:@"basic_text" ofType:CDTQIndexTypeText])
+              .toNot.beNil();
+
+          NSDictionary* query = @{ @"$text" : @{@"$search" : @12} };
+          expect([im find:query]).to.beNil();
         });
-        
+
         it(@"can perform a text search across multiple fields", ^{
-            expect([im ensureIndexed:@[ @"name", @"comment" ]
-                            withName:@"basic_text"
-                                type:@"text"]).toNot.beNil();
-            
-            // Will find fred12 and fred34 as well as mike12 since Fred is also mentioned
-            // in mike12's comment
-            NSDictionary* query = @{ @"$text" : @{@"$search" : @"Fred" } };
-            CDTQResultSet* result = [im find:query];
-            expect(result.documentIds).to.containsInAnyOrder(@[ @"mike12", @"fred12", @"fred34" ]);
+          expect([im ensureIndexed:@[ @"name", @"comment" ]
+                          withName:@"basic_text"
+                            ofType:CDTQIndexTypeText])
+              .toNot.beNil();
+
+          // Will find fred12 and fred34 as well as mike12 since Fred is also mentioned
+          // in mike12's comment
+          NSDictionary* query = @{ @"$text" : @{@"$search" : @"Fred"} };
+          CDTQResultSet* result = [im find:query];
+          expect(result.documentIds).to.containsInAnyOrder(@[ @"mike12", @"fred12", @"fred34" ]);
         });
-        
+
         it(@"can perform a text search targeting specific fields", ^{
-            expect([im ensureIndexed:@[ @"name", @"comment" ]
-                            withName:@"basic_text"
-                                type:@"text"]).toNot.beNil();
-            
-            // Will only find fred12 since he is the only named fred who's comment
-            // states that he "lives in Bristol"
-            NSDictionary* query = @{ @"$text" : @{@"$search" : @"name:fred "
-                                                               @"comment:lives in Bristol" } };
-            CDTQResultSet* result = [im find:query];
-            expect(result.documentIds).to.containsInAnyOrder(@[ @"fred12" ]);
+          expect([im ensureIndexed:@[ @"name", @"comment" ]
+                          withName:@"basic_text"
+                            ofType:CDTQIndexTypeText])
+              .toNot.beNil();
+
+          // Will only find fred12 since he is the only named fred who's comment
+          // states that he "lives in Bristol"
+          NSDictionary* query = @{
+              @"$text" : @{
+                  @"$search" : @"name:fred "
+                               @"comment:lives in Bristol"
+              }
+          };
+          CDTQResultSet* result = [im find:query];
+          expect(result.documentIds).to.containsInAnyOrder(@[ @"fred12" ]);
         });
-        
+
         it(@"can perform a text search using prefix searches", ^{
-            expect([im ensureIndexed:@[ @"comment" ]
-                            withName:@"basic_text"
-                                type:@"text"]).toNot.beNil();
-            
-            NSDictionary* query = @{ @"$text" : @{@"$search" : @"liv* riv*" } };
-            CDTQResultSet* result = [im find:query];
-            expect(result.documentIds).to.containsInAnyOrder(@[ @"mike34" ]);
+          expect([im ensureIndexed:@[ @"comment" ] withName:@"basic_text" ofType:CDTQIndexTypeText])
+              .toNot.beNil();
+
+          NSDictionary* query = @{ @"$text" : @{@"$search" : @"liv* riv*"} };
+          CDTQResultSet* result = [im find:query];
+          expect(result.documentIds).to.containsInAnyOrder(@[ @"mike34" ]);
         });
-        
+
         it(@"retuns empty result set when missing wildcards in prefix searches", ^{
-            expect([im ensureIndexed:@[ @"comment" ]
-                            withName:@"basic_text"
-                                type:@"text"]).toNot.beNil();
-            
-            NSDictionary* query = @{ @"$text" : @{@"$search" : @"liv riv" } };
-            CDTQResultSet* result = [im find:query];
-            expect(result).toNot.beNil();
-            expect(result.documentIds.count).to.equal(0);
+          expect([im ensureIndexed:@[ @"comment" ] withName:@"basic_text" ofType:CDTQIndexTypeText])
+              .toNot.beNil();
+
+          NSDictionary* query = @{ @"$text" : @{@"$search" : @"liv riv"} };
+          CDTQResultSet* result = [im find:query];
+          expect(result).toNot.beNil();
+          expect(result.documentIds.count).to.equal(0);
         });
-        
+
         it(@"can perform a text search using ID", ^{
-            expect([im ensureIndexed:@[ @"comment" ]
-                            withName:@"basic_text"
-                                type:@"text"]).toNot.beNil();
-            
-            NSDictionary* query = @{ @"$text" : @{@"$search" : @"_id:mike*" } };
-            CDTQResultSet* result = [im find:query];
-            expect(result.documentIds).to.containsInAnyOrder(@[ @"mike12", @"mike34", @"mike72" ]);
+          expect([im ensureIndexed:@[ @"comment" ] withName:@"basic_text" ofType:CDTQIndexTypeText])
+              .toNot.beNil();
+
+          NSDictionary* query = @{ @"$text" : @{@"$search" : @"_id:mike*"} };
+          CDTQResultSet* result = [im find:query];
+          expect(result.documentIds).to.containsInAnyOrder(@[ @"mike12", @"mike34", @"mike72" ]);
         });
-        
+
         it(@"can perform a text search using the Porter tokenizer stemmer", ^{
-            expect([im ensureIndexed:@[ @"comment" ]
-                            withName:@"basic_text"
-                                type:@"text"
-                            settings:@{ @"tokenize" : @"porter" }]).toNot.beNil();
-            
-            NSDictionary* query = @{ @"$text" : @{@"$search" : @"retire memory" } };
-            CDTQResultSet* result = [im find:query];
-            expect(result.documentIds).to.containsInAnyOrder(@[ @"mike72" ]);
+          expect([im ensureIndexed:@[ @"comment" ]
+                          withName:@"basic_text"
+                            ofType:CDTQIndexTypeText
+                          settings:@{
+                              @"tokenize" : @"porter"
+                          }])
+              .toNot.beNil();
+
+          NSDictionary* query = @{ @"$text" : @{@"$search" : @"retire memory"} };
+          CDTQResultSet* result = [im find:query];
+          expect(result.documentIds).to.containsInAnyOrder(@[ @"mike72" ]);
         });
-        
+
         it(@"returns empty result set when using default tokenizer stemmer", ^{
-            expect([im ensureIndexed:@[ @"comment" ]
-                            withName:@"basic_text"
-                                type:@"text"]).toNot.beNil();
-            
-            NSDictionary* query = @{ @"$text" : @{@"$search" : @"retire memory" } };
-            CDTQResultSet* result = [im find:query];
-            expect(result).toNot.beNil();
-            expect(result.documentIds.count).to.equal(0);
+          expect([im ensureIndexed:@[ @"comment" ] withName:@"basic_text" ofType:CDTQIndexTypeText])
+              .toNot.beNil();
+
+          NSDictionary* query = @{ @"$text" : @{@"$search" : @"retire memory"} };
+          CDTQResultSet* result = [im find:query];
+          expect(result).toNot.beNil();
+          expect(result.documentIds.count).to.equal(0);
         });
 
     });

--- a/CDTDatastoreTests/CDTQUnindexedMatcherTests.m
+++ b/CDTDatastoreTests/CDTQUnindexedMatcherTests.m
@@ -5,15 +5,16 @@
 //  Created by Michael Rhodes on 31/10/2014.
 //  Copyright (c) 2014 Cloudant. All rights reserved.
 //
-
-#import <CloudantSync.h>
-#import <CDTQIndexManager.h>
-#import <CDTQIndexUpdater.h>
-#import <CDTQIndexCreator.h>
-#import <CDTQResultSet.h>
-#import <CDTQQueryExecutor.h>
-#import <CDTQUnindexedMatcher.h>
-#import <CDTQQueryValidator.h>
+#import <CDTDatastore/CDTQIndexCreator.h>
+#import <CDTDatastore/CDTQIndexManager.h>
+#import <CDTDatastore/CDTQIndexUpdater.h>
+#import <CDTDatastore/CDTQQueryExecutor.h>
+#import <CDTDatastore/CDTQQueryValidator.h>
+#import <CDTDatastore/CDTQResultSet.h>
+#import <CDTDatastore/CDTQUnindexedMatcher.h>
+#import <CDTDatastore/CloudantSync.h>
+#import <Expecta/Expecta.h>
+#import <Specta/Specta.h>
 
 SpecBegin(CDTQUnindexedMatcher) describe(@"matcherWithSelector", ^{
 

--- a/CDTDatastoreTests/CDTQValueExtractorTests.m
+++ b/CDTDatastoreTests/CDTQValueExtractorTests.m
@@ -5,9 +5,10 @@
 //  Created by Michael Rhodes on 09/27/2014.
 //  Copyright (c) 2014 Michael Rhodes. All rights reserved.
 //
-
-#import <CloudantSync.h>
-#import <CDTQValueExtractor.h>
+#import <CDTDatastore/CDTQValueExtractor.h>
+#import <CDTDatastore/CloudantSync.h>
+#import <Expecta/Expecta.h>
+#import <Specta/Specta.h>
 
 SpecBegin(CDTQValueExtractor)
 


### PR DESCRIPTION
## What
Use an enum for the index type parameter rather than a string.
## How
- Deprecate the methods which present a string parameter for the index type
- Create a new enum `CDTQIndexType`
- Add new methods to replace the deprecated methods.
- Add conversion methods to support going from the text representation to the enum representation.
- Behaviour change: Using the string version for the index type will result in an exception being thrown if it is not possible to match the text to one of the defined enum values

## Why
Using an enum will reduce confusion for users, where they are attempting to provide a custom index type
when the purpose of the parameter is to pass a fixed set of index types.
## Reviewers
reviewer @mikerhodes 
reviewer @brynh

## Issues
fixes #231 