### PR TITLE
Adjust nullability annotations for HTTP classes

### DIFF
--- a/CDTDatastore/HTTP/CDTHTTPInterceptorContext.h
+++ b/CDTDatastore/HTTP/CDTHTTPInterceptorContext.h
@@ -18,6 +18,8 @@
 #import <Foundation/Foundation.h>
 #import "CDTMacros.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface CDTHTTPInterceptorContext : NSObject
 
 @property (nonnull, readwrite, nonatomic, strong) NSMutableURLRequest *request;
@@ -30,16 +32,15 @@
  *  Calling this method from your code will result in
  *  an exception being thrown.
  **/
-- (nullable instancetype)init UNAVAILABLE_ATTRIBUTE;
+- (instancetype)init UNAVAILABLE_ATTRIBUTE;
 
 /**
  *  Initalizes a CDTURLSessionInterceptorContext
  *
  *  @param request the request this context should represent
  **/
-- (nullable instancetype)initWithRequest:(nonnull NSMutableURLRequest *)request
-    NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithRequest:(nonnull NSMutableURLRequest *)request NS_DESIGNATED_INITIALIZER;
 
 @end
 
-
+NS_ASSUME_NONNULL_END

--- a/CDTDatastore/HTTP/CDTURLSession.h
+++ b/CDTDatastore/HTTP/CDTURLSession.h
@@ -39,9 +39,11 @@
  * @param requestInterceptors array of interceptors that should be run before each request is made.
  * @param sessionConfigDelegate the delegate used to customise the NSURLSessionConfiguration.
  **/
-- (nullable instancetype)initWithCallbackThread:(nonnull NSThread *)thread
-                            requestInterceptors:(nullable NSArray *)requestInterceptors
-                          sessionConfigDelegate:(nullable NSObject<CDTNSURLSessionConfigurationDelegate> *)sessionConfigDelegate  NS_DESIGNATED_INITIALIZER;
+- (nonnull instancetype)initWithCallbackThread:(nonnull NSThread *)thread
+                           requestInterceptors:(nullable NSArray *)requestInterceptors
+                         sessionConfigDelegate:
+                             (nullable NSObject<CDTNSURLSessionConfigurationDelegate> *)
+                                 sessionConfigDelegate NS_DESIGNATED_INITIALIZER;
 
 /**
  * Performs a data task for a request.


### PR DESCRIPTION
In light of NSObject never returning null from init, CDTHTTPInterceptorContext and
CDTURLSession can safely be nonnull too.