### PR TITLE
Correctly generate a Temp dir for TDBlobStore

### DIFF
--- a/CDTDatastore/touchdb/TDBlobStore.m
+++ b/CDTDatastore/touchdb/TDBlobStore.m
@@ -255,13 +255,8 @@ NSString *const CDTBlobStoreErrorDomain = @"CDTBlobStoreErrorDomain";
         _tempDir = [NSTemporaryDirectory() copy];
 #else
         NSError* error;
-        NSURL* parentURL = [NSURL fileURLWithPath:_path isDirectory:YES];
-        NSURL* tempDirURL =
-            [[NSFileManager defaultManager] URLForDirectory:NSItemReplacementDirectory
-                                                   inDomain:NSUserDomainMask
-                                          appropriateForURL:parentURL
-                                                     create:YES
-                                                      error:&error];
+        NSURL *tempDirURL = [NSURL fileURLWithPath:NSTemporaryDirectory() isDirectory:YES];
+
         _tempDir = [tempDirURL.path copy];
         CDTLogInfo(CDTDATASTORE_LOG_CONTEXT, @"TDBlobStore %@ created tempDir %@", _path, _tempDir);
         if (!_tempDir)


### PR DESCRIPTION
## What
Correctly generate a temporary directory for TDBlobStore.

## How
Use `NSTemporyDirectory()` to get a temp dir path.

## Testing
No new tests, encrypted blob store tests now pass on Jenkins with this change.

## Reviewers
reviewer @ricellis

## Notes
The main reason for the change is documented here: http://nshipster.com/nstemporarydirectory/ 
Long story: the current way we are generating tmp dirs is incorrect, the current way is designed for moving files around.