### PR TITLE
Fix semantic issue warnings

### DIFF
--- a/CDTDatastoreTests/Attachments/AttachmentCRUD.m
+++ b/CDTDatastoreTests/Attachments/AttachmentCRUD.m
@@ -209,7 +209,7 @@
     NSError *error = nil;
     NSString *attachmentName = @"test_an_attachment";
 
-    NSDictionary *dict = @{@"hello": @"world"};
+    NSMutableDictionary *dict = [@{ @"hello" : @"world" } mutableCopy];
 
     CDTDocumentRevision *document = [CDTDocumentRevision revision];
     document.body = dict;
@@ -217,7 +217,7 @@
     CDTDocumentRevision *rev = [self.datastore createDocumentFromRevision:document
                                                                     error:&error];
     document = [rev copy];
-    document.attachments = @{};
+    document.attachments = [@{} mutableCopy];
 
     CDTDocumentRevision *rev2 = [self.datastore updateDocumentFromRevision: document
                                                                      error:&error];
@@ -233,8 +233,8 @@
                                                                           type:@"image/jpg"];
 
     document = [rev2 copy];
-    document.attachments = @{attachment.name:attachment};
-    
+    document.attachments = [@{ attachment.name : attachment } mutableCopy];
+
     CDTDocumentRevision *rev3 = [self.datastore updateDocumentFromRevision:document
                                                                      error:&error];
 
@@ -288,8 +288,8 @@
     CDTDocumentRevision *rev = [self.datastore createDocumentFromRevision:document
                                                                     error:&error];
     document = [rev copy];
-    document.attachments = @{};
-    
+    document.attachments = [@{} mutableCopy];
+
     CDTDocumentRevision *rev2 = [self.datastore updateDocumentFromRevision: document
                                                                      error:&error];
     
@@ -352,7 +352,7 @@
 {
     NSError *error = nil;
 
-    NSDictionary *dict = @{@"hello": @"world"};
+    NSMutableDictionary *dict = [@{ @"hello" : @"world" } mutableCopy];
 
     CDTDocumentRevision *document = [CDTDocumentRevision revision];
     document.body = dict;
@@ -367,7 +367,7 @@
                                             name:@"bonsai-boston"
                                             type:@"image/jpg"];
     document = [rev copy];
-    document.attachments = @{imgAttachment.name:imgAttachment};
+    document.attachments = [@{ imgAttachment.name : imgAttachment } mutableCopy];
     rev = [self.datastore updateDocumentFromRevision:document error:&error];
 
 
@@ -411,7 +411,7 @@
 {
     NSError *error = nil;
 
-    NSDictionary *dict = @{@"hello": @"world"};
+    NSMutableDictionary *dict = [@{ @"hello" : @"world" } mutableCopy];
 
     CDTDocumentRevision *document = [CDTDocumentRevision revision];
     document.body = dict;
@@ -437,7 +437,7 @@
                                             type:@"text/plain"];
 
     document = [rev copy];
-    document.attachments = @{imgAttachment.name:imgAttachment,txtAttachment.name:txtAttachment};
+    document.attachments = [@{imgAttachment.name:imgAttachment,txtAttachment.name:txtAttachment} mutableCopy];
     rev = [self.datastore updateDocumentFromRevision:document error:&error];
     
 
@@ -528,7 +528,7 @@
 {
     NSError *error = nil;
 
-    NSDictionary *dict = @{@"hello": @"world"};
+    NSMutableDictionary *dict = [@{ @"hello" : @"world" } mutableCopy];
 
     CDTDocumentRevision *rev = [CDTDocumentRevision revision];
     rev.body = dict;
@@ -541,9 +541,9 @@
                                     initWithData:imageData
                                             name:@"bonsai-boston"
                                             type:@"image/jpg"];
-    
-    rev.attachments = @{imgAttachment.name:imgAttachment};
-    
+
+    rev.attachments = [@{ imgAttachment.name : imgAttachment } mutableCopy];
+
     CDTDocumentRevision * savedRev = [self.datastore createDocumentFromRevision:rev
                                                                           error:&error];
     
@@ -621,7 +621,7 @@
     NSError *error = nil;
     NSString *attachmentName = @"test_an_attachment";
 
-    NSDictionary *dict = @{@"hello": @"world"};
+    NSMutableDictionary *dict = [@{ @"hello" : @"world" } mutableCopy];
 
     CDTDocumentRevision *document = [CDTDocumentRevision revision];
     document.body = dict;
@@ -640,7 +640,7 @@
                                     initWithData:data name:attachmentName type:@"image/jpg"];
 
     document = [rev1 copy];
-    document.attachments = @{imgAttachment.name:imgAttachment};
+    document.attachments = [@{ imgAttachment.name : imgAttachment } mutableCopy];
     CDTDocumentRevision *rev2 = [self.datastore updateDocumentFromRevision:document
                                                                      error:&error];
 
@@ -663,7 +663,7 @@
     NSError *error = nil;
     NSString *attachmentName = @"test_an_attachment";
 
-    NSDictionary *dict = @{@"hello": @"world"};
+    NSMutableDictionary *dict = [@{ @"hello" : @"world" } mutableCopy];
 
     CDTDocumentRevision *document = [CDTDocumentRevision revision];
     document.body = dict;
@@ -681,7 +681,7 @@
                                             type:@"image/jpg"];
 
     document = [rev1 copy];
-    document.attachments = @{imgAttachment.name:imgAttachment};
+    document.attachments = [@{ imgAttachment.name : imgAttachment } mutableCopy];
     CDTDocumentRevision *rev2 = [self.datastore updateDocumentFromRevision:document
                                                                      error:&error];
 
@@ -698,7 +698,7 @@
     NSData *inputMD5 = [self MD5:txtData];
 
     document = [rev2 copy];
-    document.attachments = @{attachment2.name:attachment2};
+    document.attachments = [@{ attachment2.name : attachment2 } mutableCopy];
     CDTDocumentRevision *rev3 = [self.datastore updateDocumentFromRevision:document
                                                                      error:&error];
 
@@ -757,7 +757,7 @@
     NSData *data;
     NSDictionary *attachments;
 
-    NSDictionary *dict = @{@"hello": @"world"};
+    NSMutableDictionary *dict = [@{ @"hello" : @"world" } mutableCopy];
     CDTDocumentRevision *document = [CDTDocumentRevision revision];
     document.body = dict;
     CDTDocumentRevision *rev1 = [self.datastore createDocumentFromRevision:document
@@ -772,7 +772,7 @@
                                                                           type:@"image/jpg"];
 
     document = [rev1 copy];
-    document.attachments = @{attachment.name:attachment};
+    document.attachments = [@{ attachment.name : attachment } mutableCopy];
     CDTDocumentRevision *rev2 = [self.datastore updateDocumentFromRevision:document
                                                                      error:&error];
 
@@ -838,7 +838,7 @@
     NSError *error = nil;
     NSString *attachmentName = @"test_an_attachment";
 
-    NSDictionary *dict = @{@"hello": @"world"};
+    NSMutableDictionary *dict = [@{ @"hello" : @"world" } mutableCopy];
 
     CDTDocumentRevision *document = [CDTDocumentRevision revision];
     document.body = dict;
@@ -858,7 +858,7 @@
                                             type:@"image/jpg"];
 
     document = [rev1 copy];
-    document.attachments = @{imgAttachment.name:imgAttachment};
+    document.attachments = [@{ imgAttachment.name : imgAttachment } mutableCopy];
     CDTDocumentRevision *rev2 = [self.datastore updateDocumentFromRevision:document
                                                                      error:&error];
 
@@ -964,7 +964,7 @@
 {
     NSError *error;
 
-    NSDictionary *dict = @{@"hello": @"world"};
+    NSMutableDictionary *dict = [@{ @"hello" : @"world" } mutableCopy];
 
     CDTDocumentRevision *mutableRev = [CDTDocumentRevision revision];
     mutableRev.body = dict;
@@ -976,7 +976,7 @@
                                                                        size:100];
 
     mutableRev = [rev1 copy];
-    mutableRev.attachments = @{attachment.name:attachment};
+    mutableRev.attachments = [@{ attachment.name : attachment } mutableCopy];
     CDTDocumentRevision *rev2 = [self.datastore updateDocumentFromRevision:mutableRev error:&error];
 
     // Should fail, we shouldn't get a revision and should get a decent error
@@ -1014,8 +1014,8 @@
 - (void)testNilAttachmentStreamWithGoodAttachmentStream
 {
     NSString *attachmentName = @"test_an_attachment";
-    
-    NSDictionary *dict = @{@"hello": @"world"};
+
+    NSMutableDictionary *dict = [@{ @"hello" : @"world" } mutableCopy];
     CDTDocumentRevision *mutableRev = [CDTDocumentRevision revision];
     mutableRev.body = dict;
 
@@ -1031,8 +1031,10 @@
     
     NSError *error = nil;
     mutableRev = [rev copy];
-    mutableRev.attachments = @{attachmentName:attachment,@"nullAttachment":nullAttachment};
-    
+    mutableRev.attachments =
+        [@{ attachmentName : attachment,
+            @"nullAttachment" : nullAttachment } mutableCopy];
+
     CDTDocumentRevision *rev2 = [self.datastore updateDocumentFromRevision:mutableRev error:&error];
     
 
@@ -1075,8 +1077,8 @@
 
 -(void) testCreateDocumentWithaSharedAttachment {
     NSString *attachmentName = @"test_an_attachment";
-    
-    NSDictionary *dict = @{@"hello": @"world"};
+
+    NSMutableDictionary *dict = [@{ @"hello" : @"world" } mutableCopy];
 
     NSError *error;
     
@@ -1090,8 +1092,8 @@
 
     CDTDocumentRevision *mutableRev = [CDTDocumentRevision revision];
     mutableRev.body = dict;
-    mutableRev.attachments=@{attachment.name : attachment};
-    
+    mutableRev.attachments = [@{ attachment.name : attachment } mutableCopy];
+
     CDTDocumentRevision *rev = [self.datastore createDocumentFromRevision:mutableRev  error:&error];
     
     
@@ -1123,8 +1125,8 @@
     CDTDocumentRevision *rev = [self.datastore createDocumentFromRevision:document
                                                                     error:&error];
     document = [rev copy];
-    document.attachments = @{};
-    
+    document.attachments = [@{} mutableCopy];
+
     CDTDocumentRevision *rev2 = [self.datastore updateDocumentFromRevision: document
                                                                      error:&error];
     
@@ -1166,8 +1168,8 @@
     CDTDocumentRevision *rev = [self.datastore createDocumentFromRevision:document
                                                                     error:&error];
     document = [rev copy];
-    document.attachments = @{};
-    
+    document.attachments = [@{} mutableCopy];
+
     CDTDocumentRevision *rev2 = [self.datastore updateDocumentFromRevision: document
                                                                      error:&error];
     
@@ -1183,10 +1185,9 @@
 
     document = [rev2 copy];
     document.attachments = [@{attachment.name:attachment} mutableCopy];
-    
-    CDTDocumentRevision *rev3 = [self.datastore updateDocumentFromRevision:document
-                                                                     error:&error];
-    
+
+    [self.datastore updateDocumentFromRevision:document error:&error];
+
     //attachments have been completed inerted, now attempt to get them via all docs
     
     NSArray * allDocuuments = [self.datastore getDocumentsWithIds:@[rev.docId]];

--- a/CDTDatastoreTests/CDTDatastoreQueryTests.m
+++ b/CDTDatastoreTests/CDTDatastoreQueryTests.m
@@ -48,15 +48,15 @@ SpecBegin(CDTDatastoreQuery) describe(@"When using datastore query", ^{
         CDTDocumentRevision *rev;
 
         rev = [CDTDocumentRevision revisionWithDocId:@"mike12"];
-        rev.body = @{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" };
+        rev.body = [@{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" } mutableCopy];
         [ds createDocumentFromRevision:rev error:nil];
 
         rev = [CDTDocumentRevision revisionWithDocId:@"mike34"];
-        rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"dog" };
+        rev.body = [@{ @"name" : @"mike", @"age" : @34, @"pet" : @"dog" } mutableCopy];
         [ds createDocumentFromRevision:rev error:nil];
 
         rev = [CDTDocumentRevision revisionWithDocId:@"mike72"];
-        rev.body = @{ @"name" : @"mike", @"age" : @67, @"pet" : @"cat" };
+        rev.body = [@{ @"name" : @"mike", @"age" : @67, @"pet" : @"cat" } mutableCopy];
         [ds createDocumentFromRevision:rev error:nil];
 
         [ds ensureIndexed:@[ @"name" ] withName:@"index name"];
@@ -73,8 +73,8 @@ SpecBegin(CDTDatastoreQuery) describe(@"When using datastore query", ^{
         CDTDatastore *ds2 = [factory datastoreNamed:@"test2" error:nil];
         expect([ds2 ensureIndexed:@[ @"name", @"age" ] withName:@"pet"]).toNot.beNil();
 
-        CDTQIndexManager *im = objc_getAssociatedObject(ds, @selector(CDTQManager));
-        CDTQIndexManager *im2 = objc_getAssociatedObject(ds2, @selector(CDTQManager));
+        CDTQIndexManager *im = objc_getAssociatedObject(ds, NSSelectorFromString(@"CDTQManager"));
+        CDTQIndexManager *im2 = objc_getAssociatedObject(ds2, NSSelectorFromString(@"CDTQManager"));
 
         expect([im listIndexes]).toNot.equal([im2 listIndexes]);
     });
@@ -119,7 +119,7 @@ SpecBegin(CDTDatastoreQuery) describe(@"When using datastore query", ^{
         CDTQResultSet *results = [ds find:query];
         expect(results).toNot.beNil();
         CDTDocumentRevision *rev = [CDTDocumentRevision revision];
-        rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"dolhpin" };
+        rev.body = [@{ @"name" : @"mike", @"age" : @34, @"pet" : @"dolhpin" } mutableCopy];
         [ds createDocumentFromRevision:rev error:nil];
         expect([ds updateAllIndexes]).to.beTruthy();
     });

--- a/CDTDatastoreTests/CDTFetchChangesTests.m
+++ b/CDTDatastoreTests/CDTFetchChangesTests.m
@@ -244,7 +244,8 @@
     for (NSUInteger i = 0; i < counter; i++) {
         CDTDocumentRevision *rev =
             [CDTDocumentRevision revisionWithDocId:[CDTFetchChangesTests docIdWithIndex:i]];
-        rev.body = @{ [NSString stringWithFormat:@"hello-%lu", (unsigned long)i] : @"world" };
+        rev.body = [
+            @{ [NSString stringWithFormat:@"hello-%lu", (unsigned long)i] : @"world" } mutableCopy];
 
         [datastore createDocumentFromRevision:rev error:nil];
     }

--- a/CDTDatastoreTests/CDTQFilterFieldsTest.m
+++ b/CDTDatastoreTests/CDTQFilterFieldsTest.m
@@ -53,23 +53,23 @@ SpecBegin(CDTQFilterFieldsTest)
             CDTDocumentRevision *rev;
 
             rev = [CDTDocumentRevision revisionWithDocId:@"mike12"];
-            rev.body = @{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" };
+            rev.body = [@{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             rev = [CDTDocumentRevision revisionWithDocId:@"mike34"];
-            rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"dog" };
+            rev.body = [@{ @"name" : @"mike", @"age" : @34, @"pet" : @"dog" } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             rev = [CDTDocumentRevision revisionWithDocId:@"mike72"];
-            rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"cat" };
+            rev.body = [@{ @"name" : @"mike", @"age" : @34, @"pet" : @"cat" } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             rev = [CDTDocumentRevision revisionWithDocId:@"fred34"];
-            rev.body = @{ @"name" : @"fred", @"age" : @34, @"pet" : @"cat" };
+            rev.body = [@{ @"name" : @"fred", @"age" : @34, @"pet" : @"cat" } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             rev = [CDTDocumentRevision revisionWithDocId:@"fred12"];
-            rev.body = @{ @"name" : @"fred", @"age" : @12 };
+            rev.body = [@{ @"name" : @"fred", @"age" : @12 } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             im = [CDTQIndexManager managerUsingDatastore:ds error:nil];

--- a/CDTDatastoreTests/CDTQIndexManagerTests.m
+++ b/CDTDatastoreTests/CDTQIndexManagerTests.m
@@ -88,39 +88,39 @@ SpecBegin(CDTQIndexManager)
 
             CDTDocumentRevision *rev = [CDTDocumentRevision revision];
 
-            rev.body = @{
+            rev.body = [@{
                 @"name" : @"mike",
                 @"age" : @12,
                 @"pet" : @{@"species" : @"cat", @"name" : @"mike"}
-            };
+            } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
-            rev.body = @{
+            rev.body = [@{
                 @"name" : @"mike",
                 @"age" : @12,
                 @"pet" : @{@"species" : @"cat", @"name" : @"mike"}
-            };
+            } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
-            rev.body = @{
+            rev.body = [@{
                 @"name" : @"mike",
                 @"age" : @12,
                 @"pet" : @{@"species" : @"cat", @"name" : @"mike"}
-            };
+            } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
-            rev.body = @{
+            rev.body = [@{
                 @"name" : @"mike",
                 @"age" : @12,
                 @"pet" : @{@"species" : @"cat", @"name" : @"mike"}
-            };
+            } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
-            rev.body = @{
+            rev.body = [@{
                 @"name" : @"mike",
                 @"age" : @12,
                 @"pet" : @{@"species" : @"cat", @"name" : @"mike"}
-            };
+            } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             [im ensureIndexed:@[ @"name", @"address" ] withName:@"basic"];
@@ -135,39 +135,39 @@ SpecBegin(CDTQIndexManager)
 
             CDTDocumentRevision *rev = [CDTDocumentRevision revision];
 
-            rev.body = @{
+            rev.body = [@{
                 @"name" : @"mike",
                 @"age" : @12,
                 @"pet" : @{@"species" : @"cat", @"name" : @"mike"}
-            };
+            } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
-            rev.body = @{
+            rev.body = [@{
                 @"name" : @"mike",
                 @"age" : @12,
                 @"pet" : @{@"species" : @"cat", @"name" : @"mike"}
-            };
+            } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
-            rev.body = @{
+            rev.body = [@{
                 @"name" : @"mike",
                 @"age" : @12,
                 @"pet" : @{@"species" : @"cat", @"name" : @"mike"}
-            };
+            } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
-            rev.body = @{
+            rev.body = [@{
                 @"name" : @"mike",
                 @"age" : @12,
                 @"pet" : @{@"species" : @"cat", @"name" : @"mike"}
-            };
+            } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
-            rev.body = @{
+            rev.body = [@{
                 @"name" : @"mike",
                 @"age" : @12,
                 @"pet" : @{@"species" : @"cat", @"name" : @"mike"}
-            };
+            } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             [im ensureIndexed:@[ @"name", @"address" ] withName:@"basic"];
@@ -186,11 +186,11 @@ SpecBegin(CDTQIndexManager)
 
             CDTDocumentRevision *rev = [CDTDocumentRevision revision];
 
-            rev.body = @{
-                         @"name" : @"mike",
-                         @"age" : @12,
-                         @"pet" : @{@"species" : @"cat", @"name" : @"mike"}
-                         };
+            rev.body = [@{
+                @"name" : @"mike",
+                @"age" : @12,
+                @"pet" : @{@"species" : @"cat", @"name" : @"mike"}
+            } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             expect([im ensureIndexed:@[ @"name" ] withName:@"basic" ofType:CDTQIndexTypeText])

--- a/CDTDatastoreTests/CDTQIndexUpdaterTests.m
+++ b/CDTDatastoreTests/CDTQIndexUpdaterTests.m
@@ -92,7 +92,7 @@ SpecBegin(CDTQIndexUpdater)
             it(@"returns correctly for single field", ^{
                 CDTDocumentRevision *rev;
                 rev = [CDTDocumentRevision revisionWithDocId:@"id123"];
-                rev.body = @{ @"name" : @"mike" };
+                rev.body = [@{ @"name" : @"mike" } mutableCopy];
                 CDTDocumentRevision *saved = [ds createDocumentFromRevision:rev error:nil];
                 CDTQSqlParts *parts = [CDTQIndexUpdater partsToIndexRevision:saved
                                                                      inIndex:@"anIndex"
@@ -107,7 +107,7 @@ SpecBegin(CDTQIndexUpdater)
             it(@"returns correctly for two fields", ^{
                 CDTDocumentRevision *rev;
                 rev = [CDTDocumentRevision revisionWithDocId:@"id123"];
-                rev.body = @{ @"name" : @"mike", @"age" : @12 };
+                rev.body = [@{ @"name" : @"mike", @"age" : @12 } mutableCopy];
                 CDTDocumentRevision *saved = [ds createDocumentFromRevision:rev error:nil];
                 CDTQSqlParts *parts =
                     [CDTQIndexUpdater partsToIndexRevision:saved
@@ -123,13 +123,13 @@ SpecBegin(CDTQIndexUpdater)
             it(@"returns correctly for multiple fields", ^{
                 CDTDocumentRevision *rev;
                 rev = [CDTDocumentRevision revisionWithDocId:@"id123"];
-                rev.body = @{
+                rev.body = [@{
                     @"name" : @"mike",
                     @"age" : @12,
                     @"pet" : @"cat",
                     @"car" : @"mini",
                     @"ignored" : @"something"
-                };
+                } mutableCopy];
                 CDTDocumentRevision *saved = [ds createDocumentFromRevision:rev error:nil];
                 CDTQSqlParts *parts =
                     [CDTQIndexUpdater partsToIndexRevision:saved
@@ -147,7 +147,10 @@ SpecBegin(CDTQIndexUpdater)
             it(@"returns correctly for missing fields", ^{
                 CDTDocumentRevision *rev;
                 rev = [CDTDocumentRevision revisionWithDocId:@"id123"];
-                rev.body = @{ @"name" : @"mike", @"pet" : @"cat", @"ignored" : @"something" };
+                rev.body =
+                    [@{ @"name" : @"mike",
+                        @"pet" : @"cat",
+                        @"ignored" : @"something" } mutableCopy];
                 CDTDocumentRevision *saved = [ds createDocumentFromRevision:rev error:nil];
                 CDTQSqlParts *parts =
                     [CDTQIndexUpdater partsToIndexRevision:saved
@@ -164,7 +167,10 @@ SpecBegin(CDTQIndexUpdater)
             it(@"still indexes a blank row if no fields", ^{
                 CDTDocumentRevision *rev;
                 rev = [CDTDocumentRevision revisionWithDocId:@"id123"];
-                rev.body = @{ @"name" : @"mike", @"pet" : @"cat", @"ignored" : @"something" };
+                rev.body =
+                    [@{ @"name" : @"mike",
+                        @"pet" : @"cat",
+                        @"ignored" : @"something" } mutableCopy];
                 CDTDocumentRevision *saved = [ds createDocumentFromRevision:rev error:nil];
                 CDTQSqlParts *parts =
                     [CDTQIndexUpdater partsToIndexRevision:saved
@@ -181,7 +187,9 @@ SpecBegin(CDTQIndexUpdater)
                 it(@"indexes a single array field", ^{
                     CDTDocumentRevision *rev;
                     rev = [CDTDocumentRevision revisionWithDocId:@"id123"];
-                    rev.body = @{ @"name" : @"mike", @"pet" : @[ @"cat", @"dog", @"parrot" ] };
+                    rev.body =
+                        [@{ @"name" : @"mike",
+                            @"pet" : @[ @"cat", @"dog", @"parrot" ] } mutableCopy];
                     CDTDocumentRevision *saved = [ds createDocumentFromRevision:rev error:nil];
                     NSArray *statements =
                         [CDTQIndexUpdater partsToIndexRevision:saved
@@ -217,7 +225,9 @@ SpecBegin(CDTQIndexUpdater)
                 it(@"indexes a single array field in subdoc", ^{
                     CDTDocumentRevision *rev;
                     rev = [CDTDocumentRevision revisionWithDocId:@"id123"];
-                    rev.body = @{ @"name" : @"mike", @"pet" : @{@"species" : @[ @"cat", @"dog" ]} };
+                    rev.body =
+                        [@{ @"name" : @"mike",
+                            @"pet" : @{@"species" : @[ @"cat", @"dog" ]} } mutableCopy];
                     CDTDocumentRevision *saved = [ds createDocumentFromRevision:rev error:nil];
                     NSArray *statements =
                         [CDTQIndexUpdater partsToIndexRevision:saved
@@ -248,11 +258,11 @@ SpecBegin(CDTQIndexUpdater)
                 it(@"rejects multiple array fields", ^{
                     CDTDocumentRevision *rev;
                     rev = [CDTDocumentRevision revisionWithDocId:@"id123"];
-                    rev.body = @{
+                    rev.body = [@{
                         @"name" : @"mike",
                         @"pet" : @[ @"cat", @"dog", @"parrot" ],
                         @"pet2" : @[ @"cat", @"dog", @"parrot" ]
-                    };
+                    } mutableCopy];
                     CDTDocumentRevision *saved = [ds createDocumentFromRevision:rev error:nil];
                     NSArray *statements =
                         [CDTQIndexUpdater partsToIndexRevision:saved
@@ -266,7 +276,7 @@ SpecBegin(CDTQIndexUpdater)
                     // Only the "name" field should be included as a result of this test.
                 CDTDocumentRevision *rev;
                 rev = [CDTDocumentRevision revisionWithDocId:@"id123"];
-                    rev.body = @{ @"name" : @"mike", @"pet" : @[] };
+                rev.body = [@{ @"name" : @"mike", @"pet" : @[] } mutableCopy];
                     CDTDocumentRevision *saved = [ds createDocumentFromRevision:rev error:nil];
                     NSArray *statements = [CDTQIndexUpdater partsToIndexRevision:saved
                                                                          inIndex:@"anIndex"
@@ -285,7 +295,7 @@ SpecBegin(CDTQIndexUpdater)
                 it(@"returns correctly for empty array in a subdoc", ^{
                     CDTDocumentRevision *rev;
                     rev = [CDTDocumentRevision revisionWithDocId:@"id123"];
-                    rev.body = @{ @"name" : @"mike", @"pet" : @{@"species" : @[] } };
+                    rev.body = [@{ @"name" : @"mike", @"pet" : @{@"species" : @[]} } mutableCopy];
                     CDTDocumentRevision *saved = [ds createDocumentFromRevision:rev error:nil];
                     NSArray *statements = [CDTQIndexUpdater partsToIndexRevision:saved
                                                                          inIndex:@"anIndex"
@@ -317,27 +327,27 @@ SpecBegin(CDTQIndexUpdater)
                 CDTDocumentRevision *rev;
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike12"];
-                rev.body = @{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" };
+                rev.body = [@{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike23"];
-                rev.body = @{ @"name" : @"mike", @"age" : @23, @"pet" : @"parrot" };
+                rev.body = [@{ @"name" : @"mike", @"age" : @23, @"pet" : @"parrot" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike34"];
-                rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"dog" };
+                rev.body = [@{ @"name" : @"mike", @"age" : @34, @"pet" : @"dog" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"john72"];
-                rev.body = @{ @"name" : @"john", @"age" : @34, @"pet" : @"fish" };
+                rev.body = [@{ @"name" : @"john", @"age" : @34, @"pet" : @"fish" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"fred34"];
-                rev.body = @{ @"name" : @"fred", @"age" : @43, @"pet" : @"snake" };
+                rev.body = [@{ @"name" : @"fred", @"age" : @43, @"pet" : @"snake" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"fred12"];
-                rev.body = @{ @"name" : @"fred", @"age" : @12 };
+                rev.body = [@{ @"name" : @"fred", @"age" : @12 } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 im = [CDTQIndexManager managerUsingDatastore:ds error:nil];
@@ -373,7 +383,7 @@ SpecBegin(CDTQIndexUpdater)
 
                 CDTDocumentRevision *rev;
                 rev = [CDTDocumentRevision revisionWithDocId:@"newdoc"];
-                rev.body = @{ @"name" : @"fred", @"age" : @12 };
+                rev.body = [@{ @"name" : @"fred", @"age" : @12 } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 expect([updater updateAllIndexes:[im listIndexes]]).to.beTruthy();
@@ -416,7 +426,7 @@ SpecBegin(CDTQIndexUpdater)
 
                     CDTDocumentRevision *rev;
                     rev = [CDTDocumentRevision revisionWithDocId:@"newdoc"];
-                    rev.body = @{ @"name" : @"fred", @"age" : @12 };
+                    rev.body = [@{ @"name" : @"fred", @"age" : @12 } mutableCopy];
                     [ds createDocumentFromRevision:rev error:nil];
                     
                     expect([updater updateAllIndexes:[im listIndexes]]).to.beTruthy();

--- a/CDTDatastoreTests/CDTQInvalidQuerySyntax.m
+++ b/CDTDatastoreTests/CDTQInvalidQuerySyntax.m
@@ -60,23 +60,23 @@ SpecBegin(CDTQQueryExecutorInvalidSyntax) describe(@"cloudant query using invali
             CDTDocumentRevision *rev;
 
             rev = [CDTDocumentRevision revisionWithDocId:@"mike12"];
-            rev.body = @{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" };
+            rev.body = [@{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             rev = [CDTDocumentRevision revisionWithDocId:@"mike34"];
-            rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"dog" };
+            rev.body = [@{ @"name" : @"mike", @"age" : @34, @"pet" : @"dog" } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             rev = [CDTDocumentRevision revisionWithDocId:@"mike72"];
-            rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"cat" };
+            rev.body = [@{ @"name" : @"mike", @"age" : @34, @"pet" : @"cat" } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             rev = [CDTDocumentRevision revisionWithDocId:@"fred34"];
-            rev.body = @{ @"name" : @"fred", @"age" : @34, @"pet" : @"cat" };
+            rev.body = [@{ @"name" : @"fred", @"age" : @34, @"pet" : @"cat" } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             rev = [CDTDocumentRevision revisionWithDocId:@"fred12"];
-            rev.body = @{ @"name" : @"fred", @"age" : @12 };
+            rev.body = [@{ @"name" : @"fred", @"age" : @12 } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             im = [CDTQIndexManager managerUsingDatastore:ds error:nil];

--- a/CDTDatastoreTests/CDTQPerformanceTests.m
+++ b/CDTDatastoreTests/CDTQPerformanceTests.m
@@ -63,12 +63,11 @@ SpecBegin(CDTQPerformance)
                 @autoreleasepool {
                     rev = [CDTDocumentRevision
                         revisionWithDocId:[NSString stringWithFormat:@"doc-%d", i]];
-                rev.body = @{
-                    @"name" : @"mike",
-                    @"age" : @34,
-                    @"docNumber" : @(i),
-                    @"pet" : @"cat"
-                };
+                    rev.body =
+                        [@{ @"name" : @"mike",
+                            @"age" : @34,
+                            @"docNumber" : @(i),
+                            @"pet" : @"cat" } mutableCopy];
 
                 if (i < 1000) {
                     [ds1k createDocumentFromRevision:rev error:nil];

--- a/CDTDatastoreTests/CDTQQueryExecutorTests.m
+++ b/CDTDatastoreTests/CDTQQueryExecutorTests.m
@@ -79,23 +79,23 @@ SharedExamplesBegin(QueryExecution)
                 CDTDocumentRevision* rev;
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike12"];
-                rev.body = @{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" };
+                rev.body = [@{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike34"];
-                rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"dog" };
+                rev.body = [@{ @"name" : @"mike", @"age" : @34, @"pet" : @"dog" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike72"];
-                rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"cat" };
+                rev.body = [@{ @"name" : @"mike", @"age" : @34, @"pet" : @"cat" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"fred34"];
-                rev.body = @{ @"name" : @"fred", @"age" : @34, @"pet" : @"cat" };
+                rev.body = [@{ @"name" : @"fred", @"age" : @34, @"pet" : @"cat" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"fred12"];
-                rev.body = @{ @"name" : @"fred", @"age" : @12 };
+                rev.body = [@{ @"name" : @"fred", @"age" : @12 } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 im = [imClass managerUsingDatastore:ds error:nil];
@@ -375,43 +375,43 @@ SharedExamplesBegin(QueryExecution)
                 CDTDocumentRevision* rev = [CDTDocumentRevision revision];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike31"];
-                rev.body = @{ @"name" : @"mike", @"score" : @31 };
+                rev.body = [@{ @"name" : @"mike", @"score" : @31 } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"fred11"];
-                rev.body = @{ @"name" : @"fred", @"score" : @11 };
+                rev.body = [@{ @"name" : @"fred", @"score" : @11 } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"john15"];
-                rev.body = @{ @"name" : @"john", @"score" : @15 };
+                rev.body = [@{ @"name" : @"john", @"score" : @15 } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"john-15"];
-                rev.body = @{ @"name" : @"john", @"score" : @-15 };
+                rev.body = [@{ @"name" : @"john", @"score" : @-15 } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"john15.2"];
-                rev.body = @{ @"name" : @"john", @"score" : @15.2 };
+                rev.body = [@{ @"name" : @"john", @"score" : @15.2 } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"john15.6"];
-                rev.body = @{ @"name" : @"john", @"score" : @15.6 };
+                rev.body = [@{ @"name" : @"john", @"score" : @15.6 } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"john0"];
-                rev.body = @{ @"name" : @"john", @"score" : @0 };
+                rev.body = [@{ @"name" : @"john", @"score" : @0 } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"john0.0"];
-                rev.body = @{ @"name" : @"john", @"score" : @0.0 };
+                rev.body = [@{ @"name" : @"john", @"score" : @0.0 } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"john0.6"];
-                rev.body = @{ @"name" : @"john", @"score" : @0.6 };
+                rev.body = [@{ @"name" : @"john", @"score" : @0.6 } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"john-0.6"];
-                rev.body = @{ @"name" : @"john", @"score" : @-0.6 };
+                rev.body = [@{ @"name" : @"john", @"score" : @-0.6 } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
                 
                 im = [imClass managerUsingDatastore:ds error:nil];
@@ -520,39 +520,39 @@ SharedExamplesBegin(QueryExecution)
                 ;
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike12"];
-                rev.body = @{
+                rev.body = [@{
                     @"name" : @"mike",
                     @"age" : @12,
                     @"pet" : @{@"species" : @"cat", @"name" : @"mike"}
-                };
+                } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike23"];
-                rev.body = @{
+                rev.body = [@{
                     @"name" : @"mike",
                     @"age" : @23,
                     @"pet" : @{@"species" : @"cat", @"name" : @{@"first" : @"mike"}}
-                };
+                } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike34"];
-                rev.body = @{
+                rev.body = [@{
                     @"name" : @"mike",
                     @"age" : @34,
                     @"pet" : @{@"species" : @"cat", @"name" : @"mike"}
-                };
+                } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike72"];
-                rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"cat" };
+                rev.body = [@{ @"name" : @"mike", @"age" : @34, @"pet" : @"cat" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"fred34"];
-                rev.body = @{ @"name" : @"fred", @"age" : @34, @"pet" : @"cat" };
+                rev.body = [@{ @"name" : @"fred", @"age" : @34, @"pet" : @"cat" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"fred12"];
-                rev.body = @{ @"name" : @"fred", @"age" : @12 };
+                rev.body = [@{ @"name" : @"fred", @"age" : @12 } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 im = [imClass managerUsingDatastore:ds error:nil];
@@ -609,31 +609,31 @@ SharedExamplesBegin(QueryExecution)
                 CDTDocumentRevision* rev;
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike12"];
-                rev.body = @{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" };
+                rev.body = [@{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike34"];
-                rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"dog" };
+                rev.body = [@{ @"name" : @"mike", @"age" : @34, @"pet" : @"dog" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike72"];
-                rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"cat" };
+                rev.body = [@{ @"name" : @"mike", @"age" : @34, @"pet" : @"cat" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"اسم34"];
-                rev.body = @{ @"name" : @"اسم", @"age" : @34, @"pet" : @"cat" };
+                rev.body = [@{ @"name" : @"اسم", @"age" : @34, @"pet" : @"cat" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"fred12"];
-                rev.body = @{ @"name" : @"fred", @"age" : @12 };
+                rev.body = [@{ @"name" : @"fred", @"age" : @12 } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"fredarabic"];
-                rev.body = @{ @"اسم" : @"fred", @"age" : @12 };
+                rev.body = [@{ @"اسم" : @"fred", @"age" : @12 } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"freddatatype"];
-                rev.body = @{ @"@datatype" : @"fred", @"age" : @12 };
+                rev.body = [@{ @"@datatype" : @"fred", @"age" : @12 } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 im = [imClass managerUsingDatastore:ds error:nil];
@@ -677,39 +677,39 @@ SharedExamplesBegin(QueryExecution)
                 CDTDocumentRevision* rev;
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike12"];
-                rev.body = @{
+                rev.body = [@{
                     @"name" : @"mike",
                     @"age" : @12,
                     @"pet" : @{@"species" : @"cat", @"name" : @"mike"}
-                };
+                } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike23"];
-                rev.body = @{
+                rev.body = [@{
                     @"name" : @"mike",
                     @"age" : @23,
                     @"pet" : @{@"species" : @"cat", @"name" : @{@"first" : @"mike"}}
-                };
+                } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike34"];
-                rev.body = @{
+                rev.body = [@{
                     @"name" : @"mike",
                     @"age" : @34,
                     @"pet" : @{@"species" : @"cat", @"name" : @"mike"}
-                };
+                } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike72"];
-                rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"cat" };
+                rev.body = [@{ @"name" : @"mike", @"age" : @34, @"pet" : @"cat" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"fred34"];
-                rev.body = @{ @"name" : @"fred", @"age" : @34, @"pet" : @"cat" };
+                rev.body = [@{ @"name" : @"fred", @"age" : @34, @"pet" : @"cat" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"fred12"];
-                rev.body = @{ @"name" : @"fred", @"age" : @12 };
+                rev.body = [@{ @"name" : @"fred", @"age" : @12 } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 im = [imClass managerUsingDatastore:ds error:nil];
@@ -774,27 +774,27 @@ SharedExamplesBegin(QueryExecution)
                 CDTDocumentRevision* rev;
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike12"];
-                rev.body = @{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" };
+                rev.body = [@{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike23"];
-                rev.body = @{ @"name" : @"mike", @"age" : @23, @"pet" : @"parrot" };
+                rev.body = [@{ @"name" : @"mike", @"age" : @23, @"pet" : @"parrot" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike34"];
-                rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"dog" };
+                rev.body = [@{ @"name" : @"mike", @"age" : @34, @"pet" : @"dog" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"john72"];
-                rev.body = @{ @"name" : @"john", @"age" : @34, @"pet" : @"fish" };
+                rev.body = [@{ @"name" : @"john", @"age" : @34, @"pet" : @"fish" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"fred34"];
-                rev.body = @{ @"name" : @"fred", @"age" : @43, @"pet" : @"snake" };
+                rev.body = [@{ @"name" : @"fred", @"age" : @43, @"pet" : @"snake" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"fred12"];
-                rev.body = @{ @"name" : @"fred", @"age" : @12 };
+                rev.body = [@{ @"name" : @"fred", @"age" : @12 } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 im = [imClass managerUsingDatastore:ds error:nil];
@@ -959,11 +959,11 @@ SharedExamplesBegin(QueryExecution)
                 CDTDocumentRevision* rev = [CDTDocumentRevision revision];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike12"];
-                rev.body = @{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" };
+                rev.body = [@{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike23"];
-                rev.body = @{ @"name" : @"mike", @"age" : @23, @"pet" : @"parrot" };
+                rev.body = [@{ @"name" : @"mike", @"age" : @23, @"pet" : @"parrot" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 im = [imClass managerUsingDatastore:ds error:nil];
@@ -1000,11 +1000,11 @@ SharedExamplesBegin(QueryExecution)
                 CDTDocumentRevision* rev = [CDTDocumentRevision revision];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike12"];
-                rev.body = @{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" };
+                rev.body = [@{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike23"];
-                rev.body = @{ @"name" : @"mike", @"age" : @23, @"pet" : @"parrot" };
+                rev.body = [@{ @"name" : @"mike", @"age" : @23, @"pet" : @"parrot" } mutableCopy];
                 CDTDocumentRevision* toRetrieve = [ds createDocumentFromRevision:rev error:nil];
                 docRev = toRetrieve.revId;
 
@@ -1042,23 +1042,23 @@ SharedExamplesBegin(QueryExecution)
                 CDTDocumentRevision* rev;
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike12"];
-                rev.body = @{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" };
+                rev.body = [@{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike34"];
-                rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"dog" };
+                rev.body = [@{ @"name" : @"mike", @"age" : @34, @"pet" : @"dog" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike72"];
-                rev.body = @{ @"name" : @"mike", @"age" : @67, @"pet" : @"cat" };
+                rev.body = [@{ @"name" : @"mike", @"age" : @67, @"pet" : @"cat" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"fred34"];
-                rev.body = @{ @"name" : @"fred", @"age" : @34, @"pet" : @"parrot" };
+                rev.body = [@{ @"name" : @"fred", @"age" : @34, @"pet" : @"parrot" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"fred12"];
-                rev.body = @{ @"name" : @"fred", @"age" : @12 };
+                rev.body = [@{ @"name" : @"fred", @"age" : @12 } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 im = [imClass managerUsingDatastore:ds error:nil];
@@ -1158,29 +1158,36 @@ SharedExamplesBegin(QueryExecution)
                 CDTDocumentRevision* rev = [CDTDocumentRevision revision];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike12"];
-                rev.body = @{ @"name" : @"mike", @"age" : @12, @"pet" : @[ @"cat", @"dog" ] };
+                rev.body =
+                    [@{ @"name" : @"mike",
+                        @"age" : @12,
+                        @"pet" : @[ @"cat", @"dog" ] } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"fred34"];
-                rev.body = @{ @"name" : @"fred", @"age" : @34, @"pet" : @"parrot" };
+                rev.body = [@{ @"name" : @"fred", @"age" : @34, @"pet" : @"parrot" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike34"];
-                rev.body = @{ @"name" : @"mike",
-                              @"age" : @34,
-                              @"pet" : @[ @"cat", @"dog", @"fish" ] };
+                rev.body =
+                    [@{ @"name" : @"mike",
+                        @"age" : @34,
+                        @"pet" : @[ @"cat", @"dog", @"fish" ] } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"fred12"];
-                rev.body = @{ @"name" : @"fred", @"age" : @12 };
+                rev.body = [@{ @"name" : @"fred", @"age" : @12 } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"john44"];
-                rev.body = @{ @"name" : @"john", @"age" : @44, @"pet" : @[ @"hamster", @"snake" ] };
+                rev.body =
+                    [@{ @"name" : @"john",
+                        @"age" : @44,
+                        @"pet" : @[ @"hamster", @"snake" ] } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"john22"];
-                rev.body = @{ @"name" : @"john", @"age" : @22, @"pet" : @"cat" };
+                rev.body = [@{ @"name" : @"john", @"age" : @22, @"pet" : @"cat" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 im = [imClass managerUsingDatastore:ds error:nil];
@@ -1329,23 +1336,23 @@ SharedExamplesBegin(QueryExecution)
                 CDTDocumentRevision* rev;
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike12"];
-                rev.body = @{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" };
+                rev.body = [@{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike34"];
-                rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"dog" };
+                rev.body = [@{ @"name" : @"mike", @"age" : @34, @"pet" : @"dog" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike72"];
-                rev.body = @{ @"name" : @"mike", @"age" : @67, @"pet" : @"cat" };
+                rev.body = [@{ @"name" : @"mike", @"age" : @67, @"pet" : @"cat" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"fred34"];
-                rev.body = @{ @"name" : @"fred", @"age" : @34, @"pet" : @"parrot" };
+                rev.body = [@{ @"name" : @"fred", @"age" : @34, @"pet" : @"parrot" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"fred12"];
-                rev.body = @{ @"name" : @"fred", @"age" : @12 };
+                rev.body = [@{ @"name" : @"fred", @"age" : @12 } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 im = [CDTQIndexManager managerUsingDatastore:ds error:nil];
@@ -1396,29 +1403,36 @@ SharedExamplesBegin(QueryExecution)
                 CDTDocumentRevision* rev;
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike12"];
-                rev.body = @{ @"name" : @"mike", @"age" : @12, @"pet" : @[ @"cat", @"dog" ] };
+                rev.body =
+                    [@{ @"name" : @"mike",
+                        @"age" : @12,
+                        @"pet" : @[ @"cat", @"dog" ] } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"fred34"];
-                rev.body = @{ @"name" : @"fred", @"age" : @34, @"pet" : @"parrot" };
+                rev.body = [@{ @"name" : @"fred", @"age" : @34, @"pet" : @"parrot" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike34"];
-                rev.body = @{ @"name" : @"mike",
-                              @"age" : @34,
-                              @"pet" : @[ @"cat", @"dog", @"fish" ] };
+                rev.body =
+                    [@{ @"name" : @"mike",
+                        @"age" : @34,
+                        @"pet" : @[ @"cat", @"dog", @"fish" ] } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"fred12"];
-                rev.body = @{ @"name" : @"fred", @"age" : @12 };
+                rev.body = [@{ @"name" : @"fred", @"age" : @12 } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"john44"];
-                rev.body = @{ @"name" : @"john", @"age" : @44, @"pet" : @[ @"hamster", @"snake" ] };
+                rev.body =
+                    [@{ @"name" : @"john",
+                        @"age" : @44,
+                        @"pet" : @[ @"hamster", @"snake" ] } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"john22"];
-                rev.body = @{ @"name" : @"john", @"age" : @22, @"pet" : @"cat" };
+                rev.body = [@{ @"name" : @"john", @"age" : @22, @"pet" : @"cat" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
                 
                 im = [imClass managerUsingDatastore:ds error:nil];
@@ -1484,15 +1498,15 @@ SharedExamplesBegin(QueryExecution)
                 CDTDocumentRevision* rev = [CDTDocumentRevision revision];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike12"];
-                rev.body = @{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" };
+                rev.body = [@{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike34"];
-                rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"dog" };
+                rev.body = [@{ @"name" : @"mike", @"age" : @34, @"pet" : @"dog" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"mike72"];
-                rev.body = @{ @"name" : @"mike", @"age" : @67, @"pet" : @"cat" };
+                rev.body = [@{ @"name" : @"mike", @"age" : @67, @"pet" : @"cat" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 im = [CDTQIndexManager managerUsingDatastore:ds error:nil];
@@ -1548,7 +1562,7 @@ SharedExamplesBegin(QueryExecution)
                 [im ensureIndexed:@[ @"large_field" ] withName:@"large"];
 
                 for (int i = 0; i < 100; i++) {
-                    rev.body = @{ @"large_field" : @"cat" };
+                    rev.body = [@{ @"large_field" : @"cat" } mutableCopy];
                     [ds createDocumentFromRevision:rev error:nil];
                 }
 
@@ -1576,7 +1590,7 @@ SharedExamplesBegin(QueryExecution)
                     for (int i = 0; i < 100; i++) {
                         rev = [CDTDocumentRevision
                             revisionWithDocId:[NSString stringWithFormat:@"d%d", i]];
-                        rev.body = @{ @"large_field" : @"cat", @"idx" : @(i) };
+                        rev.body = [@{ @"large_field" : @"cat", @"idx" : @(i) } mutableCopy];
                         [ds createDocumentFromRevision:rev error:nil];
                     }
                     NSDictionary* query = @{ @"large_field" : @"cat" };
@@ -1591,7 +1605,7 @@ SharedExamplesBegin(QueryExecution)
                     for (int i = 0; i < 150; i++) {
                         rev = [CDTDocumentRevision
                             revisionWithDocId:[NSString stringWithFormat:@"d%d", i]];
-                        rev.body = @{ @"large_field" : @"cat", @"idx" : @(i) };
+                        rev.body = [@{ @"large_field" : @"cat", @"idx" : @(i) } mutableCopy];
                         [ds createDocumentFromRevision:rev error:nil];
                     }
 
@@ -1684,23 +1698,27 @@ sharedExamplesFor(@"queries without covering indexes", ^(NSDictionary* data) {
             CDTDocumentRevision* rev;
 
             rev = [CDTDocumentRevision revisionWithDocId:@"mike12"];
-            rev.body = @{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" };
+            rev.body = [@{ @"name" : @"mike", @"age" : @12, @"pet" : @"cat" } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             rev = [CDTDocumentRevision revisionWithDocId:@"mike34"];
-            rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"dog" };
+            rev.body = [@{ @"name" : @"mike", @"age" : @34, @"pet" : @"dog" } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             rev = [CDTDocumentRevision revisionWithDocId:@"mike72"];
-            rev.body = @{ @"name" : @"mike", @"age" : @34, @"pet" : @"cat", @"town" : @"bristol" };
+            rev.body =
+                [@{ @"name" : @"mike",
+                    @"age" : @34,
+                    @"pet" : @"cat",
+                    @"town" : @"bristol" } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             rev = [CDTDocumentRevision revisionWithDocId:@"fred34"];
-            rev.body = @{ @"name" : @"fred", @"age" : @34, @"pet" : @"cat" };
+            rev.body = [@{ @"name" : @"fred", @"age" : @34, @"pet" : @"cat" } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             rev = [CDTDocumentRevision revisionWithDocId:@"fred12"];
-            rev.body = @{ @"name" : @"fred", @"age" : @12, @"town" : @"bristol" };
+            rev.body = [@{ @"name" : @"fred", @"age" : @12, @"town" : @"bristol" } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             im = [imClass managerUsingDatastore:ds error:nil];
@@ -1791,35 +1809,44 @@ sharedExamplesFor(@"queries without covering indexes", ^(NSDictionary* data) {
             CDTDocumentRevision* rev = [CDTDocumentRevision revision];
 
             rev = [CDTDocumentRevision revisionWithDocId:@"mike24"];
-            rev.body = @{ @"name" : @"mike", @"age" : @24, @"pet" : @[ @"cat" ] };
+            rev.body = [@{ @"name" : @"mike", @"age" : @24, @"pet" : @[ @"cat" ] } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             rev = [CDTDocumentRevision revisionWithDocId:@"mike12"];
-            rev.body = @{ @"name" : @"mike", @"age" : @12, @"pet" : @[ @"cat", @"dog" ] };
+            rev.body =
+                [@{ @"name" : @"mike",
+                    @"age" : @12,
+                    @"pet" : @[ @"cat", @"dog" ] } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             rev = [CDTDocumentRevision revisionWithDocId:@"fred34"];
-            rev.body = @{ @"name" : @"fred", @"age" : @34, @"pet" : @[ @"cat", @"dog" ] };
+            rev.body =
+                [@{ @"name" : @"fred",
+                    @"age" : @34,
+                    @"pet" : @[ @"cat", @"dog" ] } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             rev = [CDTDocumentRevision revisionWithDocId:@"john44"];
-            rev.body = @{ @"name" : @"john", @"age" : @44, @"pet" : @"cat" };
+            rev.body = [@{ @"name" : @"john", @"age" : @44, @"pet" : @"cat" } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             rev = [CDTDocumentRevision revisionWithDocId:@"fred72"];
-            rev.body = @{ @"name" : @"fred", @"age" : @72, @"pet" : @[ @"dog" ] };
+            rev.body = [@{ @"name" : @"fred", @"age" : @72, @"pet" : @[ @"dog" ] } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             rev = [CDTDocumentRevision revisionWithDocId:@"john12"];
-            rev.body = @{ @"name" : @"john", @"age" : @12 };
+            rev.body = [@{ @"name" : @"john", @"age" : @12 } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             rev = [CDTDocumentRevision revisionWithDocId:@"bill34"];
-            rev.body = @{ @"name" : @"bill", @"age" : @34, @"pet" : @[ @"cat", @"parrot" ] };
+            rev.body =
+                [@{ @"name" : @"bill",
+                    @"age" : @34,
+                    @"pet" : @[ @"cat", @"parrot" ] } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             rev = [CDTDocumentRevision revisionWithDocId:@"fred11"];
-            rev.body = @{ @"name" : @"fred", @"age" : @11, @"pet" : @[]};
+            rev.body = [@{ @"name" : @"fred", @"age" : @11, @"pet" : @[] } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
             
             im = [imClass managerUsingDatastore:ds error:nil];

--- a/CDTDatastoreTests/CDTQQuerySortTests.m
+++ b/CDTDatastoreTests/CDTQQuerySortTests.m
@@ -63,25 +63,28 @@ SpecBegin(CDTQQueryExecutorSorting)
 
                 CDTDocumentRevision *rev = [CDTDocumentRevision revisionWithDocId:@"mike12"];
 
-                rev.body = @{
+                rev.body = [@{
                     @"name" : @"mike",
                     @"age" : @12,
                     @"pet" : @[ @"cat", @"dog" ],
                     @"same" : @"all"
-                };
+                } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"fred34"];
-                rev.body = @{
-                    @"name" : @"fred",
-                    @"age" : @34,
-                    @"pet" : @"parrot",
-                    @"same" : @"all"
-                };
+                rev.body =
+                    [@{ @"name" : @"fred",
+                        @"age" : @34,
+                        @"pet" : @"parrot",
+                        @"same" : @"all" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 rev = [CDTDocumentRevision revisionWithDocId:@"fred11"];
-                rev.body = @{ @"name" : @"fred", @"age" : @11, @"pet" : @"fish", @"same" : @"all" };
+                rev.body =
+                    [@{ @"name" : @"fred",
+                        @"age" : @11,
+                        @"pet" : @"fish",
+                        @"same" : @"all" } mutableCopy];
                 [ds createDocumentFromRevision:rev error:nil];
 
                 im = [CDTQIndexManager managerUsingDatastore:ds error:nil];

--- a/CDTDatastoreTests/CDTQTextSearchTests.m
+++ b/CDTDatastoreTests/CDTQTextSearchTests.m
@@ -65,48 +65,59 @@ SpecBegin(CDTQQueryExecutorTextSearch) describe(@"cdtq", ^{
             CDTDocumentRevision *rev;
 
             rev = [CDTDocumentRevision revisionWithDocId:@"mike12"];
-            rev.body = @{ @"name" : @"mike",
-                          @"age" : @12,
-                          @"pet" : @"cat",
-                          @"comment" : @"He lives in Bristol, UK and his best friend is Fred."};
+            rev.body = [@{
+                @"name" : @"mike",
+                @"age" : @12,
+                @"pet" : @"cat",
+                @"comment" : @"He lives in Bristol, UK and his best friend is Fred."
+            } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             rev = [CDTDocumentRevision revisionWithDocId:@"mike34"];
-            rev.body = @{ @"name" : @"mike",
-                          @"age" : @34,
-                          @"pet" : @"dog",
-                          @"comment" : @"He lives in a van down by the river in Bristol."};
+            rev.body = [@{
+                @"name" : @"mike",
+                @"age" : @34,
+                @"pet" : @"dog",
+                @"comment" : @"He lives in a van down by the river in Bristol."
+            } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             rev = [CDTDocumentRevision revisionWithDocId:@"mike72"];
-            rev.body = @{ @"name" : @"mike",
-                          @"age" : @72,
-                          @"pet" : @"cat",
-                          @"comment" : @"He's retired and has memories of spending time "
-                                       @"with his cat Remus."};
+            rev.body = [@{
+                @"name" : @"mike",
+                @"age" : @72,
+                @"pet" : @"cat",
+                @"comment" : @"He's retired and has memories of spending time "
+                             @"with his cat Remus."
+            } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             rev = [CDTDocumentRevision revisionWithDocId:@"fred34"];
-            rev.body = @{ @"name" : @"fred",
-                          @"age" : @34,
-                          @"pet" : @"cat",
-                          @"comment" : @"He lives next door to Mike and his cat Romulus "
-                                       @"is brother to Remus."};
+            rev.body = [@{
+                @"name" : @"fred",
+                @"age" : @34,
+                @"pet" : @"cat",
+                @"comment" : @"He lives next door to Mike and his cat Romulus "
+                             @"is brother to Remus."
+            } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             rev = [CDTDocumentRevision revisionWithDocId:@"fred12"];
-            rev.body = @{ @"name" : @"fred",
-                          @"age" : @12,
-                          @"pet" : @"cat",
-                          @"comment" : @"He lives in Bristol, UK and his best friend is Mike."};
+            rev.body = [@{
+                @"name" : @"fred",
+                @"age" : @12,
+                @"pet" : @"cat",
+                @"comment" : @"He lives in Bristol, UK and his best friend is Mike."
+            } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
 
             rev = [CDTDocumentRevision revisionWithDocId:@"john34"];
-            rev.body =
-                @{ @"name" : @"john",
-                   @"age" : @34,
-                   @"pet" : @"cat",
-                   @"comment" : @"وهو يعيش في بريستول، المملكة المتحدة، وأفضل صديق له هو مايك."};
+            rev.body = [@{
+                @"name" : @"john",
+                @"age" : @34,
+                @"pet" : @"cat",
+                @"comment" : @"وهو يعيش في بريستول، المملكة المتحدة، وأفضل صديق له هو مايك."
+            } mutableCopy];
             [ds createDocumentFromRevision:rev error:nil];
             
             im = [CDTQIndexManager managerUsingDatastore:ds error:nil];

--- a/CDTDatastoreTests/DatastoreActions.m
+++ b/CDTDatastoreTests/DatastoreActions.m
@@ -98,11 +98,11 @@
     NSError *error;
     CDTDatastore *datastore = [self.factory datastoreNamed:@"test_database" error:&error];
     CDTDocumentRevision *rev = [CDTDocumentRevision revisionWithDocId:@"myDocId"];
-    rev.body = @{ @"hello" : @"world" };
-    
+    rev.body = [@{ @"hello" : @"world" } mutableCopy];
+
     CDTDocumentRevision *revision = [datastore createDocumentFromRevision:rev error:&error];
     rev = [revision copy];
-    rev.body = @{ @"hello" : @"world", @"test" : @"testy" };
+    rev.body = [@{ @"hello" : @"world", @"test" : @"testy" } mutableCopy];
     revision = [datastore updateDocumentFromRevision:rev error:&error];
     
     XCTAssertTrue([datastore compactWithError:&error],@"Compaction failed");

--- a/CDTDatastoreTests/DatastoreCRUD.m
+++ b/CDTDatastoreTests/DatastoreCRUD.m
@@ -87,8 +87,8 @@
 {
     NSError * error;
     CDTDocumentRevision *revision = [CDTDocumentRevision revision];
-    revision.body = @{@"infinity":@(INFINITY)};
-    
+    revision.body = [@{ @"infinity" : @(INFINITY) } mutableCopy];
+
     CDTDocumentRevision * rev = [self.datastore createDocumentFromRevision:revision
                                                                      error:&error];
     
@@ -103,8 +103,8 @@
 -(void) testDocumentWithNonSerialisableValue {
     NSError * error;
     CDTDocumentRevision *revision = [CDTDocumentRevision revision];
-    revision.body = @{@"nonserialisable":[NSDate date]};
-    
+    revision.body = [@{ @"nonserialisable" : [NSDate date] } mutableCopy];
+
     CDTDocumentRevision * rev = [self.datastore createDocumentFromRevision:revision
                                                                      error:&error];
     
@@ -1860,8 +1860,8 @@
     NSError * error;
     CDTDocumentRevision *mutableRev;
     mutableRev = [CDTDocumentRevision revisionWithDocId:@"aTestDocId"];
-    mutableRev.body = @{@"hello":@"world"};
-    
+    mutableRev.body = [@{ @"hello" : @"world" } mutableCopy];
+
     CDTDocumentRevision * rev = [self.datastore createDocumentFromRevision:mutableRev error:&error];
     
     XCTAssertNotNil(rev, @"Document was not created");

--- a/CDTDatastoreTests/DatastoreConflicts.m
+++ b/CDTDatastoreTests/DatastoreConflicts.m
@@ -27,7 +27,6 @@
 #import "CDTConflictResolver.h"
 #import "CDTHelperOneUseKeyProvider.h"
 
-#import "FMDatabaseAdditions.h"
 #import "FMDatabaseQueue.h"
 #import "TDJSON.h"
 #import "FMResultSet.h"
@@ -97,7 +96,7 @@
     
     NSError *error;
     CDTDocumentRevision *mutableRevision = [CDTDocumentRevision revisionWithDocId:anId];
-    mutableRevision.body = @{ @"foo1.a" : @"bar1.a" };
+    mutableRevision.body = [@{ @"foo1.a" : @"bar1.a" } mutableCopy];
     CDTDocumentRevision *rev1;
     rev1 = [datastore createDocumentFromRevision:mutableRevision error:&error];
     
@@ -113,20 +112,20 @@
                                                                               name:@"bonsai-boston"
                                                                               type:@"image/jpg"];
         mutableRevision = [rev1 copy];
-        mutableRevision.attachments = @{attachment.name:attachment};
-        mutableRevision.body = @{@"foo2.a":@"bar2.a"};
+        mutableRevision.attachments = [@{ attachment.name : attachment } mutableCopy];
+        mutableRevision.body = [@{ @"foo2.a" : @"bar2.a" } mutableCopy];
         rev2a = [self.datastore updateDocumentFromRevision:mutableRevision error:&error];
         
     }
     else{
         mutableRevision = [rev1 copy];
-        mutableRevision.body = @{@"foo2.a":@"bar2.a"};
+        mutableRevision.body = [@{ @"foo2.a" : @"bar2.a" } mutableCopy];
         rev2a = [datastore updateDocumentFromRevision:mutableRevision error:&error];
     }
     
     error = nil;
     mutableRevision = [rev2a copy];
-    mutableRevision.body = @{@"foo3.a":@"bar3.a"};
+    mutableRevision.body = [@{ @"foo3.a" : @"bar3.a" } mutableCopy];
     [datastore updateDocumentFromRevision:mutableRevision error:&error];
     
     error = nil;
@@ -208,8 +207,8 @@
 {
     NSError *error;
     CDTDocumentRevision *mutableRev = [CDTDocumentRevision revision];
-    mutableRev.body = body;
-    
+    mutableRev.body = [body mutableCopy];
+
     CDTDocumentRevision *rev = [self.datastore createDocumentFromRevision:mutableRev error:&error];
     
     XCTAssertNil(error, @"Error creating document");

--- a/CDTDatastoreTests/Events/CDTDatastoreEvents.m
+++ b/CDTDatastoreTests/Events/CDTDatastoreEvents.m
@@ -89,8 +89,8 @@
 - (void)testEventFiredOnCreate
 {
     CDTDocumentRevision *rev = [CDTDocumentRevision revision];
-    rev.body = @{@"hello": @"world"};
-    
+    rev.body = [@{ @"hello" : @"world" } mutableCopy];
+
     XCTAssertNotNil([self.datastore createDocumentFromRevision:rev error:nil],
                    @"Document wasn't created");
     
@@ -104,7 +104,7 @@
 - (void)testEventFiredOnUpdate
 {
     CDTDocumentRevision *mutableRev = [CDTDocumentRevision revision];
-    mutableRev.body = @{@"hello": @"world"};
+    mutableRev.body = [@{ @"hello" : @"world" } mutableCopy];
     CDTDocumentRevision *rev1 = [self.datastore createDocumentFromRevision:mutableRev error:nil];
     
     XCTAssertNotNil(rev1, @"Document wasn't created");
@@ -116,7 +116,7 @@
     XCTAssertEqual(self.otherWatcher.counter, (NSInteger)0, @"Event incorrectly fired");
 
     mutableRev = [rev1 copy];
-    mutableRev.body = @{@"hello2": @"world2"};
+    mutableRev.body = [@{ @"hello2" : @"world2" } mutableCopy];
     XCTAssertNotNil([self.datastore updateDocumentFromRevision:mutableRev error:nil],
                    @"Document wasn't updated");
     
@@ -128,7 +128,7 @@
 - (void)testEventFiredOnDelete
 {
     CDTDocumentRevision *mutableRev = [CDTDocumentRevision revision];
-    mutableRev.body = @{@"hello": @"world"};
+    mutableRev.body = [@{ @"hello" : @"world" } mutableCopy];
     CDTDocumentRevision *rev1 = [self.datastore createDocumentFromRevision:mutableRev error:nil];
     
     XCTAssertNotNil(rev1, @"Document wasn't created");
@@ -151,7 +151,7 @@
 {
     NSError * error;
     CDTDocumentRevision *rev = [CDTDocumentRevision revisionWithDocId:@"aTestDocId"];
-    rev.body = @{ @"hello" : @"world" };
+    rev.body = [@{ @"hello" : @"world" } mutableCopy];
 
     rev = [self.datastore createDocumentFromRevision:rev error:&error];
 


### PR DESCRIPTION
## What
Fix Xcode warnings for "Semantic Issue".

## Why
Having many "Semantic Issue" warnings means there could potentially be important semantic issues that we are warned about but go unnoticed.

## How
All the warnings of type "Semantic Issue" have been rectified so they're no longer generating warnings.

## Testing
No additional tests required.

## Reviewers
reviewer: @rhyshort 
