### PR TITLE
Move query tests to using enum for creating indexes

### DIFF
--- a/CDTDatastoreTests/CDTDatastoreQueryTests.m
+++ b/CDTDatastoreTests/CDTDatastoreQueryTests.m
@@ -122,20 +122,23 @@ SpecBegin(CDTDatastoreQuery) describe(@"When using datastore query", ^{
         [ds createDocumentFromRevision:rev error:nil];
         expect([ds updateAllIndexes]).to.beTruthy();
     });
-    
+
     it(@"can create a text index", ^{
-        NSString *indexName = [ds ensureIndexed:@[ @"name" ] withName:@"text_idx" type:@"text"];
-        expect(indexName).to.equal(@"text_idx");
+      NSString *indexName =
+          [ds ensureIndexed:@[ @"name" ] withName:@"text_idx" ofType:CDTQIndexTypeText];
+      expect(indexName).to.equal(@"text_idx");
     });
-    
+
     it(@"can create a text index with defined settings", ^{
-        NSString *indexName = [ds ensureIndexed:@[ @"name" ]
-                                       withName:@"text_idx"
-                                           type:@"text"
-                                       settings:@{@"tokenize": @"porter"}];
-        expect(indexName).to.equal(@"text_idx");
+      NSString *indexName = [ds ensureIndexed:@[ @"name" ]
+                                     withName:@"text_idx"
+                                       ofType:CDTQIndexTypeText
+                                     settings:@{
+                                         @"tokenize" : @"porter"
+                                     }];
+      expect(indexName).to.equal(@"text_idx");
     });
-    
+
     it(@"can check if text search is enabled", ^{
         expect([ds isTextSearchEnabled]).to.equal(@YES);
     });

--- a/CDTDatastoreTests/CDTQIndexCreatorTests.m
+++ b/CDTDatastoreTests/CDTQIndexCreatorTests.m
@@ -219,63 +219,68 @@ SpecBegin(CDTQIndexCreator)
             });
 
             it(@"supports using the json type", ^{
-                NSString *name =
-                    [im ensureIndexed:@[ @{ @"name" : @"asc" }, @{
-                        @"age" : @"desc"
-                    } ] withName:@"basic"
-                                 type:@"json"];
-                expect(name).to.equal(@"basic");
+              NSString *name = [im ensureIndexed:@[ @{ @"name" : @"asc" },
+                                                    @{ @"age" : @"desc" } ]
+                                        withName:@"basic"
+                                          ofType:CDTQIndexTypeJSON];
+              expect(name).to.equal(@"basic");
             });
 
             it(@"supports using the text type", ^{
-                NSString *name = [im ensureIndexed:@[ @{ @"name" : @"asc" }, @{ @"age" : @"desc"} ]
-                                          withName:@"basic"
-                                              type:@"text"];
-                expect(name).to.equal(@"basic");
-                NSDictionary *indexes = im.listIndexes;
-                expect(indexes.count).to.equal(1);
-                NSDictionary *index = indexes[@"basic"];
-                expect(index[@"type"]).to.equal(@"text");
-                expect(index[@"settings"]).to.equal(@"{\"tokenize\":\"simple\"}");
+              NSString *name = [im ensureIndexed:@[ @{ @"name" : @"asc" },
+                                                    @{ @"age" : @"desc" } ]
+                                        withName:@"basic"
+                                          ofType:CDTQIndexTypeText];
+              expect(name).to.equal(@"basic");
+              NSDictionary *indexes = im.listIndexes;
+              expect(indexes.count).to.equal(1);
+              NSDictionary *index = indexes[@"basic"];
+              expect(index[@"type"]).to.equal(@"text");
+              expect(index[@"settings"]).to.equal(@"{\"tokenize\":\"simple\"}");
             });
-            
+
             it(@"supports using the text type with a tokenize setting", ^{
-                NSString *name = [im ensureIndexed:@[ @{ @"name" : @"asc" }, @{ @"age" : @"desc"} ]
-                                          withName:@"basic"
-                                              type:@"text"
-                                          settings:@{ @"tokenize" : @"porter" }];
-                expect(name).to.equal(@"basic");
-                NSDictionary *indexes = im.listIndexes;
-                expect(indexes.count).to.equal(1);
-                NSDictionary *index = indexes[@"basic"];
-                expect(index[@"type"]).to.equal(@"text");
-                expect(index[@"settings"]).to.equal(@"{\"tokenize\":\"porter\"}");
+              NSString *name = [im ensureIndexed:@[ @{ @"name" : @"asc" },
+                                                    @{ @"age" : @"desc" } ]
+                                        withName:@"basic"
+                                          ofType:CDTQIndexTypeText
+                                        settings:@{
+                                            @"tokenize" : @"porter"
+                                        }];
+              expect(name).to.equal(@"basic");
+              NSDictionary *indexes = im.listIndexes;
+              expect(indexes.count).to.equal(1);
+              NSDictionary *index = indexes[@"basic"];
+              expect(index[@"type"]).to.equal(@"text");
+              expect(index[@"settings"]).to.equal(@"{\"tokenize\":\"porter\"}");
             });
-            
+
             it(@"supports coexistence of text and json indexes", ^{
-                NSString *name = [im ensureIndexed:@[ @{ @"name" : @"asc" }, @{ @"age" : @"desc"} ]
-                                          withName:@"textIndex"
-                                              type:@"text"];
-                expect(name).to.equal(@"textIndex");
-                name = [im ensureIndexed:@[ @{ @"name" : @"asc" }, @{ @"age" : @"desc"} ]
-                                withName:@"jsonIndex"
-                                    type:@"json"];
-                expect(name).to.equal(@"jsonIndex");
-                expect(im.listIndexes.allKeys).to.containsInAnyOrder(@[ @"textIndex",
-                                                                        @"jsonIndex" ]);
-                
+              NSString *name = [im ensureIndexed:@[ @{ @"name" : @"asc" },
+                                                    @{ @"age" : @"desc" } ]
+                                        withName:@"textIndex"
+                                          ofType:CDTQIndexTypeText];
+              expect(name).to.equal(@"textIndex");
+              name = [im ensureIndexed:@[ @{ @"name" : @"asc" },
+                                          @{ @"age" : @"desc" } ]
+                              withName:@"jsonIndex"
+                                ofType:CDTQIndexTypeJSON];
+              expect(name).to.equal(@"jsonIndex");
+              expect(im.listIndexes.allKeys).to.containsInAnyOrder(@[ @"textIndex", @"jsonIndex" ]);
+
             });
-            
-            
+
             it(@"correctly limits text index creation to one", ^{
-                NSString *name = [im ensureIndexed:@[ @{ @"name" : @"asc" }, @{ @"age" : @"desc"} ]
-                                          withName:@"basic"
-                                              type:@"text"];
-                expect(name).to.equal(@"basic");
-                name = [im ensureIndexed:@[ @{ @"name" : @"asc" }, @{ @"age" : @"desc"} ]
-                                withName:@"anotherTextIndex"
-                                    type:@"text"];
-                expect(name).to.beNil();
+              NSString *name = [im ensureIndexed:@[ @{ @"name" : @"asc" },
+                                                    @{ @"age" : @"desc" } ]
+                                        withName:@"basic"
+                                          ofType:CDTQIndexTypeText];
+              expect(name).to.equal(@"basic");
+              name = [im ensureIndexed:@[ @{ @"name" : @"asc" },
+                                          @{ @"age" : @"desc" } ]
+                              withName:@"anotherTextIndex"
+                                ofType:CDTQIndexTypeText];
+              expect(name).to.beNil();
             });
 
             it(@"doesn't support using the geo type", ^{

--- a/CDTDatastoreTests/CDTQIndexManagerTests.m
+++ b/CDTDatastoreTests/CDTQIndexManagerTests.m
@@ -192,10 +192,9 @@ SpecBegin(CDTQIndexManager)
                          @"pet" : @{@"species" : @"cat", @"name" : @"mike"}
                          };
             [ds createDocumentFromRevision:rev error:nil];
-            
-            expect([im ensureIndexed:@[ @"name" ]
-                            withName:@"basic"
-                                type:@"text"]).to.equal(@"basic");
+
+            expect([im ensureIndexed:@[ @"name" ] withName:@"basic" ofType:CDTQIndexTypeText])
+                .to.equal(@"basic");
             expect([im listIndexes][@"basic"]).toNot.beNil();
             
             expect([im deleteIndexNamed:@"basic"]).to.equal(@YES);

--- a/CDTDatastoreTests/CDTQIndexTests.m
+++ b/CDTDatastoreTests/CDTQIndexTests.m
@@ -35,19 +35,21 @@ describe(@"When creating an instance of index", ^{
         expect(index.indexName).to.equal(@"basic");
         expect(index.fieldNames).to.containsInAnyOrder(@[ @"name", @"age" ]);
         expect(index.indexType).to.equal(@"json");
+        expect(index.type).to.equal(CDTQIndexTypeJSON);
         expect(index.indexSettings).to.beNil();
     });
-    
-    it(@"constructs an index instance with the TEXT index type and default index settings", ^{
-        CDTQIndex *index = [CDTQIndex index:indexName withFields:fieldNames ofType:@"text"];
 
-        expect(index.indexName).to.equal(@"basic");
-        expect(index.fieldNames).to.containsInAnyOrder(@[ @"name", @"age" ]);
-        expect(index.indexType).to.equal(@"text");
-        expect(index.indexSettings.count).to.equal(1);
-        expect(index.indexSettings[ @"tokenize" ]).to.equal(@"simple");
+    it(@"constructs an index instance with the TEXT index type and default index settings", ^{
+      CDTQIndex *index = [CDTQIndex index:indexName withFields:fieldNames type:CDTQIndexTypeText];
+
+      expect(index.indexName).to.equal(@"basic");
+      expect(index.fieldNames).to.containsInAnyOrder(@[ @"name", @"age" ]);
+      expect(index.indexType).to.equal(@"text");
+      expect(index.type).to.equal(CDTQIndexTypeText);
+      expect(index.indexSettings.count).to.equal(1);
+      expect(index.indexSettings[@"tokenize"]).to.equal(@"simple");
     });
-    
+
     it(@"returns nil when no fields are provided", ^{
         expect([CDTQIndex index:indexName withFields:nil]).to.beNil();
         
@@ -87,22 +89,28 @@ describe(@"When creating an instance of index", ^{
     });
 
     it(@"returns nil when index settings are invalid", ^{
-        expect([CDTQIndex index:indexName
-                     withFields:fieldNames
-                         ofType:@"text"
-                   withSettings:@{ @"foo": @"bar" }]).to.beNil();
+      expect([CDTQIndex index:indexName
+                   withFields:fieldNames
+                         type:CDTQIndexTypeText
+                 withSettings:@{
+                     @"foo" : @"bar"
+                 }])
+          .to.beNil();
     });
-    
+
     it(@"constructs index instance but ignores index settings when appropriate", ^{
         // json indexes do not support index settings.  Index settings will be ignored.
         CDTQIndex *index = [CDTQIndex index:indexName
                                  withFields:fieldNames
-                                     ofType:@"json"
-                               withSettings:@{ @"tokenize": @"porter" }];
+                                       type:CDTQIndexTypeJSON
+                               withSettings:@{
+                                   @"tokenize" : @"porter"
+                               }];
 
         expect(index.indexName).to.equal(@"basic");
         expect(index.fieldNames).to.containsInAnyOrder(@[ @"name", @"age" ]);
         expect(index.indexType).to.equal(@"json");
+        expect(index.type).to.equal(CDTQIndexTypeJSON);
         expect(index.indexSettings).to.beNil();
     });
     
@@ -110,12 +118,15 @@ describe(@"When creating an instance of index", ^{
         // text indexes support the tokenize setting.
         CDTQIndex *index = [CDTQIndex index:indexName
                                  withFields:fieldNames
-                                     ofType:@"text"
-                               withSettings:@{ @"tokenize": @"porter" }];
+                                       type:CDTQIndexTypeText
+                               withSettings:@{
+                                   @"tokenize" : @"porter"
+                               }];
 
         expect(index.indexName).to.equal(@"basic");
         expect(index.fieldNames).to.containsInAnyOrder(@[ @"name", @"age" ]);
         expect(index.indexType).to.equal(@"text");
+        expect(index.type).to.equal(CDTQIndexTypeText);
         expect(index.indexSettings[ @"tokenize" ]).to.equal(@"porter");
     });
     
@@ -134,31 +145,33 @@ describe(@"When comparing index content", ^{
     it(@"correctly compares index type inequality", ^{
         // Construct an index instance of default index type "json"
         CDTQIndex *index = [CDTQIndex index:indexName withFields:fieldNames];
-        
-        expect([index compareIndexTypeTo:@"text" withIndexSettings:nil]).to.equal(NO);
+
+        expect([index compareToIndexType:CDTQIndexTypeText withIndexSettings:nil]).to.equal(NO);
     });
     
     it(@"correctly compares index type equality", ^{
         // Construct an index instance of default index type "json"
         CDTQIndex *index = [CDTQIndex index:indexName withFields:fieldNames];
-        
-        expect([index compareIndexTypeTo:@"json" withIndexSettings:nil]).to.equal(YES);
+
+        expect([index compareToIndexType:CDTQIndexTypeJSON withIndexSettings:nil]).to.equal(YES);
     });
     
     it(@"correctly compares index setting inequality", ^{
         // Construct a "text" index instance with default index settings of { "tokenize": "simple" }
-        CDTQIndex *index = [CDTQIndex index:indexName withFields:fieldNames ofType:@"text"];
-        
-        expect([index compareIndexTypeTo:@"text"
-                       withIndexSettings:@"{\"tokenize\":\"porter\"}"]).to.equal(NO);
+        CDTQIndex *index = [CDTQIndex index:indexName withFields:fieldNames type:CDTQIndexTypeText];
+
+        expect([index compareToIndexType:CDTQIndexTypeText
+                       withIndexSettings:@"{\"tokenize\":\"porter\"}"])
+            .to.equal(NO);
     });
     
     it(@"correctly compares index setting equality", ^{
         // Construct a "text" index instance with default index settings of { "tokenize": "simple" }
-        CDTQIndex *index = [CDTQIndex index:indexName withFields:fieldNames ofType:@"text"];
-        
-        expect([index compareIndexTypeTo:@"text"
-                       withIndexSettings:@"{\"tokenize\":\"simple\"}"]).to.equal(YES);
+        CDTQIndex *index = [CDTQIndex index:indexName withFields:fieldNames type:CDTQIndexTypeText];
+
+        expect([index compareToIndexType:CDTQIndexTypeText
+                       withIndexSettings:@"{\"tokenize\":\"simple\"}"])
+            .to.equal(YES);
     });
     
 });
@@ -172,13 +185,13 @@ describe(@"When retrieving index settings as a String", ^{
         fieldNames = @[ @"name", @"age" ];
         indexName = @"basic";
     });
-    
+
     it(@"returns a String representation of the index settings", ^{
-        CDTQIndex *index = [CDTQIndex index:indexName withFields:fieldNames ofType:@"text"];
-        
-        expect([index settingsAsJSON]).to.equal(@"{\"tokenize\":\"simple\"}");
+      CDTQIndex *index = [CDTQIndex index:indexName withFields:fieldNames type:CDTQIndexTypeText];
+
+      expect([index settingsAsJSON]).to.equal(@"{\"tokenize\":\"simple\"}");
     });
-    
+
     it(@"returns nil when appropriate", ^{
         CDTQIndex *index = [CDTQIndex index:indexName withFields:fieldNames];
         

--- a/CDTDatastoreTests/CDTQIndexUpdaterTests.m
+++ b/CDTDatastoreTests/CDTQIndexUpdaterTests.m
@@ -374,14 +374,16 @@ SpecBegin(CDTQIndexUpdater)
                 expect([updater sequenceNumberForIndex:@"basic"]).to.equal(7);
 
             });
-            
-            describe(@"when using a text index", ^{
-                it(@"sets correct sequence number", ^{
-                    
+
+            describe(
+                @"when using a text index", ^{
+                  it(@"sets correct sequence number", ^{
+
                     expect([im ensureIndexed:@[ @"pet", @"name" ]
                                     withName:@"basic"
-                                        type:@"text"]).toNot.beNil();
-                    
+                                      ofType:CDTQIndexTypeText])
+                        .toNot.beNil();
+
                     FMDatabaseQueue *queue =
                         (FMDatabaseQueue *)[im performSelector:@selector(database)];
                     
@@ -392,13 +394,14 @@ SpecBegin(CDTQIndexUpdater)
                     expect([updater updateAllIndexes:[im listIndexes]]).to.beTruthy();
                     
                     expect([updater sequenceNumberForIndex:@"basic"]).to.equal(6);
-                    
-                });
-                
-                it(@"sets correct sequence number after update", ^{
+
+                  });
+
+                  it(@"sets correct sequence number after update", ^{
                     expect([im ensureIndexed:@[ @"pet", @"name" ]
                                     withName:@"basic"
-                                        type:@"text"]).toNot.beNil();
+                                      ofType:CDTQIndexTypeText])
+                        .toNot.beNil();
                     FMDatabaseQueue *queue =
                         (FMDatabaseQueue *)[im performSelector:@selector(database)];
                     CDTQIndexUpdater *updater =
@@ -412,9 +415,9 @@ SpecBegin(CDTQIndexUpdater)
                     expect([updater updateAllIndexes:[im listIndexes]]).to.beTruthy();
                     
                     expect([updater sequenceNumberForIndex:@"basic"]).to.equal(7);
-                    
+
+                  });
                 });
-            });
 
         });
     });

--- a/CDTDatastoreTests/CDTQQuerySqlTranslatorTests.m
+++ b/CDTDatastoreTests/CDTQQuerySqlTranslatorTests.m
@@ -447,8 +447,8 @@ SpecBegin(CDTQQuerySqlTranslator) describe(@"cdtq", ^{
             im = [CDTQIndexManager managerUsingDatastore:ds error:nil];
             
             [im ensureIndexed:@[ @"name", @"age", @"pet" ] withName:@"basic"];
-            [im ensureIndexed:@[ @"comments" ] withName:@"basic_text" type:@"text"];
-            
+            [im ensureIndexed:@[ @"comments" ] withName:@"basic_text" ofType:CDTQIndexTypeText];
+
             expect([[im listIndexes] count]).to.equal(2);
         });
         

--- a/CDTDatastoreTests/CDTQTextSearchTests.m
+++ b/CDTDatastoreTests/CDTQTextSearchTests.m
@@ -114,54 +114,52 @@ SpecBegin(CDTQQueryExecutorTextSearch) describe(@"cdtq", ^{
         });
 
         it(@"can perform a search consisting of a single text clause", ^{
-            expect([im ensureIndexed:@[ @"comment" ]
-                            withName:@"basic_text"
-                                type:@"text"]).toNot.beNil();
-            
-            NSDictionary* query = @{ @"$text" : @{@"$search" : @"lives in Bristol"} };
-            CDTQResultSet* result = [im find:query];
-            expect(result.documentIds).to.containsInAnyOrder(@[ @"mike12", @"mike34", @"fred12" ]);
+          expect([im ensureIndexed:@[ @"comment" ] withName:@"basic_text" ofType:CDTQIndexTypeText])
+              .toNot.beNil();
+
+          NSDictionary* query = @{ @"$text" : @{@"$search" : @"lives in Bristol"} };
+          CDTQResultSet* result = [im find:query];
+          expect(result.documentIds).to.containsInAnyOrder(@[ @"mike12", @"mike34", @"fred12" ]);
         });
-        
+
         it(@"can perform a phrase search", ^{
-            expect([im ensureIndexed:@[ @"comment" ]
-                            withName:@"basic_text"
-                                type:@"text"]).toNot.beNil();
-            
-            NSDictionary* query = @{ @"$text" : @{@"$search" : @"\"lives in Bristol\""} };
-            CDTQResultSet* result = [im find:query];
-            expect(result.documentIds).to.containsInAnyOrder(@[ @"mike12", @"fred12" ]);
+          expect([im ensureIndexed:@[ @"comment" ] withName:@"basic_text" ofType:CDTQIndexTypeText])
+              .toNot.beNil();
+
+          NSDictionary* query = @{ @"$text" : @{@"$search" : @"\"lives in Bristol\""} };
+          CDTQResultSet* result = [im find:query];
+          expect(result.documentIds).to.containsInAnyOrder(@[ @"mike12", @"fred12" ]);
         });
-        
+
         it(@"can perform a search containing an apostrophe", ^{
-            expect([im ensureIndexed:@[ @"comment" ]
-                            withName:@"basic_text"
-                                type:@"text"]).toNot.beNil();
-            
-            NSDictionary* query = @{ @"$text" : @{@"$search" : @"he's retired"} };
-            CDTQResultSet* result = [im find:query];
-            expect(result.documentIds).to.containsInAnyOrder(@[ @"mike72" ]);
+          expect([im ensureIndexed:@[ @"comment" ] withName:@"basic_text" ofType:CDTQIndexTypeText])
+              .toNot.beNil();
+
+          NSDictionary* query = @{ @"$text" : @{@"$search" : @"he's retired"} };
+          CDTQResultSet* result = [im find:query];
+          expect(result.documentIds).to.containsInAnyOrder(@[ @"mike72" ]);
         });
-        
+
         it(@"can perform a search consisting of a single text clause with a sort", ^{
-            expect([im ensureIndexed:@[ @"name", @"comment" ]
-                            withName:@"basic_text"
-                                type:@"text"]).toNot.beNil();
-            
-            NSDictionary* query = @{ @"$text" : @{@"$search" : @"best friend"} };
-            NSArray *order = @[ @{ @"name" : @"asc" } ];
-            CDTQResultSet* result = [im find:query skip:0 limit:0 fields:nil sort: order];
-            expect(result.documentIds).to.containsInAnyOrder(@[ @"mike12", @"fred12" ]);
-            expect(result.documentIds[0]).to.equal(@"fred12");
-            expect(result.documentIds[1]).to.equal(@"mike12");
+          expect([im ensureIndexed:@[ @"name", @"comment" ]
+                          withName:@"basic_text"
+                            ofType:CDTQIndexTypeText])
+              .toNot.beNil();
+
+          NSDictionary* query = @{ @"$text" : @{@"$search" : @"best friend"} };
+          NSArray* order = @[ @{ @"name" : @"asc" } ];
+          CDTQResultSet* result = [im find:query skip:0 limit:0 fields:nil sort:order];
+          expect(result.documentIds).to.containsInAnyOrder(@[ @"mike12", @"fred12" ]);
+          expect(result.documentIds[0]).to.equal(@"fred12");
+          expect(result.documentIds[1]).to.equal(@"mike12");
         });
-        
+
         it(@"can perform a compound AND query search containing a text clause", ^{
             expect([im ensureIndexed:@[ @"name" ] withName:@"basic"]).toNot.beNil();
-            expect([im ensureIndexed:@[ @"comment" ]
-                            withName:@"basic_text"
-                                type:@"text"]).toNot.beNil();
-            
+            expect(
+                [im ensureIndexed:@[ @"comment" ] withName:@"basic_text" ofType:CDTQIndexTypeText])
+                .toNot.beNil();
+
             NSDictionary* query = @{ @"name" : @"mike",
                                      @"$text" : @{@"$search" : @"best friend"} };
             CDTQResultSet* result = [im find:query];
@@ -170,10 +168,10 @@ SpecBegin(CDTQQueryExecutorTextSearch) describe(@"cdtq", ^{
         
         it(@"can perform a compound OR query search containing a text clause", ^{
             expect([im ensureIndexed:@[ @"name" ] withName:@"basic"]).toNot.beNil();
-            expect([im ensureIndexed:@[ @"comment" ]
-                            withName:@"basic_text"
-                                type:@"text"]).toNot.beNil();
-            
+            expect(
+                [im ensureIndexed:@[ @"comment" ] withName:@"basic_text" ofType:CDTQIndexTypeText])
+                .toNot.beNil();
+
             NSDictionary* query = @{ @"$or" : @[ @{ @"name" : @"mike" },
                                                  @{ @"$text" : @{@"$search" : @"best friend"} } ] };
             CDTQResultSet* result = [im find:query];
@@ -199,202 +197,202 @@ SpecBegin(CDTQQueryExecutorTextSearch) describe(@"cdtq", ^{
             // indexes.
             expect([im ensureIndexed:@[ @"name", @"comment" ]
                             withName:@"basic_text"
-                                type:@"text"]).toNot.beNil();
-            
+                              ofType:CDTQIndexTypeText])
+                .toNot.beNil();
+
             NSDictionary* query = @{ @"$or" : @[ @{ @"name" : @"mike" },
                                                  @{ @"$text" : @{@"$search" : @"best friend"} } ] };
             expect([im find:query]).to.beNil();
         });
-        
+
         it(@"can perform a text search containing non-ascii values", ^{
-            expect([im ensureIndexed:@[ @"comment" ]
-                            withName:@"basic_text"
-                                type:@"text"]).toNot.beNil();
-            
-            NSDictionary* query = @{ @"$text" : @{@"$search" : @"\"صديق له هو\""} };
-            CDTQResultSet* result = [im find:query];
-            expect(result.documentIds).to.containsInAnyOrder(@[ @"john34" ]);
+          expect([im ensureIndexed:@[ @"comment" ] withName:@"basic_text" ofType:CDTQIndexTypeText])
+              .toNot.beNil();
+
+          NSDictionary* query = @{ @"$text" : @{@"$search" : @"\"صديق له هو\""} };
+          CDTQResultSet* result = [im find:query];
+          expect(result.documentIds).to.containsInAnyOrder(@[ @"john34" ]);
         });
-        
+
         it(@"returns empty result set for unmatched phrase search", ^{
-            expect([im ensureIndexed:@[ @"comment" ]
-                            withName:@"basic_text"
-                                type:@"text"]).toNot.beNil();
-            
-            NSDictionary* query = @{ @"$text" : @{@"$search" : @"\"remus romulus\""} };
-            CDTQResultSet* result = [im find:query];
-            expect(result).toNot.beNil();
-            expect(result.documentIds.count).to.equal(0);
+          expect([im ensureIndexed:@[ @"comment" ] withName:@"basic_text" ofType:CDTQIndexTypeText])
+              .toNot.beNil();
+
+          NSDictionary* query = @{ @"$text" : @{@"$search" : @"\"remus romulus\""} };
+          CDTQResultSet* result = [im find:query];
+          expect(result).toNot.beNil();
+          expect(result.documentIds.count).to.equal(0);
         });
-        
+
         it(@"returns correct result set for non-contiguous word search", ^{
-            expect([im ensureIndexed:@[ @"comment" ]
-                            withName:@"basic_text"
-                                type:@"text"]).toNot.beNil();
-            
-            // The search predicate "Remus Romulus" normalizes to "Remus AND Romulus" in SQLite
-            NSDictionary* query = @{ @"$text" : @{@"$search" : @"remus romulus"} };
-            CDTQResultSet* result = [im find:query];
-            expect(result.documentIds).to.containsInAnyOrder(@[ @"fred34" ]);
+          expect([im ensureIndexed:@[ @"comment" ] withName:@"basic_text" ofType:CDTQIndexTypeText])
+              .toNot.beNil();
+
+          // The search predicate "Remus Romulus" normalizes to "Remus AND Romulus" in SQLite
+          NSDictionary* query = @{ @"$text" : @{@"$search" : @"remus romulus"} };
+          CDTQResultSet* result = [im find:query];
+          expect(result.documentIds).to.containsInAnyOrder(@[ @"fred34" ]);
         });
-        
+
         it(@"can perform text search using enhanced query syntax OR operator", ^{
-            expect([im ensureIndexed:@[ @"comment" ]
-                            withName:@"basic_text"
-                                type:@"text"]).toNot.beNil();
-            
-            // Enhanced Query Syntax - logical operators must be uppercase otherwise they will
-            // be treated as a search token
-            NSDictionary* query = @{ @"$text" : @{@"$search" : @"Remus OR Romulus"} };
-            CDTQResultSet* result = [im find:query];
-            expect(result.documentIds).to.containsInAnyOrder(@[ @"fred34", @"mike72" ]);
+          expect([im ensureIndexed:@[ @"comment" ] withName:@"basic_text" ofType:CDTQIndexTypeText])
+              .toNot.beNil();
+
+          // Enhanced Query Syntax - logical operators must be uppercase otherwise they will
+          // be treated as a search token
+          NSDictionary* query = @{ @"$text" : @{@"$search" : @"Remus OR Romulus"} };
+          CDTQResultSet* result = [im find:query];
+          expect(result.documentIds).to.containsInAnyOrder(@[ @"fred34", @"mike72" ]);
         });
-        
+
         it(@"can perform text search using enhanced query syntax NOT operator", ^{
-            expect([im ensureIndexed:@[ @"comment" ]
-                            withName:@"basic_text"
-                                type:@"text"]).toNot.beNil();
-            
-            // Enhanced Query Syntax - logical operators must be uppercase otherwise they will
-            // be treated as a search token
-            // - NOT operator only works between tokens as in (token1 NOT token2)
-            NSDictionary* query = @{ @"$text" : @{@"$search" : @"Remus NOT Romulus"} };
-            CDTQResultSet* result = [im find:query];
-            expect(result.documentIds).to.containsInAnyOrder(@[ @"mike72" ]);
+          expect([im ensureIndexed:@[ @"comment" ] withName:@"basic_text" ofType:CDTQIndexTypeText])
+              .toNot.beNil();
+
+          // Enhanced Query Syntax - logical operators must be uppercase otherwise they will
+          // be treated as a search token
+          // - NOT operator only works between tokens as in (token1 NOT token2)
+          NSDictionary* query = @{ @"$text" : @{@"$search" : @"Remus NOT Romulus"} };
+          CDTQResultSet* result = [im find:query];
+          expect(result.documentIds).to.containsInAnyOrder(@[ @"mike72" ]);
         });
-        
+
         it(@"can perform text search using enhanced query syntax with parentheses", ^{
-            expect([im ensureIndexed:@[ @"comment" ]
-                            withName:@"basic_text"
-                                type:@"text"]).toNot.beNil();
-            
-            // Parentheses are used to override SQLite enhanced query syntax operator precedence
-            // - Operator precedence is NOT -> AND -> OR
-            NSDictionary* query = @{ @"$text" : @{@"$search" : @"(Remus OR Romulus) "
-                                                               @"AND \"lives next door\""} };
-            CDTQResultSet* result = [im find:query];
-            expect(result.documentIds).to.containsInAnyOrder(@[ @"fred34" ]);
+          expect([im ensureIndexed:@[ @"comment" ] withName:@"basic_text" ofType:CDTQIndexTypeText])
+              .toNot.beNil();
+
+          // Parentheses are used to override SQLite enhanced query syntax operator precedence
+          // - Operator precedence is NOT -> AND -> OR
+          NSDictionary* query = @{
+              @"$text" : @{
+                  @"$search" : @"(Remus OR Romulus) "
+                               @"AND \"lives next door\""
+              }
+          };
+          CDTQResultSet* result = [im find:query];
+          expect(result.documentIds).to.containsInAnyOrder(@[ @"fred34" ]);
         });
-        
+
         it(@"can perform text search using NEAR operator", ^{
-            expect([im ensureIndexed:@[ @"comment" ]
-                            withName:@"basic_text"
-                                type:@"text"]).toNot.beNil();
-            
-            // NEAR provides the ability to search for terms/phrases in proximity to each other
-            // - By specifying a value for NEAR as in NEAR/2 you can define the range of proximity.
-            //   If left out it defaults to 10
-            NSDictionary* query = @{ @"$text" : @{@"$search" : @"\"he lives\" NEAR/2 Bristol" } };
-            CDTQResultSet* result = [im find:query];
-            expect(result.documentIds).to.containsInAnyOrder(@[ @"mike12", @"fred12" ]);
+          expect([im ensureIndexed:@[ @"comment" ] withName:@"basic_text" ofType:CDTQIndexTypeText])
+              .toNot.beNil();
+
+          // NEAR provides the ability to search for terms/phrases in proximity to each other
+          // - By specifying a value for NEAR as in NEAR/2 you can define the range of proximity.
+          //   If left out it defaults to 10
+          NSDictionary* query = @{ @"$text" : @{@"$search" : @"\"he lives\" NEAR/2 Bristol"} };
+          CDTQResultSet* result = [im find:query];
+          expect(result.documentIds).to.containsInAnyOrder(@[ @"mike12", @"fred12" ]);
         });
-        
+
         it(@"is case insensitive when using the default tokenizer", ^{
-            expect([im ensureIndexed:@[ @"comment" ]
-                            withName:@"basic_text"
-                                type:@"text"]).toNot.beNil();
-            
-            // Search is generally case-insensitive unless a custom tokenizer is provided
-            NSDictionary* query = @{ @"$text" : @{@"$search" : @"rEmUs RoMuLuS" } };
-            CDTQResultSet* result = [im find:query];
-            expect(result.documentIds).to.containsInAnyOrder(@[ @"fred34" ]);
+          expect([im ensureIndexed:@[ @"comment" ] withName:@"basic_text" ofType:CDTQIndexTypeText])
+              .toNot.beNil();
+
+          // Search is generally case-insensitive unless a custom tokenizer is provided
+          NSDictionary* query = @{ @"$text" : @{@"$search" : @"rEmUs RoMuLuS"} };
+          CDTQResultSet* result = [im find:query];
+          expect(result.documentIds).to.containsInAnyOrder(@[ @"fred34" ]);
         });
-        
+
         it(@"treats non-string field as a string when performing a text search", ^{
-            expect([im ensureIndexed:@[ @"age" ]
-                            withName:@"basic_text"
-                                type:@"text"]).toNot.beNil();
-            
-            NSDictionary* query = @{ @"$text" : @{@"$search" : @"12" } };
-            CDTQResultSet* result = [im find:query];
-            expect(result.documentIds).to.containsInAnyOrder(@[ @"mike12", @"fred12" ]);
+          expect([im ensureIndexed:@[ @"age" ] withName:@"basic_text" ofType:CDTQIndexTypeText])
+              .toNot.beNil();
+
+          NSDictionary* query = @{ @"$text" : @{@"$search" : @"12"} };
+          CDTQResultSet* result = [im find:query];
+          expect(result.documentIds).to.containsInAnyOrder(@[ @"mike12", @"fred12" ]);
         });
-        
+
         it(@"returns nil when text search criteria is not a string", ^{
-            expect([im ensureIndexed:@[ @"age" ]
-                            withName:@"basic_text"
-                                type:@"text"]).toNot.beNil();
-            
-            NSDictionary* query = @{ @"$text" : @{@"$search" : @12 } };
-            expect([im find:query]).to.beNil();
+          expect([im ensureIndexed:@[ @"age" ] withName:@"basic_text" ofType:CDTQIndexTypeText])
+              .toNot.beNil();
+
+          NSDictionary* query = @{ @"$text" : @{@"$search" : @12} };
+          expect([im find:query]).to.beNil();
         });
-        
+
         it(@"can perform a text search across multiple fields", ^{
-            expect([im ensureIndexed:@[ @"name", @"comment" ]
-                            withName:@"basic_text"
-                                type:@"text"]).toNot.beNil();
-            
-            // Will find fred12 and fred34 as well as mike12 since Fred is also mentioned
-            // in mike12's comment
-            NSDictionary* query = @{ @"$text" : @{@"$search" : @"Fred" } };
-            CDTQResultSet* result = [im find:query];
-            expect(result.documentIds).to.containsInAnyOrder(@[ @"mike12", @"fred12", @"fred34" ]);
+          expect([im ensureIndexed:@[ @"name", @"comment" ]
+                          withName:@"basic_text"
+                            ofType:CDTQIndexTypeText])
+              .toNot.beNil();
+
+          // Will find fred12 and fred34 as well as mike12 since Fred is also mentioned
+          // in mike12's comment
+          NSDictionary* query = @{ @"$text" : @{@"$search" : @"Fred"} };
+          CDTQResultSet* result = [im find:query];
+          expect(result.documentIds).to.containsInAnyOrder(@[ @"mike12", @"fred12", @"fred34" ]);
         });
-        
+
         it(@"can perform a text search targeting specific fields", ^{
-            expect([im ensureIndexed:@[ @"name", @"comment" ]
-                            withName:@"basic_text"
-                                type:@"text"]).toNot.beNil();
-            
-            // Will only find fred12 since he is the only named fred who's comment
-            // states that he "lives in Bristol"
-            NSDictionary* query = @{ @"$text" : @{@"$search" : @"name:fred "
-                                                               @"comment:lives in Bristol" } };
-            CDTQResultSet* result = [im find:query];
-            expect(result.documentIds).to.containsInAnyOrder(@[ @"fred12" ]);
+          expect([im ensureIndexed:@[ @"name", @"comment" ]
+                          withName:@"basic_text"
+                            ofType:CDTQIndexTypeText])
+              .toNot.beNil();
+
+          // Will only find fred12 since he is the only named fred who's comment
+          // states that he "lives in Bristol"
+          NSDictionary* query = @{
+              @"$text" : @{
+                  @"$search" : @"name:fred "
+                               @"comment:lives in Bristol"
+              }
+          };
+          CDTQResultSet* result = [im find:query];
+          expect(result.documentIds).to.containsInAnyOrder(@[ @"fred12" ]);
         });
-        
+
         it(@"can perform a text search using prefix searches", ^{
-            expect([im ensureIndexed:@[ @"comment" ]
-                            withName:@"basic_text"
-                                type:@"text"]).toNot.beNil();
-            
-            NSDictionary* query = @{ @"$text" : @{@"$search" : @"liv* riv*" } };
-            CDTQResultSet* result = [im find:query];
-            expect(result.documentIds).to.containsInAnyOrder(@[ @"mike34" ]);
+          expect([im ensureIndexed:@[ @"comment" ] withName:@"basic_text" ofType:CDTQIndexTypeText])
+              .toNot.beNil();
+
+          NSDictionary* query = @{ @"$text" : @{@"$search" : @"liv* riv*"} };
+          CDTQResultSet* result = [im find:query];
+          expect(result.documentIds).to.containsInAnyOrder(@[ @"mike34" ]);
         });
-        
+
         it(@"retuns empty result set when missing wildcards in prefix searches", ^{
-            expect([im ensureIndexed:@[ @"comment" ]
-                            withName:@"basic_text"
-                                type:@"text"]).toNot.beNil();
-            
-            NSDictionary* query = @{ @"$text" : @{@"$search" : @"liv riv" } };
-            CDTQResultSet* result = [im find:query];
-            expect(result).toNot.beNil();
-            expect(result.documentIds.count).to.equal(0);
+          expect([im ensureIndexed:@[ @"comment" ] withName:@"basic_text" ofType:CDTQIndexTypeText])
+              .toNot.beNil();
+
+          NSDictionary* query = @{ @"$text" : @{@"$search" : @"liv riv"} };
+          CDTQResultSet* result = [im find:query];
+          expect(result).toNot.beNil();
+          expect(result.documentIds.count).to.equal(0);
         });
-        
+
         it(@"can perform a text search using ID", ^{
-            expect([im ensureIndexed:@[ @"comment" ]
-                            withName:@"basic_text"
-                                type:@"text"]).toNot.beNil();
-            
-            NSDictionary* query = @{ @"$text" : @{@"$search" : @"_id:mike*" } };
-            CDTQResultSet* result = [im find:query];
-            expect(result.documentIds).to.containsInAnyOrder(@[ @"mike12", @"mike34", @"mike72" ]);
+          expect([im ensureIndexed:@[ @"comment" ] withName:@"basic_text" ofType:CDTQIndexTypeText])
+              .toNot.beNil();
+
+          NSDictionary* query = @{ @"$text" : @{@"$search" : @"_id:mike*"} };
+          CDTQResultSet* result = [im find:query];
+          expect(result.documentIds).to.containsInAnyOrder(@[ @"mike12", @"mike34", @"mike72" ]);
         });
-        
+
         it(@"can perform a text search using the Porter tokenizer stemmer", ^{
-            expect([im ensureIndexed:@[ @"comment" ]
-                            withName:@"basic_text"
-                                type:@"text"
-                            settings:@{ @"tokenize" : @"porter" }]).toNot.beNil();
-            
-            NSDictionary* query = @{ @"$text" : @{@"$search" : @"retire memory" } };
-            CDTQResultSet* result = [im find:query];
-            expect(result.documentIds).to.containsInAnyOrder(@[ @"mike72" ]);
+          expect([im ensureIndexed:@[ @"comment" ]
+                          withName:@"basic_text"
+                            ofType:CDTQIndexTypeText
+                          settings:@{
+                              @"tokenize" : @"porter"
+                          }])
+              .toNot.beNil();
+
+          NSDictionary* query = @{ @"$text" : @{@"$search" : @"retire memory"} };
+          CDTQResultSet* result = [im find:query];
+          expect(result.documentIds).to.containsInAnyOrder(@[ @"mike72" ]);
         });
-        
+
         it(@"returns empty result set when using default tokenizer stemmer", ^{
-            expect([im ensureIndexed:@[ @"comment" ]
-                            withName:@"basic_text"
-                                type:@"text"]).toNot.beNil();
-            
-            NSDictionary* query = @{ @"$text" : @{@"$search" : @"retire memory" } };
-            CDTQResultSet* result = [im find:query];
-            expect(result).toNot.beNil();
-            expect(result.documentIds.count).to.equal(0);
+          expect([im ensureIndexed:@[ @"comment" ] withName:@"basic_text" ofType:CDTQIndexTypeText])
+              .toNot.beNil();
+
+          NSDictionary* query = @{ @"$text" : @{@"$search" : @"retire memory"} };
+          CDTQResultSet* result = [im find:query];
+          expect(result).toNot.beNil();
+          expect(result.documentIds.count).to.equal(0);
         });
 
     });


### PR DESCRIPTION
## What
Migrate Query tests to using the APIs which use enums instead of Strings.

## How
Replace all method calls that use strings to denote the index type to using enums where possible

## Reviewers
reviewer @mikerhodes 
## Issues
Part of #231  