### PR TITLE
Improve disk full errors.

### DIFF
--- a/CDTDatastore/Attachments/CDTDatastore+Attachments.h
+++ b/CDTDatastore/Attachments/CDTDatastore+Attachments.h
@@ -72,6 +72,7 @@ typedef NS_ENUM(NSInteger, CDTAttachmentError) {
  */
 - (BOOL)addAttachment:(NSDictionary *)attachmentData
                 toRev:(CDTDocumentRevision *)revision
-           inDatabase:(FMDatabase *)db;
+           inDatabase:(FMDatabase *)db
+                error:(NSError *__autoreleasing *)error;
 
 @end

--- a/CDTDatastore/Attachments/CDTDatastore+Attachments.m
+++ b/CDTDatastore/Attachments/CDTDatastore+Attachments.m
@@ -205,6 +205,7 @@ static NSString *const CDTAttachmentsErrorDomain = @"CDTAttachmentsErrorDomain";
 - (BOOL)addAttachment:(NSDictionary *)attachmentData
                 toRev:(CDTDocumentRevision *)revision
            inDatabase:(FMDatabase *)db
+                error:(NSError *__autoreleasing *)error
 {
     if (attachmentData == nil) {
         return NO;
@@ -234,6 +235,7 @@ static NSString *const CDTAttachmentsErrorDomain = @"CDTAttachmentsErrorDomain";
     success = [db executeUpdate:[SQL_DELETE_ATTACHMENT_ROW copy] withParameterDictionary:params];
 
     if (!success) {
+        *error = [db lastError];
         return NO;
     }
 
@@ -249,11 +251,14 @@ static NSString *const CDTAttachmentsErrorDomain = @"CDTAttachmentsErrorDomain";
     };
 
     // insert new record
-    success = [db executeUpdate:[SQL_INSERT_ATTACHMENT_ROW copy] withParameterDictionary:params];
+    success = success =
+        [db executeUpdate:[SQL_INSERT_ATTACHMENT_ROW copy] withParameterDictionary:params];
 
     // We don't remove the blob from the store on !success because
     // it could be referenced from another attachment (as files are
     // only stored once per sha1 of file data).
+
+    if (!success) *error = [db lastError];
 
     return success;
 }

--- a/CDTDatastore/touchdb/TDStatus.h
+++ b/CDTDatastore/touchdb/TDStatus.h
@@ -32,6 +32,7 @@ typedef NS_ENUM(NSInteger, TDStatus) {
     kTDStatusDuplicate = 412,  // Formally known as "Precondition Failed"
     kTDStatusUnsupportedType = 415,
     kTDStatusServerError = 500,
+    kTDStatusInsufficientStorage = 507,
 
     // Non-HTTP errors:
     kTDStatusBadEncoding = 490,

--- a/CDTDatastore/touchdb/TD_Database+LocalDocs.m
+++ b/CDTDatastore/touchdb/TD_Database+LocalDocs.m
@@ -24,6 +24,7 @@
 
 #import <FMDB/FMDatabase.h>
 #import <FMDB/FMDatabaseQueue.h>
+#import <sqlite3.h>
 
 @implementation TD_Database (LocalDocs)
 
@@ -85,7 +86,10 @@
                 if (![db executeUpdate:@"UPDATE localdocs SET revid=?, json=? "
                                         "WHERE docid=? AND revid=?",
                                        newRevID, json, docID, prevRevID]) {
-                    *outStatus = kTDStatusDBError;
+                    if (db.lastErrorCode == SQLITE_FULL)
+                        *outStatus = kTDStatusInsufficientStorage;
+                    else
+                        *outStatus = kTDStatusDBError;
                     return;
                 }
             } else {
@@ -95,7 +99,10 @@
                 if (![db executeUpdate:@"INSERT OR IGNORE INTO localdocs (docid, revid, json) "
                                         "VALUES (?, ?, ?)",
                                        docID, newRevID, json]) {
-                    *outStatus = kTDStatusDBError;
+                    if (db.lastErrorCode == SQLITE_FULL)
+                        *outStatus = kTDStatusInsufficientStorage;
+                    else
+                        *outStatus = kTDStatusDBError;
                     return;
                 }
             }


### PR DESCRIPTION
## What
Improve disk full errors

## How
Return an error with the HTTP status code: 507. Which is for insufficient storage. In order to do this some methods have been updated to use variants `executeUpdate`  which return an error so it can be passed back up the stack, others have been updated to use `lastErrorCode` to retrieve the error code to set the correct TDStatus value.


## Issues
Part of #271 

## Notes

This doesn't cover all the cases that could return ` SQLITE_FULL` error, but it is a start.