### PR TITLE
Fix nullability annotations

### DIFF
--- a/CDTDatastore/Attachments/CDTAttachment.h
+++ b/CDTDatastore/Attachments/CDTAttachment.h
@@ -20,6 +20,8 @@
 
 #import "CDTBlobReader.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  Base class for attachments in the datastore.
 
@@ -43,16 +45,18 @@
 @interface CDTAttachment : NSObject
 
 // common
-@property (nonnull, nonatomic, strong, readonly) NSString *name;
+@property (nonatomic, strong, readonly) NSString *name;
 
 /** Mimetype string */
-@property (nonnull, nonatomic, strong, readonly) NSString *type;
+@property (nonatomic, strong, readonly) NSString *type;
 
 /* Size in bytes, may be -1 if not known (e.g., HTTP URL for new attachment) */
 @property (nonatomic, readonly) NSInteger size;
 
 /** Subclasses should call this to initialise instance vars */
-- (nullable instancetype)initWithName:(nonnull NSString *)name type:(nonnull NSString *)type size:(NSInteger)size;
+- (instancetype)initWithName:(NSString *)name
+                        type:(NSString *)type
+                        size:(NSInteger)size;
 
 /** Get unopened input stream for this attachment */
 - (nullable NSData *)dataFromAttachmentContent;
@@ -72,15 +76,15 @@
 @property (nonatomic, readonly) TDAttachmentEncoding encoding;
 
 /** sha of file, used for file path on disk. */
-@property (nonnull, nonatomic, readonly) NSData *key;
+@property (nonatomic, readonly) NSData *key;
 
-- (nullable instancetype)initWithBlob:(nonnull id<CDTBlobReader>)blob
-                        name:(nonnull NSString *)name
-                        type:(nonnull NSString *)type
+- (instancetype)initWithBlob:(id<CDTBlobReader>)blob
+                        name:(NSString *)name
+                        type:(NSString *)type
                         size:(NSInteger)size
                       revpos:(NSInteger)revpos
                     sequence:(SequenceNumber)sequence
-                         key:(nonnull NSData *)keyData
+                         key:(NSData *)keyData
                     encoding:(TDAttachmentEncoding)encoding;
 
 @end
@@ -95,7 +99,9 @@
  Create a new unsaved attachment using an NSData instance
  as the source of attachment data.
  */
-- (nullable instancetype)initWithData:(nonnull NSData *)data name:(nonnull NSString *)name type:(nonnull NSString *)type;
+- (instancetype)initWithData:(NSData *)data
+                        name:(NSString *)name
+                        type:(NSString *)type;
 
 @end
 
@@ -105,7 +111,9 @@
  */
 @interface CDTUnsavedFileAttachment : CDTAttachment
 
-- (nullable instancetype)initWithPath:(nonnull NSString *)filePath name:(nonnull NSString *)name type:(nonnull NSString *)type;
+- (nullable instancetype)initWithPath:(NSString *)filePath
+                                 name:(NSString *)name
+                                 type:(NSString *)type;
 
 @end
 
@@ -122,15 +130,15 @@ __attribute__((deprecated))
  the _attachments object in a couch get request
 
  @param name The name of the attachment eg example.txt
- @param jsonData The decoded jsonData reccived from couchdb / cloudant
+ @param jsonData The decoded jsonData received from couchdb / cloudant
  @param document the URL of the document this attachment is attached to
  @param error will point to an NSError object in case of error
 
  */
-+ (nullable CDTSavedHTTPAttachment *)createAttachmentWithName:(nonnull NSString *)name
-                                            JSONData:(nonnull NSDictionary *)jsonData
-                                       attachmentURL:(nonnull NSURL *)attachmentURL
-                                               error:(NSError *__autoreleasing __nullable  * __nullable )error;
++ (nullable CDTSavedHTTPAttachment *)createAttachmentWithName:(NSString *)name
+                                                     JSONData:(NSDictionary *)jsonData
+                                                attachmentURL:(NSURL *)attachmentURL
+                                                        error:(NSError *__autoreleasing __nullable  * __nullable)error;
 /**
 
  Creates an attachment that represents a remote HTTP accessed attachment
@@ -139,18 +147,18 @@ __attribute__((deprecated))
  @param name the name of the attachment
  @param type the mime type of the attachment eg image/jpeg
  @param size the size of the file in bytes (-1 if unkown)
- @param data attschment data if it has already been downloaded
+ @param data attachment data if it has already been downloaded
 
  */
-- (nullable instancetype)initWithDocumentURL:(nonnull NSURL *)attachmentURL
-                     name:(nonnull NSString *)name
-                     type:(nonnull NSString *)type
-                     size:(NSInteger)size
-                     data:(nullable NSData *)data;
+- (instancetype)initWithDocumentURL:(NSURL *)attachmentURL
+                               name:(NSString *)name
+                               type:(NSString *)type
+                               size:(NSInteger)size
+                               data:(nullable NSData *)data;
 
 /**
 
- Returns the data for an attachment. If attachment data requries downloading, (ie it was not
+ Returns the data for an attachment. If attachment data requires downloading, (ie it was not
  provided
  in the JSON with the document download) it will block while downloading the data from the remote
  server
@@ -160,3 +168,4 @@ __attribute__((deprecated))
  */
 - (nullable NSData *)dataFromAttachmentContent;
 @end
+NS_ASSUME_NONNULL_END

--- a/CDTDatastore/CDTDatastore+Conflicts.h
+++ b/CDTDatastore/CDTDatastore+Conflicts.h
@@ -29,7 +29,7 @@
  Resolve conflicts for a specific document using an object that conforms to the
  CDTConflictResolver protocol
 
- This method creates an NSArry of CDTDocumentRevision objects representing each of the conflicting
+ This method creates an NSArray of CDTDocumentRevision objects representing each of the conflicting
  revisions in a particular document tree and passes that array to the given
  [CDTConflictResolver resolve:conflicts:]. The [CDTConflictResolver resolve:conflicts:] method
  must return the winning revision either chosen from the array or a new document revision defined

--- a/CDTDatastore/CDTDatastore.h
+++ b/CDTDatastore/CDTDatastore.h
@@ -74,8 +74,8 @@ extern NSString * __nonnull const CDTDatastoreChangeNotification;
  *
  * Creates a CDTDatastore instance.
  *
- * @param manager this datastore's maanger, must not be nil.
- * @param database the database where this datastore should save documents
+ * @param manager this datastore's manager, must not be nil.
+ * @param database the database where this datastore should save documents.
  *
  */
 - (nullable instancetype)initWithManager:(nonnull CDTDatastoreManager *)manager database:(nonnull TD_Database *)database;

--- a/CDTDatastore/CDTFetchChanges.h
+++ b/CDTDatastore/CDTFetchChanges.h
@@ -180,8 +180,7 @@
 
  @return An initialised fetch operation.
  */
-- (nullable instancetype)initWithDatastore:(nonnull CDTDatastore *)datastore
-               startSequenceValue:(nullable NSString *)startSequenceValue;
-
+- (nonnull instancetype)initWithDatastore:(nonnull CDTDatastore *)datastore
+                       startSequenceValue:(nullable NSString *)startSequenceValue;
 
 @end

--- a/CDTDatastore/CDTReplicator/CDTAbstractReplication.h
+++ b/CDTDatastore/CDTReplicator/CDTAbstractReplication.h
@@ -18,7 +18,9 @@
 
 @class CDTDatastore;
 
-extern NSString* __nonnull const CDTReplicationErrorDomain;
+NS_ASSUME_NONNULL_BEGIN
+
+extern NSString* const CDTReplicationErrorDomain;
 
 /**
  * Replication errors.
@@ -128,24 +130,21 @@ typedef NS_ENUM(NSInteger, CDTReplicationErrors) {
 */
 @property (nullable, nonatomic, copy) NSDictionary<NSString*,NSString*>* optionalHeaders;
 
-NS_ASSUME_NONNULL_BEGIN
-
 /**
  The interceptors that will be executed for this replication.
  */
-@property (nonnull, nonatomic, readonly, strong) NSArray<NSObject<CDTHTTPInterceptor>*> * httpInterceptors;
- 
+@property (nonatomic, readonly, strong) NSArray<NSObject<CDTHTTPInterceptor>*>* httpInterceptors;
 
 /**
   Adds an interceptor to the interceptors array.
  @param interceptor the interceptor to append to the interceptors array.
  */
-- (void)addInterceptor:(nonnull NSObject<CDTHTTPInterceptor>*)interceptor;
+- (void)addInterceptor:(NSObject<CDTHTTPInterceptor>*)interceptor;
 /**
   Appends the contents of the array to the interceptors array.
  @param interceptors to append to the interceptors array.
  */
-- (void)addInterceptors:(nonnull NSArray<NSObject<CDTHTTPInterceptor>*>*)interceptors;
+- (void)addInterceptors:(NSArray<NSObject<CDTHTTPInterceptor>*>*)interceptors;
 /**
  Clears the interceptor array.
  
@@ -154,12 +153,10 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)clearInterceptors;
 
-NS_ASSUME_NONNULL_END
-
 /**
  Returns the default "User-Agent" header value used in HTTP requests made during replication.
 */
-+ (nonnull NSString*)defaultUserAgentHTTPHeader;
++ (NSString*)defaultUserAgentHTTPHeader;
 
 /*
  ---------------------------------------------------------------------------------------
@@ -191,6 +188,9 @@ NS_ASSUME_NONNULL_END
  @return YES on valid URL.
 
  */
-- (BOOL)validateRemoteDatastoreURL:(nonnull NSURL*)url error:(NSError* __autoreleasing __nullable * __nullable)error;
+- (BOOL)validateRemoteDatastoreURL:(NSURL*)url
+                             error:(NSError* __autoreleasing __nullable* __nullable)error;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/CDTDatastore/CDTReplicator/CDTPullReplication.h
+++ b/CDTDatastore/CDTReplicator/CDTPullReplication.h
@@ -54,7 +54,8 @@
  @return a CDTPullReplication object.
 
  */
-+ (nullable instancetype)replicationWithSource:(nonnull NSURL *)source target:(nonnull CDTDatastore *)target;
++ (nonnull instancetype)replicationWithSource:(nonnull NSURL *)source
+                                       target:(nonnull CDTDatastore *)target;
 
 /**
  @name Accessing the replication source and target

--- a/CDTDatastore/CDTReplicator/CDTPushReplication.h
+++ b/CDTDatastore/CDTReplicator/CDTPushReplication.h
@@ -59,7 +59,8 @@ typedef BOOL (^CDTFilterBlock)(CDTDocumentRevision *__nonnull revision,
  @return a CDTPushReplication object.
 
  */
-+ (nullable instancetype)replicationWithSource:(nonnull CDTDatastore *)source target:(nonnull NSURL *)target;
++ (nonnull instancetype)replicationWithSource:(nonnull CDTDatastore *)source
+                                       target:(nonnull NSURL *)target;
 
 /**
  @name Accessing the replication source and target

--- a/CDTDatastore/CDTReplicator/CDTReplicatorDelegate.h
+++ b/CDTDatastore/CDTReplicator/CDTReplicatorDelegate.h
@@ -70,9 +70,10 @@
  *
  * <p>May be called from any worker thread.</p>
  *
- * @param replicator the replicator issuing the event.
+ * @param replicator the replicator issuing the event, or nil if the replicator is in the
+ *        process of being deallocated when the error occurs.
  * @param info information about the error that occurred.
  */
-- (void)replicatorDidError:(nonnull CDTReplicator *)replicator info:(nonnull NSError *)info;
+- (void)replicatorDidError:(nullable CDTReplicator *)replicator info:(nonnull NSError *)info;
 
 @end

--- a/CDTDatastore/CDTReplicator/CDTReplicatorFactory.h
+++ b/CDTDatastore/CDTReplicator/CDTReplicatorFactory.h
@@ -60,8 +60,7 @@
 
  @param dsManager the manager of the datastores that this factory will replicate to and from.
  */
-- (nullable instancetype)initWithDatastoreManager:(nonnull CDTDatastoreManager *)dsManager;
-
+- (nonnull instancetype)initWithDatastoreManager:(nonnull CDTDatastoreManager *)dsManager;
 
 /**---------------------------------------------------------------------------------------
  * @name Creating replication jobs

--- a/CDTDatastore/HTTP/CDTHTTPInterceptorContext.h
+++ b/CDTDatastore/HTTP/CDTHTTPInterceptorContext.h
@@ -22,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface CDTHTTPInterceptorContext : NSObject
 
-@property (nonnull, readwrite, nonatomic, strong) NSMutableURLRequest *request;
+@property (readwrite, nonatomic, strong) NSMutableURLRequest *request;
 @property (nonatomic) BOOL shouldRetry;
 @property (nullable, readwrite, nonatomic, strong) NSHTTPURLResponse *response;
 
@@ -39,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @param request the request this context should represent
  **/
-- (instancetype)initWithRequest:(nonnull NSMutableURLRequest *)request NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithRequest:(NSMutableURLRequest *)request NS_DESIGNATED_INITIALIZER;
 
 @end
 

--- a/CDTDatastore/HTTP/CDTSessionCookieInterceptor.h
+++ b/CDTDatastore/HTTP/CDTSessionCookieInterceptor.h
@@ -20,9 +20,9 @@
 
 @interface CDTSessionCookieInterceptor : NSObject <CDTHTTPInterceptor>
 
-- (nullable instancetype)init NS_UNAVAILABLE;
+- (nonnull instancetype)init NS_UNAVAILABLE;
 
-- (nullable instancetype)initWithUsername:(nonnull NSString*)username
-                                 password:(nonnull NSString*)password NS_DESIGNATED_INITIALIZER;
+- (nonnull instancetype)initWithUsername:(nonnull NSString *)username
+                                password:(nonnull NSString *)password NS_DESIGNATED_INITIALIZER;
 
 @end

--- a/CDTDatastore/HTTP/CDTURLSession.h
+++ b/CDTDatastore/HTTP/CDTURLSession.h
@@ -24,13 +24,15 @@
  the thread which created the object.
  */
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface CDTURLSession : NSObject <NSURLSessionDataDelegate>
 
 /**
  * Initalises a CDTURLSession without a delegate and an empty array of interceptors. Calling this 
  * method will result in completionHandlers being called on the thread which called this method.
  **/
-- (nonnull instancetype)init;
+- (instancetype)init;
 
 /**
  * Initalise a CDTURLSession.
@@ -39,11 +41,10 @@
  * @param requestInterceptors array of interceptors that should be run before each request is made.
  * @param sessionConfigDelegate the delegate used to customise the NSURLSessionConfiguration.
  **/
-- (nonnull instancetype)initWithCallbackThread:(nonnull NSThread *)thread
-                           requestInterceptors:(nullable NSArray *)requestInterceptors
-                         sessionConfigDelegate:
-                             (nullable NSObject<CDTNSURLSessionConfigurationDelegate> *)
-                                 sessionConfigDelegate NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithCallbackThread:(NSThread *)thread
+                   requestInterceptors:(nullable NSArray *)requestInterceptors
+                 sessionConfigDelegate:(nullable NSObject<CDTNSURLSessionConfigurationDelegate> *)
+                                           sessionConfigDelegate NS_DESIGNATED_INITIALIZER;
 
 /**
  * Performs a data task for a request.
@@ -54,8 +55,9 @@
  * @return returns a task to used the make the request. `resume` needs to be called
  * in order for the task to start making the request.
  */
-- (nonnull CDTURLSessionTask *)dataTaskWithRequest:(nonnull NSURLRequest *)request
-                                      taskDelegate:(nullable NSObject<CDTURLSessionTaskDelegate> *)taskDelegate;
+- (CDTURLSessionTask *)dataTaskWithRequest:(NSURLRequest *)request
+                              taskDelegate:
+                                  (nullable NSObject<CDTURLSessionTaskDelegate> *)taskDelegate;
 
 /**
  * Creates a NSURLSessionDataTask for the given request and associates the given CDTURLSessionTask
@@ -66,8 +68,8 @@
  *
  * @return returns an NSURLSessionDataTask.
  */
-- (nonnull NSURLSessionDataTask *)createDataTaskWithRequest:(nonnull NSURLRequest *)request
-                                         associatedWithTask:(nonnull CDTURLSessionTask *)task;
+- (NSURLSessionDataTask *)createDataTaskWithRequest:(NSURLRequest *)request
+                                 associatedWithTask:(CDTURLSessionTask *)task;
 
 /**
  * Disassociates an NSURLSessionDataTask from any CDTURLSessionTask it was previously associated
@@ -77,6 +79,8 @@
  *
  * @param task The NSURLSessionDataTask to be disassociated from any CDTURLSessionTask.
  */
-- (void) disassociateTask:(nonnull NSURLSessionDataTask *)task;
+- (void)disassociateTask:(NSURLSessionDataTask *)task;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/CDTDatastore/HTTP/CDTURLSessionTask.h
+++ b/CDTDatastore/HTTP/CDTURLSessionTask.h
@@ -17,6 +17,8 @@
 #import <Foundation/Foundation.h>
 #import "CDTMacros.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class CDTURLSession;
 
 @protocol CDTURLSessionTaskDelegate
@@ -44,9 +46,9 @@
  *
  *  @param task the NSURLSessionTask to be wrapped
  */
-- (nullable instancetype)initWithSession:(nonnull CDTURLSession *)session
-                                 request:(nonnull NSURLRequest *)request
-                            interceptors:(nullable NSArray *)interceptors NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithSession:(CDTURLSession *)session
+                        request:(NSURLRequest *)request
+                   interceptors:(nullable NSArray *)interceptors NS_DESIGNATED_INITIALIZER;
 
 /*
  * Resumes the execution of this task
@@ -68,8 +70,7 @@
  * @param the thread on which to process the response if the interceptors do not indicate
  *        that we need to retry the request.
  */
-- (void)processResponse:(nonnull NSURLResponse *)response
-               onThread:(nonnull NSThread *)thread;
+- (void)processResponse:(NSURLResponse *)response onThread:(NSThread *)thread;
 
 /**
  * Process the given error. If the when we process the error with the interceptors
@@ -80,11 +81,12 @@
  * @param the thread on which to process the error if the interceptors do not indicate
  *        that we need to retry the request.
  */
-- (void)processError:(nonnull NSError *)error
-            onThread:(nonnull NSThread *)thread;
+- (void)processError:(NSError *)error onThread:(NSThread *)thread;
 
-- (void) completedThread:(nonnull NSThread *)thread;
+- (void)completedThread:(NSThread *)thread;
 
 - (void)processData:(nullable NSData*)data;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/CDTDatastore/query/CDTQIndex.h
+++ b/CDTDatastore/query/CDTQIndex.h
@@ -89,7 +89,7 @@ extern NSString *const kCDTQTextType __deprecated;
 + (nullable instancetype)index:(NSString *)indexName
                     withFields:(NSArray *)fieldNames
                           type:(CDTQIndexType)indexType
-                  withSettings:(NSDictionary *)indexSettings;
+                  withSettings:(nullable NSDictionary *)indexSettings;
 
 /**
  * Compares the index type and accompanying settings with the passed in arguments.

--- a/CDTDatastore/query/CDTQIndexManager.h
+++ b/CDTDatastore/query/CDTQIndexManager.h
@@ -128,7 +128,7 @@ managerUsingDatastore:(CDTDatastore *)datastore
 - (NSString *)ensureIndexed:(NSArray<NSString *> *)fieldNames
                    withName:(NSString *)indexName
                      ofType:(CDTQIndexType)type
-                   settings:(NSDictionary *)indexSettings;
+                   settings:(nullable NSDictionary *)indexSettings;
 
 - (BOOL)deleteIndexNamed:(NSString *)indexName;
 

--- a/CDTDatastoreTests/Attachments/AttachmentCRUD.m
+++ b/CDTDatastoreTests/Attachments/AttachmentCRUD.m
@@ -785,7 +785,7 @@
     // Delete the attachment we added
     //
     document = [rev2 copy];
-    document.attachments = nil;
+    document.attachments = [[NSMutableDictionary alloc] init];
     CDTDocumentRevision *rev3 = [self.datastore updateDocumentFromRevision:document
                                                                      error:&error];
 
@@ -894,10 +894,13 @@
 
 - (void) testNilDataPreventsInitAttachment
 {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
     CDTAttachment *attachment = [[CDTUnsavedDataAttachment alloc]
                                  initWithData:nil
                                          name:@"test_attachment"
                                          type:@"image/jpg"];
+#pragma clang diagnostic pop
     XCTAssertNil(attachment, @"Shouldn't be able to create attachment with nil data");
 }
 

--- a/CDTDatastoreTests/Attachments/AttachmentCRUD.m
+++ b/CDTDatastoreTests/Attachments/AttachmentCRUD.m
@@ -209,7 +209,7 @@
     NSError *error = nil;
     NSString *attachmentName = @"test_an_attachment";
 
-    NSDictionary *dict = @{@"hello": @"world"};
+    NSMutableDictionary *dict = [@{ @"hello" : @"world" } mutableCopy];
 
     CDTDocumentRevision *document = [CDTDocumentRevision revision];
     document.body = dict;
@@ -217,7 +217,7 @@
     CDTDocumentRevision *rev = [self.datastore createDocumentFromRevision:document
                                                                     error:&error];
     document = [rev copy];
-    document.attachments = @{};
+    document.attachments = [@{} mutableCopy];
 
     CDTDocumentRevision *rev2 = [self.datastore updateDocumentFromRevision: document
                                                                      error:&error];
@@ -233,8 +233,8 @@
                                                                           type:@"image/jpg"];
 
     document = [rev2 copy];
-    document.attachments = @{attachment.name:attachment};
-    
+    document.attachments = [@{ attachment.name : attachment } mutableCopy];
+
     CDTDocumentRevision *rev3 = [self.datastore updateDocumentFromRevision:document
                                                                      error:&error];
 
@@ -288,8 +288,8 @@
     CDTDocumentRevision *rev = [self.datastore createDocumentFromRevision:document
                                                                     error:&error];
     document = [rev copy];
-    document.attachments = @{};
-    
+    document.attachments = [@{} mutableCopy];
+
     CDTDocumentRevision *rev2 = [self.datastore updateDocumentFromRevision: document
                                                                      error:&error];
     
@@ -352,7 +352,7 @@
 {
     NSError *error = nil;
 
-    NSDictionary *dict = @{@"hello": @"world"};
+    NSMutableDictionary *dict = [@{ @"hello" : @"world" } mutableCopy];
 
     CDTDocumentRevision *document = [CDTDocumentRevision revision];
     document.body = dict;
@@ -367,7 +367,7 @@
                                             name:@"bonsai-boston"
                                             type:@"image/jpg"];
     document = [rev copy];
-    document.attachments = @{imgAttachment.name:imgAttachment};
+    document.attachments = [@{ imgAttachment.name : imgAttachment } mutableCopy];
     rev = [self.datastore updateDocumentFromRevision:document error:&error];
 
 
@@ -411,7 +411,7 @@
 {
     NSError *error = nil;
 
-    NSDictionary *dict = @{@"hello": @"world"};
+    NSMutableDictionary *dict = [@{ @"hello" : @"world" } mutableCopy];
 
     CDTDocumentRevision *document = [CDTDocumentRevision revision];
     document.body = dict;
@@ -437,7 +437,7 @@
                                             type:@"text/plain"];
 
     document = [rev copy];
-    document.attachments = @{imgAttachment.name:imgAttachment,txtAttachment.name:txtAttachment};
+    document.attachments = [@{imgAttachment.name:imgAttachment,txtAttachment.name:txtAttachment} mutableCopy];
     rev = [self.datastore updateDocumentFromRevision:document error:&error];
     
 
@@ -528,7 +528,7 @@
 {
     NSError *error = nil;
 
-    NSDictionary *dict = @{@"hello": @"world"};
+    NSMutableDictionary *dict = [@{ @"hello" : @"world" } mutableCopy];
 
     CDTDocumentRevision *rev = [CDTDocumentRevision revision];
     rev.body = dict;
@@ -541,9 +541,9 @@
                                     initWithData:imageData
                                             name:@"bonsai-boston"
                                             type:@"image/jpg"];
-    
-    rev.attachments = @{imgAttachment.name:imgAttachment};
-    
+
+    rev.attachments = [@{ imgAttachment.name : imgAttachment } mutableCopy];
+
     CDTDocumentRevision * savedRev = [self.datastore createDocumentFromRevision:rev
                                                                           error:&error];
     
@@ -621,7 +621,7 @@
     NSError *error = nil;
     NSString *attachmentName = @"test_an_attachment";
 
-    NSDictionary *dict = @{@"hello": @"world"};
+    NSMutableDictionary *dict = [@{ @"hello" : @"world" } mutableCopy];
 
     CDTDocumentRevision *document = [CDTDocumentRevision revision];
     document.body = dict;
@@ -640,7 +640,7 @@
                                     initWithData:data name:attachmentName type:@"image/jpg"];
 
     document = [rev1 copy];
-    document.attachments = @{imgAttachment.name:imgAttachment};
+    document.attachments = [@{ imgAttachment.name : imgAttachment } mutableCopy];
     CDTDocumentRevision *rev2 = [self.datastore updateDocumentFromRevision:document
                                                                      error:&error];
 
@@ -663,7 +663,7 @@
     NSError *error = nil;
     NSString *attachmentName = @"test_an_attachment";
 
-    NSDictionary *dict = @{@"hello": @"world"};
+    NSMutableDictionary *dict = [@{ @"hello" : @"world" } mutableCopy];
 
     CDTDocumentRevision *document = [CDTDocumentRevision revision];
     document.body = dict;
@@ -681,7 +681,7 @@
                                             type:@"image/jpg"];
 
     document = [rev1 copy];
-    document.attachments = @{imgAttachment.name:imgAttachment};
+    document.attachments = [@{ imgAttachment.name : imgAttachment } mutableCopy];
     CDTDocumentRevision *rev2 = [self.datastore updateDocumentFromRevision:document
                                                                      error:&error];
 
@@ -698,7 +698,7 @@
     NSData *inputMD5 = [self MD5:txtData];
 
     document = [rev2 copy];
-    document.attachments = @{attachment2.name:attachment2};
+    document.attachments = [@{ attachment2.name : attachment2 } mutableCopy];
     CDTDocumentRevision *rev3 = [self.datastore updateDocumentFromRevision:document
                                                                      error:&error];
 
@@ -757,7 +757,7 @@
     NSData *data;
     NSDictionary *attachments;
 
-    NSDictionary *dict = @{@"hello": @"world"};
+    NSMutableDictionary *dict = [@{ @"hello" : @"world" } mutableCopy];
     CDTDocumentRevision *document = [CDTDocumentRevision revision];
     document.body = dict;
     CDTDocumentRevision *rev1 = [self.datastore createDocumentFromRevision:document
@@ -772,7 +772,7 @@
                                                                           type:@"image/jpg"];
 
     document = [rev1 copy];
-    document.attachments = @{attachment.name:attachment};
+    document.attachments = [@{ attachment.name : attachment } mutableCopy];
     CDTDocumentRevision *rev2 = [self.datastore updateDocumentFromRevision:document
                                                                      error:&error];
 
@@ -838,7 +838,7 @@
     NSError *error = nil;
     NSString *attachmentName = @"test_an_attachment";
 
-    NSDictionary *dict = @{@"hello": @"world"};
+    NSMutableDictionary *dict = [@{ @"hello" : @"world" } mutableCopy];
 
     CDTDocumentRevision *document = [CDTDocumentRevision revision];
     document.body = dict;
@@ -858,7 +858,7 @@
                                             type:@"image/jpg"];
 
     document = [rev1 copy];
-    document.attachments = @{imgAttachment.name:imgAttachment};
+    document.attachments = [@{ imgAttachment.name : imgAttachment } mutableCopy];
     CDTDocumentRevision *rev2 = [self.datastore updateDocumentFromRevision:document
                                                                      error:&error];
 
@@ -964,7 +964,7 @@
 {
     NSError *error;
 
-    NSDictionary *dict = @{@"hello": @"world"};
+    NSMutableDictionary *dict = [@{ @"hello" : @"world" } mutableCopy];
 
     CDTDocumentRevision *mutableRev = [CDTDocumentRevision revision];
     mutableRev.body = dict;
@@ -976,7 +976,7 @@
                                                                        size:100];
 
     mutableRev = [rev1 copy];
-    mutableRev.attachments = @{attachment.name:attachment};
+    mutableRev.attachments = [@{ attachment.name : attachment } mutableCopy];
     CDTDocumentRevision *rev2 = [self.datastore updateDocumentFromRevision:mutableRev error:&error];
 
     // Should fail, we shouldn't get a revision and should get a decent error
@@ -1014,8 +1014,8 @@
 - (void)testNilAttachmentStreamWithGoodAttachmentStream
 {
     NSString *attachmentName = @"test_an_attachment";
-    
-    NSDictionary *dict = @{@"hello": @"world"};
+
+    NSMutableDictionary *dict = [@{ @"hello" : @"world" } mutableCopy];
     CDTDocumentRevision *mutableRev = [CDTDocumentRevision revision];
     mutableRev.body = dict;
 
@@ -1031,8 +1031,10 @@
     
     NSError *error = nil;
     mutableRev = [rev copy];
-    mutableRev.attachments = @{attachmentName:attachment,@"nullAttachment":nullAttachment};
-    
+    mutableRev.attachments =
+        [@{ attachmentName : attachment,
+            @"nullAttachment" : nullAttachment } mutableCopy];
+
     CDTDocumentRevision *rev2 = [self.datastore updateDocumentFromRevision:mutableRev error:&error];
     
 
@@ -1075,8 +1077,8 @@
 
 -(void) testCreateDocumentWithaSharedAttachment {
     NSString *attachmentName = @"test_an_attachment";
-    
-    NSDictionary *dict = @{@"hello": @"world"};
+
+    NSMutableDictionary *dict = [@{ @"hello" : @"world" } mutableCopy];
 
     NSError *error;
     
@@ -1090,8 +1092,8 @@
 
     CDTDocumentRevision *mutableRev = [CDTDocumentRevision revision];
     mutableRev.body = dict;
-    mutableRev.attachments=@{attachment.name : attachment};
-    
+    mutableRev.attachments = [@{ attachment.name : attachment } mutableCopy];
+
     CDTDocumentRevision *rev = [self.datastore createDocumentFromRevision:mutableRev  error:&error];
     
     
@@ -1123,8 +1125,8 @@
     CDTDocumentRevision *rev = [self.datastore createDocumentFromRevision:document
                                                                     error:&error];
     document = [rev copy];
-    document.attachments = @{};
-    
+    document.attachments = [@{} mutableCopy];
+
     CDTDocumentRevision *rev2 = [self.datastore updateDocumentFromRevision: document
                                                                      error:&error];
     
@@ -1166,8 +1168,8 @@
     CDTDocumentRevision *rev = [self.datastore createDocumentFromRevision:document
                                                                     error:&error];
     document = [rev copy];
-    document.attachments = @{};
-    
+    document.attachments = [@{} mutableCopy];
+
     CDTDocumentRevision *rev2 = [self.datastore updateDocumentFromRevision: document
                                                                      error:&error];
     
@@ -1183,10 +1185,9 @@
 
     document = [rev2 copy];
     document.attachments = [@{attachment.name:attachment} mutableCopy];
-    
-    CDTDocumentRevision *rev3 = [self.datastore updateDocumentFromRevision:document
-                                                                     error:&error];
-    
+
+    [self.datastore updateDocumentFromRevision:document error:&error];
+
     //attachments have been completed inerted, now attempt to get them via all docs
     
     NSArray * allDocuuments = [self.datastore getDocumentsWithIds:@[rev.docId]];

--- a/CDTDatastoreTests/CDTDatastoreQueryTests.m
+++ b/CDTDatastoreTests/CDTDatastoreQueryTests.m
@@ -48,15 +48,15 @@ SpecBegin(CDTDatastoreQuery) describe(@"When using datastore query", ^{
         CDTDocumentRevision *rev;
 
         rev = [CDTDocumentRevision revisionWithDocId:@"mike12"];
-        rev.body = @{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" };
+        rev.body = [@{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" } mutableCopy];
         [ds createDocumentFromRevision:rev error:nil];
 
         rev = [CDTDocumentRevision revisionWithDocId:@"mike34"];
-        rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"dog" };
+        rev.body = [@{ @"name" : @"mike", @"age" : @34, @"pet" : @"dog" } mutableCopy];
         [ds createDocumentFromRevision:rev error:nil];
 
         rev = [CDTDocumentRevision revisionWithDocId:@"mike72"];
-        rev.body = @{ @"name" : @"mike", @"age" : @67, @"pet" : @"cat" };
+        rev.body = [@{ @"name" : @"mike", @"age" : @67, @"pet" : @"cat" } mutableCopy];
         [ds createDocumentFromRevision:rev error:nil];
 
         [ds ensureIndexed:@[ @"name" ] withName:@"index name"];
@@ -73,8 +73,8 @@ SpecBegin(CDTDatastoreQuery) describe(@"When using datastore query", ^{
         CDTDatastore *ds2 = [factory datastoreNamed:@"test2" error:nil];
         expect([ds2 ensureIndexed:@[ @"name", @"age" ] withName:@"pet"]).toNot.beNil();
 
-        CDTQIndexManager *im = objc_getAssociatedObject(ds, @selector(CDTQManager));
-        CDTQIndexManager *im2 = objc_getAssociatedObject(ds2, @selector(CDTQManager));
+        CDTQIndexManager *im = objc_getAssociatedObject(ds, NSSelectorFromString(@"CDTQManager"));
+        CDTQIndexManager *im2 = objc_getAssociatedObject(ds2, NSSelectorFromString(@"CDTQManager"));
 
         expect([im listIndexes]).toNot.equal([im2 listIndexes]);
     });
@@ -119,7 +119,7 @@ SpecBegin(CDTDatastoreQuery) describe(@"When using datastore query", ^{
         CDTQResultSet *results = [ds find:query];
         expect(results).toNot.beNil();
         CDTDocumentRevision *rev = [CDTDocumentRevision revision];
-        rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"dolhpin" };
+        rev.body = [@{ @"name" : @"mike", @"age" : @34, @"pet" : @"dolhpin" } mutableCopy];
         [ds createDocumentFromRevision:rev error:nil];
         expect([ds updateAllIndexes]).to.beTruthy();
     });

--- a/CDTDatastoreTests/CDTFetchChangesTests.m
+++ b/CDTDatastoreTests/CDTFetchChangesTests.m
@@ -244,7 +244,8 @@
     for (NSUInteger i = 0; i < counter; i++) {
         CDTDocumentRevision *rev =
             [CDTDocumentRevision revisionWithDocId:[CDTFetchChangesTests docIdWithIndex:i]];
-        rev.body = @{ [NSString stringWithFormat:@"hello-%lu", (unsigned long)i] : @"world" };
+        rev.body = [
+            @{ [NSString stringWithFormat:@"hello-%lu", (unsigned long)i] : @"world" } mutableCopy];
 
         [datastore createDocumentFromRevision:rev error:nil];
     }

--- a/CDTDatastoreTests/CDTQFilterFieldsTest.m
+++ b/CDTDatastoreTests/CDTQFilterFieldsTest.m
@@ -53,23 +53,23 @@ SpecBegin(CDTQFilterFieldsTest)
             CDTDocumentRevision *rev;
 
             rev = [CDTDocumentRevision revisionWithDocId:@"mike12"];
-            rev.body = @{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" };
+            rev.body = [@{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             rev = [CDTDocumentRevision revisionWithDocId:@"mike34"];
-            rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"dog" };
+            rev.body = [@{ @"name" : @"mike", @"age" : @34, @"pet" : @"dog" } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             rev = [CDTDocumentRevision revisionWithDocId:@"mike72"];
-            rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"cat" };
+            rev.body = [@{ @"name" : @"mike", @"age" : @34, @"pet" : @"cat" } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             rev = [CDTDocumentRevision revisionWithDocId:@"fred34"];
-            rev.body = @{ @"name" : @"fred", @"age" : @34, @"pet" : @"cat" };
+            rev.body = [@{ @"name" : @"fred", @"age" : @34, @"pet" : @"cat" } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             rev = [CDTDocumentRevision revisionWithDocId:@"fred12"];
-            rev.body = @{ @"name" : @"fred", @"age" : @12 };
+            rev.body = [@{ @"name" : @"fred", @"age" : @12 } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             im = [CDTQIndexManager managerUsingDatastore:ds error:nil];

--- a/CDTDatastoreTests/CDTQIndexCreatorTests.m
+++ b/CDTDatastoreTests/CDTQIndexCreatorTests.m
@@ -91,7 +91,10 @@ SpecBegin(CDTQIndexCreator)
             });
 
             it(@"doesn't create an index on nil fields", ^{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
                 NSString *name = [im ensureIndexed:nil withName:@"basic"];
+#pragma clang diagnostic pop
                 expect(name).to.equal(nil);
 
                 NSDictionary *indexes = [im listIndexes];
@@ -99,7 +102,10 @@ SpecBegin(CDTQIndexCreator)
             });
 
             it(@"doesn't create an index without a name", ^{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
                 NSString *name = [im ensureIndexed:@[ @"name" ] withName:nil];
+#pragma clang diagnostic pop
                 expect(name).to.equal(nil);
 
                 NSDictionary *indexes = [im listIndexes];

--- a/CDTDatastoreTests/CDTQIndexManagerTests.m
+++ b/CDTDatastoreTests/CDTQIndexManagerTests.m
@@ -88,39 +88,39 @@ SpecBegin(CDTQIndexManager)
 
             CDTDocumentRevision *rev = [CDTDocumentRevision revision];
 
-            rev.body = @{
+            rev.body = [@{
                 @"name" : @"mike",
                 @"age" : @12,
                 @"pet" : @{@"species" : @"cat", @"name" : @"mike"}
-            };
+            } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
-            rev.body = @{
+            rev.body = [@{
                 @"name" : @"mike",
                 @"age" : @12,
                 @"pet" : @{@"species" : @"cat", @"name" : @"mike"}
-            };
+            } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
-            rev.body = @{
+            rev.body = [@{
                 @"name" : @"mike",
                 @"age" : @12,
                 @"pet" : @{@"species" : @"cat", @"name" : @"mike"}
-            };
+            } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
-            rev.body = @{
+            rev.body = [@{
                 @"name" : @"mike",
                 @"age" : @12,
                 @"pet" : @{@"species" : @"cat", @"name" : @"mike"}
-            };
+            } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
-            rev.body = @{
+            rev.body = [@{
                 @"name" : @"mike",
                 @"age" : @12,
                 @"pet" : @{@"species" : @"cat", @"name" : @"mike"}
-            };
+            } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             [im ensureIndexed:@[ @"name", @"address" ] withName:@"basic"];
@@ -135,39 +135,39 @@ SpecBegin(CDTQIndexManager)
 
             CDTDocumentRevision *rev = [CDTDocumentRevision revision];
 
-            rev.body = @{
+            rev.body = [@{
                 @"name" : @"mike",
                 @"age" : @12,
                 @"pet" : @{@"species" : @"cat", @"name" : @"mike"}
-            };
+            } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
-            rev.body = @{
+            rev.body = [@{
                 @"name" : @"mike",
                 @"age" : @12,
                 @"pet" : @{@"species" : @"cat", @"name" : @"mike"}
-            };
+            } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
-            rev.body = @{
+            rev.body = [@{
                 @"name" : @"mike",
                 @"age" : @12,
                 @"pet" : @{@"species" : @"cat", @"name" : @"mike"}
-            };
+            } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
-            rev.body = @{
+            rev.body = [@{
                 @"name" : @"mike",
                 @"age" : @12,
                 @"pet" : @{@"species" : @"cat", @"name" : @"mike"}
-            };
+            } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
-            rev.body = @{
+            rev.body = [@{
                 @"name" : @"mike",
                 @"age" : @12,
                 @"pet" : @{@"species" : @"cat", @"name" : @"mike"}
-            };
+            } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             [im ensureIndexed:@[ @"name", @"address" ] withName:@"basic"];
@@ -186,11 +186,11 @@ SpecBegin(CDTQIndexManager)
 
             CDTDocumentRevision *rev = [CDTDocumentRevision revision];
 
-            rev.body = @{
-                         @"name" : @"mike",
-                         @"age" : @12,
-                         @"pet" : @{@"species" : @"cat", @"name" : @"mike"}
-                         };
+            rev.body = [@{
+                @"name" : @"mike",
+                @"age" : @12,
+                @"pet" : @{@"species" : @"cat", @"name" : @"mike"}
+            } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             expect([im ensureIndexed:@[ @"name" ] withName:@"basic" ofType:CDTQIndexTypeText])

--- a/CDTDatastoreTests/CDTQIndexTests.m
+++ b/CDTDatastoreTests/CDTQIndexTests.m
@@ -51,13 +51,19 @@ describe(@"When creating an instance of index", ^{
     });
 
     it(@"returns nil when no fields are provided", ^{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
         expect([CDTQIndex index:indexName withFields:nil]).to.beNil();
+#pragma clang diagnostic pop
         
         expect([CDTQIndex index:indexName withFields:@[]]).to.beNil();
     });
     
     it(@"returns nil when no index name is provided", ^{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
         expect([CDTQIndex index:nil withFields:fieldNames]).to.beNil();
+#pragma clang diagnostic pop
         
         expect([CDTQIndex index:@"" withFields:fieldNames]).to.beNil();
     });

--- a/CDTDatastoreTests/CDTQIndexUpdaterTests.m
+++ b/CDTDatastoreTests/CDTQIndexUpdaterTests.m
@@ -58,14 +58,20 @@ SpecBegin(CDTQIndexUpdater)
         describe(@"when generating DELETE index entries statements", ^{
 
             it(@"returns nil for no _id", ^{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
                 CDTQSqlParts *parts =
                     [CDTQIndexUpdater partsToDeleteIndexEntriesForDocId:nil fromIndex:@"anIndex"];
+#pragma clang diagnostic pop
                 expect(parts).to.beNil();
             });
 
             it(@"returns nil for no index name", ^{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
                 CDTQSqlParts *parts =
                     [CDTQIndexUpdater partsToDeleteIndexEntriesForDocId:@"123" fromIndex:nil];
+#pragma clang diagnostic pop
                 expect(parts).to.beNil();
             });
 

--- a/CDTDatastoreTests/CDTQIndexUpdaterTests.m
+++ b/CDTDatastoreTests/CDTQIndexUpdaterTests.m
@@ -92,7 +92,7 @@ SpecBegin(CDTQIndexUpdater)
             it(@"returns correctly for single field", ^{
                 CDTDocumentRevision *rev;
                 rev = [CDTDocumentRevision revisionWithDocId:@"id123"];
-                rev.body = @{ @"name" : @"mike" };
+                rev.body = [@{ @"name" : @"mike" } mutableCopy];
                 CDTDocumentRevision *saved = [ds createDocumentFromRevision:rev error:nil];
                 CDTQSqlParts *parts = [CDTQIndexUpdater partsToIndexRevision:saved
                                                                      inIndex:@"anIndex"
@@ -107,7 +107,7 @@ SpecBegin(CDTQIndexUpdater)
             it(@"returns correctly for two fields", ^{
                 CDTDocumentRevision *rev;
                 rev = [CDTDocumentRevision revisionWithDocId:@"id123"];
-                rev.body = @{ @"name" : @"mike", @"age" : @12 };
+                rev.body = [@{ @"name" : @"mike", @"age" : @12 } mutableCopy];
                 CDTDocumentRevision *saved = [ds createDocumentFromRevision:rev error:nil];
                 CDTQSqlParts *parts =
                     [CDTQIndexUpdater partsToIndexRevision:saved
@@ -123,13 +123,13 @@ SpecBegin(CDTQIndexUpdater)
             it(@"returns correctly for multiple fields", ^{
                 CDTDocumentRevision *rev;
                 rev = [CDTDocumentRevision revisionWithDocId:@"id123"];
-                rev.body = @{
+                rev.body = [@{
                     @"name" : @"mike",
                     @"age" : @12,
                     @"pet" : @"cat",
                     @"car" : @"mini",
                     @"ignored" : @"something"
-                };
+                } mutableCopy];
                 CDTDocumentRevision *saved = [ds createDocumentFromRevision:rev error:nil];
                 CDTQSqlParts *parts =
                     [CDTQIndexUpdater partsToIndexRevision:saved
@@ -147,7 +147,10 @@ SpecBegin(CDTQIndexUpdater)
             it(@"returns correctly for missing fields", ^{
                 CDTDocumentRevision *rev;
                 rev = [CDTDocumentRevision revisionWithDocId:@"id123"];
-                rev.body = @{ @"name" : @"mike", @"pet" : @"cat", @"ignored" : @"something" };
+                rev.body =
+                    [@{ @"name" : @"mike",
+                        @"pet" : @"cat",
+                        @"ignored" : @"something" } mutableCopy];
                 CDTDocumentRevision *saved = [ds createDocumentFromRevision:rev error:nil];
                 CDTQSqlParts *parts =
                     [CDTQIndexUpdater partsToIndexRevision:saved
@@ -164,7 +167,10 @@ SpecBegin(CDTQIndexUpdater)
             it(@"still indexes a blank row if no fields", ^{
                 CDTDocumentRevision *rev;
                 rev = [CDTDocumentRevision revisionWithDocId:@"id123"];
-                rev.body = @{ @"name" : @"mike", @"pet" : @"cat", @"ignored" : @"something" };
+                rev.body =
+                    [@{ @"name" : @"mike",
+                        @"pet" : @"cat",
+                        @"ignored" : @"something" } mutableCopy];
                 CDTDocumentRevision *saved = [ds createDocumentFromRevision:rev error:nil];
                 CDTQSqlParts *parts =
                     [CDTQIndexUpdater partsToIndexRevision:saved
@@ -181,7 +187,9 @@ SpecBegin(CDTQIndexUpdater)
                 it(@"indexes a single array field", ^{
                     CDTDocumentRevision *rev;
                     rev = [CDTDocumentRevision revisionWithDocId:@"id123"];
-                    rev.body = @{ @"name" : @"mike", @"pet" : @[ @"cat", @"dog", @"parrot" ] };
+                    rev.body =
+                        [@{ @"name" : @"mike",
+                            @"pet" : @[ @"cat", @"dog", @"parrot" ] } mutableCopy];
                     CDTDocumentRevision *saved = [ds createDocumentFromRevision:rev error:nil];
                     NSArray *statements =
                         [CDTQIndexUpdater partsToIndexRevision:saved
@@ -217,7 +225,9 @@ SpecBegin(CDTQIndexUpdater)
                 it(@"indexes a single array field in subdoc", ^{
                     CDTDocumentRevision *rev;
                     rev = [CDTDocumentRevision revisionWithDocId:@"id123"];
-                    rev.body = @{ @"name" : @"mike", @"pet" : @{@"species" : @[ @"cat", @"dog" ]} };
+                    rev.body =
+                        [@{ @"name" : @"mike",
+                            @"pet" : @{@"species" : @[ @"cat", @"dog" ]} } mutableCopy];
                     CDTDocumentRevision *saved = [ds createDocumentFromRevision:rev error:nil];
                     NSArray *statements =
                         [CDTQIndexUpdater partsToIndexRevision:saved
@@ -248,11 +258,11 @@ SpecBegin(CDTQIndexUpdater)
                 it(@"rejects multiple array fields", ^{
                     CDTDocumentRevision *rev;
                     rev = [CDTDocumentRevision revisionWithDocId:@"id123"];
-                    rev.body = @{
+                    rev.body = [@{
                         @"name" : @"mike",
                         @"pet" : @[ @"cat", @"dog", @"parrot" ],
                         @"pet2" : @[ @"cat", @"dog", @"parrot" ]
-                    };
+                    } mutableCopy];
                     CDTDocumentRevision *saved = [ds createDocumentFromRevision:rev error:nil];
                     NSArray *statements =
                         [CDTQIndexUpdater partsToIndexRevision:saved
@@ -266,7 +276,7 @@ SpecBegin(CDTQIndexUpdater)
                     // Only the "name" field should be included as a result of this test.
                 CDTDocumentRevision *rev;
                 rev = [CDTDocumentRevision revisionWithDocId:@"id123"];
-                    rev.body = @{ @"name" : @"mike", @"pet" : @[] };
+                rev.body = [@{ @"name" : @"mike", @"pet" : @[] } mutableCopy];
                     CDTDocumentRevision *saved = [ds createDocumentFromRevision:rev error:nil];
                     NSArray *statements = [CDTQIndexUpdater partsToIndexRevision:saved
                                                                          inIndex:@"anIndex"
@@ -285,7 +295,7 @@ SpecBegin(CDTQIndexUpdater)
                 it(@"returns correctly for empty array in a subdoc", ^{
                     CDTDocumentRevision *rev;
                     rev = [CDTDocumentRevision revisionWithDocId:@"id123"];
-                    rev.body = @{ @"name" : @"mike", @"pet" : @{@"species" : @[] } };
+                    rev.body = [@{ @"name" : @"mike", @"pet" : @{@"species" : @[]} } mutableCopy];
                     CDTDocumentRevision *saved = [ds createDocumentFromRevision:rev error:nil];
                     NSArray *statements = [CDTQIndexUpdater partsToIndexRevision:saved
                                                                          inIndex:@"anIndex"
@@ -317,27 +327,27 @@ SpecBegin(CDTQIndexUpdater)
                 CDTDocumentRevision *rev;
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike12"];
-                rev.body = @{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" };
+                rev.body = [@{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike23"];
-                rev.body = @{ @"name" : @"mike", @"age" : @23, @"pet" : @"parrot" };
+                rev.body = [@{ @"name" : @"mike", @"age" : @23, @"pet" : @"parrot" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike34"];
-                rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"dog" };
+                rev.body = [@{ @"name" : @"mike", @"age" : @34, @"pet" : @"dog" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"john72"];
-                rev.body = @{ @"name" : @"john", @"age" : @34, @"pet" : @"fish" };
+                rev.body = [@{ @"name" : @"john", @"age" : @34, @"pet" : @"fish" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"fred34"];
-                rev.body = @{ @"name" : @"fred", @"age" : @43, @"pet" : @"snake" };
+                rev.body = [@{ @"name" : @"fred", @"age" : @43, @"pet" : @"snake" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"fred12"];
-                rev.body = @{ @"name" : @"fred", @"age" : @12 };
+                rev.body = [@{ @"name" : @"fred", @"age" : @12 } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 im = [CDTQIndexManager managerUsingDatastore:ds error:nil];
@@ -373,7 +383,7 @@ SpecBegin(CDTQIndexUpdater)
 
                 CDTDocumentRevision *rev;
                 rev = [CDTDocumentRevision revisionWithDocId:@"newdoc"];
-                rev.body = @{ @"name" : @"fred", @"age" : @12 };
+                rev.body = [@{ @"name" : @"fred", @"age" : @12 } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 expect([updater updateAllIndexes:[im listIndexes]]).to.beTruthy();
@@ -416,7 +426,7 @@ SpecBegin(CDTQIndexUpdater)
 
                     CDTDocumentRevision *rev;
                     rev = [CDTDocumentRevision revisionWithDocId:@"newdoc"];
-                    rev.body = @{ @"name" : @"fred", @"age" : @12 };
+                    rev.body = [@{ @"name" : @"fred", @"age" : @12 } mutableCopy];
                     [ds createDocumentFromRevision:rev error:nil];
                     
                     expect([updater updateAllIndexes:[im listIndexes]]).to.beTruthy();

--- a/CDTDatastoreTests/CDTQInvalidQuerySyntax.m
+++ b/CDTDatastoreTests/CDTQInvalidQuerySyntax.m
@@ -60,23 +60,23 @@ SpecBegin(CDTQQueryExecutorInvalidSyntax) describe(@"cloudant query using invali
             CDTDocumentRevision *rev;
 
             rev = [CDTDocumentRevision revisionWithDocId:@"mike12"];
-            rev.body = @{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" };
+            rev.body = [@{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             rev = [CDTDocumentRevision revisionWithDocId:@"mike34"];
-            rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"dog" };
+            rev.body = [@{ @"name" : @"mike", @"age" : @34, @"pet" : @"dog" } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             rev = [CDTDocumentRevision revisionWithDocId:@"mike72"];
-            rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"cat" };
+            rev.body = [@{ @"name" : @"mike", @"age" : @34, @"pet" : @"cat" } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             rev = [CDTDocumentRevision revisionWithDocId:@"fred34"];
-            rev.body = @{ @"name" : @"fred", @"age" : @34, @"pet" : @"cat" };
+            rev.body = [@{ @"name" : @"fred", @"age" : @34, @"pet" : @"cat" } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             rev = [CDTDocumentRevision revisionWithDocId:@"fred12"];
-            rev.body = @{ @"name" : @"fred", @"age" : @12 };
+            rev.body = [@{ @"name" : @"fred", @"age" : @12 } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             im = [CDTQIndexManager managerUsingDatastore:ds error:nil];

--- a/CDTDatastoreTests/CDTQPerformanceTests.m
+++ b/CDTDatastoreTests/CDTQPerformanceTests.m
@@ -63,12 +63,11 @@ SpecBegin(CDTQPerformance)
                 @autoreleasepool {
                     rev = [CDTDocumentRevision
                         revisionWithDocId:[NSString stringWithFormat:@"doc-%d", i]];
-                rev.body = @{
-                    @"name" : @"mike",
-                    @"age" : @34,
-                    @"docNumber" : @(i),
-                    @"pet" : @"cat"
-                };
+                    rev.body =
+                        [@{ @"name" : @"mike",
+                            @"age" : @34,
+                            @"docNumber" : @(i),
+                            @"pet" : @"cat" } mutableCopy];
 
                 if (i < 1000) {
                     [ds1k createDocumentFromRevision:rev error:nil];

--- a/CDTDatastoreTests/CDTQQueryExecutorTests.m
+++ b/CDTDatastoreTests/CDTQQueryExecutorTests.m
@@ -79,23 +79,23 @@ SharedExamplesBegin(QueryExecution)
                 CDTDocumentRevision* rev;
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike12"];
-                rev.body = @{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" };
+                rev.body = [@{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike34"];
-                rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"dog" };
+                rev.body = [@{ @"name" : @"mike", @"age" : @34, @"pet" : @"dog" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike72"];
-                rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"cat" };
+                rev.body = [@{ @"name" : @"mike", @"age" : @34, @"pet" : @"cat" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"fred34"];
-                rev.body = @{ @"name" : @"fred", @"age" : @34, @"pet" : @"cat" };
+                rev.body = [@{ @"name" : @"fred", @"age" : @34, @"pet" : @"cat" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"fred12"];
-                rev.body = @{ @"name" : @"fred", @"age" : @12 };
+                rev.body = [@{ @"name" : @"fred", @"age" : @12 } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 im = [imClass managerUsingDatastore:ds error:nil];
@@ -375,43 +375,43 @@ SharedExamplesBegin(QueryExecution)
                 CDTDocumentRevision* rev = [CDTDocumentRevision revision];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike31"];
-                rev.body = @{ @"name" : @"mike", @"score" : @31 };
+                rev.body = [@{ @"name" : @"mike", @"score" : @31 } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"fred11"];
-                rev.body = @{ @"name" : @"fred", @"score" : @11 };
+                rev.body = [@{ @"name" : @"fred", @"score" : @11 } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"john15"];
-                rev.body = @{ @"name" : @"john", @"score" : @15 };
+                rev.body = [@{ @"name" : @"john", @"score" : @15 } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"john-15"];
-                rev.body = @{ @"name" : @"john", @"score" : @-15 };
+                rev.body = [@{ @"name" : @"john", @"score" : @-15 } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"john15.2"];
-                rev.body = @{ @"name" : @"john", @"score" : @15.2 };
+                rev.body = [@{ @"name" : @"john", @"score" : @15.2 } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"john15.6"];
-                rev.body = @{ @"name" : @"john", @"score" : @15.6 };
+                rev.body = [@{ @"name" : @"john", @"score" : @15.6 } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"john0"];
-                rev.body = @{ @"name" : @"john", @"score" : @0 };
+                rev.body = [@{ @"name" : @"john", @"score" : @0 } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"john0.0"];
-                rev.body = @{ @"name" : @"john", @"score" : @0.0 };
+                rev.body = [@{ @"name" : @"john", @"score" : @0.0 } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"john0.6"];
-                rev.body = @{ @"name" : @"john", @"score" : @0.6 };
+                rev.body = [@{ @"name" : @"john", @"score" : @0.6 } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"john-0.6"];
-                rev.body = @{ @"name" : @"john", @"score" : @-0.6 };
+                rev.body = [@{ @"name" : @"john", @"score" : @-0.6 } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
                 
                 im = [imClass managerUsingDatastore:ds error:nil];
@@ -520,39 +520,39 @@ SharedExamplesBegin(QueryExecution)
                 ;
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike12"];
-                rev.body = @{
+                rev.body = [@{
                     @"name" : @"mike",
                     @"age" : @12,
                     @"pet" : @{@"species" : @"cat", @"name" : @"mike"}
-                };
+                } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike23"];
-                rev.body = @{
+                rev.body = [@{
                     @"name" : @"mike",
                     @"age" : @23,
                     @"pet" : @{@"species" : @"cat", @"name" : @{@"first" : @"mike"}}
-                };
+                } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike34"];
-                rev.body = @{
+                rev.body = [@{
                     @"name" : @"mike",
                     @"age" : @34,
                     @"pet" : @{@"species" : @"cat", @"name" : @"mike"}
-                };
+                } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike72"];
-                rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"cat" };
+                rev.body = [@{ @"name" : @"mike", @"age" : @34, @"pet" : @"cat" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"fred34"];
-                rev.body = @{ @"name" : @"fred", @"age" : @34, @"pet" : @"cat" };
+                rev.body = [@{ @"name" : @"fred", @"age" : @34, @"pet" : @"cat" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"fred12"];
-                rev.body = @{ @"name" : @"fred", @"age" : @12 };
+                rev.body = [@{ @"name" : @"fred", @"age" : @12 } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 im = [imClass managerUsingDatastore:ds error:nil];
@@ -609,31 +609,31 @@ SharedExamplesBegin(QueryExecution)
                 CDTDocumentRevision* rev;
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike12"];
-                rev.body = @{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" };
+                rev.body = [@{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike34"];
-                rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"dog" };
+                rev.body = [@{ @"name" : @"mike", @"age" : @34, @"pet" : @"dog" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike72"];
-                rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"cat" };
+                rev.body = [@{ @"name" : @"mike", @"age" : @34, @"pet" : @"cat" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"اسم34"];
-                rev.body = @{ @"name" : @"اسم", @"age" : @34, @"pet" : @"cat" };
+                rev.body = [@{ @"name" : @"اسم", @"age" : @34, @"pet" : @"cat" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"fred12"];
-                rev.body = @{ @"name" : @"fred", @"age" : @12 };
+                rev.body = [@{ @"name" : @"fred", @"age" : @12 } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"fredarabic"];
-                rev.body = @{ @"اسم" : @"fred", @"age" : @12 };
+                rev.body = [@{ @"اسم" : @"fred", @"age" : @12 } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"freddatatype"];
-                rev.body = @{ @"@datatype" : @"fred", @"age" : @12 };
+                rev.body = [@{ @"@datatype" : @"fred", @"age" : @12 } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 im = [imClass managerUsingDatastore:ds error:nil];
@@ -677,39 +677,39 @@ SharedExamplesBegin(QueryExecution)
                 CDTDocumentRevision* rev;
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike12"];
-                rev.body = @{
+                rev.body = [@{
                     @"name" : @"mike",
                     @"age" : @12,
                     @"pet" : @{@"species" : @"cat", @"name" : @"mike"}
-                };
+                } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike23"];
-                rev.body = @{
+                rev.body = [@{
                     @"name" : @"mike",
                     @"age" : @23,
                     @"pet" : @{@"species" : @"cat", @"name" : @{@"first" : @"mike"}}
-                };
+                } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike34"];
-                rev.body = @{
+                rev.body = [@{
                     @"name" : @"mike",
                     @"age" : @34,
                     @"pet" : @{@"species" : @"cat", @"name" : @"mike"}
-                };
+                } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike72"];
-                rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"cat" };
+                rev.body = [@{ @"name" : @"mike", @"age" : @34, @"pet" : @"cat" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"fred34"];
-                rev.body = @{ @"name" : @"fred", @"age" : @34, @"pet" : @"cat" };
+                rev.body = [@{ @"name" : @"fred", @"age" : @34, @"pet" : @"cat" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"fred12"];
-                rev.body = @{ @"name" : @"fred", @"age" : @12 };
+                rev.body = [@{ @"name" : @"fred", @"age" : @12 } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 im = [imClass managerUsingDatastore:ds error:nil];
@@ -774,27 +774,27 @@ SharedExamplesBegin(QueryExecution)
                 CDTDocumentRevision* rev;
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike12"];
-                rev.body = @{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" };
+                rev.body = [@{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike23"];
-                rev.body = @{ @"name" : @"mike", @"age" : @23, @"pet" : @"parrot" };
+                rev.body = [@{ @"name" : @"mike", @"age" : @23, @"pet" : @"parrot" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike34"];
-                rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"dog" };
+                rev.body = [@{ @"name" : @"mike", @"age" : @34, @"pet" : @"dog" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"john72"];
-                rev.body = @{ @"name" : @"john", @"age" : @34, @"pet" : @"fish" };
+                rev.body = [@{ @"name" : @"john", @"age" : @34, @"pet" : @"fish" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"fred34"];
-                rev.body = @{ @"name" : @"fred", @"age" : @43, @"pet" : @"snake" };
+                rev.body = [@{ @"name" : @"fred", @"age" : @43, @"pet" : @"snake" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"fred12"];
-                rev.body = @{ @"name" : @"fred", @"age" : @12 };
+                rev.body = [@{ @"name" : @"fred", @"age" : @12 } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 im = [imClass managerUsingDatastore:ds error:nil];
@@ -959,11 +959,11 @@ SharedExamplesBegin(QueryExecution)
                 CDTDocumentRevision* rev = [CDTDocumentRevision revision];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike12"];
-                rev.body = @{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" };
+                rev.body = [@{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike23"];
-                rev.body = @{ @"name" : @"mike", @"age" : @23, @"pet" : @"parrot" };
+                rev.body = [@{ @"name" : @"mike", @"age" : @23, @"pet" : @"parrot" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 im = [imClass managerUsingDatastore:ds error:nil];
@@ -1000,11 +1000,11 @@ SharedExamplesBegin(QueryExecution)
                 CDTDocumentRevision* rev = [CDTDocumentRevision revision];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike12"];
-                rev.body = @{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" };
+                rev.body = [@{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike23"];
-                rev.body = @{ @"name" : @"mike", @"age" : @23, @"pet" : @"parrot" };
+                rev.body = [@{ @"name" : @"mike", @"age" : @23, @"pet" : @"parrot" } mutableCopy];
                 CDTDocumentRevision* toRetrieve = [ds createDocumentFromRevision:rev error:nil];
                 docRev = toRetrieve.revId;
 
@@ -1042,23 +1042,23 @@ SharedExamplesBegin(QueryExecution)
                 CDTDocumentRevision* rev;
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike12"];
-                rev.body = @{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" };
+                rev.body = [@{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike34"];
-                rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"dog" };
+                rev.body = [@{ @"name" : @"mike", @"age" : @34, @"pet" : @"dog" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike72"];
-                rev.body = @{ @"name" : @"mike", @"age" : @67, @"pet" : @"cat" };
+                rev.body = [@{ @"name" : @"mike", @"age" : @67, @"pet" : @"cat" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"fred34"];
-                rev.body = @{ @"name" : @"fred", @"age" : @34, @"pet" : @"parrot" };
+                rev.body = [@{ @"name" : @"fred", @"age" : @34, @"pet" : @"parrot" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"fred12"];
-                rev.body = @{ @"name" : @"fred", @"age" : @12 };
+                rev.body = [@{ @"name" : @"fred", @"age" : @12 } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 im = [imClass managerUsingDatastore:ds error:nil];
@@ -1158,29 +1158,36 @@ SharedExamplesBegin(QueryExecution)
                 CDTDocumentRevision* rev = [CDTDocumentRevision revision];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike12"];
-                rev.body = @{ @"name" : @"mike", @"age" : @12, @"pet" : @[ @"cat", @"dog" ] };
+                rev.body =
+                    [@{ @"name" : @"mike",
+                        @"age" : @12,
+                        @"pet" : @[ @"cat", @"dog" ] } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"fred34"];
-                rev.body = @{ @"name" : @"fred", @"age" : @34, @"pet" : @"parrot" };
+                rev.body = [@{ @"name" : @"fred", @"age" : @34, @"pet" : @"parrot" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike34"];
-                rev.body = @{ @"name" : @"mike",
-                              @"age" : @34,
-                              @"pet" : @[ @"cat", @"dog", @"fish" ] };
+                rev.body =
+                    [@{ @"name" : @"mike",
+                        @"age" : @34,
+                        @"pet" : @[ @"cat", @"dog", @"fish" ] } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"fred12"];
-                rev.body = @{ @"name" : @"fred", @"age" : @12 };
+                rev.body = [@{ @"name" : @"fred", @"age" : @12 } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"john44"];
-                rev.body = @{ @"name" : @"john", @"age" : @44, @"pet" : @[ @"hamster", @"snake" ] };
+                rev.body =
+                    [@{ @"name" : @"john",
+                        @"age" : @44,
+                        @"pet" : @[ @"hamster", @"snake" ] } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"john22"];
-                rev.body = @{ @"name" : @"john", @"age" : @22, @"pet" : @"cat" };
+                rev.body = [@{ @"name" : @"john", @"age" : @22, @"pet" : @"cat" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 im = [imClass managerUsingDatastore:ds error:nil];
@@ -1329,23 +1336,23 @@ SharedExamplesBegin(QueryExecution)
                 CDTDocumentRevision* rev;
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike12"];
-                rev.body = @{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" };
+                rev.body = [@{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike34"];
-                rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"dog" };
+                rev.body = [@{ @"name" : @"mike", @"age" : @34, @"pet" : @"dog" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike72"];
-                rev.body = @{ @"name" : @"mike", @"age" : @67, @"pet" : @"cat" };
+                rev.body = [@{ @"name" : @"mike", @"age" : @67, @"pet" : @"cat" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"fred34"];
-                rev.body = @{ @"name" : @"fred", @"age" : @34, @"pet" : @"parrot" };
+                rev.body = [@{ @"name" : @"fred", @"age" : @34, @"pet" : @"parrot" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"fred12"];
-                rev.body = @{ @"name" : @"fred", @"age" : @12 };
+                rev.body = [@{ @"name" : @"fred", @"age" : @12 } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 im = [CDTQIndexManager managerUsingDatastore:ds error:nil];
@@ -1396,29 +1403,36 @@ SharedExamplesBegin(QueryExecution)
                 CDTDocumentRevision* rev;
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike12"];
-                rev.body = @{ @"name" : @"mike", @"age" : @12, @"pet" : @[ @"cat", @"dog" ] };
+                rev.body =
+                    [@{ @"name" : @"mike",
+                        @"age" : @12,
+                        @"pet" : @[ @"cat", @"dog" ] } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"fred34"];
-                rev.body = @{ @"name" : @"fred", @"age" : @34, @"pet" : @"parrot" };
+                rev.body = [@{ @"name" : @"fred", @"age" : @34, @"pet" : @"parrot" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike34"];
-                rev.body = @{ @"name" : @"mike",
-                              @"age" : @34,
-                              @"pet" : @[ @"cat", @"dog", @"fish" ] };
+                rev.body =
+                    [@{ @"name" : @"mike",
+                        @"age" : @34,
+                        @"pet" : @[ @"cat", @"dog", @"fish" ] } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"fred12"];
-                rev.body = @{ @"name" : @"fred", @"age" : @12 };
+                rev.body = [@{ @"name" : @"fred", @"age" : @12 } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"john44"];
-                rev.body = @{ @"name" : @"john", @"age" : @44, @"pet" : @[ @"hamster", @"snake" ] };
+                rev.body =
+                    [@{ @"name" : @"john",
+                        @"age" : @44,
+                        @"pet" : @[ @"hamster", @"snake" ] } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"john22"];
-                rev.body = @{ @"name" : @"john", @"age" : @22, @"pet" : @"cat" };
+                rev.body = [@{ @"name" : @"john", @"age" : @22, @"pet" : @"cat" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
                 
                 im = [imClass managerUsingDatastore:ds error:nil];
@@ -1484,15 +1498,15 @@ SharedExamplesBegin(QueryExecution)
                 CDTDocumentRevision* rev = [CDTDocumentRevision revision];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike12"];
-                rev.body = @{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" };
+                rev.body = [@{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike34"];
-                rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"dog" };
+                rev.body = [@{ @"name" : @"mike", @"age" : @34, @"pet" : @"dog" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike72"];
-                rev.body = @{ @"name" : @"mike", @"age" : @67, @"pet" : @"cat" };
+                rev.body = [@{ @"name" : @"mike", @"age" : @67, @"pet" : @"cat" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 im = [CDTQIndexManager managerUsingDatastore:ds error:nil];
@@ -1548,7 +1562,7 @@ SharedExamplesBegin(QueryExecution)
                 [im ensureIndexed:@[ @"large_field" ] withName:@"large"];
 
                 for (int i = 0; i < 100; i++) {
-                    rev.body = @{ @"large_field" : @"cat" };
+                    rev.body = [@{ @"large_field" : @"cat" } mutableCopy];
                     [ds createDocumentFromRevision:rev error:nil];
                 }
 
@@ -1576,7 +1590,7 @@ SharedExamplesBegin(QueryExecution)
                     for (int i = 0; i < 100; i++) {
                         rev = [CDTDocumentRevision
                             revisionWithDocId:[NSString stringWithFormat:@"d%d", i]];
-                        rev.body = @{ @"large_field" : @"cat", @"idx" : @(i) };
+                        rev.body = [@{ @"large_field" : @"cat", @"idx" : @(i) } mutableCopy];
                         [ds createDocumentFromRevision:rev error:nil];
                     }
                     NSDictionary* query = @{ @"large_field" : @"cat" };
@@ -1591,7 +1605,7 @@ SharedExamplesBegin(QueryExecution)
                     for (int i = 0; i < 150; i++) {
                         rev = [CDTDocumentRevision
                             revisionWithDocId:[NSString stringWithFormat:@"d%d", i]];
-                        rev.body = @{ @"large_field" : @"cat", @"idx" : @(i) };
+                        rev.body = [@{ @"large_field" : @"cat", @"idx" : @(i) } mutableCopy];
                         [ds createDocumentFromRevision:rev error:nil];
                     }
 
@@ -1684,23 +1698,27 @@ sharedExamplesFor(@"queries without covering indexes", ^(NSDictionary* data) {
             CDTDocumentRevision* rev;
 
             rev = [CDTDocumentRevision revisionWithDocId:@"mike12"];
-            rev.body = @{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" };
+            rev.body = [@{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             rev = [CDTDocumentRevision revisionWithDocId:@"mike34"];
-            rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"dog" };
+            rev.body = [@{ @"name" : @"mike", @"age" : @34, @"pet" : @"dog" } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             rev = [CDTDocumentRevision revisionWithDocId:@"mike72"];
-            rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"cat", @"town" : @"bristol" };
+            rev.body =
+                [@{ @"name" : @"mike",
+                    @"age" : @34,
+                    @"pet" : @"cat",
+                    @"town" : @"bristol" } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             rev = [CDTDocumentRevision revisionWithDocId:@"fred34"];
-            rev.body = @{ @"name" : @"fred", @"age" : @34, @"pet" : @"cat" };
+            rev.body = [@{ @"name" : @"fred", @"age" : @34, @"pet" : @"cat" } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             rev = [CDTDocumentRevision revisionWithDocId:@"fred12"];
-            rev.body = @{ @"name" : @"fred", @"age" : @12, @"town" : @"bristol" };
+            rev.body = [@{ @"name" : @"fred", @"age" : @12, @"town" : @"bristol" } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             im = [imClass managerUsingDatastore:ds error:nil];
@@ -1791,35 +1809,44 @@ sharedExamplesFor(@"queries without covering indexes", ^(NSDictionary* data) {
             CDTDocumentRevision* rev = [CDTDocumentRevision revision];
 
             rev = [CDTDocumentRevision revisionWithDocId:@"mike24"];
-            rev.body = @{ @"name" : @"mike", @"age" : @24, @"pet" : @[ @"cat" ] };
+            rev.body = [@{ @"name" : @"mike", @"age" : @24, @"pet" : @[ @"cat" ] } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             rev = [CDTDocumentRevision revisionWithDocId:@"mike12"];
-            rev.body = @{ @"name" : @"mike", @"age" : @12, @"pet" : @[ @"cat", @"dog" ] };
+            rev.body =
+                [@{ @"name" : @"mike",
+                    @"age" : @12,
+                    @"pet" : @[ @"cat", @"dog" ] } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             rev = [CDTDocumentRevision revisionWithDocId:@"fred34"];
-            rev.body = @{ @"name" : @"fred", @"age" : @34, @"pet" : @[ @"cat", @"dog" ] };
+            rev.body =
+                [@{ @"name" : @"fred",
+                    @"age" : @34,
+                    @"pet" : @[ @"cat", @"dog" ] } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             rev = [CDTDocumentRevision revisionWithDocId:@"john44"];
-            rev.body = @{ @"name" : @"john", @"age" : @44, @"pet" : @"cat" };
+            rev.body = [@{ @"name" : @"john", @"age" : @44, @"pet" : @"cat" } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             rev = [CDTDocumentRevision revisionWithDocId:@"fred72"];
-            rev.body = @{ @"name" : @"fred", @"age" : @72, @"pet" : @[ @"dog" ] };
+            rev.body = [@{ @"name" : @"fred", @"age" : @72, @"pet" : @[ @"dog" ] } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             rev = [CDTDocumentRevision revisionWithDocId:@"john12"];
-            rev.body = @{ @"name" : @"john", @"age" : @12 };
+            rev.body = [@{ @"name" : @"john", @"age" : @12 } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             rev = [CDTDocumentRevision revisionWithDocId:@"bill34"];
-            rev.body = @{ @"name" : @"bill", @"age" : @34, @"pet" : @[ @"cat", @"parrot" ] };
+            rev.body =
+                [@{ @"name" : @"bill",
+                    @"age" : @34,
+                    @"pet" : @[ @"cat", @"parrot" ] } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             rev = [CDTDocumentRevision revisionWithDocId:@"fred11"];
-            rev.body = @{ @"name" : @"fred", @"age" : @11, @"pet" : @[]};
+            rev.body = [@{ @"name" : @"fred", @"age" : @11, @"pet" : @[] } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
             
             im = [imClass managerUsingDatastore:ds error:nil];

--- a/CDTDatastoreTests/CDTQQueryExecutorTests.m
+++ b/CDTDatastoreTests/CDTQQueryExecutorTests.m
@@ -106,7 +106,10 @@ SharedExamplesBegin(QueryExecution)
             });
 
             it(@"returns nil for no query", ^{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
                 CDTQResultSet* result = [im find:nil];
+#pragma clang diagnostic pop
                 expect(result).to.beNil();
             });
 

--- a/CDTDatastoreTests/CDTQQuerySortTests.m
+++ b/CDTDatastoreTests/CDTQQuerySortTests.m
@@ -63,25 +63,28 @@ SpecBegin(CDTQQueryExecutorSorting)
 
                 CDTDocumentRevision *rev = [CDTDocumentRevision revisionWithDocId:@"mike12"];
 
-                rev.body = @{
+                rev.body = [@{
                     @"name" : @"mike",
                     @"age" : @12,
                     @"pet" : @[ @"cat", @"dog" ],
                     @"same" : @"all"
-                };
+                } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"fred34"];
-                rev.body = @{
-                    @"name" : @"fred",
-                    @"age" : @34,
-                    @"pet" : @"parrot",
-                    @"same" : @"all"
-                };
+                rev.body =
+                    [@{ @"name" : @"fred",
+                        @"age" : @34,
+                        @"pet" : @"parrot",
+                        @"same" : @"all" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"fred11"];
-                rev.body = @{ @"name" : @"fred", @"age" : @11, @"pet" : @"fish", @"same" : @"all" };
+                rev.body =
+                    [@{ @"name" : @"fred",
+                        @"age" : @11,
+                        @"pet" : @"fish",
+                        @"same" : @"all" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 im = [CDTQIndexManager managerUsingDatastore:ds error:nil];

--- a/CDTDatastoreTests/CDTQQuerySortTests.m
+++ b/CDTDatastoreTests/CDTQQuerySortTests.m
@@ -315,7 +315,10 @@ SpecBegin(CDTQQueryExecutorSorting)
                     [CDTQQueryExecutor sqlToSortIds:smallDocIdSet usingOrder:@[] indexes:indexes];
                 expect(parts).to.beNil();
                 parts =
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
                     [CDTQQueryExecutor sqlToSortIds:smallDocIdSet usingOrder:nil indexes:indexes];
+#pragma clang diagnostic pop
                 expect(parts).to.beNil();
             });
 
@@ -324,7 +327,10 @@ SpecBegin(CDTQQueryExecutorSorting)
                 NSArray *order = @[ @{ @"y" : @"desc" } ];
                 parts = [CDTQQueryExecutor sqlToSortIds:smallDocIdSet usingOrder:order indexes:@{}];
                 expect(parts).to.beNil();
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
                 parts = [CDTQQueryExecutor sqlToSortIds:smallDocIdSet usingOrder:order indexes:nil];
+#pragma clang diagnostic pop
                 expect(parts).to.beNil();
             });
 

--- a/CDTDatastoreTests/CDTQQuerySqlTranslatorTests.m
+++ b/CDTDatastoreTests/CDTQQuerySqlTranslatorTests.m
@@ -1029,11 +1029,14 @@ SpecBegin(CDTQQuerySqlTranslator) describe(@"cdtq", ^{
         });
 
         it(@"returns nil for no index name", ^{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
             CDTQSqlParts *parts = [CDTQQuerySqlTranslator
                 selectStatementForAndClause:@[
                                                @{ @"name" : @{@"$eq" : @"mike"} }
                                             ]
                                  usingIndex:nil];
+#pragma clang diagnostic pop
             expect(parts).to.beNil();
         });
 

--- a/CDTDatastoreTests/CDTQTextSearchTests.m
+++ b/CDTDatastoreTests/CDTQTextSearchTests.m
@@ -65,48 +65,59 @@ SpecBegin(CDTQQueryExecutorTextSearch) describe(@"cdtq", ^{
             CDTDocumentRevision *rev;
 
             rev = [CDTDocumentRevision revisionWithDocId:@"mike12"];
-            rev.body = @{ @"name" : @"mike",
-                          @"age" : @12,
-                          @"pet" : @"cat",
-                          @"comment" : @"He lives in Bristol, UK and his best friend is Fred."};
+            rev.body = [@{
+                @"name" : @"mike",
+                @"age" : @12,
+                @"pet" : @"cat",
+                @"comment" : @"He lives in Bristol, UK and his best friend is Fred."
+            } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             rev = [CDTDocumentRevision revisionWithDocId:@"mike34"];
-            rev.body = @{ @"name" : @"mike",
-                          @"age" : @34,
-                          @"pet" : @"dog",
-                          @"comment" : @"He lives in a van down by the river in Bristol."};
+            rev.body = [@{
+                @"name" : @"mike",
+                @"age" : @34,
+                @"pet" : @"dog",
+                @"comment" : @"He lives in a van down by the river in Bristol."
+            } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             rev = [CDTDocumentRevision revisionWithDocId:@"mike72"];
-            rev.body = @{ @"name" : @"mike",
-                          @"age" : @72,
-                          @"pet" : @"cat",
-                          @"comment" : @"He's retired and has memories of spending time "
-                                       @"with his cat Remus."};
+            rev.body = [@{
+                @"name" : @"mike",
+                @"age" : @72,
+                @"pet" : @"cat",
+                @"comment" : @"He's retired and has memories of spending time "
+                             @"with his cat Remus."
+            } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             rev = [CDTDocumentRevision revisionWithDocId:@"fred34"];
-            rev.body = @{ @"name" : @"fred",
-                          @"age" : @34,
-                          @"pet" : @"cat",
-                          @"comment" : @"He lives next door to Mike and his cat Romulus "
-                                       @"is brother to Remus."};
+            rev.body = [@{
+                @"name" : @"fred",
+                @"age" : @34,
+                @"pet" : @"cat",
+                @"comment" : @"He lives next door to Mike and his cat Romulus "
+                             @"is brother to Remus."
+            } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             rev = [CDTDocumentRevision revisionWithDocId:@"fred12"];
-            rev.body = @{ @"name" : @"fred",
-                          @"age" : @12,
-                          @"pet" : @"cat",
-                          @"comment" : @"He lives in Bristol, UK and his best friend is Mike."};
+            rev.body = [@{
+                @"name" : @"fred",
+                @"age" : @12,
+                @"pet" : @"cat",
+                @"comment" : @"He lives in Bristol, UK and his best friend is Mike."
+            } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             rev = [CDTDocumentRevision revisionWithDocId:@"john34"];
-            rev.body =
-                @{ @"name" : @"john",
-                   @"age" : @34,
-                   @"pet" : @"cat",
-                   @"comment" : @"وهو يعيش في بريستول، المملكة المتحدة، وأفضل صديق له هو مايك."};
+            rev.body = [@{
+                @"name" : @"john",
+                @"age" : @34,
+                @"pet" : @"cat",
+                @"comment" : @"وهو يعيش في بريستول، المملكة المتحدة، وأفضل صديق له هو مايك."
+            } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
             
             im = [CDTQIndexManager managerUsingDatastore:ds error:nil];

--- a/CDTDatastoreTests/CDTReplicationTests.m
+++ b/CDTDatastoreTests/CDTReplicationTests.m
@@ -175,9 +175,10 @@
 }
 
 -(void)testReplicatorIsNilForNilDatastoreManager {
-    
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
     XCTAssertNil([[CDTReplicatorFactory alloc] initWithDatastoreManager:nil], @"Replication factory should be nil");
-    
+#pragma clang diagnostic pop
 }
 
 -(void)testDictionaryForPullReplicationDocument

--- a/CDTDatastoreTests/DatastoreActions.m
+++ b/CDTDatastoreTests/DatastoreActions.m
@@ -98,11 +98,11 @@
     NSError *error;
     CDTDatastore *datastore = [self.factory datastoreNamed:@"test_database" error:&error];
     CDTDocumentRevision *rev = [CDTDocumentRevision revisionWithDocId:@"myDocId"];
-    rev.body = @{ @"hello" : @"world" };
-    
+    rev.body = [@{ @"hello" : @"world" } mutableCopy];
+
     CDTDocumentRevision *revision = [datastore createDocumentFromRevision:rev error:&error];
     rev = [revision copy];
-    rev.body = @{ @"hello" : @"world", @"test" : @"testy" };
+    rev.body = [@{ @"hello" : @"world", @"test" : @"testy" } mutableCopy];
     revision = [datastore updateDocumentFromRevision:rev error:&error];
     
     XCTAssertTrue([datastore compactWithError:&error],@"Compaction failed");

--- a/CDTDatastoreTests/DatastoreCRUD.m
+++ b/CDTDatastoreTests/DatastoreCRUD.m
@@ -87,8 +87,8 @@
 {
     NSError * error;
     CDTDocumentRevision *revision = [CDTDocumentRevision revision];
-    revision.body = @{@"infinity":@(INFINITY)};
-    
+    revision.body = [@{ @"infinity" : @(INFINITY) } mutableCopy];
+
     CDTDocumentRevision * rev = [self.datastore createDocumentFromRevision:revision
                                                                      error:&error];
     
@@ -103,8 +103,8 @@
 -(void) testDocumentWithNonSerialisableValue {
     NSError * error;
     CDTDocumentRevision *revision = [CDTDocumentRevision revision];
-    revision.body = @{@"nonserialisable":[NSDate date]};
-    
+    revision.body = [@{ @"nonserialisable" : [NSDate date] } mutableCopy];
+
     CDTDocumentRevision * rev = [self.datastore createDocumentFromRevision:revision
                                                                      error:&error];
     
@@ -1860,8 +1860,8 @@
     NSError * error;
     CDTDocumentRevision *mutableRev;
     mutableRev = [CDTDocumentRevision revisionWithDocId:@"aTestDocId"];
-    mutableRev.body = @{@"hello":@"world"};
-    
+    mutableRev.body = [@{ @"hello" : @"world" } mutableCopy];
+
     CDTDocumentRevision * rev = [self.datastore createDocumentFromRevision:mutableRev error:&error];
     
     XCTAssertNotNil(rev, @"Document was not created");

--- a/CDTDatastoreTests/DatastoreConflicts.m
+++ b/CDTDatastoreTests/DatastoreConflicts.m
@@ -27,7 +27,6 @@
 #import "CDTConflictResolver.h"
 #import "CDTHelperOneUseKeyProvider.h"
 
-#import "FMDatabaseAdditions.h"
 #import "FMDatabaseQueue.h"
 #import "TDJSON.h"
 #import "FMResultSet.h"
@@ -97,7 +96,7 @@
     
     NSError *error;
     CDTDocumentRevision *mutableRevision = [CDTDocumentRevision revisionWithDocId:anId];
-    mutableRevision.body = @{ @"foo1.a" : @"bar1.a" };
+    mutableRevision.body = [@{ @"foo1.a" : @"bar1.a" } mutableCopy];
     CDTDocumentRevision *rev1;
     rev1 = [datastore createDocumentFromRevision:mutableRevision error:&error];
     
@@ -113,20 +112,20 @@
                                                                               name:@"bonsai-boston"
                                                                               type:@"image/jpg"];
         mutableRevision = [rev1 copy];
-        mutableRevision.attachments = @{attachment.name:attachment};
-        mutableRevision.body = @{@"foo2.a":@"bar2.a"};
+        mutableRevision.attachments = [@{ attachment.name : attachment } mutableCopy];
+        mutableRevision.body = [@{ @"foo2.a" : @"bar2.a" } mutableCopy];
         rev2a = [self.datastore updateDocumentFromRevision:mutableRevision error:&error];
         
     }
     else{
         mutableRevision = [rev1 copy];
-        mutableRevision.body = @{@"foo2.a":@"bar2.a"};
+        mutableRevision.body = [@{ @"foo2.a" : @"bar2.a" } mutableCopy];
         rev2a = [datastore updateDocumentFromRevision:mutableRevision error:&error];
     }
     
     error = nil;
     mutableRevision = [rev2a copy];
-    mutableRevision.body = @{@"foo3.a":@"bar3.a"};
+    mutableRevision.body = [@{ @"foo3.a" : @"bar3.a" } mutableCopy];
     [datastore updateDocumentFromRevision:mutableRevision error:&error];
     
     error = nil;
@@ -208,8 +207,8 @@
 {
     NSError *error;
     CDTDocumentRevision *mutableRev = [CDTDocumentRevision revision];
-    mutableRev.body = body;
-    
+    mutableRev.body = [body mutableCopy];
+
     CDTDocumentRevision *rev = [self.datastore createDocumentFromRevision:mutableRev error:&error];
     
     XCTAssertNil(error, @"Error creating document");

--- a/CDTDatastoreTests/Events/CDTDatastoreEvents.m
+++ b/CDTDatastoreTests/Events/CDTDatastoreEvents.m
@@ -89,8 +89,8 @@
 - (void)testEventFiredOnCreate
 {
     CDTDocumentRevision *rev = [CDTDocumentRevision revision];
-    rev.body = @{@"hello": @"world"};
-    
+    rev.body = [@{ @"hello" : @"world" } mutableCopy];
+
     XCTAssertNotNil([self.datastore createDocumentFromRevision:rev error:nil],
                    @"Document wasn't created");
     
@@ -104,7 +104,7 @@
 - (void)testEventFiredOnUpdate
 {
     CDTDocumentRevision *mutableRev = [CDTDocumentRevision revision];
-    mutableRev.body = @{@"hello": @"world"};
+    mutableRev.body = [@{ @"hello" : @"world" } mutableCopy];
     CDTDocumentRevision *rev1 = [self.datastore createDocumentFromRevision:mutableRev error:nil];
     
     XCTAssertNotNil(rev1, @"Document wasn't created");
@@ -116,7 +116,7 @@
     XCTAssertEqual(self.otherWatcher.counter, (NSInteger)0, @"Event incorrectly fired");
 
     mutableRev = [rev1 copy];
-    mutableRev.body = @{@"hello2": @"world2"};
+    mutableRev.body = [@{ @"hello2" : @"world2" } mutableCopy];
     XCTAssertNotNil([self.datastore updateDocumentFromRevision:mutableRev error:nil],
                    @"Document wasn't updated");
     
@@ -128,7 +128,7 @@
 - (void)testEventFiredOnDelete
 {
     CDTDocumentRevision *mutableRev = [CDTDocumentRevision revision];
-    mutableRev.body = @{@"hello": @"world"};
+    mutableRev.body = [@{ @"hello" : @"world" } mutableCopy];
     CDTDocumentRevision *rev1 = [self.datastore createDocumentFromRevision:mutableRev error:nil];
     
     XCTAssertNotNil(rev1, @"Document wasn't created");
@@ -151,7 +151,7 @@
 {
     NSError * error;
     CDTDocumentRevision *rev = [CDTDocumentRevision revisionWithDocId:@"aTestDocId"];
-    rev.body = @{ @"hello" : @"world" };
+    rev.body = [@{ @"hello" : @"world" } mutableCopy];
 
     rev = [self.datastore createDocumentFromRevision:rev error:&error];
 


### PR DESCRIPTION
Note: It may be easier to review this PR by commit since the first commit makes all the changes to nullability, but when combined with the second commit, which changes some files to use NS_ASSUME_NONNULL_BEGIN/END it loses some clarity over which things have changed their nullability.

## What
Correct nullability annotations.

## Why
When nullability annotations were originally added, there was a misconception that `NSObject`'s `init` method could sometime return `nil`. This lead to some methods being incorrectly annotated as `nullable` when they should be `nonnull`.

## How
The code has been reinspected and the annotations updated to reflect the nullability.

## Testing
There are no additional tests added, but existing tests that pass `nil` to method arguments annotated as `nonnull` have been updated to eliminate the warnings generated by the compiler. Since Objective-C doesn't enforce that `nonnull` arguments are only passed non-null objects, these tests are still legitimate and we may safely hide the warnings.

## Reviewers
reviewer: @rhyshort 
