### PR TITLE
Make Replication a one liner.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 
 language: objective-c
-osx_image: xcode7.2
+osx_image: xcode8
 
 before_install:
   - export LANG=en_US.UTF-8

--- a/CDTDatastore/CDTReplicator/CDTDatastore+Replication.h
+++ b/CDTDatastore/CDTReplicator/CDTDatastore+Replication.h
@@ -40,6 +40,28 @@ NS_ASSUME_NONNULL_BEGIN
                                      withDelegate:(nullable NSObject<CDTReplicatorDelegate>*)delegate
                                             error:(NSError *__autoreleasing *) error;
 
+
+/**
+ Asynchronously pushes data in this datastore to the server.
+
+ @param target            The URL of the remote database to push the data to.
+ @param completionHandler A block to call when the replication completes or errors.
+ */
+- (void) pushReplicationWithTarget:(NSURL*) target
+                 completionHandler:(void (^ __nonnull)(NSError* __nullable)) completionHandler
+         NS_SWIFT_NAME(push(to:completionHandler:));
+
+
+/**
+ Asynchronously pull data from a remote server to this local datastore.
+
+ @param source            The URL of the remote database from which to pull data.
+ @param completionHandler A block to call when the replication completes or errors.
+ */
+- (void) pullReplicationWithSource:(NSURL*) source
+                 completionHandler:(void (^ __nonnull)(NSError* __nullable)) completionHandler
+         NS_SWIFT_NAME(pull(from:completionHandler:));
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/CDTDatastore/CloudantSync.h
+++ b/CDTDatastore/CloudantSync.h
@@ -36,3 +36,4 @@
 #import "CDTPullReplication.h"
 #import "CDTReplicatorFactory.h"
 #import "CDTReplicatorDelegate.h"
+#import "CDTDatastore+Replication.h"

--- a/CDTDatastoreReplicationAcceptanceTests/ReplicationAcceptance.m
+++ b/CDTDatastoreReplicationAcceptanceTests/ReplicationAcceptance.m
@@ -288,6 +288,40 @@
     XCTAssertEqual(previousNumberOfTimesCalled, interceptor.timesCalled);
 }
 
+-(void)testPullReplicationUsingOneLiner
+{
+    NSLog(@"Creating documents...");
+    [self createRemoteDocs:10];
+
+
+    XCTestExpectation* expectation = [self expectationWithDescription:@"pullReplication"];
+    NSLog(@"Replicating from %@", self.primaryRemoteDatabaseURL);
+    [self.datastore pullReplicationWithSource:self.primaryRemoteDatabaseURL completionHandler:^(NSError *error) {
+        XCTAssertNil(error);
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:10.0 handler:nil];
+    [self compareDatastore:self.datastore withDatabase:self.primaryRemoteDatabaseURL];
+}
+
+-(void)testPushReplicatorUsingOneLiner
+{
+    NSLog(@"Creating documents...");
+    [self createLocalDocs: 10];
+
+    XCTestExpectation* expectation = [self expectationWithDescription:@"pullReplication"];
+
+    NSLog(@"Replicating to %@", self.primaryRemoteDatabaseURL);
+    [self.datastore pushReplicationWithTarget:self.primaryRemoteDatabaseURL completionHandler:^(NSError *error) {
+        XCTAssertNil(error);
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:10.0 handler:nil];
+    [self compareDatastore:self.datastore withDatabase:self.primaryRemoteDatabaseURL];
+}
+
 /**
  Verifies that a modifed context object is
  successfully passed down the interceptor pipeline for requests.


### PR DESCRIPTION
## What
Make replication a one liner.

## How
- Added new methods to CDTDatastore+Replication to make replication easier to set up.
    - Objc looks like :
```objc
[self.datastore pushReplicationWithTarget:remoteURL completionHandler:^(NSError *error) {
        // do something
    }];

[self.datastore pullReplicationWithSource:remoteURL completionHandler:^(NSError *error) {
        // do something
    }];
```
   - Swift looks like:
```swift
self.datastore.push(to: remote) { error in 
    // do something
}
self.datastore.pull(from: remote) { error in 
    // do something
 }
```
- Added CDTDatastore+Replication to CloudantSync.h

## Testing

Two new tests have been added to ReplicationAcceptance since they require a remote database.
The tests are hardcoded to use 10 documents as this is likely to complete within the
timeout for the expectation.

## Issues

Resolves #268

## Notes

This change requires Xcode 8.