### PR TITLE
Enable usage of special characters in index names.

### DIFF
--- a/CDTDatastore/query/CDTQIndexCreator.m
+++ b/CDTDatastore/query/CDTQIndexCreator.m
@@ -319,7 +319,7 @@
         [clauses addObject:clause];
     }
 
-    NSString *sql = [NSString stringWithFormat:@"CREATE TABLE %@ ( %@ );", tableName,
+    NSString *sql = [NSString stringWithFormat:@"CREATE TABLE \"%@\" ( %@ );", tableName,
                                                [clauses componentsJoinedByString:@", "]];
     return [CDTQSqlParts partsForSql:sql parameters:@[]];
 }
@@ -343,8 +343,9 @@
         [clauses addObject:[NSString stringWithFormat:@"\"%@\"", fieldName]];
     }
 
-    NSString *sql = [NSString stringWithFormat:@"CREATE INDEX %@ ON %@ ( %@ );", sqlIndexName,
-                                               tableName, [clauses componentsJoinedByString:@", "]];
+    NSString *sql =
+        [NSString stringWithFormat:@"CREATE INDEX \"%@\" ON \"%@\" ( %@ );", sqlIndexName,
+                                   tableName, [clauses componentsJoinedByString:@", "]];
     return [CDTQSqlParts partsForSql:sql parameters:@[]];
 }
 
@@ -383,11 +384,11 @@
                                     parameter,
                                     indexSettings[parameter]]];
     }
-    
-    NSString *sql = [NSString stringWithFormat:@"CREATE VIRTUAL TABLE %@ USING FTS4 ( %@, %@ );",
-                     tableName,
-                     [clauses componentsJoinedByString:@", "],
-                     [settingsClauses componentsJoinedByString:@", "]];
+
+    NSString *sql =
+        [NSString stringWithFormat:@"CREATE VIRTUAL TABLE \"%@\" USING FTS4 ( %@, %@ );", tableName,
+                                   [clauses componentsJoinedByString:@", "],
+                                   [settingsClauses componentsJoinedByString:@", "]];
     return [CDTQSqlParts partsForSql:sql parameters:@[]];
 }
 

--- a/CDTDatastore/query/CDTQIndexUpdater.m
+++ b/CDTDatastore/query/CDTQIndexUpdater.m
@@ -272,7 +272,7 @@
 
     NSString *tableName = [CDTQIndexManager tableNameForIndex:indexName];
 
-    NSString *sqlDelete = @"DELETE FROM %@ WHERE _id = ?;";
+    NSString *sqlDelete = @"DELETE FROM \"%@\" WHERE _id = ?;";
     sqlDelete = [NSString stringWithFormat:sqlDelete, tableName];
 
     return [CDTQSqlParts partsForSql:sqlDelete parameters:@[ docId ]];
@@ -406,7 +406,7 @@
 
     // If there are no fields, we just index blank for the doc ID
     NSString *sql;
-    sql = @"INSERT INTO %@ ( %@ ) VALUES ( %@ );";
+    sql = @"INSERT INTO \"%@\" ( %@ ) VALUES ( %@ );";
     sql = [NSString stringWithFormat:sql, [CDTQIndexManager tableNameForIndex:indexName],
                                      [sqlSafeFieldNames componentsJoinedByString:@", "],
                                      [placeholders componentsJoinedByString:@", "]];

--- a/CDTDatastore/query/CDTQQuerySqlTranslator.m
+++ b/CDTDatastore/query/CDTQQuerySqlTranslator.m
@@ -99,7 +99,7 @@
 
         if (allDocsIndex.length > 0) {
             NSString *tableName = [CDTQIndexManager tableNameForIndex:allDocsIndex];
-            NSString *sql = [NSString stringWithFormat:@"SELECT _id FROM %@;", tableName];
+            NSString *sql = [NSString stringWithFormat:@"SELECT _id FROM \"%@\";", tableName];
             sqlNode.sql = [CDTQSqlParts partsForSql:sql parameters:@[]];
         }
 
@@ -545,10 +545,9 @@
                                    fieldName,
                                    sqlOperator,
                                    operand];
-    NSString *subSelect = [NSString stringWithFormat:@"SELECT _id FROM %@ WHERE %@",
-                           tableName,
-                           whereForSubSelect];
-    
+    NSString *subSelect = [NSString
+        stringWithFormat:@"SELECT _id FROM \"%@\" WHERE %@", tableName, whereForSubSelect];
+
     return [NSString stringWithFormat:@"_id NOT IN (%@)", subSelect];
 }
 
@@ -584,7 +583,7 @@
 
     NSString *tableName = [CDTQIndexManager tableNameForIndex:indexName];
 
-    NSString *sql = @"SELECT _id FROM %@ WHERE %@;";
+    NSString *sql = @"SELECT _id FROM \"%@\" WHERE %@;";
     sql = [NSString stringWithFormat:sql, tableName, where.sqlWithPlaceholders];
 
     CDTQSqlParts *parts = [CDTQSqlParts partsForSql:sql parameters:where.placeholderValues];
@@ -604,8 +603,8 @@
     
     NSString *tableName = [CDTQIndexManager tableNameForIndex:indexName];
     NSString *search = textClause[TEXT][SEARCH];
-    
-    NSString *sql = @"SELECT _id FROM %@ WHERE %@ MATCH ?;";
+
+    NSString *sql = @"SELECT _id FROM \"%@\" WHERE \"%@\" MATCH ?;";
     sql = [NSString stringWithFormat:sql, tableName, tableName];
     
     CDTQSqlParts *parts = [CDTQSqlParts partsForSql:sql parameters:@[ search ]];

--- a/CDTDatastoreTests/CDTDatastoreQueryTests.m
+++ b/CDTDatastoreTests/CDTDatastoreQueryTests.m
@@ -6,12 +6,13 @@
 //  Copyright (c) 2014 Michael Rhodes. All rights reserved.
 //
 
-#import <CDTDatastore/CloudantSync.h>
 #import <CDTDatastore/CDTDatastore+Query.h>
+#import <CDTDatastore/CDTLogging.h>
 #import <CDTDatastore/CDTQResultSet.h>
-#import <objc/runtime.h>
-#import <Specta/Specta.h>
+#import <CDTDatastore/CloudantSync.h>
 #import <Expecta/Expecta.h>
+#import <Specta/Specta.h>
+#import <objc/runtime.h>
 
 SpecBegin(CDTDatastoreQuery) describe(@"When using datastore query", ^{
 
@@ -58,7 +59,7 @@ SpecBegin(CDTDatastoreQuery) describe(@"When using datastore query", ^{
         rev.body = @{ @"name" : @"mike", @"age" : @67, @"pet" : @"cat" };
         [ds createDocumentFromRevision:rev error:nil];
 
-        [ds ensureIndexed:@[ @"name" ] withName:@"name"];
+        [ds ensureIndexed:@[ @"name" ] withName:@"index name"];
     });
 
     afterEach(^{
@@ -127,6 +128,12 @@ SpecBegin(CDTDatastoreQuery) describe(@"When using datastore query", ^{
       NSString *indexName =
           [ds ensureIndexed:@[ @"name" ] withName:@"text_idx" ofType:CDTQIndexTypeText];
       expect(indexName).to.equal(@"text_idx");
+    });
+
+    it(@"can create an index with a space in it's name", ^{
+      NSString *indexName =
+          [ds ensureIndexed:@[ @"name" ] withName:@"my index" ofType:CDTQIndexTypeJSON];
+      expect(indexName).to.equal(@"my index");
     });
 
     it(@"can create a text index with defined settings", ^{

--- a/CDTDatastoreTests/CDTQIndexCreatorTests.m
+++ b/CDTDatastoreTests/CDTQIndexCreatorTests.m
@@ -11,6 +11,7 @@
 #import <CDTDatastore/CDTQQueryExecutor.h>
 #import <CDTDatastore/CDTQResultSet.h>
 #import <CDTDatastore/CloudantSync.h>
+#import <Expecta/Expecta.h>
 #import <Specta/Specta.h>
 #import "Matchers/CDTQContainsInAnyOrderMatcher.h"
 
@@ -482,7 +483,7 @@ SpecBegin(CDTQIndexCreator)
                     [CDTQIndexCreator createIndexTableStatementForIndexName:@"anIndex"
                                                                  fieldNames:fieldNames];
                 expect(parts.sqlWithPlaceholders)
-                    .to.equal(@"CREATE TABLE _t_cloudant_sync_query_index_anIndex"
+                    .to.equal(@"CREATE TABLE \"_t_cloudant_sync_query_index_anIndex\""
                                " ( \"_id\" NONE, \"name\" NONE );");
                 expect(parts.placeholderValues).to.equal(@[]);
             });
@@ -493,7 +494,7 @@ SpecBegin(CDTQIndexCreator)
                     [CDTQIndexCreator createIndexTableStatementForIndexName:@"anIndex"
                                                                  fieldNames:fieldNames];
                 expect(parts.sqlWithPlaceholders)
-                    .to.equal(@"CREATE TABLE _t_cloudant_sync_query_index_anIndex"
+                    .to.equal(@"CREATE TABLE \"_t_cloudant_sync_query_index_anIndex\""
                                " ( \"_id\" NONE, \"name\" NONE, \"age\" NONE, \"pet\" NONE );");
                 expect(parts.placeholderValues).to.equal(@[]);
             });
@@ -514,8 +515,8 @@ SpecBegin(CDTQIndexCreator)
                     [CDTQIndexCreator createIndexIndexStatementForIndexName:@"anIndex"
                                                                  fieldNames:fieldNames];
                 expect(parts.sqlWithPlaceholders)
-                    .to.equal(@"CREATE INDEX _t_cloudant_sync_query_index_anIndex_index "
-                               "ON _t_cloudant_sync_query_index_anIndex"
+                    .to.equal(@"CREATE INDEX \"_t_cloudant_sync_query_index_anIndex_index\" "
+                               "ON \"_t_cloudant_sync_query_index_anIndex\""
                                " ( \"_id\", \"name\" );");
                 expect(parts.placeholderValues).to.equal(@[]);
             });
@@ -526,8 +527,8 @@ SpecBegin(CDTQIndexCreator)
                     [CDTQIndexCreator createIndexIndexStatementForIndexName:@"anIndex"
                                                                  fieldNames:fieldNames];
                 expect(parts.sqlWithPlaceholders)
-                    .to.equal(@"CREATE INDEX _t_cloudant_sync_query_index_anIndex_index "
-                               "ON _t_cloudant_sync_query_index_anIndex"
+                    .to.equal(@"CREATE INDEX \"_t_cloudant_sync_query_index_anIndex_index\" "
+                               "ON \"_t_cloudant_sync_query_index_anIndex\""
                                " ( \"_id\", \"name\", \"age\", \"pet\" );");
                 expect(parts.placeholderValues).to.equal(@[]);
             });

--- a/CDTDatastoreTests/CDTQIndexUpdaterTests.m
+++ b/CDTDatastoreTests/CDTQIndexUpdaterTests.m
@@ -73,7 +73,8 @@ SpecBegin(CDTQIndexUpdater)
                 CDTQSqlParts *parts =
                     [CDTQIndexUpdater partsToDeleteIndexEntriesForDocId:@"123"
                                                               fromIndex:@"anIndex"];
-                NSString *sql = @"DELETE FROM _t_cloudant_sync_query_index_anIndex WHERE _id = ?;";
+                NSString *sql =
+                    @"DELETE FROM \"_t_cloudant_sync_query_index_anIndex\" WHERE _id = ?;";
                 expect(parts.sqlWithPlaceholders).to.equal(sql);
                 expect(parts.placeholderValues).to.equal(@[ @"123" ]);
             });
@@ -91,7 +92,7 @@ SpecBegin(CDTQIndexUpdater)
                                                                      inIndex:@"anIndex"
                                                               withFieldNames:@[ @"name" ]][0];
 
-                NSString *sql = @"INSERT INTO _t_cloudant_sync_query_index_anIndex "
+                NSString *sql = @"INSERT INTO \"_t_cloudant_sync_query_index_anIndex\" "
                                  "( \"_id\", \"_rev\", \"name\" ) VALUES ( ?, ?, ? );";
                 expect(parts.sqlWithPlaceholders).to.equal(sql);
                 expect(parts.placeholderValues).to.equal(@[ @"id123", saved.revId, @"mike" ]);
@@ -107,7 +108,7 @@ SpecBegin(CDTQIndexUpdater)
                                                    inIndex:@"anIndex"
                                             withFieldNames:@[ @"age", @"name" ]][0];
 
-                NSString *sql = @"INSERT INTO _t_cloudant_sync_query_index_anIndex "
+                NSString *sql = @"INSERT INTO \"_t_cloudant_sync_query_index_anIndex\" "
                                  "( \"_id\", \"_rev\", \"age\", \"name\" ) VALUES ( ?, ?, ?, ? );";
                 expect(parts.sqlWithPlaceholders).to.equal(sql);
                 expect(parts.placeholderValues).to.equal(@[ @"id123", saved.revId, @12, @"mike" ]);
@@ -129,7 +130,7 @@ SpecBegin(CDTQIndexUpdater)
                                                    inIndex:@"anIndex"
                                             withFieldNames:@[ @"age", @"name", @"pet", @"car" ]][0];
 
-                NSString *sql = @"INSERT INTO _t_cloudant_sync_query_index_anIndex "
+                NSString *sql = @"INSERT INTO \"_t_cloudant_sync_query_index_anIndex\" "
                                  "( \"_id\", \"_rev\", \"age\", \"name\", \"pet\", \"car\" ) "
                                  "VALUES ( ?, ?, ?, ?, ?, ? );";
                 expect(parts.sqlWithPlaceholders).to.equal(sql);
@@ -147,7 +148,7 @@ SpecBegin(CDTQIndexUpdater)
                                                    inIndex:@"anIndex"
                                             withFieldNames:@[ @"age", @"name", @"pet", @"car" ]][0];
 
-                NSString *sql = @"INSERT INTO _t_cloudant_sync_query_index_anIndex "
+                NSString *sql = @"INSERT INTO \"_t_cloudant_sync_query_index_anIndex\" "
                                  "( \"_id\", \"_rev\", \"name\", \"pet\" ) VALUES ( ?, ?, ?, ? );";
                 expect(parts.sqlWithPlaceholders).to.equal(sql);
                 expect(parts.placeholderValues)
@@ -163,7 +164,7 @@ SpecBegin(CDTQIndexUpdater)
                     [CDTQIndexUpdater partsToIndexRevision:saved
                                                    inIndex:@"anIndex"
                                             withFieldNames:@[ @"car", @"van" ]][0];
-                NSString *sql = @"INSERT INTO _t_cloudant_sync_query_index_anIndex "
+                NSString *sql = @"INSERT INTO \"_t_cloudant_sync_query_index_anIndex\" "
                                  "( \"_id\", \"_rev\" ) VALUES ( ?, ? );";
                 expect(parts.sqlWithPlaceholders).to.equal(sql);
                 expect(parts.placeholderValues).to.equal(@[ @"id123", saved.revId ]);
@@ -186,21 +187,21 @@ SpecBegin(CDTQIndexUpdater)
                     NSString *sql;
 
                     parts = statements[0];
-                    sql = @"INSERT INTO _t_cloudant_sync_query_index_anIndex "
+                    sql = @"INSERT INTO \"_t_cloudant_sync_query_index_anIndex\" "
                            "( \"_id\", \"_rev\", \"pet\", \"name\" ) VALUES ( ?, ?, ?, ? );";
                     expect(parts.sqlWithPlaceholders).to.equal(sql);
                     expect(parts.placeholderValues)
                         .to.equal(@[ @"id123", saved.revId, @"cat", @"mike" ]);
 
                     parts = statements[1];
-                    sql = @"INSERT INTO _t_cloudant_sync_query_index_anIndex "
+                    sql = @"INSERT INTO \"_t_cloudant_sync_query_index_anIndex\" "
                            "( \"_id\", \"_rev\", \"pet\", \"name\" ) VALUES ( ?, ?, ?, ? );";
                     expect(parts.sqlWithPlaceholders).to.equal(sql);
                     expect(parts.placeholderValues)
                         .to.equal(@[ @"id123", saved.revId, @"dog", @"mike" ]);
 
                     parts = statements[2];
-                    sql = @"INSERT INTO _t_cloudant_sync_query_index_anIndex "
+                    sql = @"INSERT INTO \"_t_cloudant_sync_query_index_anIndex\" "
                            "( \"_id\", \"_rev\", \"pet\", \"name\" ) VALUES ( ?, ?, ?, ? );";
                     expect(parts.sqlWithPlaceholders).to.equal(sql);
                     expect(parts.placeholderValues)
@@ -223,7 +224,7 @@ SpecBegin(CDTQIndexUpdater)
 
                     parts = statements[0];
                     sql =
-                        @"INSERT INTO _t_cloudant_sync_query_index_anIndex "
+                        @"INSERT INTO \"_t_cloudant_sync_query_index_anIndex\" "
                          "( \"_id\", \"_rev\", \"pet.species\", \"name\" ) VALUES ( ?, ?, ?, ? );";
                     expect(parts.sqlWithPlaceholders).to.equal(sql);
                     expect(parts.placeholderValues)
@@ -231,7 +232,7 @@ SpecBegin(CDTQIndexUpdater)
 
                     parts = statements[1];
                     sql =
-                        @"INSERT INTO _t_cloudant_sync_query_index_anIndex "
+                        @"INSERT INTO \"_t_cloudant_sync_query_index_anIndex\" "
                          "( \"_id\", \"_rev\", \"pet.species\", \"name\" ) VALUES ( ?, ?, ?, ? );";
                     expect(parts.sqlWithPlaceholders).to.equal(sql);
                     expect(parts.placeholderValues)
@@ -268,8 +269,8 @@ SpecBegin(CDTQIndexUpdater)
                                                                                     @"pet" ] ];
                     expect(statements.count).to.equal(1);
                     CDTQSqlParts *parts = statements[0];
-                    
-                    NSString *sql = @"INSERT INTO _t_cloudant_sync_query_index_anIndex "
+
+                    NSString *sql = @"INSERT INTO \"_t_cloudant_sync_query_index_anIndex\" "
                                      "( \"_id\", \"_rev\", \"name\" ) VALUES ( ?, ?, ? );";
                     expect(parts.sqlWithPlaceholders).to.equal(sql);
                     expect(parts.placeholderValues).to.equal(@[ @"id123", saved.revId, @"mike" ]);
@@ -287,8 +288,8 @@ SpecBegin(CDTQIndexUpdater)
                                                                                    @"pet.species"]];
                     expect(statements.count).to.equal(1);
                     CDTQSqlParts *parts = statements[0];
-                    
-                    NSString *sql = @"INSERT INTO _t_cloudant_sync_query_index_anIndex "
+
+                    NSString *sql = @"INSERT INTO \"_t_cloudant_sync_query_index_anIndex\" "
                                      "( \"_id\", \"_rev\", \"name\" ) VALUES ( ?, ?, ? );";
                     expect(parts.sqlWithPlaceholders).to.equal(sql);
                     expect(parts.placeholderValues).to.equal(@[ @"id123", saved.revId, @"mike" ]);

--- a/CDTDatastoreTests/CDTQQuerySqlTranslatorTests.m
+++ b/CDTDatastoreTests/CDTQQuerySqlTranslatorTests.m
@@ -83,7 +83,7 @@ SpecBegin(CDTQQuerySqlTranslator) describe(@"cdtq", ^{
             expect(and.children.count).to.equal(1);
 
             CDTQSqlQueryNode *sqlNode = and.children[0];
-            NSString *sql = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
+            NSString *sql = @"SELECT _id FROM \"_t_cloudant_sync_query_index_basic\" "
                              "WHERE \"name\" = ?;";
             expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sql);
             expect(sqlNode.sql.placeholderValues).to.equal(@[ @"mike" ]);
@@ -105,10 +105,10 @@ SpecBegin(CDTQQuerySqlTranslator) describe(@"cdtq", ^{
             expect(and.children.count).to.equal(1);
 
             CDTQSqlQueryNode *sqlNode = and.children[0];
-            NSString *sql = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
+            NSString *sql = @"SELECT _id FROM \"_t_cloudant_sync_query_index_basic\" "
                              "WHERE \"pet\" = ? AND \"name\" = ?;";
-            NSString *otherSql = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
-            "WHERE \"name\" = ? AND \"pet\" = ?;";
+            NSString *otherSql = @"SELECT _id FROM \"_t_cloudant_sync_query_index_basic\" "
+                                  "WHERE \"name\" = ? AND \"pet\" = ?;";
             expect(sqlNode.sql.sqlWithPlaceholders).to.isEqualToEither(sql,otherSql);
             expect(sqlNode.sql.placeholderValues).to.containsInAnyOrder(@[ @"cat", @"mike" ]);
         });
@@ -128,7 +128,7 @@ SpecBegin(CDTQQuerySqlTranslator) describe(@"cdtq", ^{
             expect(and.children.count).to.equal(1);
 
             CDTQSqlQueryNode *sqlNode = and.children[0];
-            NSString *sql = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
+            NSString *sql = @"SELECT _id FROM \"_t_cloudant_sync_query_index_basic\" "
                              "WHERE \"name\" = ? AND \"pet\" = ?;";
             expect(sqlNode.sql.sqlWithPlaceholders).to.equal(sql);
             expect(sqlNode.sql.placeholderValues).to.equal(@[ @"mike", @"cat" ]);
@@ -158,7 +158,7 @@ SpecBegin(CDTQQuerySqlTranslator) describe(@"cdtq", ^{
             CDTQAndQueryNode *and = (CDTQAndQueryNode *)node;
             expect(and.children.count).to.equal(2);
 
-            NSString *sql = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
+            NSString *sql = @"SELECT _id FROM \"_t_cloudant_sync_query_index_basic\" "
                              "WHERE \"name\" = ? AND \"pet\" = ?;";
 
             // As the embedded AND is the same as the top-level AND, both
@@ -197,7 +197,7 @@ SpecBegin(CDTQQuerySqlTranslator) describe(@"cdtq", ^{
             CDTQAndQueryNode *and = (CDTQAndQueryNode *)node;
             expect(and.children.count).to.equal(2);
 
-            NSString *sql = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
+            NSString *sql = @"SELECT _id FROM \"_t_cloudant_sync_query_index_basic\" "
                              "WHERE \"name\" = ? AND \"pet\" = ?;";
 
             // As the embedded AND is the same as the top-level AND, both
@@ -230,10 +230,10 @@ SpecBegin(CDTQQuerySqlTranslator) describe(@"cdtq", ^{
             CDTQOrQueryNode * or = (CDTQOrQueryNode *)node;
             expect(or .children.count).to.equal(2);
 
-            NSString *sqlLeft = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
+            NSString *sqlLeft = @"SELECT _id FROM \"_t_cloudant_sync_query_index_basic\" "
                                  "WHERE \"name\" = ?;";
 
-            NSString *sqlRight = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
+            NSString *sqlRight = @"SELECT _id FROM \"_t_cloudant_sync_query_index_basic\" "
                                   "WHERE \"pet\" = ?;";
 
             CDTQSqlQueryNode *sqlNode;
@@ -271,10 +271,10 @@ SpecBegin(CDTQQuerySqlTranslator) describe(@"cdtq", ^{
             CDTQOrQueryNode * or = (CDTQOrQueryNode *)node;
             expect(or .children.count).to.equal(3);
 
-            NSString *sqlLeft = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
+            NSString *sqlLeft = @"SELECT _id FROM \"_t_cloudant_sync_query_index_basic\" "
                                  "WHERE \"name\" = ?;";
 
-            NSString *sqlRight = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
+            NSString *sqlRight = @"SELECT _id FROM \"_t_cloudant_sync_query_index_basic\" "
                                   "WHERE \"pet\" = ?;";
 
             CDTQSqlQueryNode *sqlNode;
@@ -324,13 +324,13 @@ SpecBegin(CDTQQuerySqlTranslator) describe(@"cdtq", ^{
             CDTQOrQueryNode * or = (CDTQOrQueryNode *)node;
             expect(or .children.count).to.equal(4);
 
-            NSString *sqlLeft = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
+            NSString *sqlLeft = @"SELECT _id FROM \"_t_cloudant_sync_query_index_basic\" "
                                  "WHERE \"name\" = ?;";
 
-            NSString *sqlRight = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
+            NSString *sqlRight = @"SELECT _id FROM \"_t_cloudant_sync_query_index_basic\" "
                                   "WHERE \"pet\" = ?;";
 
-            NSString *sqlAnd = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
+            NSString *sqlAnd = @"SELECT _id FROM \"_t_cloudant_sync_query_index_basic\" "
                                 "WHERE \"name\" = ? AND \"pet\" = ?;";
 
             CDTQSqlQueryNode *sqlNode;
@@ -396,13 +396,13 @@ SpecBegin(CDTQQuerySqlTranslator) describe(@"cdtq", ^{
             CDTQOrQueryNode * or = (CDTQOrQueryNode *)node;
             expect(or .children.count).to.equal(3);
 
-            NSString *sqlLeft = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
+            NSString *sqlLeft = @"SELECT _id FROM \"_t_cloudant_sync_query_index_basic\" "
                                  "WHERE \"name\" = ?;";
 
-            NSString *sqlRight = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
+            NSString *sqlRight = @"SELECT _id FROM \"_t_cloudant_sync_query_index_basic\" "
                                   "WHERE \"pet\" = ?;";
 
-            NSString *sqlAnd = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
+            NSString *sqlAnd = @"SELECT _id FROM \"_t_cloudant_sync_query_index_basic\" "
                                 "WHERE \"name\" = ? AND \"pet\" = ?;";
 
             CDTQSqlQueryNode *sqlNode;
@@ -468,10 +468,10 @@ SpecBegin(CDTQQuerySqlTranslator) describe(@"cdtq", ^{
             
             CDTQAndQueryNode *and = (CDTQAndQueryNode *)node;
             expect(and.children.count).to.equal(1);
-            
-            NSString *sql = @"SELECT _id FROM _t_cloudant_sync_query_index_basic_text "
-                             "WHERE _t_cloudant_sync_query_index_basic_text MATCH ?;";
-            
+
+            NSString *sql = @"SELECT _id FROM \"_t_cloudant_sync_query_index_basic_text\" "
+                             "WHERE \"_t_cloudant_sync_query_index_basic_text\" MATCH ?;";
+
             CDTQSqlQueryNode *sqlNode;
             
             sqlNode = and.children[0];
@@ -496,12 +496,12 @@ SpecBegin(CDTQQuerySqlTranslator) describe(@"cdtq", ^{
             
             CDTQAndQueryNode *and = (CDTQAndQueryNode *)node;
             expect(and.children.count).to.equal(2);
-            
-            NSString *sqlLeft = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
+
+            NSString *sqlLeft = @"SELECT _id FROM \"_t_cloudant_sync_query_index_basic\" "
                                  "WHERE \"name\" = ?;";
-            NSString *sqlRight = @"SELECT _id FROM _t_cloudant_sync_query_index_basic_text "
-                                  "WHERE _t_cloudant_sync_query_index_basic_text MATCH ?;";
-            
+            NSString *sqlRight = @"SELECT _id FROM \"_t_cloudant_sync_query_index_basic_text\" "
+                                  "WHERE \"_t_cloudant_sync_query_index_basic_text\" MATCH ?;";
+
             CDTQSqlQueryNode *sqlNode;
             
             sqlNode = and.children[0];
@@ -532,12 +532,12 @@ SpecBegin(CDTQQuerySqlTranslator) describe(@"cdtq", ^{
             
             CDTQOrQueryNode *or = (CDTQOrQueryNode *)node;
             expect(or.children.count).to.equal(2);
-            
-            NSString *sqlLeft = @"SELECT _id FROM _t_cloudant_sync_query_index_basic "
+
+            NSString *sqlLeft = @"SELECT _id FROM \"_t_cloudant_sync_query_index_basic\" "
                                  "WHERE \"name\" = ?;";
-            NSString *sqlRight = @"SELECT _id FROM _t_cloudant_sync_query_index_basic_text "
-                                  "WHERE _t_cloudant_sync_query_index_basic_text MATCH ?;";
-            
+            NSString *sqlRight = @"SELECT _id FROM \"_t_cloudant_sync_query_index_basic_text\" "
+                                  "WHERE \"_t_cloudant_sync_query_index_basic_text\" MATCH ?;";
+
             CDTQSqlQueryNode *sqlNode;
             
             sqlNode = or.children[0];
@@ -861,8 +861,8 @@ SpecBegin(CDTQQuerySqlTranslator) describe(@"cdtq", ^{
                                               @{ @"name" : @{@"$not" : @{@"$eq" : @"mike"}} }
                                            ] usingIndex:@"named"];
                 NSString *expected = @"_id NOT IN (SELECT _id "
-                                                 @"FROM _t_cloudant_sync_query_index_named "
-                                                 @"WHERE \"name\" = ?)";
+                                     @"FROM \"_t_cloudant_sync_query_index_named\" "
+                                     @"WHERE \"name\" = ?)";
                 expect(parts.sqlWithPlaceholders).to.equal(expected);
                 expect(parts.placeholderValues).to.equal(@[ @"mike" ]);
             });
@@ -876,15 +876,15 @@ SpecBegin(CDTQQuerySqlTranslator) describe(@"cdtq", ^{
                 CDTQSqlParts *parts = [CDTQQuerySqlTranslator wherePartsForAndClause:query
                                                                           usingIndex:@"named"];
                 NSString *expected = @"_id NOT IN (SELECT _id "
-                                                 @"FROM _t_cloudant_sync_query_index_named "
-                                                 @"WHERE \"name\" = ?) "
+                                     @"FROM \"_t_cloudant_sync_query_index_named\" "
+                                     @"WHERE \"name\" = ?) "
                                      @"AND "
                                      @"\"age\" = ? "
                                      @"AND "
                                      @"_id NOT IN (SELECT _id "
-                                                 @"FROM _t_cloudant_sync_query_index_named "
-                                                 @"WHERE \"pet\" = ?)";
-                
+                                     @"FROM \"_t_cloudant_sync_query_index_named\" "
+                                     @"WHERE \"pet\" = ?)";
+
                 expect(parts.sqlWithPlaceholders)
                     .to.equal(expected);
                 expect(parts.placeholderValues).to.equal(@[ @"mike", @12, @"cat" ]);
@@ -898,8 +898,8 @@ SpecBegin(CDTQQuerySqlTranslator) describe(@"cdtq", ^{
                                               @{ @"name" : @{@"$not" : @{@"$gt" : @"mike"}} }
                                            ] usingIndex:@"named"];
                 NSString *expected = @"_id NOT IN (SELECT _id "
-                                                 @"FROM _t_cloudant_sync_query_index_named "
-                                                 @"WHERE \"name\" > ?)";
+                                     @"FROM \"_t_cloudant_sync_query_index_named\" "
+                                     @"WHERE \"name\" > ?)";
                 expect(parts.sqlWithPlaceholders).to.equal(expected);
                 expect(parts.placeholderValues).to.equal(@[ @"mike" ]);
             });
@@ -912,8 +912,8 @@ SpecBegin(CDTQQuerySqlTranslator) describe(@"cdtq", ^{
                                               @{ @"name" : @{@"$not" : @{@"$gte" : @"mike"}} }
                                            ] usingIndex:@"named"];
                 NSString *expected = @"_id NOT IN (SELECT _id "
-                                                 @"FROM _t_cloudant_sync_query_index_named "
-                                                 @"WHERE \"name\" >= ?)";
+                                     @"FROM \"_t_cloudant_sync_query_index_named\" "
+                                     @"WHERE \"name\" >= ?)";
                 expect(parts.sqlWithPlaceholders).to.equal(expected);
                 expect(parts.placeholderValues).to.equal(@[ @"mike" ]);
             });
@@ -926,8 +926,8 @@ SpecBegin(CDTQQuerySqlTranslator) describe(@"cdtq", ^{
                                               @{ @"name" : @{@"$not" : @{@"$lt" : @"mike"}} }
                                            ] usingIndex:@"named"];
                 NSString *expected = @"_id NOT IN (SELECT _id "
-                                                 @"FROM _t_cloudant_sync_query_index_named "
-                                                 @"WHERE \"name\" < ?)";
+                                     @"FROM \"_t_cloudant_sync_query_index_named\" "
+                                     @"WHERE \"name\" < ?)";
                 expect(parts.sqlWithPlaceholders).to.equal(expected);
                 expect(parts.placeholderValues).to.equal(@[ @"mike" ]);
             });
@@ -940,8 +940,8 @@ SpecBegin(CDTQQuerySqlTranslator) describe(@"cdtq", ^{
                                               @{ @"name" : @{@"$not" : @{@"$lte" : @"mike"}} }
                                            ] usingIndex:@"named"];
                 NSString *expected = @"_id NOT IN (SELECT _id "
-                                                 @"FROM _t_cloudant_sync_query_index_named "
-                                                 @"WHERE \"name\" <= ?)";
+                                     @"FROM \"_t_cloudant_sync_query_index_named\" "
+                                     @"WHERE \"name\" <= ?)";
                 expect(parts.sqlWithPlaceholders).to.equal(expected);
                 expect(parts.placeholderValues).to.equal(@[ @"mike" ]);
             });
@@ -954,7 +954,7 @@ SpecBegin(CDTQQuerySqlTranslator) describe(@"cdtq", ^{
                                  @{ @"name" : @{ @"$not" : @{ @"$in" : @[ @"mike", @"fred" ]} } }
                                             ] usingIndex:@"named"];
                 NSString *expected = @"_id NOT IN (SELECT _id "
-                                     @"FROM _t_cloudant_sync_query_index_named "
+                                     @"FROM \"_t_cloudant_sync_query_index_named\" "
                                      @"WHERE \"name\" IN ( ?, ? ))";
                 expect(parts.sqlWithPlaceholders).to.equal(expected);
                 expect(parts.placeholderValues).to.equal(@[ @"mike", @"fred" ]);
@@ -972,7 +972,7 @@ SpecBegin(CDTQQuerySqlTranslator) describe(@"cdtq", ^{
                                                                  ]
                                                     usingIndex:@"named"];
                 NSString *expected = @"_id NOT IN (SELECT _id "
-                                     @"FROM _t_cloudant_sync_query_index_named "
+                                     @"FROM \"_t_cloudant_sync_query_index_named\" "
                                      @"WHERE \"age\" % ? = ?)";
                 expect(parts.sqlWithPlaceholders).to.equal(expected);
                 expect(parts.placeholderValues).to.equal(@[ @2, @1 ]);
@@ -991,8 +991,8 @@ SpecBegin(CDTQQuerySqlTranslator) describe(@"cdtq", ^{
             CDTQSqlParts *parts = [CDTQQuerySqlTranslator wherePartsForAndClause:clause
                                                                       usingIndex:@"named"];
             NSString *expected = @"_id NOT IN (SELECT _id "
-                                             @"FROM _t_cloudant_sync_query_index_named "
-                                             @"WHERE \"name\" = ?) "
+                                 @"FROM \"_t_cloudant_sync_query_index_named\" "
+                                 @"WHERE \"name\" = ?) "
                                  @"AND \"name\" = ?";
             expect(parts.sqlWithPlaceholders).to.equal(expected);
             expect(parts.placeholderValues).to.equal(@[ @"mike", @"john" ]);
@@ -1012,8 +1012,8 @@ SpecBegin(CDTQQuerySqlTranslator) describe(@"cdtq", ^{
                                  @"AND \"age\" <= ? "
                                  @"AND \"name\" = ? "
                                  @"AND _id NOT IN (SELECT _id "
-                                                 @"FROM _t_cloudant_sync_query_index_named "
-                                                 @"WHERE \"age\" = ?) "
+                                 @"FROM \"_t_cloudant_sync_query_index_named\" "
+                                 @"WHERE \"age\" = ?) "
                                  @"AND \"age\" = ?";
             expect(parts.sqlWithPlaceholders).to.equal(expected);
             expect(parts.placeholderValues).to.equal(@[ @12, @54, @"mike", @30, @42 ]);
@@ -1043,7 +1043,7 @@ SpecBegin(CDTQQuerySqlTranslator) describe(@"cdtq", ^{
                                                @{ @"name" : @{@"$eq" : @"mike"} }
                                             ]
                                  usingIndex:@"anIndex"];
-            NSString *sql = @"SELECT _id FROM _t_cloudant_sync_query_index_anIndex "
+            NSString *sql = @"SELECT _id FROM \"_t_cloudant_sync_query_index_anIndex\" "
                              "WHERE \"name\" = ?;";
             expect(parts.sqlWithPlaceholders).to.equal(sql);
             expect(parts.placeholderValues).to.equal(@[ @"mike" ]);
@@ -1057,7 +1057,7 @@ SpecBegin(CDTQQuerySqlTranslator) describe(@"cdtq", ^{
             ];
             CDTQSqlParts *parts = [CDTQQuerySqlTranslator selectStatementForAndClause:andClause
                                                                            usingIndex:@"anIndex"];
-            NSString *sql = @"SELECT _id FROM _t_cloudant_sync_query_index_anIndex "
+            NSString *sql = @"SELECT _id FROM \"_t_cloudant_sync_query_index_anIndex\" "
                              "WHERE \"name\" = ? AND \"age\" = ? AND \"pet\" = ?;";
             expect(parts.sqlWithPlaceholders).to.equal(sql);
             expect(parts.placeholderValues).to.equal(@[ @"mike", @12, @"cat" ]);

--- a/CDTDatastoreTests/CDTQTextSearchTests.m
+++ b/CDTDatastoreTests/CDTQTextSearchTests.m
@@ -119,8 +119,21 @@ SpecBegin(CDTQQueryExecutorTextSearch) describe(@"cdtq", ^{
 
           NSDictionary* query = @{ @"$text" : @{@"$search" : @"lives in Bristol"} };
           CDTQResultSet* result = [im find:query];
+
           expect(result.documentIds).to.containsInAnyOrder(@[ @"mike12", @"mike34", @"fred12" ]);
         });
+
+        it(@"can perform a search consisting of a single text clause with a index name including a "
+           @"space",
+           ^{
+             expect(
+                 [im ensureIndexed:@[ @"comment" ] withName:@"basic text" ofType:CDTQIndexTypeText])
+                 .toNot.beNil();
+
+             NSDictionary* query = @{ @"$text" : @{@"$search" : @"lives in Bristol"} };
+             CDTQResultSet* result = [im find:query];
+             expect(result.documentIds).to.containsInAnyOrder(@[ @"mike12", @"mike34", @"fred12" ]);
+           });
 
         it(@"can perform a phrase search", ^{
           expect([im ensureIndexed:@[ @"comment" ] withName:@"basic_text" ofType:CDTQIndexTypeText])


### PR DESCRIPTION
## What
Enable the usage of special characters in index names such as ` `.

## How
Quote SQL Identifiers in SQL Statements

## Tests
Added new tests to make sure indexes are escaped
Modified existing tests to match the generated SQL

## Reviewers

reviewer: @alfinkel
reviewer: @emlaver

## Issues

Fixes #230