### PR TITLE
Add concurrency controls for open, close and delete

### DIFF
--- a/CDTDatastore/touchdb/TD_Database.h
+++ b/CDTDatastore/touchdb/TD_Database.h
@@ -57,13 +57,13 @@ extern const TDChangesOptions kDefaultTDChangesOptions;
 
 /** A TouchDB database. */
 @interface TD_Database : NSObject {
+
    @private
     NSString* _path;
     NSString* _name;
     FMDatabaseQueue* _fmdbQueue;
     id<CDTEncryptionKeyProvider> _keyProviderToOpenDB;
     BOOL _readOnly;
-    BOOL _open;
     int _transactionLevel;
     NSMutableDictionary* _views;
     NSMutableDictionary* _validations;

--- a/CDTDatastoreTests/TD_DatabaseDeletionTests.m
+++ b/CDTDatastoreTests/TD_DatabaseDeletionTests.m
@@ -22,6 +22,10 @@
 
 static BOOL databaseDeletionTestWasDatabaseAtPathDeleted = NO;
 
+@interface TD_Database()
+- (BOOL) closeInternal; // expose the internal close method.
+@end
+
 @interface TD_MockDatabase : TD_Database
 
 @property (assign, nonatomic) BOOL isCloseExecuted;
@@ -44,11 +48,11 @@ static BOOL databaseDeletionTestWasDatabaseAtPathDeleted = NO;
 }
 
 #pragma mark - TD_Database methods
-- (BOOL)close
+- (BOOL)closeInternal
 {
     self.isCloseExecuted = YES;
 
-    return (self.forceCloseFailure ? NO : [super close]);
+    return (self.forceCloseFailure ? NO : [super closeInternal]);
 }
 
 + (BOOL)deleteClosedDatabaseAtPath:(NSString *)path error:(NSError **)outError


### PR DESCRIPTION
## What
Add concurrency controls for open, close and delete TD_Database operations.

##How
Use a serial dispatch queue when closing and providing isOpen via an atomic
property rather than the current direct interaction with the ivar.

## Tests

No additional tests, CI indicates all tests pass.

## Issues
Resolves #273