### PR TITLE
Implemented `ensureIndexed:` API for `CDTDatastore+query` and `CDTQIndexManager`

### DIFF
--- a/CDTDatastore/query/CDTDatastore+Query.h
+++ b/CDTDatastore/query/CDTDatastore+Query.h
@@ -49,20 +49,30 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSDictionary<NSString *, NSArray<NSString *> *> *)listIndexes;
 
 /**
+ Add a single, possibly compound, index for the given field names.
+
+ This function generates a name for the new index.
+
+ @param fieldNames List of fieldnames in the sort format
+ @returns name of created index
+ */
+- (nullable NSString *)ensureIndexed:(NSArray<NSString *> *)fieldNames;
+
+/**
  Create a new index over a set of fields.
- 
+
  Fields in sub-documents can be specified using dotted notation.
- 
+
  An example:
- 
+
      { "name": "mike", "address": { "street": "Any Road" } }
- 
+
  The field name "name" would index "mike", while the field name
  "address.street" would index "Any Road".
- 
+
  Indexing an array will add each value in the array to the index.
  There may only be one array field per index.
- 
+
  @return The name of the index if it's created successfully.
  */
 - (nullable NSString *)ensureIndexed:(NSArray<NSString *> *)fieldNames

--- a/CDTDatastore/query/CDTDatastore+Query.m
+++ b/CDTDatastore/query/CDTDatastore+Query.m
@@ -41,6 +41,10 @@
 {
     return [self.CDTQManager listIndexes];
 }
+- (nullable NSString *)ensureIndexed:(NSArray<NSString *> *)fieldNames
+{
+    return [self.CDTQManager ensureIndexed:fieldNames];
+}
 
 - (NSString *)ensureIndexed:(NSArray *)fieldNames withName:(NSString *)indexName
 {

--- a/CDTDatastore/query/CDTQIndexManager.h
+++ b/CDTDatastore/query/CDTQIndexManager.h
@@ -107,6 +107,8 @@ managerUsingDatastore:(CDTDatastore *)datastore
 /** Internal */
 + (NSDictionary<NSString *, NSArray<NSString *> *> *)listIndexesInDatabase:(FMDatabase *)db;
 
+- (nullable NSString *)ensureIndexed:(NSArray<NSString *> *)fieldNames;
+
 - (nullable NSString *)ensureIndexed:(NSArray<NSString *> *)fieldNames
                             withName:(NSString *)indexName;
 

--- a/CDTDatastore/query/CDTQIndexManager.m
+++ b/CDTDatastore/query/CDTQIndexManager.m
@@ -214,8 +214,10 @@ static const int VERSION = 2;
  */
 - (NSString *)ensureIndexed:(NSArray * /* NSString */)fieldNames
 {
-    CDTLogError(CDTQ_LOG_CONTEXT, @"-ensureIndexed: not implemented");
-    return nil;
+    uint8_t randBytes[20];
+    arc4random_buf(randBytes, sizeof(randBytes));
+    NSString *indexName = TDHexFromBytes(randBytes, sizeof(randBytes));
+    return [self ensureIndexed:fieldNames withName:indexName];
 }
 
 /**

--- a/CDTDatastoreTests/CDTQIndexCreatorTests.m
+++ b/CDTDatastoreTests/CDTQIndexCreatorTests.m
@@ -65,6 +65,15 @@ SpecBegin(CDTQIndexCreator)
                 expect(im).toNot.beNil();
             });
 
+            it(@"can create an index without providing an index name", ^{
+              NSString *name = [im ensureIndexed:@[ @"foo", @"bar" ]];
+              expect(name).notTo.beNil();
+              NSDictionary *indexes = [im listIndexes];
+              expect(indexes.allKeys.count).to.equal(1);
+              expect(indexes.allKeys).to.contain(name);
+
+            });
+
             it(@"doesn't create an index on no fields", ^{
                 NSString *name = [im ensureIndexed:@[] withName:@"basic"];
                 expect(name).to.equal(nil);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - [NEW] Added replication policies, allowing users to easily create policies such as "Replicate
    every 2 hours, only when on Wifi". See the [Replication Policies User Guide](doc/replication-policies.md).
+- [NEW] Added new Indexing API `ensureIndexed:`. This API will attempt to
+   generate index names.
 - [IMPROVED] Replications will use session cookies to authenticate rather than
    using Basic Auth for every request.
 


### PR DESCRIPTION
## What
Implement `ensureIndexed:` API.

## How
Generate an index name when `ensureIndexed:` is called.


## Testing
One new test added to make sure the api successfully generates index names.

## Reviewers
reviewer @tomblench 

## Issues 
Fixes #229