### PR TITLE
Exclude tests from iOS

### DIFF
--- a/CDTDatastoreTests/CDTReplicationTests.m
+++ b/CDTDatastoreTests/CDTReplicationTests.m
@@ -206,6 +206,8 @@
     XCTAssertEqualObjects([push.httpInterceptors[0] class], [CDTSessionCookieInterceptor class]);
 }
 
+// this test can only run on macOS and not iOS because it needs to start a server
+#if TARGET_OS_MAC && !TARGET_OS_IPHONE
 - (void)test429Retry
 {
     NSError *error = nil;
@@ -254,7 +256,10 @@
     
     [server stop];
 }
+#endif
 
+// this test can only run on macOS and not iOS because it needs to start a server
+#if TARGET_OS_MAC && !TARGET_OS_IPHONE
 - (void)testFiltersWithChangesFeed
 {
     NSError *error = nil;
@@ -302,6 +307,7 @@
 
     [server stop];
 }
+#endif
 
 -(void)testReplicatorIsNilForNilDatastoreManager {
 #pragma clang diagnostic push


### PR DESCRIPTION
- _What_: Exclude failing tests from building and running on iOS

- _Why_: The iOS platform doesn't allow us to listen on arbitrary ports, which we need to do in these tests

Testing: It should be sufficient for these test to only run on the macOS platform.

Issue: #308 