### PR TITLE
Log error message for Operators which require NSString or NSNumber types

### DIFF
--- a/CDTDatastore/query/CDTQQueryValidator.m
+++ b/CDTDatastore/query/CDTQQueryValidator.m
@@ -518,9 +518,11 @@
         return [CDTQQueryValidator validateModArgument:predicateValue];
     } else if ([operator isEqualToString:SEARCH]) {
         return [CDTQQueryValidator validateTextSearchArgument:predicateValue];
+    } else if ([predicateValue isKindOfClass:[NSString class]] || [predicateValue isKindOfClass:[NSNumber class]]) {
+        return YES;
     } else {
-        return (([predicateValue isKindOfClass:[NSString class]] ||
-                 [predicateValue isKindOfClass:[NSNumber class]]));
+        CDTLogError(CDTQ_LOG_CONTEXT,@"Only types NSString and NSNumber can be used with %@ operator", operator);
+        return NO;
     }
 }
 


### PR DESCRIPTION
## What
Log error message when validation fails for operators which require NSString or
NSNumber types for it's argument.

## Why

The selector :`{"type": ["customer", "contact"]} ` would previous trigger a Query failure, but would not trigger a error message to be logged. Since the `find` method will only return `nil` on failure, it is important to have a message printed to the log to indicate the error condition.

## Issues

Fixes #290