### PR TITLE
Warnings fix

### DIFF
--- a/CDTDatastore.xcodeproj/project.pbxproj
+++ b/CDTDatastore.xcodeproj/project.pbxproj
@@ -1182,40 +1182,12 @@
 /* End PBXBuildRule section */
 
 /* Begin PBXContainerItemProxy section */
-		9873857D1C47BB5D00937212 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 98F77B2D1C43FC9F00515CC3 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 987383011C47B38800937212;
-			remoteInfo = CDTDatastoreOSX;
-		};
-		9873857F1C47BB6400937212 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 98F77B2D1C43FC9F00515CC3 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 987383EF1C47B3C400937212;
-			remoteInfo = CDTDatastoreEncryptionOSX;
-		};
-		987385961C47EE0200937212 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 98F77B2D1C43FC9F00515CC3 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 98F785D21C456B1300515CC3;
-			remoteInfo = CDTDatastoreEncryption;
-		};
 		9873859A1C47F62500937212 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 98F77B2D1C43FC9F00515CC3 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 98F77B351C43FC9F00515CC3;
 			remoteInfo = CDTDatastore;
-		};
-		987385BA1C47F63900937212 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 98F77B2D1C43FC9F00515CC3 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 987383011C47B38800937212;
-			remoteInfo = CDTDatastoreOSX;
 		};
 		98F77B421C43FC9F00515CC3 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -3094,7 +3066,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				987385801C47BB6400937212 /* PBXTargetDependency */,
 			);
 			name = CDTDatastoreEncryptionTestsOSX;
 			productName = CDTDatastoreEncryptionTests;
@@ -3116,7 +3087,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				9873857E1C47BB5D00937212 /* PBXTargetDependency */,
 			);
 			name = CDTDatastoreReplicationAcceptanceTestsOSX;
 			productName = CDTDatastoreReplicationAcceptanceTests;
@@ -3180,7 +3150,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				987385B91C47F63900937212 /* PBXTargetDependency */,
 			);
 			name = CDTDatastoreEncryptedReplicationAcceptanceTestsOSX;
 			productName = CDTDatastoreReplicationAcceptanceTests;
@@ -3266,7 +3235,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				987385971C47EE0200937212 /* PBXTargetDependency */,
 			);
 			name = CDTDatastoreEncryptionTests;
 			productName = CDTDatastoreEncryptionTests;
@@ -3299,7 +3267,7 @@
 		98F77B2D1C43FC9F00515CC3 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0720;
+				LastUpgradeCheck = 0730;
 				ORGANIZATIONNAME = IBM;
 				TargetAttributes = {
 					98F77B351C43FC9F00515CC3 = {
@@ -4696,30 +4664,10 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		9873857E1C47BB5D00937212 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 987383011C47B38800937212 /* CDTDatastoreOSX */;
-			targetProxy = 9873857D1C47BB5D00937212 /* PBXContainerItemProxy */;
-		};
-		987385801C47BB6400937212 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 987383EF1C47B3C400937212 /* CDTDatastoreEncryptionOSX */;
-			targetProxy = 9873857F1C47BB6400937212 /* PBXContainerItemProxy */;
-		};
-		987385971C47EE0200937212 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 98F785D21C456B1300515CC3 /* CDTDatastoreEncryption */;
-			targetProxy = 987385961C47EE0200937212 /* PBXContainerItemProxy */;
-		};
 		987385991C47F62500937212 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 98F77B351C43FC9F00515CC3 /* CDTDatastore */;
 			targetProxy = 9873859A1C47F62500937212 /* PBXContainerItemProxy */;
-		};
-		987385B91C47F63900937212 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 987383011C47B38800937212 /* CDTDatastoreOSX */;
-			targetProxy = 987385BA1C47F63900937212 /* PBXContainerItemProxy */;
 		};
 		98F77B431C43FC9F00515CC3 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -4757,8 +4705,8 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = BC7093DFD397FCFAE59C4821 /* Pods-CDTDatastoreOSX.debug.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
+				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -4778,8 +4726,8 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 47D10054F235C27FE5C1F8AE /* Pods-CDTDatastoreOSX.release.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
+				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -4799,8 +4747,8 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = EF6A12738FBB7654A4281965 /* Pods-CDTDatastoreEncryptionOSX.debug.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
+				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -4821,8 +4769,8 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 79D67CFD887438B4449E25C5 /* Pods-CDTDatastoreEncryptionOSX.release.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
+				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -4842,8 +4790,8 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = BFAF32A65C2FFA689AE448B6 /* Pods-CDTDatastoreEncryptionTestsOSX.debug.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
+				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = CDTDatastoreEncryptionTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks @loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
@@ -4857,8 +4805,8 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 865DF77B87F77B54AA3C53E0 /* Pods-CDTDatastoreEncryptionTestsOSX.release.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
+				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = CDTDatastoreEncryptionTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks @loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
@@ -4872,7 +4820,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = C966C1819F047772D89D8C4D /* Pods-CDTDatastoreReplicationAcceptanceTestsOSX.debug.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
+				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = CDTDatastoreReplicationAcceptanceTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks @loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
@@ -4886,7 +4834,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 2E5476EA72C94B51A626BE21 /* Pods-CDTDatastoreReplicationAcceptanceTestsOSX.release.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
+				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = CDTDatastoreReplicationAcceptanceTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks @loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
@@ -4900,7 +4848,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = DC8CE6EF9EDE2B0118CD09F7 /* Pods-CDTDatastoreTestsOSX.debug.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
+				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = CDTDatastoreTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks @executable_path/../Frameworks @loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
@@ -4914,7 +4862,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = B3E4A1E21382536128103DE8 /* Pods-CDTDatastoreTestsOSX.release.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
+				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = CDTDatastoreTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks @executable_path/../Frameworks @loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
@@ -4928,6 +4876,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 92EF171B6751664EF6E94197 /* Pods-CDTDatastoreEncryptedReplicationAcceptanceTests.debug.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = NO;
 				INFOPLIST_FILE = CDTDatastoreReplicationAcceptanceTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.cloudant.CDTDatastoreReplicationAcceptanceTests;
@@ -4939,6 +4888,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 73EC9650A63363E9B13CAFB8 /* Pods-CDTDatastoreEncryptedReplicationAcceptanceTests.release.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = NO;
 				INFOPLIST_FILE = CDTDatastoreReplicationAcceptanceTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.cloudant.CDTDatastoreReplicationAcceptanceTests;
@@ -4950,7 +4900,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 76C739592E027E636BEB950E /* Pods-CDTDatastoreEncryptedReplicationAcceptanceTestsOSX.debug.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
+				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = CDTDatastoreReplicationAcceptanceTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks @loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
@@ -4964,7 +4914,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 5738A8EE4C978050FC1818DD /* Pods-CDTDatastoreEncryptedReplicationAcceptanceTestsOSX.release.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
+				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = CDTDatastoreReplicationAcceptanceTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks @loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
@@ -5102,6 +5052,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 986E886E041283B45ECF9B5A /* Pods-CDTDatastoreTests.debug.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = NO;
 				INFOPLIST_FILE = CDTDatastoreTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.cloudant.CDTDatastoreTests;
@@ -5113,6 +5064,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = E3EF68CCCD8A5406B1B865A0 /* Pods-CDTDatastoreTests.release.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = NO;
 				INFOPLIST_FILE = CDTDatastoreTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.cloudant.CDTDatastoreTests;
@@ -5124,6 +5076,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 7751531C9D386AC3DB8C2E7E /* Pods-CDTDatastoreReplicationAcceptanceTests.debug.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = NO;
 				INFOPLIST_FILE = CDTDatastoreReplicationAcceptanceTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.cloudant.CDTDatastoreReplicationAcceptanceTests;
@@ -5135,6 +5088,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 1B4BA67944461CF1FCA4EE43 /* Pods-CDTDatastoreReplicationAcceptanceTests.release.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = NO;
 				INFOPLIST_FILE = CDTDatastoreReplicationAcceptanceTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.cloudant.CDTDatastoreReplicationAcceptanceTests;

--- a/CDTDatastore.xcodeproj/xcshareddata/xcschemes/CDTDatastore.xcscheme
+++ b/CDTDatastore.xcodeproj/xcshareddata/xcschemes/CDTDatastore.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0730"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/CDTDatastore.xcodeproj/xcshareddata/xcschemes/CDTDatastoreEncryptedReplicationAcceptanceTests.xcscheme
+++ b/CDTDatastore.xcodeproj/xcshareddata/xcschemes/CDTDatastoreEncryptedReplicationAcceptanceTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0730"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/CDTDatastore.xcodeproj/xcshareddata/xcschemes/CDTDatastoreEncryptedReplicationAcceptanceTestsOSX.xcscheme
+++ b/CDTDatastore.xcodeproj/xcshareddata/xcschemes/CDTDatastoreEncryptedReplicationAcceptanceTestsOSX.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0730"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/CDTDatastore.xcodeproj/xcshareddata/xcschemes/CDTDatastoreEncryption.xcscheme
+++ b/CDTDatastore.xcodeproj/xcshareddata/xcschemes/CDTDatastoreEncryption.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0730"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/CDTDatastore.xcodeproj/xcshareddata/xcschemes/CDTDatastoreEncryptionOSX.xcscheme
+++ b/CDTDatastore.xcodeproj/xcshareddata/xcschemes/CDTDatastoreEncryptionOSX.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0730"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/CDTDatastore.xcodeproj/xcshareddata/xcschemes/CDTDatastoreEncryptionTests.xcscheme
+++ b/CDTDatastore.xcodeproj/xcshareddata/xcschemes/CDTDatastoreEncryptionTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0730"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/CDTDatastore.xcodeproj/xcshareddata/xcschemes/CDTDatastoreEncryptionTestsOSX.xcscheme
+++ b/CDTDatastore.xcodeproj/xcshareddata/xcschemes/CDTDatastoreEncryptionTestsOSX.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0730"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/CDTDatastore.xcodeproj/xcshareddata/xcschemes/CDTDatastoreOSX.xcscheme
+++ b/CDTDatastore.xcodeproj/xcshareddata/xcschemes/CDTDatastoreOSX.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0730"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/CDTDatastore.xcodeproj/xcshareddata/xcschemes/CDTDatastoreReplicationAcceptanceTests.xcscheme
+++ b/CDTDatastore.xcodeproj/xcshareddata/xcschemes/CDTDatastoreReplicationAcceptanceTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0730"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/CDTDatastore.xcodeproj/xcshareddata/xcschemes/CDTDatastoreReplicationAcceptanceTestsOSX.xcscheme
+++ b/CDTDatastore.xcodeproj/xcshareddata/xcschemes/CDTDatastoreReplicationAcceptanceTestsOSX.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0730"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/CDTDatastore.xcodeproj/xcshareddata/xcschemes/CDTDatastoreTests.xcscheme
+++ b/CDTDatastore.xcodeproj/xcshareddata/xcschemes/CDTDatastoreTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0730"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/CDTDatastore.xcodeproj/xcshareddata/xcschemes/CDTDatastoreTestsOSX.xcscheme
+++ b/CDTDatastore.xcodeproj/xcshareddata/xcschemes/CDTDatastoreTestsOSX.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0730"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/CDTDatastore/CDTDatastore+Conflicts.m
+++ b/CDTDatastore/CDTDatastore+Conflicts.m
@@ -14,10 +14,10 @@
 //  and limitations under the License.
 
 #import "CDTDatastore+Conflicts.h"
-#import "CDTDatastore+Internal.h"
 #import "TD_Database+Attachments.h"
 #import "CDTDocumentRevision.h"
 #import "CDTDatastore+Attachments.h"
+#import "CDTDatastore+Internal.h"
 #import "CDTAttachment.h"
 #import "TD_Revision.h"
 #import "TD_Database+Conflicts.h"

--- a/CDTDatastore/CDTFetchChanges.m
+++ b/CDTDatastore/CDTFetchChanges.m
@@ -15,10 +15,10 @@
 
 #import "CDTFetchChanges.h"
 
-#import "CDTDatastore.h"
 #import "CDTDocumentRevision.h"
 
 #import "TD_Database.h"
+#import "CDTDatastore.h"
 
 #define CDTFETCHCHANGES_DEFAULT_OPTION_LIMIT 500
 

--- a/CDTDatastore/query/CDTQIndex.h
+++ b/CDTDatastore/query/CDTQIndex.h
@@ -110,7 +110,8 @@ extern NSString *const kCDTQTextType __deprecated;
  * @param indexSettings the indexSettings to compare to as an NSString
  * @return YES/NO - whether there is a match
  */
-- (BOOL)compareToIndexType:(CDTQIndexType)indexType withIndexSettings:(NSString *)indexSettings;
+- (BOOL)compareToIndexType:(CDTQIndexType)indexType
+         withIndexSettings:(nullable NSString *)indexSettings;
 
 /**
  * Converts the index settings to a JSON string

--- a/CDTDatastore/query/CDTQIndexCreator.m
+++ b/CDTDatastore/query/CDTQIndexCreator.m
@@ -66,8 +66,11 @@
     if (!index) {
         return nil;
     }
-    
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     if ([index.indexType.lowercaseString isEqualToString:@"text"]) {
+#pragma clang diagnostic pop
         if (![CDTQIndexManager ftsAvailableInDatabase:self.database]) {
             CDTLogError(CDTQ_LOG_CONTEXT, @"Text search not supported.  To add support for text "
                                           @"search, enable FTS compile options in SQLite.");
@@ -120,8 +123,11 @@
         NSSet *existingFields = [NSSet setWithArray:existingIndex[@"fields"]];
         NSSet *newFields = [NSSet setWithArray:fieldNames];
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         if ([existingFields isEqualToSet:newFields] &&
             [index compareIndexTypeTo:existingType withIndexSettings:existingSettings]) {
+#pragma clang diagnostic pop
             BOOL success = [CDTQIndexUpdater updateIndex:index.indexName
                                               withFields:fieldNames
                                               inDatabase:_database
@@ -138,11 +144,14 @@
     [_database inTransaction:^(FMDatabase *db, BOOL *rollback) {
 
         // Insert metadata table entries
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         NSArray *inserts = [CDTQIndexCreator
                             insertMetadataStatementsForIndexName:index.indexName
                                                             type:index.indexType
                                                         settings:index.settingsAsJSON
                                                       fieldNames:fieldNames];
+#pragma clang diagnostic pop
         for (CDTQSqlParts *sql in inserts) {
             success = success && [db executeUpdate:sql.sqlWithPlaceholders
                                      withArgumentsInArray:sql.placeholderValues];
@@ -151,7 +160,10 @@
         // Create SQLite data structures to support the index
         // For JSON index type create a SQLite table and a SQLite index
         // For TEXT index type create a SQLite virtual table
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         if ([index.indexType.lowercaseString isEqualToString:kCDTQTextType]) {
+#pragma clang diagnostic pop
             // Create the virtual table for the TEXT index
             CDTQSqlParts *createVirtualTable =
             [CDTQIndexCreator createVirtualTableStatementForIndexName:index.indexName
@@ -246,12 +258,18 @@
  */
 + (BOOL) indexLimitReached:(CDTQIndex *)index basedOnIndexes:(NSDictionary *)existingIndexes
 {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     if ([index.indexType.lowercaseString isEqualToString:kCDTQTextType]) {
+#pragma clang diagnostic pop
         for (NSString *name in existingIndexes.allKeys) {
             NSDictionary *existingIndex = existingIndexes[name];
             NSString *type = existingIndex[@"type"];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             if ([type.lowercaseString isEqualToString:kCDTQTextType] &&
                 ![name.lowercaseString isEqualToString:index.indexName.lowercaseString]) {
+#pragma clang diagnostic pop
                 CDTLogError(CDTQ_LOG_CONTEXT, @"The text index %@ already exists.  "
                                                "One text index per datastore permitted.  "
                                                "Delete %@ and recreate %@",

--- a/CDTDatastore/touchdb/TDMisc.m
+++ b/CDTDatastore/touchdb/TDMisc.m
@@ -119,14 +119,10 @@ NSString* TDEscapeID(NSString* docOrRevID)
     docOrRevID = [docOrRevID stringByReplacingOccurrencesOfString:@"/" withString:@"%2F"];
     return docOrRevID;
 #else
-    CFStringRef escaped = CFURLCreateStringByAddingPercentEscapes(
-        NULL, (CFStringRef)docOrRevID, NULL, (CFStringRef) @"?&/", kCFStringEncodingUTF8);
-#ifdef __OBJC_GC__
-    return NSMakeCollectable(escaped);
-#else
-    return (__bridge_transfer NSString*)escaped;
-#endif
-
+    NSMutableCharacterSet* mcs = [[NSCharacterSet URLQueryAllowedCharacterSet] mutableCopy];
+    [mcs removeCharactersInString:@"?&/"];
+    NSString* escaped = [docOrRevID stringByAddingPercentEncodingWithAllowedCharacters:mcs];
+    return escaped;
 #endif
 }
 
@@ -137,13 +133,10 @@ NSString* TDEscapeURLParam(NSString* param)
     param = [param stringByReplacingOccurrencesOfString:@"&" withString:@"%26"];
     return param;
 #else
-    CFStringRef escaped = CFURLCreateStringByAddingPercentEscapes(
-        NULL, (CFStringRef)param, NULL, (CFStringRef) @"&", kCFStringEncodingUTF8);
-#ifdef __OBJC_GC__
-    return NSMakeCollectable(escaped);
-#else
-    return (__bridge_transfer NSString*)escaped;
-#endif
+    NSMutableCharacterSet* mcs = [[NSCharacterSet URLQueryAllowedCharacterSet] mutableCopy];
+    [mcs removeCharactersInString:@"&"];
+    NSString* escaped = [param stringByAddingPercentEncodingWithAllowedCharacters:mcs];
+    return escaped;
 #endif
 }
 

--- a/CDTDatastoreEncryptionTests/Attachments/CDTBlobEncryptedDataTests.m
+++ b/CDTDatastoreEncryptionTests/Attachments/CDTBlobEncryptedDataTests.m
@@ -199,7 +199,7 @@
     XCTAssertTrue(error && [error.domain isEqualToString:CDTBlobEncryptedDataErrorDomain] &&
                       (error.code == CDTBlobEncryptedDataErrorFileTooSmall),
                   @"In this situation the expected error is: (%@, %li)",
-                  CDTBlobEncryptedDataErrorDomain, CDTBlobEncryptedDataErrorFileTooSmall);
+                  CDTBlobEncryptedDataErrorDomain, (long)CDTBlobEncryptedDataErrorFileTooSmall);
 }
 
 - (void)testDataWithErrorFailsIfFileStartsWithVersion0
@@ -218,9 +218,9 @@
     
     XCTAssertNil(data, @"Data is not encrypted, is corrupted or the version is wrong");
     XCTAssertTrue(error && [error.domain isEqualToString:CDTBlobEncryptedDataErrorDomain] &&
-                  (error.code == CDTBlobEncryptedDataErrorWrongVersion),
+                      (error.code == CDTBlobEncryptedDataErrorWrongVersion),
                   @"In this situation the expected error is: (%@, %li)",
-                  CDTBlobEncryptedDataErrorDomain, CDTBlobEncryptedDataErrorWrongVersion);
+                  CDTBlobEncryptedDataErrorDomain, (long)CDTBlobEncryptedDataErrorWrongVersion);
 }
 
 - (void)testDataWithErrorFailsIfFileDoesNotStartWithCorrectVersion
@@ -241,7 +241,7 @@
     XCTAssertTrue(error && [error.domain isEqualToString:CDTBlobEncryptedDataErrorDomain] &&
                       (error.code == CDTBlobEncryptedDataErrorWrongVersion),
                   @"In this situation the expected error is: (%@, %li)",
-                  CDTBlobEncryptedDataErrorDomain, CDTBlobEncryptedDataErrorWrongVersion);
+                  CDTBlobEncryptedDataErrorDomain, (long)CDTBlobEncryptedDataErrorWrongVersion);
 }
 
 - (void)testDataWithErrorReturnsEmptyIfThereIsNotEncryptedData

--- a/CDTDatastoreEncryptionTests/CDTEncryptionKeySimpleProviderTests.m
+++ b/CDTDatastoreEncryptionTests/CDTEncryptionKeySimpleProviderTests.m
@@ -41,7 +41,10 @@
 
 - (void)testInitWithNilFails
 {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
     XCTAssertNil([[CDTEncryptionKeySimpleProvider alloc] initWithKey:nil], @"Data is mandatory");
+#pragma clang diagnostic pop
 }
 
 - (void)testInitWithWrongDataLength

--- a/CDTDatastoreEncryptionTests/TDBlobStoreEncryptionTests.m
+++ b/CDTDatastoreEncryptionTests/TDBlobStoreEncryptionTests.m
@@ -286,7 +286,7 @@
       NSData *data = dataFromHexadecimalString(TDBLOBSTOREENCRYPTIONTESTS_LOREM_SHA1DIGEST);
 
       TDBlobKey key;
-      [data getBytes:key.bytes];
+      [data getBytes:key.bytes length:SHA_DIGEST_LENGTH];
 
       reader = [_blobStore blobForKey:key withDatabase:db];
     }];

--- a/CDTDatastoreReplicationAcceptanceTests/Attachments.m
+++ b/CDTDatastoreReplicationAcceptanceTests/Attachments.m
@@ -209,9 +209,12 @@
                   @"Local and remote database attachment comparison failed");
     
     NSDictionary *responseDict = response.body.JSONObject;
-    
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     CDTDocumentRevision *remoteRevision = [CDTDocumentRevision createRevisionFromJson:responseDict forDocument:docURL error:&error];
-    
+#pragma clang diagnostic pop
+
     XCTAssertNotNil(remoteRevision,@"Remote Revision was nil");
     XCTAssertEqual(remoteRevision.attachments.count, 1,@"Remote attachments were not equal to 1");
 

--- a/CDTDatastoreReplicationAcceptanceTests/ReplicationAcceptance.m
+++ b/CDTDatastoreReplicationAcceptanceTests/ReplicationAcceptance.m
@@ -714,7 +714,8 @@
     
     NSArray *localDocs = [self.datastore getDocumentsWithIds:docids];
     XCTAssertNotNil(localDocs, @"nil");
-    XCTAssertTrue(localDocs.count == totalReplicated, @"unexpected number of docs: %@",localDocs.count);
+    XCTAssertTrue(localDocs.count == totalReplicated, @"unexpected number of docs: %lu",
+                  (unsigned long)localDocs.count);
     XCTAssertTrue(self.datastore.documentCount == totalReplicated,
                  @"Incorrect number of documents created %lu", self.datastore.documentCount);
     
@@ -795,9 +796,10 @@
         [NSThread sleepForTimeInterval:1.0f];
     }
 
-    XCTAssertEqual(replicator.state, CDTReplicatorStateStopped, @"expected a different state: %d (%@)",
-                   replicator.state, [CDTReplicator stringForReplicatorState:replicator.state]);
-    
+    XCTAssertEqual(replicator.state, CDTReplicatorStateStopped,
+                   @"expected a different state: %ld (%@)", (long)replicator.state,
+                   [CDTReplicator stringForReplicatorState:replicator.state]);
+
     BOOL docComparison = [self compareDocCount:self.datastore
       expectFewerDocsInRemoteDatabase:self.primaryRemoteDatabaseURL];
     
@@ -1467,8 +1469,8 @@
     TD_Database *tdb = self.datastore.database;
     
     NSString *checkpointDocId = [tdrep remoteCheckpointDocID];
-    NSString *localLastSequence = [tdb lastSequenceWithCheckpointID:checkpointDocId];
-    
+    NSObject *localLastSequence = [tdb lastSequenceWithCheckpointID:checkpointDocId];
+
     //make sure the remote database has the appropriate document
     NSString *remoteCheckpointPath = [NSString stringWithFormat:@"_local/%@", checkpointDocId];
     NSURL *docURL = [self.primaryRemoteDatabaseURL URLByAppendingPathComponent:remoteCheckpointPath];
@@ -1512,8 +1514,8 @@
     TD_Database *tdb = self.datastore.database;
     
     NSString *checkpointDocId = [tdrep remoteCheckpointDocID];
-    NSString *localLastSequence = [tdb lastSequenceWithCheckpointID:checkpointDocId];
-    
+    NSObject *localLastSequence = [tdb lastSequenceWithCheckpointID:checkpointDocId];
+
     //make sure the remote database has the appropriate document
     NSString *remoteCheckpointPath = [NSString stringWithFormat:@"_local/%@", checkpointDocId];
     NSURL *docURL = [self.primaryRemoteDatabaseURL URLByAppendingPathComponent:remoteCheckpointPath];

--- a/CDTDatastoreTests/Attachments/AttachmentCRUD.m
+++ b/CDTDatastoreTests/Attachments/AttachmentCRUD.m
@@ -127,12 +127,15 @@
     
     
     XCTAssertNil(error, @"Error should have been nil");
-    
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     CDTDocumentRevision * rev = [CDTDocumentRevision createRevisionFromJson:dict
                                                                 forDocument:[NSURL
                                                                              URLWithString:@"http://localhost:5984/temp/doc"]
                                                                       error:&error];
-    
+#pragma clang diagnostic pop
+
     XCTAssertNil(error, @"Error occured creating document with valid data");
     XCTAssertNotNil(rev, @"Revision was nil");
     XCTAssertEqualObjects(@"someIdHere",
@@ -146,8 +149,9 @@
     
     XCTAssertEqualObjects(body, rev.body, @"Body was different");
     XCTAssertFalse(rev.deleted, @"Document is not marked as deleted");
-    XCTAssertEqual([rev.attachments count], (NSUInteger) 1, @"Attachment count is wrong, expected 1 actual %d", [rev.attachments count]);
-    
+    XCTAssertEqual([rev.attachments count], (NSUInteger)1,
+                   @"Attachment count is wrong, expected 1 actual %lu",
+                   (unsigned long)[rev.attachments count]);
 }
 
 -(void)testDocumentRevisionFactoryWithAttachmentDataExcluded
@@ -181,11 +185,14 @@
     
     
     XCTAssertNil(error, @"Error should have been nil");
-    
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     CDTDocumentRevision * rev = [CDTDocumentRevision createRevisionFromJson:dict
                                                                 forDocument:attachmentDir
                                                                       error:&error];
-    
+#pragma clang diagnostic pop
+
     XCTAssertNil(error, @"Error occured creating document with valid data");
     XCTAssertNotNil(rev, @"Revision was nil");
     XCTAssertEqualObjects(@"someIdHere",
@@ -199,7 +206,9 @@
     
     XCTAssertEqualObjects(body, rev.body, @"Body was different");
     XCTAssertFalse(rev.deleted, @"Document is not marked as deleted");
-    XCTAssertEqual([rev.attachments count], (NSUInteger) 1, @"Attachment count is wrong, expected 1 actual %d", [rev.attachments count]);
+    XCTAssertEqual([rev.attachments count], (NSUInteger)1,
+                   @"Attachment count is wrong, expected 1 actual %lu",
+                   (unsigned long)[rev.attachments count]);
     XCTAssertEqualObjects(data, [[rev.attachments objectForKey:@"bonsai-boston.jpg"]dataFromAttachmentContent],@"data was not the same");
     
 }
@@ -251,8 +260,8 @@
         NSData *data = dataFromHexadecimalString(@"D55F9AC778BAF2256FA4DE87AAC61F590EBE66E0");
         
         TDBlobKey key;
-        [data getBytes:key.bytes];
-        
+        [data getBytes:key.bytes length:SHA_DIGEST_LENGTH];
+
         filename = [TD_Database filenameForKey:key inBlobFilenamesTableInDatabase:db];
     }];
     
@@ -323,8 +332,8 @@
         NSData *data = dataFromHexadecimalString(@"D55F9AC778BAF2256FA4DE87AAC61F590EBE66E0");
         
         TDBlobKey key;
-        [data getBytes:key.bytes];
-        
+        [data getBytes:key.bytes length:SHA_DIGEST_LENGTH];
+
         filename = [TD_Database filenameForKey:key inBlobFilenamesTableInDatabase:db];
     }];
     
@@ -383,8 +392,8 @@
         NSData *data = dataFromHexadecimalString(@"D55F9AC778BAF2256FA4DE87AAC61F590EBE66E0");
         
         TDBlobKey key;
-        [data getBytes:key.bytes];
-        
+        [data getBytes:key.bytes length:SHA_DIGEST_LENGTH];
+
         filename = [TD_Database filenameForKey:key inBlobFilenamesTableInDatabase:db];
     }];
     
@@ -485,14 +494,14 @@
         NSData *data = dataFromHexadecimalString(@"D55F9AC778BAF2256FA4DE87AAC61F590EBE66E0");
         
         TDBlobKey key;
-        [data getBytes:key.bytes];
-        
+        [data getBytes:key.bytes length:SHA_DIGEST_LENGTH];
+
         filenameImage = [TD_Database filenameForKey:key inBlobFilenamesTableInDatabase:db];
         
         data = dataFromHexadecimalString(@"3FF2989BCCF52150BBA806BAE1DB2E0B06AD6F88");
-        
-        [data getBytes:key.bytes];
-        
+
+        [data getBytes:key.bytes length:SHA_DIGEST_LENGTH];
+
         filenameText = [TD_Database filenameForKey:key inBlobFilenamesTableInDatabase:db];
     }];
     
@@ -583,14 +592,14 @@
         NSData *data = dataFromHexadecimalString(@"D55F9AC778BAF2256FA4DE87AAC61F590EBE66E0");
         
         TDBlobKey key;
-        [data getBytes:key.bytes];
-        
+        [data getBytes:key.bytes length:SHA_DIGEST_LENGTH];
+
         filenameImage = [TD_Database filenameForKey:key inBlobFilenamesTableInDatabase:db];
         
         data = dataFromHexadecimalString(@"3FF2989BCCF52150BBA806BAE1DB2E0B06AD6F88");
-        
-        [data getBytes:key.bytes];
-        
+
+        [data getBytes:key.bytes length:SHA_DIGEST_LENGTH];
+
         filenameText = [TD_Database filenameForKey:key inBlobFilenamesTableInDatabase:db];
     }];
     
@@ -718,14 +727,14 @@
         NSData *data = dataFromHexadecimalString(@"D55F9AC778BAF2256FA4DE87AAC61F590EBE66E0");
         
         TDBlobKey key;
-        [data getBytes:key.bytes];
-        
+        [data getBytes:key.bytes length:SHA_DIGEST_LENGTH];
+
         filenameImage = [TD_Database filenameForKey:key inBlobFilenamesTableInDatabase:db];
         
         data = dataFromHexadecimalString(@"3FF2989BCCF52150BBA806BAE1DB2E0B06AD6F88");
-        
-        [data getBytes:key.bytes];
-        
+
+        [data getBytes:key.bytes length:SHA_DIGEST_LENGTH];
+
         filenameText = [TD_Database filenameForKey:key inBlobFilenamesTableInDatabase:db];
     }];
     
@@ -807,8 +816,8 @@
         NSData *data = dataFromHexadecimalString(@"D55F9AC778BAF2256FA4DE87AAC61F590EBE66E0");
         
         TDBlobKey key;
-        [data getBytes:key.bytes];
-        
+        [data getBytes:key.bytes length:SHA_DIGEST_LENGTH];
+
         filename = [TD_Database filenameForKey:key inBlobFilenamesTableInDatabase:db];
     }];
     
@@ -882,8 +891,8 @@
         NSData *data = dataFromHexadecimalString(@"D55F9AC778BAF2256FA4DE87AAC61F590EBE66E0");
         
         TDBlobKey key;
-        [data getBytes:key.bytes];
-        
+        [data getBytes:key.bytes length:SHA_DIGEST_LENGTH];
+
         filename = [TD_Database filenameForKey:key inBlobFilenamesTableInDatabase:db];
     }];
     
@@ -1142,16 +1151,16 @@
 
     document = [rev2 copy];
     document.attachments = [@{attachment.name:attachment} mutableCopy];
-    
-    CDTDocumentRevision *rev3 = [self.datastore updateDocumentFromRevision:document
-                                                                     error:&error];
-    
+
+    [self.datastore updateDocumentFromRevision:document error:&error];
+
     //attachments have been completed inerted, now attempt to get them via all docs
     
     NSArray * allDocuuments = [self.datastore getAllDocuments];
     
     for(CDTDocumentRevision * revision in allDocuuments){
-        XCTAssertTrue([revision.attachments count] == 1, @"Attachment count is %d not 1", [revision.attachments count]);
+        XCTAssertTrue([revision.attachments count] == 1, @"Attachment count is %lu not 1",
+                      (unsigned long)[revision.attachments count]);
     }
 }
 
@@ -1191,13 +1200,13 @@
     //attachments have been completed inerted, now attempt to get them via all docs
     
     NSArray * allDocuuments = [self.datastore getDocumentsWithIds:@[rev.docId]];
-    
-    XCTAssertTrue([allDocuuments count] == 1,
-                 @"Unexpected number of documents 1 expected got %d",
-                 [allDocuuments count]);
-    
+
+    XCTAssertTrue([allDocuuments count] == 1, @"Unexpected number of documents 1 expected got %lu",
+                  (unsigned long)[allDocuuments count]);
+
     for(CDTDocumentRevision * revision in allDocuuments){
-        XCTAssertTrue([revision.attachments count] == 1, @"Attachment count is %d not 1", [revision.attachments count]);
+        XCTAssertTrue([revision.attachments count] == 1, @"Attachment count is %lu not 1",
+                      (unsigned long)[revision.attachments count]);
     }
 }
 

--- a/CDTDatastoreTests/CDTQIndexCreatorTests.m
+++ b/CDTDatastoreTests/CDTQIndexCreatorTests.m
@@ -302,10 +302,13 @@ SpecBegin(CDTQIndexCreator)
             it(@"doesn't support using the geo type", ^{
 
               @try {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                   [im ensureIndexed:@[ @{ @"name" : @"asc" },
                                        @{ @"age" : @"desc" } ]
                            withName:@"basic"
                                type:@"geo"];
+#pragma clang diagnostic pop
                   expect(nil).toNot.beNil();
               } @catch (NSException *e) {
                   expect(nil).to.beNil();
@@ -314,10 +317,13 @@ SpecBegin(CDTQIndexCreator)
 
             it(@"doesn't support using the unplanned type", ^{
               @try {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                   [im ensureIndexed:@[ @{ @"name" : @"asc" },
                                        @{ @"age" : @"desc" } ]
                            withName:@"basic"
                                type:@"frog"];
+#pragma clang diagnostic pop
                   expect(nil).toNot.beNil();
               } @catch (NSException *e) {
                   expect(nil).to.beNil();

--- a/CDTDatastoreTests/CDTQIndexTests.m
+++ b/CDTDatastoreTests/CDTQIndexTests.m
@@ -34,7 +34,10 @@ describe(@"When creating an instance of index", ^{
         
         expect(index.indexName).to.equal(@"basic");
         expect(index.fieldNames).to.containsInAnyOrder(@[ @"name", @"age" ]);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         expect(index.indexType).to.equal(@"json");
+#pragma clang diagnostic pop
         expect(index.type).to.equal(CDTQIndexTypeJSON);
         expect(index.indexSettings).to.beNil();
     });
@@ -44,7 +47,10 @@ describe(@"When creating an instance of index", ^{
 
       expect(index.indexName).to.equal(@"basic");
       expect(index.fieldNames).to.containsInAnyOrder(@[ @"name", @"age" ]);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
       expect(index.indexType).to.equal(@"text");
+#pragma clang diagnostic pop
       expect(index.type).to.equal(CDTQIndexTypeText);
       expect(index.indexSettings.count).to.equal(1);
       expect(index.indexSettings[@"tokenize"]).to.equal(@"simple");
@@ -70,7 +76,11 @@ describe(@"When creating an instance of index", ^{
 
     it(@"returns nil when index type is specifically nil or blank", ^{
       @try {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
           [CDTQIndex index:indexName withFields:fieldNames ofType:nil];
+#pragma clang diagnostic pop
           expect(nil).toNot.beNil();
       } @catch (NSException *exception) {
           expect(nil).to.beNil();
@@ -78,7 +88,10 @@ describe(@"When creating an instance of index", ^{
 
       @
       try {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
           [CDTQIndex index:indexName withFields:fieldNames ofType:@""];
+#pragma clang diagnostic pop
           expect(nil).toNot.beNil();
       } @catch (NSException *exception) {
           expect(nil).to.beNil();
@@ -87,7 +100,10 @@ describe(@"When creating an instance of index", ^{
 
     it(@"returns nil when index type is invalid", ^{
       @try {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
           [CDTQIndex index:indexName withFields:fieldNames ofType:@"blah"];
+#pragma clang diagnostic pop
           expect(nil).toNot.beNil();
       } @catch (NSException *exception) {
           expect(nil).to.beNil();
@@ -115,7 +131,10 @@ describe(@"When creating an instance of index", ^{
 
         expect(index.indexName).to.equal(@"basic");
         expect(index.fieldNames).to.containsInAnyOrder(@[ @"name", @"age" ]);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         expect(index.indexType).to.equal(@"json");
+#pragma clang diagnostic pop
         expect(index.type).to.equal(CDTQIndexTypeJSON);
         expect(index.indexSettings).to.beNil();
     });
@@ -131,7 +150,10 @@ describe(@"When creating an instance of index", ^{
 
         expect(index.indexName).to.equal(@"basic");
         expect(index.fieldNames).to.containsInAnyOrder(@[ @"name", @"age" ]);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         expect(index.indexType).to.equal(@"text");
+#pragma clang diagnostic pop
         expect(index.type).to.equal(CDTQIndexTypeText);
         expect(index.indexSettings[ @"tokenize" ]).to.equal(@"porter");
     });

--- a/CDTDatastoreTests/CDTReplicationTests.m
+++ b/CDTDatastoreTests/CDTReplicationTests.m
@@ -472,7 +472,7 @@
                        @"header: %@, pullDoc: %@", optionalHeaders, pullDoc);
         XCTAssertNotNil(error, @"Error was not set");
         XCTAssertEqual(error.code, CDTReplicationErrorProhibitedOptionalHttpHeader,
-                       @"Wrote error code: %@", error.code);
+                       @"Wrote error code: %ld", (long)error.code);
     }
     //make sure the lower case versions fail too
     for (NSString* prohibitedHeader in prohibitedLowerArray) {
@@ -484,7 +484,7 @@
                     @"header: %@, pullDoc: %@", optionalHeaders, pullDoc);
         XCTAssertNotNil(error, @"Error was not set");
         XCTAssertEqual(error.code, CDTReplicationErrorProhibitedOptionalHttpHeader,
-                       @"Wrote error code: %@", error.code);
+                       @"Wrote error code: %ld", (long)error.code);
     }
 }
 

--- a/CDTDatastoreTests/DBQueryUtils.m
+++ b/CDTDatastoreTests/DBQueryUtils.m
@@ -181,10 +181,10 @@ NSString* const DBQueryUtilsErrorDomain = @"DBQueryUtilsErrorDomain";
             expectCount += [modifiedRowCount[table] integerValue];  //we expect there to be one new row in the modifiedTables
         
         NSInteger foundCount = [self rowCountForTable:table];
-        XCTAssertTrue( foundCount == expectCount,
-                     @"For table %@: row count mismatch. initial number of rows %d expected %d found %d.",
-                     table, initCount, expectCount, foundCount);
-        
+        XCTAssertTrue(
+            foundCount == expectCount,
+            @"For table %@: row count mismatch. initial number of rows %ld expected %ld found %ld.",
+            table, (long)initCount, (long)expectCount, (long)foundCount);
     }
 }
 

--- a/CDTDatastoreTests/DatastoreCRUD.m
+++ b/CDTDatastoreTests/DatastoreCRUD.m
@@ -129,12 +129,15 @@
     
     
     XCTAssertNil(error, @"Error should have been nil");
-    
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     CDTDocumentRevision * rev = [CDTDocumentRevision createRevisionFromJson:dict
                                                                 forDocument:[NSURL
                                                                              URLWithString:@"http://localhost:5984/temp/doc"]
                                                                       error:&error];
-    
+#pragma clang diagnostic pop
+
     XCTAssertNil(error, @"Error occured creating document with valid data");
     XCTAssertNotNil(rev, @"Revision was nil");
     XCTAssertEqualObjects(@"someIdHere", rev.docId, @"docId was different, expected someIdHere actual %@",rev.docId);
@@ -148,10 +151,6 @@
 -(void)testDocumentRevisionValidDataDeletedDocWithBody
 {
     NSError * error;
-    NSDictionary *body = @{ @"aKey":@"aValue",
-                            @"hello":@"world"
-                            };
-    
     NSDictionary * dict = @{@"_id":@"someIdHere",
                             @"_rev":@"3-750dac460a6cc41e6999f8943b8e603e",
                             @"_deleted":[NSNumber numberWithBool:YES],
@@ -161,12 +160,15 @@
 
     
     XCTAssertNil(error, @"Error should have been nil");
-    
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     CDTDocumentRevision * rev = [CDTDocumentRevision createRevisionFromJson:dict
                                                                 forDocument:[NSURL
                                                                              URLWithString:@"http://localhost:5984/temp/doc"]
                                                                       error:&error];
-    
+#pragma clang diagnostic pop
+
     XCTAssertNil(error, @"Error occured creating document with valid data");
     XCTAssertNotNil(rev, @"Revision was nil");
     XCTAssertEqualObjects(@"someIdHere", rev.docId, @"docId was different, expected someIdHere actual %@",rev.docId);
@@ -185,12 +187,15 @@
     
     
     XCTAssertNil(error, @"Error should have been nil");
-    
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     CDTDocumentRevision * rev = [CDTDocumentRevision createRevisionFromJson:dict
                                                                 forDocument:[NSURL
                                                                              URLWithString:@"http://localhost:5984/temp/doc"]
                                                                       error:&error];
-    
+#pragma clang diagnostic pop
+
     XCTAssertNil(error, @"Error occured creating document with valid data");
     XCTAssertNotNil(rev, @"Revision was nil");
     XCTAssertEqualObjects(@"someIdHere", rev.docId, @"docId was different, expected someIdHere actual %@",rev.docId);
@@ -210,12 +215,15 @@
                             };
     
     XCTAssertNil(error, @"Error should have been nil");
-    
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     CDTDocumentRevision * rev = [CDTDocumentRevision createRevisionFromJson:dict
                                                                 forDocument:[NSURL
                                                                              URLWithString:@"http://localhost:5984/temp/doc"]
                                                                       error:&error];
-    
+#pragma clang diagnostic pop
+
     XCTAssertNotNil(error, @"Error did not occur whencreating document with invalid data");
     XCTAssertNil(rev, @"Revision was not nil");
 
@@ -238,12 +246,15 @@
     NSDictionary * body = @{@"aKey":@"aValue",@"hello":@"world"};
     
     XCTAssertNil(error, @"Error should have been nil");
-    
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     CDTDocumentRevision * rev = [CDTDocumentRevision createRevisionFromJson:dict
                                                                 forDocument:[NSURL
                                                                              URLWithString:@"http://localhost:5984/temp/doc"]
                                                                       error:&error];
-    
+#pragma clang diagnostic pop
+
     XCTAssertNil(error, @"Error occured creating document with valid data");
     XCTAssertNotNil(rev, @"Revision was nil");
     XCTAssertEqualObjects(@"someIdHere",
@@ -329,15 +340,18 @@
 
     CDTDocumentRevision *rev;
     rev = [CDTDocumentRevision revisionWithDocId:testDocId];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
     rev.body = nil;
     rev.attachments = nil;
+#pragma clang diagnostic pop
     [self.datastore documentCount]; //this calls ensureDatabaseOpen, which calls TD_Database open:, which
     
     NSMutableDictionary *initialRowCount = [self.dbutil getAllTablesRowCount];
     
     CDTDocumentRevision *ob = [self.datastore createDocumentFromRevision:rev error:&error];
     XCTAssertNotNil(error, @"No Error creating document!");
-    XCTAssertTrue(error.code == 400, @"Error was not a 400. Found %ld", error.code);
+    XCTAssertTrue(error.code == 400, @"Error was not a 400. Found %ld", (long)error.code);
     XCTAssertNil(ob, @"CDTDocumentRevision object was not nil");
     
     [self.dbutil checkTableRowCount:initialRowCount modifiedBy:nil];
@@ -377,7 +391,7 @@
     doc.body = [@{key:value} mutableCopy];
     ob = [self.datastore createDocumentFromRevision:doc error:&error];
     XCTAssertNotNil(error, @"Error was nil when creating second doc with same doc_id");
-    XCTAssertTrue(error.code == 409, @"Error was not a 409. Found %ld", error.code);
+    XCTAssertTrue(error.code == 409, @"Error was not a 409. Found %ld", (long)error.code);
     XCTAssertNil(ob, @"CDTDocumentRevision object was not nil when creating second doc with same doc_id");
 }
 
@@ -467,7 +481,10 @@
 {
     NSError *error;
     CDTDocumentRevision *doc = [CDTDocumentRevision revision];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
     doc.body = nil;
+#pragma clang diagnostic pop
     CDTDocumentRevision *saved = [self.datastore createDocumentFromRevision:doc error:&error];
     XCTAssertNil(saved, @"Document was created without a body");
 }
@@ -476,7 +493,10 @@
 {
     NSError *error;
     CDTDocumentRevision *doc = [CDTDocumentRevision revisionWithDocId:@"doc1"];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
     doc.body = nil;
+#pragma clang diagnostic pop
     CDTDocumentRevision *saved = [self.datastore createDocumentFromRevision:doc error:&error];
     XCTAssertNil(saved, @"Document with Id but no body created");
 }
@@ -666,7 +686,7 @@
     NSString *revId = ob.revId;
     CDTDocumentRevision *retrieved = [self.datastore getDocumentWithId:docId rev:revId error:&error];
     XCTAssertNotNil(error, @"Error should not be nil.");
-    XCTAssertTrue(error.code == 404, @"Error was not a 404. Found %ld", error.code);
+    XCTAssertTrue(error.code == 404, @"Error was not a 404. Found %ld", (long)error.code);
     XCTAssertNil(retrieved, @"retrieved object was nil");
     
 }
@@ -769,7 +789,9 @@
                                      @"Document ID mismatch: %@", [result stringForColumn:@"docid"]);
                 
                 NSString *revid = [result stringForColumn:@"revid"];
-                XCTAssertTrue([TD_Revision generationFromRevID:revid] - 1 == revPrefix, @"revision out of order: Found Rev: %@ and previous prefix %@", revid, revPrefix);
+                XCTAssertTrue([TD_Revision generationFromRevID:revid] - 1 == revPrefix,
+                              @"revision out of order: Found Rev: %@ and previous prefix %ld",
+                              revid, (long)revPrefix);
                 revPrefix = [TD_Revision generationFromRevID:revid];
                 
                 XCTAssertFalse([result boolForColumn:@"deleted"], @"deleted? %@", [result stringForColumn:@"deleted"]);
@@ -880,7 +902,7 @@
     NSDictionary *actualDict = actual.body;
     
     for (NSString *key in [expectedDict keyEnumerator]) {
-        XCTAssertNotNil([actualDict objectForKey:key], @"Actual didn't contain key %s", key);
+        XCTAssertNotNil([actualDict objectForKey:key], @"Actual didn't contain key %@", key);
         XCTAssertEqualObjects([actualDict objectForKey:key], [expectedDict objectForKey:key], @"Actual value didn't match expected value");
     }
 }
@@ -1007,7 +1029,7 @@
     CDTDocumentRevision *ob2 = [self.datastore updateDocumentFromRevision:rev error:&error];
     
     XCTAssertNotNil(error, @"No error when updating document with bad id");
-    XCTAssertTrue(error.code == 404, @"Error was not a 404. Found %ld", error.code);
+    XCTAssertTrue(error.code == 404, @"Error was not a 404. Found %ld", (long)error.code);
     XCTAssertNil(ob2, @"CDTDocumentRevision object was not nil after update with bad rev");
     
     //expect the database to be unmodified
@@ -1135,10 +1157,13 @@
     error = nil;
 
     rev = [ob copy];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
     rev.body = nil;
+#pragma clang diagnostic pop
     CDTDocumentRevision *ob2 = [self.datastore updateDocumentFromRevision:rev error:&error];
     XCTAssertNotNil(error, @"No Error updating document with nil document body");
-    XCTAssertTrue(error.code == 400, @"Error was not a 400. Found %ld", error.code);
+    XCTAssertTrue(error.code == 400, @"Error was not a 400. Found %ld", (long)error.code);
     XCTAssertNil(ob2, @"CDTDocumentRevision object was not nil when updating with nil document body");
     
     NSDictionary *modifiedCount = nil;
@@ -1427,7 +1452,7 @@
     CDTDocumentRevision *retrieved;
     retrieved = [self.datastore getDocumentWithId:docId error:&error];
     XCTAssertNotNil(error, @"No Error getting deleted document");
-    XCTAssertTrue(error.code == 404, @"Error was not a 404. Found %ld", error.code);
+    XCTAssertTrue(error.code == 404, @"Error was not a 404. Found %ld", (long)error.code);
     XCTAssertNil(retrieved, @"retrieved object was not nil");
     
     //Now try deleting it again.
@@ -1489,7 +1514,8 @@
         XCTAssertTrue([TD_Revision generationFromRevID:[result stringForColumn:@"revid"]] == 2, @"rev: %@", [result stringForColumn:@"revid"] );
         XCTAssertTrue([result boolForColumn:@"current"], @"%@", [result stringForColumn:@"current"]);
         XCTAssertTrue([result boolForColumn:@"deleted"], @"%@", [result stringForColumn:@"current"]);
-        XCTAssertTrue([result intForColumn:@"parent"] == 1, @"Found %@", [result intForColumn:@"parent"]);
+        XCTAssertTrue([result intForColumn:@"parent"] == 1, @"Found %d",
+                      [result intForColumn:@"parent"]);
 
         // Although TD_Database+Insertion inserts an empty NSData object instead of NSNull on
         // delete,
@@ -1544,7 +1570,7 @@
     CDTDocumentRevision *retrieved;
     retrieved = [self.datastore getDocumentWithId:docId error:&error];
     XCTAssertNotNil(error, @"No Error getting deleted document");
-    XCTAssertTrue(error.code == 404, @"Error was not a 404. Found %ld", error.code);
+    XCTAssertTrue(error.code == 404, @"Error was not a 404. Found %ld", (long)error.code);
     XCTAssertNil(retrieved, @"retrieved object was not nil");
     
     // Check we can get the updated revision before it was deleted (ob2)
@@ -1667,7 +1693,7 @@
     CDTDocumentRevision *retrieved;
     retrieved = [self.datastore getDocumentWithId:docId error:&error];
     XCTAssertNotNil(error, @"No Error getting deleted document");
-    XCTAssertTrue(error.code == 404, @"Error was not a 404. Found %ld", error.code);
+    XCTAssertTrue(error.code == 404, @"Error was not a 404. Found %ld", (long)error.code);
     XCTAssertNil(retrieved, @"retrieved object was not nil");
     
     //now try updating rev 2-
@@ -1745,7 +1771,8 @@
     //make sure none of the deleted documents are found in the results.
     for(CDTDocumentRevision* aRev in result){
         for(NSDictionary *aDeletedDict in deletedDbDicts){
-            XCTAssertFalse(aDeletedDict == aRev.body, @"Found equal pointers. %d == %d", aRev.body, aDeletedDict );
+            XCTAssertFalse(aDeletedDict == aRev.body, @"Found equal pointers. %@ == %@", aRev.body,
+                           aDeletedDict);
             XCTAssertFalse([aDeletedDict isEqualToDictionary:aRev.body], @"Found deleted dictionary in results");
         }
         //is this the same as above?
@@ -1829,13 +1856,13 @@
     NSString *docId = @"idonotexist";
     CDTDocumentRevision *aRev = [self.datastore getDocumentWithId:docId error:&error ];
     XCTAssertNotNil(error, @"No Error getting document that doesn't exist");
-    XCTAssertTrue(error.code == 404, @"Error was not a 404. Found %ld", error.code);
+    XCTAssertTrue(error.code == 404, @"Error was not a 404. Found %ld", (long)error.code);
     XCTAssertNil(aRev, @"CDTDocumentRevision should be nil after getting document that doesn't exist");
     
     error = nil;
     CDTDocumentRevision *deleted = [self.datastore deleteDocumentFromRevision:aRev error:&error];
     XCTAssertNotNil(error, @"No Error deleting document that doesn't exist");
-    XCTAssertTrue(error.code == 400, @"Error was not a 400. Found %ld", error.code);
+    XCTAssertTrue(error.code == 400, @"Error was not a 400. Found %ld", (long)error.code);
     XCTAssertNil(deleted, @"CDTDocumentRevision* was not nil. Deletion successful?: %@", error);
     
     
@@ -1886,12 +1913,12 @@
     converted.body = [[TD_Body alloc] initWithProperties:body];
 
     TDStatus status;
-    
-    TD_Revision *new = [self.datastore.database putRevision:converted
-                                   prevRevisionID:rev.revId
-                                    allowConflict:YES
-                                           status:&status];
-    
+
+    [self.datastore.database putRevision:converted
+                          prevRevisionID:rev.revId
+                           allowConflict:YES
+                                  status:&status];
+
     NSArray * deleted = [self.datastore deleteDocumentWithId:mutableRev.docId error:&error];
     
     XCTAssertTrue([deleted count] == 2, @"Number of deletions do not match");

--- a/CDTDatastoreTests/DatastoreConflicts.m
+++ b/CDTDatastoreTests/DatastoreConflicts.m
@@ -772,10 +772,9 @@
     XCTAssertTrue([rev.body isEqualToDictionary:myResolver.resolvedDocumentAsDictionary],
                  @"Unexpected document: %@", rev.body);
     XCTAssertTrue([rev.attachments count] == 1,
-                 @"Unexpected number of attachments. expected %d, actual %d",
-                 1,
-                 [rev.attachments count]);
-    
+                  @"Unexpected number of attachments. expected %d, actual %lu", 1,
+                  (unsigned long)[rev.attachments count]);
+
     NSBundle *bundle = [NSBundle bundleForClass:[self class]];
     NSString *imagePath = [bundle pathForResource:@"bonsai-boston" ofType:@"jpg"];
     NSData *imageData = [NSData dataWithContentsOfFile:imagePath];

--- a/CDTDatastoreTests/DatastoreManagerTests.m
+++ b/CDTDatastoreTests/DatastoreManagerTests.m
@@ -31,9 +31,9 @@
     
     NSArray * datastores = [self.factory allDatastores];
     XCTAssertEqual((NSUInteger)5, [datastores count],
-                   @"Wrong number of datastores returned, expected 5 got %d",
-                   [datastores count]);
-    
+                   @"Wrong number of datastores returned, expected 5 got %lu",
+                   (unsigned long)[datastores count]);
+
     for(NSString * dsname in array){
         XCTAssertTrue([datastores containsObject:dsname], @"Object missing from datastores list");
     }
@@ -44,10 +44,9 @@
     
     [self.factory datastoreNamed:@"adatabase/withaslash" error:nil];
     NSArray * datastores = [self.factory allDatastores];
-    XCTAssertEqual((NSUInteger)1,
-                   [datastores count],
-                   @"Wrong number of datastores returned, expected 1 got %d",
-                   [datastores count]);
+    XCTAssertEqual((NSUInteger)1, [datastores count],
+                   @"Wrong number of datastores returned, expected 1 got %lu",
+                   (unsigned long)[datastores count]);
     XCTAssertEqualObjects(@"adatabase/withaslash",
                          [datastores objectAtIndex:0],
                          @"Datastore names do not match");
@@ -57,9 +56,8 @@
 -(void) testListEmptyDatastores {
     NSArray * datastores = [self.factory allDatastores];
     XCTAssertEqual((NSUInteger)0, [datastores count],
-                   @"Wrong number of datastores returned, expected 0 got %d",
-                   [datastores count]);
-
+                   @"Wrong number of datastores returned, expected 0 got %lu",
+                   (unsigned long)[datastores count]);
 }
 
 -(void) testSchema6ToSchema100Upgrade {

--- a/CDTDatastoreTests/TDSequenceMapTests.m
+++ b/CDTDatastoreTests/TDSequenceMapTests.m
@@ -30,7 +30,9 @@
 {
     TDSequenceMap *map = [[TDSequenceMap alloc] init];
 
-    XCTAssertEqual(map.checkpointedSequence, (SequenceNumber)0, @"TDSequenceMap.checkpointedSequence (%d), is not 0 in %s", map.checkpointedSequence, __PRETTY_FUNCTION__);
+    XCTAssertEqual(map.checkpointedSequence, (SequenceNumber)0,
+                   @"TDSequenceMap.checkpointedSequence (%lld), is not 0 in %s",
+                   map.checkpointedSequence, __PRETTY_FUNCTION__);
     XCTAssertEqualObjects(map.checkpointedValue, nil, @"TDSequenceMap.checkpointedValue is not nil in %s", __PRETTY_FUNCTION__);
     XCTAssertTrue(map.isEmpty, @"TDSequenceMap.isEmpty is not true in %s", __PRETTY_FUNCTION__);
     

--- a/CDTDatastoreTests/TD_DatabaseBlobFilenamesTests.m
+++ b/CDTDatastoreTests/TD_DatabaseBlobFilenamesTests.m
@@ -164,7 +164,7 @@
       NSData *data = dataFromHexadecimalString(TDDATABASEBLOBFILENAMESTESTS_SHA1DIGEST_01);
 
       TDBlobKey key;
-      [data getBytes:key.bytes];
+      [data getBytes:key.bytes length:SHA_DIGEST_LENGTH];
 
       filename =
           [TD_Database generateAndInsertFilenameBasedOnKey:key intoBlobFilenamesTableInDatabase:db];
@@ -183,7 +183,7 @@
       NSData *data = dataFromHexadecimalString(TDDATABASEBLOBFILENAMESTESTS_SHA1DIGEST_01);
 
       TDBlobKey key;
-      [data getBytes:key.bytes];
+      [data getBytes:key.bytes length:SHA_DIGEST_LENGTH];
 
       filename = [TD_Database generateAndInsertRandomFilenameBasedOnKey:key
                                        intoBlobFilenamesTableInDatabase:db];
@@ -204,7 +204,7 @@
       NSData *data = dataFromHexadecimalString(TDDATABASEBLOBFILENAMESTESTS_SHA1DIGEST_03);
 
       TDBlobKey key;
-      [data getBytes:key.bytes];
+      [data getBytes:key.bytes length:SHA_DIGEST_LENGTH];
 
       resultFirstInsert =
           [TD_Database insertFilename:filename withKey:key intoBlobFilenamesTableInDatabase:db];
@@ -215,7 +215,7 @@
       NSData *data = dataFromHexadecimalString(TDDATABASEBLOBFILENAMESTESTS_SHA1DIGEST_04);
 
       TDBlobKey key;
-      [data getBytes:key.bytes];
+      [data getBytes:key.bytes length:SHA_DIGEST_LENGTH];
 
       resultSecondInsert =
           [TD_Database insertFilename:filename withKey:key intoBlobFilenamesTableInDatabase:db];

--- a/CDTDatastoreTests/TD_RevisionTests.m
+++ b/CDTDatastoreTests/TD_RevisionTests.m
@@ -69,9 +69,9 @@
 
 - (void)runCollateRevEqualsTest:(const char*)rev1 rev2:(const char*)rev2 val:(int)val
 {
-    XCTAssertEqual(TDCollateRevIDs(NULL, (int)strlen(rev1), rev1, (int)strlen(rev2), rev2),
-                   val,
-                   @"TDCollateRevIDs rev1:%s, rev2:%2 does not return %d in %s", rev1, rev2, val, __PRETTY_FUNCTION__);
+    XCTAssertEqual(TDCollateRevIDs(NULL, (int)strlen(rev1), rev1, (int)strlen(rev2), rev2), val,
+                   @"TDCollateRevIDs rev1:%s, rev2:%s does not return %d in %s", rev1, rev2, val,
+                   __PRETTY_FUNCTION__);
 }
 
 - (void)testCollateRevIDs


### PR DESCRIPTION
**Note:** It may be easier to review this PR commit by commit as each commit fixes a particular warning or group of related warnings.

## What
Correct compiler warnings.

## Why
Having many compiler warnings means there could potentially be important issues that we are warned about that go unnoticed because of the sheer number of things we are being warned about.

## How
Each warning has been examined to see if it represents a real issue we need to fix or whether it can be safely ignored.  In the majority of cases the code or project setup has been fixed to eliminate the warnings. 

The cases where warnings are ignored are:
- calls to deprecated operations - these have been ignored because either: the code calling the deprecated operation is itself deprecated; or the code is deliberately designed to test an operation that has been deprecated in CDTDatastore and we still want to ensure it works until we remove it.
- passing `nil` to a method that specifies a `nonnull` argument. This has been ignored only in test cases because Objective C does not enforce that a `nil` cannot be sent to an operation in an argument specified as `nonnull`, so it is a valid test to ensure that `nil` is handled sensibly.

## Testing
No additional tests required.  Existing tests still pass.
