### PR TITLE
Fix failing replication acceptance test cases

### DIFF
--- a/CDTDatastore/CDTReplicator/CDTReplicator.m
+++ b/CDTDatastore/CDTReplicator/CDTReplicator.m
@@ -372,7 +372,9 @@ static NSString *const CDTReplicatorErrorDomain = @"CDTReplicatorErrorDomain";
                 if (strongSelf.tdReplicator.error) {
                     strongSelf.state = CDTReplicatorStateError;
                     // copy underlying error pointer
-                    strongSelf.error = strongSelf.tdReplicator.error;
+                    if (strongSelf.error == nil) {
+                        strongSelf.error = strongSelf.tdReplicator.error;
+                    }
                 } else {
                     strongSelf.state = CDTReplicatorStateStopped;
                 }
@@ -384,7 +386,9 @@ static NSString *const CDTReplicatorErrorDomain = @"CDTReplicatorErrorDomain";
                 if (strongSelf.tdReplicator.error) {
                     strongSelf.state = CDTReplicatorStateError;
                     // copy underlying error pointer
-                    strongSelf.error = strongSelf.tdReplicator.error;
+                    if (strongSelf.error == nil) {
+                        strongSelf.error = strongSelf.tdReplicator.error;
+                    }
                 } else {
                     strongSelf.state = CDTReplicatorStateComplete;
                 }
@@ -457,7 +461,9 @@ static NSString *const CDTReplicatorErrorDomain = @"CDTReplicatorErrorDomain";
         } else if (self.tdReplicator.error) {
             strongSelf.state = CDTReplicatorStateError;
             // copy underlying error pointer
-            strongSelf.error = strongSelf.tdReplicator.error;
+            if (strongSelf.error == nil) {
+                strongSelf.error = strongSelf.tdReplicator.error;
+            }
         } else {
             strongSelf.state = CDTReplicatorStateComplete;
         }


### PR DESCRIPTION
## What
The test cases below are currently failing with error message `("1001") is not equal to ("4") - Wrong error code: 1001`:
`testPullErrorsWhenLocalDatabaseIsDeleted`
`testPushErrorsWhenLocalDatabaseIsDeleted`

The error code 4 is a CDTReplicator error which is supposed to reflect the 1001 TDReplicator error code.  We need to check that the CDTReplicator `error` property is null before setting the underlying error pointer.
Original issue: #251 

## How
- Fixed failing replication acceptance test cases by checking if CDTReplicator's `strongSelf.error` is null before setting underlying error pointer

## Testing
No new unit tests. 
Existing replication tests `testPullErrorsWhenLocalDatabaseIsDeleted` and 
`testPushErrorsWhenLocalDatabaseIsDeleted`are now passing.