### PR TITLE
269 datastore documentation

### DIFF
--- a/CDTDatastore/CDTDatastoreManager.h
+++ b/CDTDatastore/CDTDatastoreManager.h
@@ -55,9 +55,6 @@ extern NSString *__nonnull const CDTDatastoreErrorDomain;
 
  All datastore files, including attachments and extensions, are deleted.
 
- Currently it is the responsibility of the caller to ensure that extensions should be shutdown (and
- their underlying databases closed) before calling this method.
-
  @param name datastore name
  @param error will point to an NSError object in case of error.
 

--- a/CDTDatastore/query/CDTQIndexManager.m
+++ b/CDTDatastore/query/CDTQIndexManager.m
@@ -120,6 +120,12 @@ static const int VERSION = 2;
     return self;
 }
 
+- (void)dealloc
+{
+    // close the database.
+    [self.database close];
+}
+
 #pragma mark List indexes
 
 /**
@@ -492,6 +498,8 @@ static const int VERSION = 2;
     }
     
     if (!success) {
+        // close the database.
+        [database close];
         database = nil;
         
         if (error) {


### PR DESCRIPTION
# What
1) Make sure databases are closed in the index manager.
2) Correct documentation of CDTDatastoreManager

## How
1) call `[database close]` in dealloc and before returning `nil` when opening the database failed because migrations couldn't be completed. 
2) Correct documentation of CDTDatastoreManager by removing incorrect doc comment.

## Issues

Fixes #269 
