### PR TITLE
Experiment with global semaphore

### DIFF
--- a/CDTDatastore/HTTP/CDTURLSession.h
+++ b/CDTDatastore/HTTP/CDTURLSession.h
@@ -26,7 +26,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface CDTURLSession : NSObject <NSURLSessionDataDelegate>
+@interface CDTURLSession : NSObject <NSURLSessionDataDelegate, NSURLSessionTaskDelegate>
 
 /**
  * Initalises a CDTURLSession without a delegate and an empty array of interceptors. Calling this 

--- a/CDTDatastore/HTTP/CDTURLSessionTask.m
+++ b/CDTDatastore/HTTP/CDTURLSessionTask.m
@@ -210,20 +210,18 @@
                                 withObject:self.requestError
                              waitUntilDone:NO];
         } else {
-            [self performSelector:@selector(callDelegateWithResponseAndData)
-                         onThread:thread
-                       withObject:nil
-                    waitUntilDone:NO];
+            [self.delegate performSelector:@selector(receivedResponse:)
+                                  onThread:thread
+                                withObject:self.response
+                             waitUntilDone:NO];
+            [self.delegate performSelector:@selector(receivedData:)
+                                  onThread:thread
+                                withObject:self.requestData
+                             waitUntilDone:NO];
         }
         self.finished = YES;
     }
 
-}
-
-- (void)callDelegateWithResponseAndData
-{
-    [self.delegate receivedResponse:self.response];
-    [self.delegate receivedData:self.requestData];
 }
 
 @end


### PR DESCRIPTION
_What_: Use a global semaphore to limit number of simultaneous `NSURLRequest`s

_Why_: #248 introduced a semaphore on a per `CDTURLSession` basis, but some `ReplicationAcceptance` tests were still failing. On closer analysis, the failing tests were those which run multiple simultaneous replications. This defeats the purpose of the semaphore because the code now makes `n*limit` simultaneous networks requests where `n` is the number of simultaneous replications.

_Testing_:
- Existing tests pass
- Added test `testSemaphoreCountsCorrectly` to ensure that the semaphore state is correctly maintained when a large number of requests are made and half of them are cancelled. (If the semaphore counted incorrectly it could cause requests to hang incorrectly or for too many simultaneous requests to be made).

reviewer: @rhyshort 
reviewer: @brynh 