### PR TITLE
Generate conflict error instead not found

### DIFF
--- a/CDTDatastore/touchdb/TD_Database.m
+++ b/CDTDatastore/touchdb/TD_Database.m
@@ -846,11 +846,18 @@ static BOOL removeItemIfExists(NSString* path, NSError** outError)
 - (BOOL)existsDocumentWithID:(NSString*)docID revisionID:(NSString*)revID database:(FMDatabase*)db
 {
     TDStatus status;
-    return [self getDocumentWithID:docID
-                        revisionID:revID
-                           options:kTDNoBody
-                            status:&status
-                          database:db] != nil;
+
+    TD_Revision* rev = [self getDocumentWithID:docID
+                                    revisionID:revID
+                                       options:kTDNoBody
+                                        status:&status
+                                      database:db];
+
+    if (status == kTDStatusDeleted) {
+        return YES;  // The doc is now a tombstone, but it does mean it exits in the tree.
+    } else {
+        return rev != nil;
+    }
 }
 
 /** Do not call from fmdbqueue */

--- a/CDTDatastoreTests/DatastoreCRUD.m
+++ b/CDTDatastoreTests/DatastoreCRUD.m
@@ -82,7 +82,6 @@
 
 #pragma mark - CREATE tests
 
-
 -(void) testDocumentWithInfinityValue
 {
     NSError * error;
@@ -1004,6 +1003,26 @@
 
 #pragma mark - UPDATE tests
 
+- (void)testUpdateDeletedDocumentWithOldRevReturns409
+{
+    NSError *error = nil;
+    CDTDocumentRevision *rev = [CDTDocumentRevision revision];
+    rev.body = [@{ @"hello" : @"world" } mutableCopy];
+
+    CDTDocumentRevision *saved = [self.datastore createDocumentFromRevision:rev error:&error];
+    XCTAssertNil(error);
+
+    error = nil;
+    [self.datastore deleteDocumentFromRevision:saved error:&error];
+    XCTAssertNil(error);
+    error = nil;
+
+    saved.body = [@{ @"hello" : @"world", @"updated" : @(YES) } mutableCopy];
+    [self.datastore updateDocumentFromRevision:saved error:&error];
+    XCTAssertNotNil(error);
+    XCTAssertEqual(409, error.code);
+}
+
 -(void)testUpdateBadDocId
 {
     NSError *error;
@@ -1389,6 +1408,25 @@
 }
 
 #pragma mark - DELETE tests
+
+- (void)testDeleteDeletedDocumentWithOldRevReturns409
+{
+    NSError *error = nil;
+    CDTDocumentRevision *rev = [CDTDocumentRevision revision];
+    rev.body = [@{ @"hello" : @"world" } mutableCopy];
+
+    CDTDocumentRevision *saved = [self.datastore createDocumentFromRevision:rev error:&error];
+    XCTAssertNil(error);
+
+    error = nil;
+    [self.datastore deleteDocumentFromRevision:saved error:&error];
+    XCTAssertNil(error);
+    error = nil;
+
+    [self.datastore deleteDocumentFromRevision:saved error:&error];
+    XCTAssertNotNil(error);
+    XCTAssertEqual(409, error.code);
+}
 
 - (void)testDeletedItem404
 {


### PR DESCRIPTION
## What
Generate conflict error ( 409 ) instead of not found ( 404 ) when updating
a document that has been deleted from an old revision and when deleting a document
that has been deleted from an old revision.

## How

Take into account the status when retrieving a document from the database to see if it exists.

## Testing

A test for each of the scenarios have been added to DatastoreCRUD.m.

## Issues

Fixes #263