### PR TITLE
Make headers for CDTDefines.h and CDTRequestLimitInterceptor.h public

### DIFF
--- a/CDTDatastore.xcodeproj/project.pbxproj
+++ b/CDTDatastore.xcodeproj/project.pbxproj
@@ -16,7 +16,7 @@
 		444F22564A61FE341E679D1E /* Pods_CDTDatastore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 661443AD245B12F70D33C303 /* Pods_CDTDatastore.framework */; };
 		6400126AA8043B4CE33B19DA /* Pods_CDTDatastoreReplicationAcceptanceTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1BEFE677789AF6FA5E2CDCFF /* Pods_CDTDatastoreReplicationAcceptanceTests.framework */; };
 		672DDDA1A88D83963155710B /* Pods_CDTDatastoreEncryptionTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A15735F4EFD5449302A3D38A /* Pods_CDTDatastoreEncryptionTests.framework */; };
-		8E2DDDF81D1BEFBE00673564 /* CDTRequestLimitInterceptor.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E2DDDF61D1BEFBE00673564 /* CDTRequestLimitInterceptor.h */; };
+		8E2DDDF81D1BEFBE00673564 /* CDTRequestLimitInterceptor.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E2DDDF61D1BEFBE00673564 /* CDTRequestLimitInterceptor.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8E2DDDF91D1BEFBE00673564 /* CDTRequestLimitInterceptor.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E2DDDF61D1BEFBE00673564 /* CDTRequestLimitInterceptor.h */; };
 		8E2DDDFA1D1BEFBE00673564 /* CDTRequestLimitInterceptor.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E2DDDF71D1BEFBE00673564 /* CDTRequestLimitInterceptor.m */; };
 		8E2DDDFB1D1BEFBE00673564 /* CDTRequestLimitInterceptor.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E2DDDF71D1BEFBE00673564 /* CDTRequestLimitInterceptor.m */; };
@@ -626,7 +626,7 @@
 		987385D91C47F6AB00937212 /* CDTDatastoreEncryption.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 98F786BE1C456B1300515CC3 /* CDTDatastoreEncryption.framework */; };
 		987385FC1C49659200937212 /* CDTDatastore.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 98F77B361C43FC9F00515CC3 /* CDTDatastore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		987386001C4D497A00937212 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 987385FF1C4D497A00937212 /* libz.tbd */; };
-		9891D10A1C511A820068FD1A /* CDTDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 9891D1091C511A820068FD1A /* CDTDefines.h */; };
+		9891D10A1C511A820068FD1A /* CDTDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 9891D1091C511A820068FD1A /* CDTDefines.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9891D10B1C511A820068FD1A /* CDTDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 9891D1091C511A820068FD1A /* CDTDefines.h */; };
 		9891D10C1C511A820068FD1A /* CDTDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 9891D1091C511A820068FD1A /* CDTDefines.h */; };
 		9891D10D1C511A820068FD1A /* CDTDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 9891D1091C511A820068FD1A /* CDTDefines.h */; };
@@ -2816,7 +2816,6 @@
 				98F77C511C43FCEE00515CC3 /* CDTEncryptionKeySimpleProvider.h in Headers */,
 				98F77C851C43FCEE00515CC3 /* CDTQQueryValidator.h in Headers */,
 				98F77C571C43FCEE00515CC3 /* CDTEncryptionKeychainData.h in Headers */,
-				8E2DDDF81D1BEFBE00673564 /* CDTRequestLimitInterceptor.h in Headers */,
 				98F77CB41C43FCEE00515CC3 /* TDCanonicalJSON.h in Headers */,
 				98F77CA71C43FCEE00515CC3 /* TD_Revision.h in Headers */,
 				98F77CB81C43FCEE00515CC3 /* TDInternal.h in Headers */,
@@ -2835,7 +2834,6 @@
 				98F77B3A1C43FC9F00515CC3 /* CDTDatastore.h in Headers */,
 				98F77C871C43FCEE00515CC3 /* CDTQResultSet.h in Headers */,
 				98F77C211C43FCEE00515CC3 /* CDTBlobReader.h in Headers */,
-				9891D10A1C511A820068FD1A /* CDTDefines.h in Headers */,
 				98F77CD91C43FCEE00515CC3 /* CDTChangedArray.h in Headers */,
 				98F77CC11C43FCEE00515CC3 /* TDMultipartReader.h in Headers */,
 				98F77C1D1C43FCEE00515CC3 /* CDTAttachment.h in Headers */,
@@ -2874,7 +2872,9 @@
 				98F77CD71C43FCEE00515CC3 /* TDStatus.h in Headers */,
 				C5AF64D51C76000C007E2551 /* CDTNSURLSessionConfigurationDelegate.h in Headers */,
 				98F77C591C43FCEE00515CC3 /* CDTEncryptionKeychainManager+Internal.h in Headers */,
+				9891D10A1C511A820068FD1A /* CDTDefines.h in Headers */,
 				98F77C761C43FCEE00515CC3 /* CDTQIndexCreator.h in Headers */,
+				8E2DDDF81D1BEFBE00673564 /* CDTRequestLimitInterceptor.h in Headers */,
 				98F77C291C43FCEE00515CC3 /* CDTDatastore+Internal.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
## What
Add `CDTDefines.h` and `CDTRequestLimitInterceptor.h` to public headers.

## Why
These are required so that CDTDatastore can be successfully used as a framework.

## Testing
sync-cordova-plugin can successfully build for iOS using the `CDTDatastore.framework` generated from this. Previously it had only worked because I had not deleted the contents of the `Headers` folder inside `CDTDatastore.framework`, so was picking up old versions of the header files. I've now updated the script I use to build a new version of the frameworks and copy them to sync-cordova so that it deletes the old frameworks used by cordova before replacing them with the new versions.