### PR TITLE
Implement bulk get

### DIFF
--- a/CDTDatastore/touchdb/TDPuller.h
+++ b/CDTDatastore/touchdb/TDPuller.h
@@ -20,10 +20,13 @@
     TDSequenceMap* _pendingSequences;    // Received but not yet copied into local DB
     NSMutableArray* _revsToPull;         // Queue of TDPulledRevisions to download
     NSMutableArray* _deletedRevsToPull;  // Separate lower-priority of deleted TDPulledRevisions
-    NSMutableArray* _bulkRevsToPull;     // TDPulledRevisions that can be fetched in bulk
+    NSMutableArray* _bulkRevsToPull;     // TDPulledRevisions that can be fetched in bulk - 'all docs trick' for first rev
+    NSMutableArray* _bulkGetRevs;        // <docid,revid> pairs to pull if the /_bulk_get endpoint is supported
     NSUInteger _httpConnectionCount;     // Number of active NSURLConnections
     TDBatcher* _downloadsToInsert;       // Queue of TDPulledRevisions, with bodies, to insert in DB
 }
+
+@property BOOL bulkGetSupported;
 
 @end
 

--- a/CDTDatastoreReplicationAcceptanceTests/ReplicationAcceptance.m
+++ b/CDTDatastoreReplicationAcceptanceTests/ReplicationAcceptance.m
@@ -72,8 +72,6 @@
  */
 @property (nonatomic, strong) NSString *primaryRemoteDatabaseName;
 
-@end
-
 /**
  This is the standard number of documents those tests requiring a number
  of documents to replicate use. 10k takes 50 minutes, 100k much longer,
@@ -87,7 +85,6 @@
 @property NSUInteger largeRevTreeSize;
 
 @end
-
 
 @implementation MyTestDelegate
 
@@ -375,8 +372,8 @@
 {
     // Create docs in local store
     NSLog(@"Creating documents...");
-    [self createLocalDocs:n_docs];
-    XCTAssertEqual(self.datastore.documentCount, n_docs, @"Incorrect number of documents created");
+    [self createLocalDocs:_n_docs];
+    XCTAssertEqual(self.datastore.documentCount, _n_docs, @"Incorrect number of documents created");
     
     
     CDTPushReplication *push = [CDTPushReplication replicationWithSource:self.datastore
@@ -403,7 +400,7 @@
         NSLog(@" -> %@", [CDTReplicator stringForReplicatorState:weakReplicator.state]);
     }
     
-    [self assertRemoteDatabaseHasDocCount:[[NSNumber numberWithUnsignedInteger:n_docs] integerValue]
+    [self assertRemoteDatabaseHasDocCount:[[NSNumber numberWithUnsignedInteger:_n_docs] integerValue]
                               deletedDocs:0];
     
     // Make sure local and remotes are the same, we can't compare the changes from the replicator
@@ -423,7 +420,7 @@
 {
     // Create docs in local store
     NSLog(@"Creating documents...");
-    [self createRemoteDocs:n_docs];
+    [self createRemoteDocs:_n_docs];
     
     CDTPullReplication *pull = [CDTPullReplication replicationWithSource:self.primaryRemoteDatabaseURL
                                                                   target:self.datastore];
@@ -449,7 +446,7 @@
         NSLog(@" -> %@", [CDTReplicator stringForReplicatorState:weakReplicator.state]);
     }
     
-    [self assertRemoteDatabaseHasDocCount:[[NSNumber numberWithUnsignedInteger:n_docs] integerValue]
+    [self assertRemoteDatabaseHasDocCount:[[NSNumber numberWithUnsignedInteger:_n_docs] integerValue]
                               deletedDocs:0];
     
     // Make sure local and remotes are the same, we can't compare the changes from the replicator


### PR DESCRIPTION
_What_: Use `_bulk_get` endpoint in `TDPuller` if the remote database supports it. Also clean up TDPuller to initialise various arrays in `init`.

_Testing_: Existing tests and RA tests pass against couch 1.6 and 2.0

reviewer: @rhyshort 