### PR TITLE
Don't expose NSMutableDictionary directly

### DIFF
--- a/CDTDatastore/HTTP/CDTHTTPInterceptorContext.h
+++ b/CDTDatastore/HTTP/CDTHTTPInterceptorContext.h
@@ -25,15 +25,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readwrite, nonatomic, strong) NSMutableURLRequest *request;
 @property (nonatomic) BOOL shouldRetry;
 @property (nullable, readwrite, nonatomic, strong) NSHTTPURLResponse *response;
-/**
- * For storing arbitrary per-context state
- * NOTE: Users are strongly encouranged to use unique keys by ensuring keys are prefixed, eg
- * com.mycompany.MyInterceptor.foo, com.mycompany.MyInterceptor.bar, where:
- * - com.company is the reversed internet domain name
- * - MyInterceptor is the name of the interceptor class
- * - foo and bar describe the values being stored.
- */
-@property (readwrite, nonatomic, strong) NSMutableDictionary<NSString*, NSObject*> *state;
 
 /**
  *  Unavaiable, use -initWithRequest
@@ -64,6 +55,26 @@ NS_ASSUME_NONNULL_BEGIN
  **/
 - (instancetype)initWithRequest:(NSMutableURLRequest *)request
                           state:(NSMutableDictionary *)state NS_DESIGNATED_INITIALIZER;
+
+/**
+ * For retrieving arbitrary per-context state
+ * @param key the key with which the value is associated
+ */                                                   
+- (NSObject*)stateForKey:(NSString*)key;
+
+/**
+ * For storing arbitrary per-context state
+ * NOTE: Users are strongly encouranged to use unique keys by ensuring keys are prefixed, eg
+ * com.mycompany.MyInterceptor.foo, com.mycompany.MyInterceptor.bar, where:
+ * - com.company is the reversed internet domain name
+ * - MyInterceptor is the name of the interceptor class
+ * - foo and bar describe the values being stored.
+ * @param value the value to store
+ * @param key the key with which the value is associated
+ */
+                                                   
+- (void)setState:(NSObject*)value
+          forKey:(NSObject*)key;
 
 @end
 

--- a/CDTDatastore/HTTP/CDTHTTPInterceptorContext.m
+++ b/CDTDatastore/HTTP/CDTHTTPInterceptorContext.m
@@ -19,16 +19,18 @@
 
 @implementation CDTHTTPInterceptorContext
 
+NSMutableDictionary<NSString*, NSObject*> *_state;
+
 -(instancetype)init {
     NSAssert(NO, @"Call the designated initaliser");
     return nil;
 }
 
-- (instancetype)initWithRequest:(NSMutableURLRequest *)request {
+- (instancetype)initWithRequest:(NSMutableURLRequest*)request {
     return [self initWithRequest:request state:[NSMutableDictionary dictionary]];
 }
 
-- (instancetype)initWithRequest:(NSMutableURLRequest *)request
+- (instancetype)initWithRequest:(NSMutableURLRequest*)request
                           state:(NSMutableDictionary*)state {
     NSParameterAssert(request);
     self = [super init];
@@ -40,5 +42,15 @@
     }
     return self;
 }
+
+- (NSObject*)stateForKey:(NSString*)key {
+    return _state[key];
+}
+
+- (void)setState:(NSObject*)value
+          forKey:(NSObject*)key {
+    [_state setValue:value forKey:key];
+}
+
 
 @end

--- a/CDTDatastoreTests/CDTReplicationTests.m
+++ b/CDTDatastoreTests/CDTReplicationTests.m
@@ -249,7 +249,7 @@
 
     // after 3 retries the sleep time should equal 2s:
     // 250ms * (2^3)
-    double lastSleepValue = [(NSNumber*)cci.lastContext.state[@"com.cloudant.CDTRequestLimitInterceptor.sleep"] doubleValue];
+    double lastSleepValue = [(NSNumber*)[cci.lastContext stateForKey:@"com.cloudant.CDTRequestLimitInterceptor.sleep"] doubleValue];
     XCTAssertEqual(2.0, lastSleepValue);
     
     [server stop];


### PR DESCRIPTION
- _What_: Instead of exposing the `state` dictionary directly, add methods for setting/retrieving values.
- _Why_: Simplify use for API users and enable future refactoring
- _Testing_: All existing tests pass