### PR TITLE
Fix bug in customiseNSURLSessionConfiguration

### DIFF
--- a/CDTDatastore/CDTReplicator/CDTNSURLSessionConfigurationDelegate.h
+++ b/CDTDatastore/CDTReplicator/CDTNSURLSessionConfigurationDelegate.h
@@ -22,8 +22,7 @@
  to NO.
  */
 @protocol CDTNSURLSessionConfigurationDelegate
-@optional
-- (nonnull NSURLSessionConfiguration*)customiseNSURLSessionConfiguration:(nonnull NSURLSessionConfiguration *)config;
+- (void)customiseNSURLSessionConfiguration:(nonnull NSURLSessionConfiguration *)config;
 @end
 
 

--- a/CDTDatastore/HTTP/CDTURLSession.m
+++ b/CDTDatastore/HTTP/CDTURLSession.m
@@ -73,7 +73,7 @@
         config = [NSURLSessionConfiguration backgroundSessionConfiguration:sessionId];
 #endif
 
-        config = [sessionConfigDelegate customiseNSURLSessionConfiguration:config];
+        [sessionConfigDelegate customiseNSURLSessionConfiguration:config];
 
         _session = [NSURLSession sessionWithConfiguration:config
                                                  delegate:self

--- a/CDTDatastoreTests/CDTURLSessionTests.m
+++ b/CDTDatastoreTests/CDTURLSessionTests.m
@@ -213,10 +213,9 @@
     XCTAssertEqual(replayingInterceptor.timesCalled, 11);
 }
 
-- (NSURLSessionConfiguration*)customiseNSURLSessionConfiguration:(nonnull NSURLSessionConfiguration *)config
+- (void)customiseNSURLSessionConfiguration:(nonnull NSURLSessionConfiguration *)config
 {
     config.timeoutIntervalForResource=1.0;
-    return config;
 }
 
 @end

--- a/Project/Project/CDTTodoReplicator.m
+++ b/Project/Project/CDTTodoReplicator.m
@@ -195,10 +195,9 @@
      replicator.changesTotal, replicator.changesProcessed, state, replicator.state];
 }
 
-- (NSURLSessionConfiguration*)customiseNSURLSessionConfiguration:(nonnull NSURLSessionConfiguration *)config {
+- (void)customiseNSURLSessionConfiguration:(nonnull NSURLSessionConfiguration *)config {
     config.allowsCellularAccess = NO; // Wifi only.
     config.sessionSendsLaunchEvents = YES;
-    return config;
 }
 
 @end

--- a/doc/replication-policies.md
+++ b/doc/replication-policies.md
@@ -130,10 +130,9 @@ Create a method to start replications and wait for their completion (on a backgr
 Setup an NSURLSessionConfigurationDelegate to customise the NSURLSession as you require:
 
 ```objc
-- (NSURLSessionConfiguration*)customiseNSURLSessionConfiguration:(nonnull NSURLSessionConfiguration *)config {
+- (void)customiseNSURLSessionConfiguration:(nonnull NSURLSessionConfiguration *)config {
     config.allowsCellularAccess = NO; // Wifi only.
     config.sessionSendsLaunchEvents = YES;
-    return config;
 }
 ```
 


### PR DESCRIPTION
## What

By default, the `NSURLSessionConfiguration` gets overwritten with nil in `CDTURLSession#initWithCallbackThread:requestInterceptors:sessionConfigDelegate:` [here](https://github.com/cloudant/CDTDatastore/blob/ec2152f57ff0c486aa262c84e4ddbbfa958764db/CDTDatastore/HTTP/CDTURLSession.m#L76).

## Why

The overwriting of the `NSURLSessionConfiguration` should be prohibited as if it is overwritten with `nil` or a `NSURLSessionConfiguration` that is not configured for background transfers, all replications will fail.

The API should only allow the customisation of the session configuration object that is created in `CDTURLSession#initWithCallbackThread:requestInterceptors:sessionConfigDelegate:`, which is configured to perform transfers in the background.

## How

Change the signature of `customiseNSURLSessionConfiguration:` in the `CDTNSURLSessionConfigurationDelegate` protocol so it returns `void` rather than an `NSURLSessionConfiguration`.  This allows customisation of the `NSURLSessionConfiguration` provided in the argument to `customiseNSURLSessionConfiguration:`, without allowing the replacement of the `NSURLSessionConfiguration`.

Change the call to `customiseNSURLSessionConfiguration:` in `CDTURLSession` so that the configuration is just passed to `customiseNSURLSessionConfiguration:` and the existing configuration is not overwritten.

## Testing

The existing tests have been updated to use the modified `customiseNSURLSessionConfiguration:`.

The `testFiltersWithChangesFeed` test in `CDTReplicationTests` exploited the ability to replace the `NSURLSessionConfiguration` in order to allow `OHHTTPStubs` to be used to mock the responses from a server.  However, `OHHTTPStubs` cannot be used with background sessions, so the use of `OHHTTPStubs` in this test has been replaced with a simple HTTP server running on localhost that responds to any request it is sent with an HTTP 404 Not Found message.

## Reviewers

reviewer: @alfinkel
reviewer: @rhyshort