### PR TITLE
New credential API.

### DIFF
--- a/CDTDatastore/CDTReplicator/CDTAbstractReplication.h
+++ b/CDTDatastore/CDTReplicator/CDTAbstractReplication.h
@@ -135,6 +135,17 @@ typedef NS_ENUM(NSInteger, CDTReplicationErrors) {
  */
 @property (nonatomic, readonly, strong) NSArray<NSObject<CDTHTTPInterceptor>*>* httpInterceptors;
 
+@property (nullable, nonatomic, readonly, strong) NSString* username;
+
+@property (nullable, nonatomic, readonly, strong) NSString* password;
+
+/**
+ * Initalises the abstract replication.
+ * @param username The user to use when authenticating with the remote server.
+ * @param password The password to use when authenticating with the remote server.
+ * @return an initialsed instance of CDTAbstractReplication.
+ */
+- (instancetype)initWithUsername:(nullable NSString*)username password:(nullable NSString*)password;
 /**
   Adds an interceptor to the interceptors array.
  @param interceptor the interceptor to append to the interceptors array.

--- a/CDTDatastore/CDTReplicator/CDTAbstractReplication.m
+++ b/CDTDatastore/CDTReplicator/CDTAbstractReplication.m
@@ -13,9 +13,10 @@
 //  and limitations under the License.
 
 #import "CDTAbstractReplication.h"
-#import "TD_DatabaseManager.h"
 #import "CDTLogging.h"
+#import "CDTSessionCookieInterceptor.h"
 #import "TDRemoteRequest.h"
+#import "TD_DatabaseManager.h"
 
 NSString *const CDTReplicationErrorDomain = @"CDTReplicationErrorDomain";
 
@@ -23,6 +24,10 @@ NSString *const CDTReplicationErrorDomain = @"CDTReplicationErrorDomain";
 
 NS_ASSUME_NONNULL_BEGIN
 @property (nonnull, nonatomic, readwrite, strong) NSArray *httpInterceptors;
+
+@property (nullable, readwrite, nonatomic, strong) NSString *username;
+@property (nullable, readwrite, nonatomic, strong) NSString *password;
+
 NS_ASSUME_NONNULL_END
 
 @end
@@ -37,6 +42,8 @@ NS_ASSUME_NONNULL_END
     if (copy) {
         copy.optionalHeaders = self.optionalHeaders;
         copy.httpInterceptors = [self.httpInterceptors copyWithZone:zone];
+        copy.username = self.username;
+        copy.password = self.password;
     }
 
     return copy;
@@ -46,9 +53,16 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)init
 {
+    return [self initWithUsername:nil password: nil];
+}
+- (instancetype)initWithUsername:(nullable NSString *)username
+                        password:(nullable NSString *)password
+{
     self = [super init];
     if (self) {
         _httpInterceptors = @[];
+        _username = username;
+        _password = password;
     }
     return self;
 }
@@ -163,6 +177,7 @@ NS_ASSUME_NONNULL_END
         }
     }
     return YES;
+
 }
 
 - (BOOL)validateRemoteDatastoreURL:(NSURL *)url error:(NSError *__autoreleasing *)error

--- a/CDTDatastore/CDTReplicator/CDTDatastore+Replication.h
+++ b/CDTDatastore/CDTReplicator/CDTDatastore+Replication.h
@@ -23,9 +23,13 @@ NS_ASSUME_NONNULL_BEGIN
  * @param target The URL of the remote database to push to.
  * @param delegate An optional delegate for the replication
  * @param error A pointer to an error that will be set if the replicator could not be created.
+ * @param username          The username to authenticate with.
+ * @param password          The password to authenticate with.
  * @return A push replicator.
  */
 - (nullable CDTReplicator*) pushReplicationTarget:(NSURL*)target
+                                         username:(nullable NSString*)username
+                                         password:(nullable NSString*)password
                                      withDelegate:(nullable NSObject<CDTReplicatorDelegate>*)delegate
                                             error:(NSError *__autoreleasing *) error;
 
@@ -34,9 +38,13 @@ NS_ASSUME_NONNULL_BEGIN
  * @param source The URL of the database from which to pull.
  * @param delegate An optional delegate for the replication.
  * @param error A pointer to an error that will be set if the replicator could not be created.
+ * @param username          The username to authenticate with.
+ * @param password          The password to authenticate with.
  * @return A pull replicator.
  */
 - (nullable CDTReplicator*) pullReplicationSource:(NSURL*)source
+                                         username:(nullable NSString*) username
+                                         password:(nullable NSString*)password
                                      withDelegate:(nullable NSObject<CDTReplicatorDelegate>*)delegate
                                             error:(NSError *__autoreleasing *) error;
 
@@ -61,6 +69,35 @@ NS_ASSUME_NONNULL_BEGIN
 - (void) pullReplicationWithSource:(NSURL*) source
                  completionHandler:(void (^ __nonnull)(NSError* __nullable)) completionHandler
          NS_SWIFT_NAME(pull(from:completionHandler:));
+
+/**
+ Asynchronously pushes data in this datastore to the server.
+
+ @param target            The URL of the remote database to push the data to.
+ @param completionHandler A block to call when the replication completes or errors.
+ @param username          The username to authenticate with.
+ @param password          The password to authenticate with.
+ */
+- (void) pushReplicationWithTarget:(NSURL*) target
+                          username:(nullable NSString*) username
+                          password:(nullable NSString*) password
+                 completionHandler:(void (^ __nonnull)(NSError* __nullable)) completionHandler
+NS_SWIFT_NAME(push(to:username:password:completionHandler:));
+
+
+/**
+ Asynchronously pull data from a remote server to this local datastore.
+
+ @param source            The URL of the remote database from which to pull data.
+ @param completionHandler A block to call when the replication completes or errors.
+ @param username          The username to authenticate with.
+ @param password          The password to authenticate with.
+ */
+- (void) pullReplicationWithSource:(NSURL*) source
+                          username:(nullable NSString*) username
+                          password:(nullable NSString*) password
+                 completionHandler:(void (^ __nonnull)(NSError* __nullable)) completionHandler
+NS_SWIFT_NAME(pull(from:username:password:completionHandler:));
 
 @end
 

--- a/CDTDatastore/CDTReplicator/CDTDatastore+Replication.m
+++ b/CDTDatastore/CDTReplicator/CDTDatastore+Replication.m
@@ -62,17 +62,22 @@
 @implementation CDTDatastore (Replication)
 
 - (CDTReplicator *)pushReplicationTarget:(NSURL *)target
+                                username:(NSString*)username
+                                password:(NSString*)password
                             withDelegate:(NSObject <CDTReplicatorDelegate> *)delegate
                                    error:(NSError *__autoreleasing *)error {
-    CDTPushReplication *push = [CDTPushReplication replicationWithSource:self target:target];
+    CDTPushReplication *push = [CDTPushReplication replicationWithSource:self target:target username:username password:password];
     return [self replicatorWithReplication:push delegate:delegate error:error];
 }
 
 - (CDTReplicator *)pullReplicationSource:(NSURL *)source
+                                username:(NSString*)username
+                                password:(NSString*)password
                             withDelegate:(NSObject <CDTReplicatorDelegate> *)delegate
                                    error:(NSError *__autoreleasing *)error {
 
-    CDTPullReplication *pull = [CDTPullReplication replicationWithSource:source target:self];
+    CDTPullReplication *pull = [CDTPullReplication replicationWithSource:source target:self username:username password:password];
+
     return [self replicatorWithReplication:pull delegate:delegate error:error];
 }
 
@@ -90,9 +95,20 @@
 - (void) pushReplicationWithTarget:(NSURL*) target
                  completionHandler:(void (^ __nonnull)(NSError* __nullable)) completionHandler
 {
+    [self pushReplicationWithTarget:target username:nil password:nil completionHandler:completionHandler];
+}
+
+- (void)pushReplicationWithTarget:(NSURL *)target
+                         username:(NSString *)username
+                         password:(NSString *)password
+                completionHandler:(void (^ __nonnull)(NSError *__nullable))completionHandler
+{
     NSError* error = nil;
     CDTDatastoreReplicationDelegate* delegate = [[CDTDatastoreReplicationDelegate alloc] initWithCompletionHandler:completionHandler];
-    CDTReplicator* replicator = [self pushReplicationTarget:target withDelegate:delegate error:&error];
+    CDTReplicator* replicator = [self pushReplicationTarget:target
+                                                      username:username
+                                                      password:password
+                                                  withDelegate:delegate error:&error];
     if (!error){
         [replicator startWithError:&error];
     }
@@ -100,19 +116,28 @@
     if (error) {
         completionHandler(error);
     }
-
 }
+
 
 - (void) pullReplicationWithSource:(NSURL*) source
                  completionHandler:(void (^ __nonnull)(NSError* __nullable)) completionHandler
 {
+    [self pullReplicationWithSource:source username:nil password:nil completionHandler:completionHandler];
+}
+
+- (void)pullReplicationWithSource:(NSURL *)source
+                         username:(NSString *)username
+                         password:(NSString *)password
+                completionHandler:(void (^ __nonnull)(NSError *__nullable))completionHandler
+{
     NSError* error = nil;
     CDTDatastoreReplicationDelegate* delegate = [[CDTDatastoreReplicationDelegate alloc] initWithCompletionHandler:completionHandler];
-    CDTReplicator* replicator = [self pullReplicationSource:source withDelegate:delegate error:&error];
+    CDTReplicator* replicator = [self pullReplicationSource:source
+                                                      username:username password:password withDelegate:delegate error:&error];
     if (!error){
         [replicator startWithError:&error];
     }
-    
+
     if (error) {
         completionHandler(error);
     }

--- a/CDTDatastore/CDTReplicator/CDTPullReplication.h
+++ b/CDTDatastore/CDTReplicator/CDTPullReplication.h
@@ -15,6 +15,8 @@
 
 #import "CDTAbstractReplication.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
 
  CDTPullReplication objects are used to configure a replication of a
@@ -27,10 +29,12 @@
     CDTDatastore *datastore = [...];
     CDTReplicatorFactory *replicatorFactory = [...];
 
-    NSURL *remote = [NSURL URLwithString:@"https://user:password@account.cloudant.com/myremotedb"];
+    NSURL *remote = [NSURL URLwithString:@"https://account.cloudant.com/myremotedb"];
 
-    CDTPullReplication* pull = [CDTPullReplication replicationWithSource:remote
-                                                                  target:datastore];
+    CDTPullReplication* pull = [CDTPullReplication replicationWithSource: remote
+                                                                  target: datastore
+                                                                username: "user"
+                                                                password: "password"];
 
     NSError *error;
     CDTReplicator *rep = [replicatorFactory oneWay:pull error:&error];
@@ -48,6 +52,8 @@
 
 /** All CDTPullReplication objects must have a source and target.
 
+  This is the same as calling [CDTPullReplication replicationWithSource: source target:target username: nil password: nil]
+
  @param source the remote server URL from which the data is replicated, if this contains user info
         it will be removed from the URL and replaced with CDTSessionCookieInterceptor
  @param target the local datastore to which the data is replicated.
@@ -56,6 +62,24 @@
  */
 + (nonnull instancetype)replicationWithSource:(nonnull NSURL *)source
                                        target:(nonnull CDTDatastore *)target;
+
+/** All CDTPullReplication objects must have a source and target.
+
+ @param source the remote server URL from which the data is replicated, if this contains user info
+        it will be removed from the URL and replaced with CDTSessionCookieInterceptor.
+ @param target the local datastore to which the data is replicated.
+ @param username the username to use when authenticating with the remote database.
+ @param password the password to use when authenticating with the remote datbase.
+ @return a CDTPullReplication object.
+
+ @warning If credentials are included with the source URL and in the parameters, the credentials in the source URL
+ will be ignored.
+
+ */
++ (instancetype)replicationWithSource:(NSURL *)source
+                               target:(CDTDatastore *)target
+                             username:(nullable NSString *)username
+                             password:(nullable NSString *)password;
 
 /**
  @name Accessing the replication source and target
@@ -154,3 +178,5 @@
 @property (nullable, nonatomic, copy) NSDictionary *filterParams;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/CDTDatastore/CDTReplicator/CDTPullReplication.m
+++ b/CDTDatastore/CDTReplicator/CDTPullReplication.m
@@ -29,19 +29,34 @@
 
 + (instancetype)replicationWithSource:(NSURL *)source target:(CDTDatastore *)target
 {
-    return [[self alloc] initWithSource:source target:target];
+    return
+        [CDTPullReplication replicationWithSource:source target:target username:nil password:nil];
 }
 
-- (instancetype)initWithSource:(NSURL *)source target:(CDTDatastore *)target
++ (instancetype)replicationWithSource:(NSURL *)source
+                               target:(CDTDatastore *)target
+                             username:(NSString *)username
+                             password:(NSString *)password
 {
-    if (self = [super init]) {
-        
+    return [[self alloc] initWithSource:source target:target username:username password:password];
+}
+
+- (instancetype)initWithSource:(NSURL *)source
+                        target:(CDTDatastore *)target
+                      username:(NSString *)username
+                      password:(NSString *)password
+{
+    if (self = [super initWithUsername:username password:password]) {
         NSURLComponents * sourceComponents = [NSURLComponents componentsWithURL:source resolvingAgainstBaseURL:NO];
         if(sourceComponents.user && sourceComponents.password){
-            CDTSessionCookieInterceptor * cookieInterceptor = [[CDTSessionCookieInterceptor alloc] initWithUsername:sourceComponents.user password:sourceComponents.password];
+            if (username && password) {
+                CDTLogWarn(CDTREPLICATION_LOG_CONTEXT, @"Credentials provided via the URL and username and password parameters, discarding URL credentials.");
+            } else {
+                CDTSessionCookieInterceptor * cookieInterceptor = [[CDTSessionCookieInterceptor alloc] initWithUsername:sourceComponents.user password:sourceComponents.password];
+                [self addInterceptor:cookieInterceptor];
+            }
             sourceComponents.user = nil;
             sourceComponents.password = nil;
-            [self addInterceptor:cookieInterceptor];
         }
         
         _source = sourceComponents.URL;

--- a/CDTDatastore/CDTReplicator/CDTPushReplication.h
+++ b/CDTDatastore/CDTReplicator/CDTPushReplication.h
@@ -16,6 +16,8 @@
 #import "CDTAbstractReplication.h"
 @class CDTDocumentRevision;
 
+NS_ASSUME_NONNULL_BEGIN
+
 typedef BOOL (^CDTFilterBlock)(CDTDocumentRevision *__nonnull revision,
                                NSDictionary *__nonnull params);
 
@@ -30,10 +32,12 @@ typedef BOOL (^CDTFilterBlock)(CDTDocumentRevision *__nonnull revision,
     CDTDatastore *datastore = [...];
     CDTReplicatorFactory *replicatorFactory = [...];
 
-    NSURL *remote = [NSURL URLwithString:@"https://user:password@account.cloudant.com/myremotedb"];
+    NSURL *remote = [NSURL URLwithString:@"https://account.cloudant.com/myremotedb"];
 
     CDTPushReplication* push = [CDTPushReplication replicationWithSource:datastore
-                                                                  target:remote];
+                                                                  target:remote
+                                                                username: "user"
+                                                                password: "password"];
 
     NSError *error;
     CDTReplicator *myrep = [replicatorFactory oneWay:push error:&error];
@@ -53,6 +57,8 @@ typedef BOOL (^CDTFilterBlock)(CDTDocumentRevision *__nonnull revision,
 
 /** All CDTPushReplication objects must have a source and target.
 
+ This is the same as calling [CDTPushReplication replicationWithSource: source target: target username: nil password:nil];
+
  @param source the local datastore from which the data is replicated.
  @param target the remote server URL to which the data is replicated, if this contains user info
         it will be removed from the URL and replaced with CDTSessionCookieInterceptor
@@ -61,6 +67,24 @@ typedef BOOL (^CDTFilterBlock)(CDTDocumentRevision *__nonnull revision,
  */
 + (nonnull instancetype)replicationWithSource:(nonnull CDTDatastore *)source
                                        target:(nonnull NSURL *)target;
+
+/** All CDTPushReplication objects must have a source and target.
+
+ @param source the local datastore from which the data is replicated.
+ @param target the remote server URL to which the data is replicated, if this contains user info
+        it will be removed from the URL and replaced with CDTSessionCookieInterceptor.
+ @param username the user to use when authenticating with the sever, or `nil` if no authentication is required.
+ @param password the password to use when authenticating with the server, or `nil` if no authentication is required.
+ @return a CDTPushReplication object.
+
+ @warning If credentials are included with the URL and in the parameters, the credentials in the target URL
+ will be ignored.
+
+ */
++ (instancetype)replicationWithSource:(CDTDatastore *)source
+                               target:(NSURL *)target
+                             username:(nullable NSString *)username
+                             password:(nullable NSString *)password;
 
 /**
  @name Accessing the replication source and target
@@ -147,3 +171,5 @@ typedef BOOL (^CDTFilterBlock)(CDTDocumentRevision *__nonnull revision,
 @property (nullable, nonatomic, copy) NSDictionary *filterParams;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/CDTDatastore/CDTReplicator/CDTPushReplication.m
+++ b/CDTDatastore/CDTReplicator/CDTPushReplication.m
@@ -30,19 +30,34 @@
 
 + (instancetype)replicationWithSource:(CDTDatastore *)source target:(NSURL *)target
 {
-    return [[self alloc] initWithSource:source target:target];
+    return
+        [CDTPushReplication replicationWithSource:source target:target username:nil password:nil];
 }
 
-- (instancetype)initWithSource:(CDTDatastore *)source target:(NSURL *)target
++ (instancetype)replicationWithSource:(CDTDatastore *)source
+                               target:(NSURL *)target
+                             username:(NSString *)username
+                             password:(NSString *)password
 {
-    if (self = [super init]) {
-        
+    return [[self alloc] initWithSource:source target:target username:username password:password];
+}
+
+- (instancetype)initWithSource:(CDTDatastore *)source
+                        target:(NSURL *)target
+                      username:(NSString *)username
+                      password:(NSString *)password
+{
+    if (self = [super initWithUsername:username password:password]) {
         NSURLComponents * targetComponents = [NSURLComponents componentsWithURL:target resolvingAgainstBaseURL:NO];
         if(targetComponents.user && targetComponents.password){
-            CDTSessionCookieInterceptor * cookieInterceptor = [[CDTSessionCookieInterceptor alloc] initWithUsername:targetComponents.user password:targetComponents.password];
+            if (username && password) {
+                CDTLogWarn(CDTREPLICATION_LOG_CONTEXT, @"Credentials provided via the URL and username and password parameters, discarding URL credentials.");
+            } else {
+                CDTSessionCookieInterceptor * cookieInterceptor = [[CDTSessionCookieInterceptor alloc] initWithUsername:targetComponents.user password:targetComponents.password];
+                [self addInterceptor:cookieInterceptor];
+            }
             targetComponents.user = nil;
             targetComponents.password = nil;
-            [self addInterceptor:cookieInterceptor];
         }
         
         _source = source;

--- a/CDTDatastore/CDTReplicator/CDTReplicator.m
+++ b/CDTDatastore/CDTReplicator/CDTReplicator.m
@@ -30,6 +30,7 @@
 #import "TDPuller.h"
 #import "TD_DatabaseManager.h"
 #import "TDStatus.h"
+#import "CDTSessionCookieInterceptor.h"
 
 const NSString *CDTReplicatorLog = @"CDTReplicator";
 static NSString *const CDTReplicatorErrorDomain = @"CDTReplicatorErrorDomain";
@@ -307,8 +308,15 @@ static NSString *const CDTReplicatorErrorDomain = @"CDTReplicatorErrorDomain";
         remote = shadowConfig.target;
     }
     
+    NSMutableArray<id<CDTHTTPInterceptor>>* interceptors = [self.cdtReplication.httpInterceptors mutableCopy];
+    if (self.cdtReplication.username && self.cdtReplication.password) {
+        CDTSessionCookieInterceptor* cookieInterceptor = [[CDTSessionCookieInterceptor alloc] initWithUsername:self.cdtReplication.username
+                                                                                                      password: self.cdtReplication.password];
+        [interceptors addObject:cookieInterceptor];
+    }
+    
     TDReplicator *repl = [[TDReplicator alloc] initWithDB:db.database remote:remote push:push continuous:continuous
-                                             interceptors:self.cdtReplication.httpInterceptors];
+                                             interceptors:interceptors];
     if (!repl) {
         if (error) {
             NSString *msg = [NSString


### PR DESCRIPTION
## What
Create a new API to make it easier to pass credentials into the replicator.

## Why
Currently users are expected to pass the credentials to authenticate with the server via an `NSURL` object in the user info section of the url. This causes some problems when attempting to pass in credentials which contain special characters  such as `@` in passwords.

## How

Expanded the `replicationWithSource:target` to `replicationWithSource:target:username:password` with a second method to maintain compatibility.  The `CDTAbstractReplication` class gains a new initialiser which takes the `username` and `password` as arguments, this enables both replications to inherit the username and password functionality. 

## Testing

New tests added to verify that the CDTSessionCookieInterceptor is added to the replicator doc when it is requested. 

## Limitations
Adding an instance of `CDTSessionCookieInterceptor` to the interceptors array happens in the `dictionaryForReplicatorDocument` it doesn't take account to see if there is another instance already added as the result of stripping the credentials. However we could change the behaviour so that we don't create the instance when striping credentials in the event that the user passes credentials in the url and through the `username` and `password` parameters.

## Issues

Part of #302