### PR TITLE
Implement backoff and retry in response to 429 error code

### DIFF
--- a/CDTDatastore.xcodeproj/project.pbxproj
+++ b/CDTDatastore.xcodeproj/project.pbxproj
@@ -16,6 +16,14 @@
 		444F22564A61FE341E679D1E /* Pods_CDTDatastore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 661443AD245B12F70D33C303 /* Pods_CDTDatastore.framework */; };
 		6400126AA8043B4CE33B19DA /* Pods_CDTDatastoreReplicationAcceptanceTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1BEFE677789AF6FA5E2CDCFF /* Pods_CDTDatastoreReplicationAcceptanceTests.framework */; };
 		672DDDA1A88D83963155710B /* Pods_CDTDatastoreEncryptionTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A15735F4EFD5449302A3D38A /* Pods_CDTDatastoreEncryptionTests.framework */; };
+		8E2DDDF81D1BEFBE00673564 /* CDTRequestLimitInterceptor.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E2DDDF61D1BEFBE00673564 /* CDTRequestLimitInterceptor.h */; };
+		8E2DDDF91D1BEFBE00673564 /* CDTRequestLimitInterceptor.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E2DDDF61D1BEFBE00673564 /* CDTRequestLimitInterceptor.h */; };
+		8E2DDDFA1D1BEFBE00673564 /* CDTRequestLimitInterceptor.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E2DDDF71D1BEFBE00673564 /* CDTRequestLimitInterceptor.m */; };
+		8E2DDDFB1D1BEFBE00673564 /* CDTRequestLimitInterceptor.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E2DDDF71D1BEFBE00673564 /* CDTRequestLimitInterceptor.m */; };
+		8E2DDDFC1D1BEFC900673564 /* CDTRequestLimitInterceptor.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E2DDDF61D1BEFBE00673564 /* CDTRequestLimitInterceptor.h */; };
+		8E2DDDFD1D1BEFCA00673564 /* CDTRequestLimitInterceptor.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E2DDDF61D1BEFBE00673564 /* CDTRequestLimitInterceptor.h */; };
+		8E2DDDFE1D1BEFCC00673564 /* CDTRequestLimitInterceptor.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E2DDDF71D1BEFBE00673564 /* CDTRequestLimitInterceptor.m */; };
+		8E2DDDFF1D1BEFCD00673564 /* CDTRequestLimitInterceptor.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E2DDDF71D1BEFBE00673564 /* CDTRequestLimitInterceptor.m */; };
 		980F22711CB818260075A843 /* CDTQFilterFieldsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 98F77E0B1C44044000515CC3 /* CDTQFilterFieldsTest.m */; };
 		980F22721CB818260075A843 /* CDTQIndexCreatorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98F77E0C1C44044000515CC3 /* CDTQIndexCreatorTests.m */; };
 		980F22731CB818260075A843 /* CDTQIndexManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98F77E0D1C44044000515CC3 /* CDTQIndexManagerTests.m */; };
@@ -1237,6 +1245,8 @@
 		8518228C4BA984DF4307790D /* Pods-CDTDatastoreEncryption.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CDTDatastoreEncryption.release.xcconfig"; path = "Pods/Target Support Files/Pods-CDTDatastoreEncryption/Pods-CDTDatastoreEncryption.release.xcconfig"; sourceTree = "<group>"; };
 		86189ACF47443730C2DDF132 /* Pods-CDTDatastore.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CDTDatastore.release.xcconfig"; path = "Pods/Target Support Files/Pods-CDTDatastore/Pods-CDTDatastore.release.xcconfig"; sourceTree = "<group>"; };
 		865DF77B87F77B54AA3C53E0 /* Pods-CDTDatastoreEncryptionTestsOSX.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CDTDatastoreEncryptionTestsOSX.release.xcconfig"; path = "Pods/Target Support Files/Pods-CDTDatastoreEncryptionTestsOSX/Pods-CDTDatastoreEncryptionTestsOSX.release.xcconfig"; sourceTree = "<group>"; };
+		8E2DDDF61D1BEFBE00673564 /* CDTRequestLimitInterceptor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDTRequestLimitInterceptor.h; sourceTree = "<group>"; };
+		8E2DDDF71D1BEFBE00673564 /* CDTRequestLimitInterceptor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTRequestLimitInterceptor.m; sourceTree = "<group>"; };
 		92EF171B6751664EF6E94197 /* Pods-CDTDatastoreEncryptedReplicationAcceptanceTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CDTDatastoreEncryptedReplicationAcceptanceTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-CDTDatastoreEncryptedReplicationAcceptanceTests/Pods-CDTDatastoreEncryptedReplicationAcceptanceTests.debug.xcconfig"; sourceTree = "<group>"; };
 		986E886E041283B45ECF9B5A /* Pods-CDTDatastoreTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CDTDatastoreTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-CDTDatastoreTests/Pods-CDTDatastoreTests.debug.xcconfig"; sourceTree = "<group>"; };
 		987382FB1C47B1DD00937212 /* CDTHelperFixedKeyProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDTHelperFixedKeyProvider.h; sourceTree = "<group>"; };
@@ -2049,6 +2059,8 @@
 				98F77BA91C43FCEE00515CC3 /* CDTURLSession.m */,
 				98F77BAA1C43FCEE00515CC3 /* CDTURLSessionTask.h */,
 				98F77BAB1C43FCEE00515CC3 /* CDTURLSessionTask.m */,
+				8E2DDDF61D1BEFBE00673564 /* CDTRequestLimitInterceptor.h */,
+				8E2DDDF71D1BEFBE00673564 /* CDTRequestLimitInterceptor.m */,
 			);
 			path = HTTP;
 			sourceTree = "<group>";
@@ -2557,6 +2569,7 @@
 				987383AA1C47B38800937212 /* TDMultiStreamWriter.h in Headers */,
 				987383AB1C47B38800937212 /* CDTEncryptionKeySimpleProvider.h in Headers */,
 				987383AC1C47B38800937212 /* CDTQQueryValidator.h in Headers */,
+				8E2DDDF91D1BEFBE00673564 /* CDTRequestLimitInterceptor.h in Headers */,
 				987383AD1C47B38800937212 /* CDTEncryptionKeychainData.h in Headers */,
 				987383AE1C47B38800937212 /* TDCanonicalJSON.h in Headers */,
 				987383AF1C47B38800937212 /* TD_Revision.h in Headers */,
@@ -2687,6 +2700,7 @@
 				987384981C47B3C400937212 /* CDTEncryptionKeySimpleProvider.h in Headers */,
 				987384991C47B3C400937212 /* CDTQQueryValidator.h in Headers */,
 				9873849A1C47B3C400937212 /* CDTEncryptionKeychainData.h in Headers */,
+				8E2DDDFD1D1BEFCA00673564 /* CDTRequestLimitInterceptor.h in Headers */,
 				9873849B1C47B3C400937212 /* TDCanonicalJSON.h in Headers */,
 				9873849C1C47B3C400937212 /* TD_Revision.h in Headers */,
 				9873849D1C47B3C400937212 /* TDInternal.h in Headers */,
@@ -2817,6 +2831,7 @@
 				98F77C511C43FCEE00515CC3 /* CDTEncryptionKeySimpleProvider.h in Headers */,
 				98F77C851C43FCEE00515CC3 /* CDTQQueryValidator.h in Headers */,
 				98F77C571C43FCEE00515CC3 /* CDTEncryptionKeychainData.h in Headers */,
+				8E2DDDF81D1BEFBE00673564 /* CDTRequestLimitInterceptor.h in Headers */,
 				98F77CB41C43FCEE00515CC3 /* TDCanonicalJSON.h in Headers */,
 				98F77CA71C43FCEE00515CC3 /* TD_Revision.h in Headers */,
 				98F77CB81C43FCEE00515CC3 /* TDInternal.h in Headers */,
@@ -2947,6 +2962,7 @@
 				98F7867C1C456B1300515CC3 /* CDTEncryptionKeySimpleProvider.h in Headers */,
 				98F7867D1C456B1300515CC3 /* CDTQQueryValidator.h in Headers */,
 				98F7867E1C456B1300515CC3 /* CDTEncryptionKeychainData.h in Headers */,
+				8E2DDDFC1D1BEFC900673564 /* CDTRequestLimitInterceptor.h in Headers */,
 				98F7867F1C456B1300515CC3 /* TDCanonicalJSON.h in Headers */,
 				98F786801C456B1300515CC3 /* TD_Revision.h in Headers */,
 				98F786811C456B1300515CC3 /* TDInternal.h in Headers */,
@@ -3268,7 +3284,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 0730;
-				ORGANIZATIONNAME = IBM;
+				ORGANIZATIONNAME = "IBM Corporation";
 				TargetAttributes = {
 					98F77B351C43FC9F00515CC3 = {
 						CreatedOnToolsVersion = 7.2;
@@ -4002,6 +4018,7 @@
 				987383161C47B38800937212 /* CDTEncryptionKeychainUtils+PBKDF2.m in Sources */,
 				987383171C47B38800937212 /* CDTEncryptionKeychainData.m in Sources */,
 				987383181C47B38800937212 /* TD_DatabaseManager.m in Sources */,
+				8E2DDDFB1D1BEFBE00673564 /* CDTRequestLimitInterceptor.m in Sources */,
 				987383191C47B38800937212 /* Test.m in Sources */,
 				9873831A1C47B38800937212 /* CDTHTTPInterceptorContext.m in Sources */,
 				9873831B1C47B38800937212 /* TDSequenceMap.m in Sources */,
@@ -4107,6 +4124,7 @@
 				987384041C47B3C400937212 /* CDTEncryptionKeychainUtils+PBKDF2.m in Sources */,
 				987384051C47B3C400937212 /* CDTEncryptionKeychainData.m in Sources */,
 				987384061C47B3C400937212 /* TD_DatabaseManager.m in Sources */,
+				8E2DDDFF1D1BEFCD00673564 /* CDTRequestLimitInterceptor.m in Sources */,
 				987384071C47B3C400937212 /* Test.m in Sources */,
 				987384081C47B3C400937212 /* CDTHTTPInterceptorContext.m in Sources */,
 				987384091C47B3C400937212 /* TDSequenceMap.m in Sources */,
@@ -4363,6 +4381,7 @@
 				98F77C641C43FCEE00515CC3 /* CDTEncryptionKeychainUtils+PBKDF2.m in Sources */,
 				98F77C581C43FCEE00515CC3 /* CDTEncryptionKeychainData.m in Sources */,
 				98F77CA61C43FCEE00515CC3 /* TD_DatabaseManager.m in Sources */,
+				8E2DDDFA1D1BEFBE00673564 /* CDTRequestLimitInterceptor.m in Sources */,
 				98F77D271C43FDA700515CC3 /* Test.m in Sources */,
 				98F77C6B1C43FCEE00515CC3 /* CDTHTTPInterceptorContext.m in Sources */,
 				98F77CD61C43FCEE00515CC3 /* TDSequenceMap.m in Sources */,
@@ -4581,6 +4600,7 @@
 				98F785E71C456B1300515CC3 /* CDTEncryptionKeychainUtils+PBKDF2.m in Sources */,
 				98F785E81C456B1300515CC3 /* CDTEncryptionKeychainData.m in Sources */,
 				98F785E91C456B1300515CC3 /* TD_DatabaseManager.m in Sources */,
+				8E2DDDFE1D1BEFCC00673564 /* CDTRequestLimitInterceptor.m in Sources */,
 				98F785EA1C456B1300515CC3 /* Test.m in Sources */,
 				98F785EB1C456B1300515CC3 /* CDTHTTPInterceptorContext.m in Sources */,
 				98F785EC1C456B1300515CC3 /* TDSequenceMap.m in Sources */,

--- a/CDTDatastore/CDTReplicator/CDTPullReplication.m
+++ b/CDTDatastore/CDTReplicator/CDTPullReplication.m
@@ -15,6 +15,7 @@
 
 #import "CDTPullReplication.h"
 #import "CDTSessionCookieInterceptor.h"
+#import "CDTRequestLimitInterceptor.h"
 #import "CDTDatastore.h"
 #import "CDTLogging.h"
 #import "TDMisc.h"

--- a/CDTDatastore/CDTReplicator/CDTPushReplication.m
+++ b/CDTDatastore/CDTReplicator/CDTPushReplication.m
@@ -16,6 +16,7 @@
 #import "CDTPushReplication.h"
 #import "CDTDatastore.h"
 #import "CDTSessionCookieInterceptor.h"
+#import "CDTRequestLimitInterceptor.h"
 #import "TDMisc.h"
 #import "CDTLogging.h"
 

--- a/CDTDatastore/HTTP/CDTHTTPInterceptorContext.h
+++ b/CDTDatastore/HTTP/CDTHTTPInterceptorContext.h
@@ -25,6 +25,15 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readwrite, nonatomic, strong) NSMutableURLRequest *request;
 @property (nonatomic) BOOL shouldRetry;
 @property (nullable, readwrite, nonatomic, strong) NSHTTPURLResponse *response;
+/**
+ * For storing arbitrary per-context state
+ * NOTE: Users are strongly encouranged to use unique keys by ensuring keys are prefixed, eg
+ * com.mycompany.MyInterceptor.foo, com.mycompany.MyInterceptor.bar, where:
+ * - com.company is the reversed internet domain name
+ * - MyInterceptor is the name of the interceptor class
+ * - foo and bar describe the values being stored.
+ */
+@property (readwrite, nonatomic, strong) NSMutableDictionary<NSString*, NSObject*> *state;
 
 /**
  *  Unavaiable, use -initWithRequest
@@ -37,9 +46,24 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  Initalizes a CDTURLSessionInterceptorContext
  *
+ *  This is equivalent to calling initWithRequest:request:[NSMutableDictionary dictionary]
+ *
  *  @param request the request this context should represent
+ *
  **/
-- (instancetype)initWithRequest:(NSMutableURLRequest *)request NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithRequest:(NSMutableURLRequest *)request;
+
+/**
+ *  Initalizes a CDTURLSessionInterceptorContext
+ *
+ *  NOTE: electing not to copy the state of a previous interceptor may cause issues (especially for 
+ *  interceptors which share state between Request and Response contexts).
+ *
+ *  @param request the request this context should represent
+ *  @param state the initial state of the interceptor pipeline, as key/value pairs
+ **/
+- (instancetype)initWithRequest:(NSMutableURLRequest *)request
+                          state:(NSMutableDictionary *)state NS_DESIGNATED_INITIALIZER;
 
 @end
 

--- a/CDTDatastore/HTTP/CDTHTTPInterceptorContext.m
+++ b/CDTDatastore/HTTP/CDTHTTPInterceptorContext.m
@@ -25,12 +25,18 @@
 }
 
 - (instancetype)initWithRequest:(NSMutableURLRequest *)request {
+    return [self initWithRequest:request state:[NSMutableDictionary dictionary]];
+}
+
+- (instancetype)initWithRequest:(NSMutableURLRequest *)request
+                          state:(NSMutableDictionary*)state {
     NSParameterAssert(request);
     self = [super init];
     
     if (self) {
         _request = request;
         _shouldRetry = NO;
+        _state = state;
     }
     return self;
 }

--- a/CDTDatastore/HTTP/CDTRequestLimitInterceptor.h
+++ b/CDTDatastore/HTTP/CDTRequestLimitInterceptor.h
@@ -1,0 +1,22 @@
+//
+//  CDTRequestLimitInterceptor.h
+//  CDTDatastore
+//
+//  Created by tomblench on 23/06/2016.
+//  Copyright © 2016 IBM Corporation. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "CDTSessionCookieInterceptor.h"
+#import "CDTLogging.h"
+
+
+
+@interface CDTRequestLimitInterceptor : NSObject <CDTHTTPInterceptor>
+
++ (nonnull instancetype)interceptor;
+- (nonnull instancetype)init;
+- (nonnull instancetype)initWithSleep:(NSTimeInterval)sleep
+                           maxRetries:(int)maxRetries NS_DESIGNATED_INITIALIZER;
+
+@end

--- a/CDTDatastore/HTTP/CDTRequestLimitInterceptor.m
+++ b/CDTDatastore/HTTP/CDTRequestLimitInterceptor.m
@@ -1,0 +1,85 @@
+//
+//  CDTRequestLimitInterceptor.m
+//  CDTDatastore
+//
+//  Created by tomblench on 23/06/2016.
+//  Copyright © 2016 IBM Corporation. All rights reserved.
+//
+
+#import "CDTRequestLimitInterceptor.h"
+
+static NSString *kSleepKey = @"com.cloudant.CDTRequestLimitInterceptor.sleep";
+static NSString *kRetryCountKey = @"com.cloudant.CDTRequestLimitInterceptor.retryCount";
+
+@interface CDTRequestLimitInterceptor ()
+
+// the initial time to sleep on receipt of a 429
+@property (readonly) NSTimeInterval initialSleep;
+
+// the maximum number of retries (after original request) to make on receipt of a
+// 429
+@property (readonly) int maxRetries;
+
+@end
+
+@implementation CDTRequestLimitInterceptor
+
++ (instancetype)interceptor
+{
+    return [[CDTRequestLimitInterceptor alloc] init];
+}
+
+- (instancetype)init
+{
+    self = [self initWithSleep:0.25 // 250ms
+                     maxRetries:3];
+    return self;
+}
+
+- (instancetype)initWithSleep:(NSTimeInterval)initialSleep
+                  maxRetries:(int)maxRetries;
+{
+    if (self = [super init]) {
+        _initialSleep = initialSleep;
+        _maxRetries = maxRetries;
+    }
+    return self;
+}
+
+/**
+ * Interceptor to retry after an exponential backoff if we receive a 429 error
+ */
+- (CDTHTTPInterceptorContext *)interceptResponseInContext:(CDTHTTPInterceptorContext *)context
+{
+    if (context.response.statusCode == 429) {
+
+        // if we are the first invocation in this pipeline, set some state
+        if (!context.state[kSleepKey]) {
+            [context.state setValue:@(self.initialSleep) forKey:kSleepKey];
+        }
+        if (!context.state[kRetryCountKey]) {
+            [context.state setValue:@0 forKey:kRetryCountKey];
+        }
+        
+        double sleep = [(NSNumber*)context.state[kSleepKey] doubleValue];
+        int retryCount = [(NSNumber*)context.state[kRetryCountKey] intValue];
+
+        if (retryCount < self.maxRetries) {
+            CDTLogInfo(CDTTD_REMOTE_REQUEST_CONTEXT, @"429 error code (too many requests) received. "
+                       "Will retry in %@ seconds.", context.state[@"sleep"]);
+            
+            // sleep for a short time before making next request
+            [NSThread sleepForTimeInterval:sleep];
+            [context.state setValue:@(sleep*2) forKey:kSleepKey]; // exponential back-off
+            [context.state setValue:@(retryCount+1) forKey:kRetryCountKey];
+            context.shouldRetry = true;
+        } else {
+            CDTLogWarn(CDTTD_REMOTE_REQUEST_CONTEXT, @"Maximum number of retries (%d) exceeded in "
+                       "CDTRequestLimitInterceptor.", self.maxRetries);
+        }
+
+    }
+    return context;
+}
+
+@end

--- a/CDTDatastoreTests/CDTSessionCookieInterceptorTests.m
+++ b/CDTDatastoreTests/CDTSessionCookieInterceptorTests.m
@@ -87,7 +87,8 @@ static const NSString *testCookieHeaderValue =
     NSURLRequest *request = [NSURLRequest requestWithURL:url];
 
     CDTHTTPInterceptorContext *context =
-        [[CDTHTTPInterceptorContext alloc] initWithRequest:[request mutableCopy]];
+        [[CDTHTTPInterceptorContext alloc] initWithRequest:[request mutableCopy]
+                                                     state:[NSMutableDictionary dictionary]];
 
     context = [interceptor interceptRequestInContext:context];
 
@@ -107,7 +108,8 @@ static const NSString *testCookieHeaderValue =
     NSURLRequest *request = [NSURLRequest requestWithURL:url];
 
     CDTHTTPInterceptorContext *context =
-        [[CDTHTTPInterceptorContext alloc] initWithRequest:[request mutableCopy]];
+        [[CDTHTTPInterceptorContext alloc] initWithRequest:[request mutableCopy]
+                                                     state:[NSMutableDictionary dictionary]];
 
     context = [interceptor interceptRequestInContext:context];
 

--- a/doc/httpinterceptors.md
+++ b/doc/httpinterceptors.md
@@ -14,6 +14,14 @@ is required and you need to implement one of the following methods:
 - To modify the outgoing request, `-interceptRequestInContext:`
 - To modify the incoming response, `-interceptResponseInContext:`
 
+If an interceptor instance needs to maintain state information across
+invocations, this should be stored in the `state` dictionary available
+on the `CDTHTTPInterceptorContext` object. Because this is shared by
+the interceptor pipeline, interceptor authors are strongly encouranged
+to use unique keys by ensuring keys are prefixed. See the
+`CDTHTTPInterceptorContext` documentation for more detais and
+`CDTRequestLimitInterceptor` source code for an example of usage.
+
 A example of a HTTP interceptor:
 
 ```objc


### PR DESCRIPTION
_What_: Wait an exponentially increasing time on receipt of each `429 Too Many Requests` error, then set `context.shouldRetry` to `true` to re-execute the request.

_Why_: From https://tools.ietf.org/html/rfc6585#section-4 
```
   The 429 status code indicates that the user has sent too many
   requests in a given amount of time ("rate limiting").
```

_Testing_: New RA test `test429Retry`. Add small class `SimpleHttpServer` to be used for sending `404` responses for existing test `testFiltersWithChangesFeed` and for sending `429` responses for new test.