### PR TITLE
Validate Attachment Dictionary

### DIFF
--- a/CDTDatastore/CDTDatastore.m
+++ b/CDTDatastore/CDTDatastore.m
@@ -451,6 +451,25 @@ NSString *const CDTDatastoreChangeNotification = @"CDTDatastoreChangeNotificatio
 {
     return [_database openWithEncryptionKeyProvider:self.keyProvider];
 }
+/**
+ * Validates that attachments are keyed by attachment name.
+ * @param attachments The attachments dictionary to validate.
+ * @return True if the attachments dictionary is of the form @[ attachment.name : attachment ],
+ * false
+ * otherwise.
+ */
+- (BOOL)validateAttachments:(NSDictionary<NSString *, CDTAttachment *> *)attachments
+{
+    __block BOOL result = YES;
+    [attachments
+        enumerateKeysAndObjectsUsingBlock:^(NSString *key, CDTAttachment *obj, BOOL *stop) {
+          if (![key isEqualToString:obj.name]) {
+              result = NO;
+              *stop = YES;
+          }
+        }];
+    return result;
+}
 
 #pragma mark fromRevision API methods
 
@@ -468,6 +487,13 @@ NSString *const CDTDatastoreChangeNotification = @"CDTDatastoreChangeNotificatio
 
     if (![self validateBodyDictionary:revision.body error:error]) {
         return nil;
+    }
+
+    if (![self validateAttachments:revision.attachments]) {
+        CDTLogWarn(
+            CDTDATASTORE_LOG_CONTEXT,
+            @"Attachments dictionary is not keyed by attachment name. "
+             "When accessing attachments on saved revisions they will be keyed by attachment name");
     }
 
     if (![self ensureDatabaseOpen]) {
@@ -617,6 +643,13 @@ NSString *const CDTDatastoreChangeNotification = @"CDTDatastoreChangeNotificatio
 
     if (![self validateBodyDictionary:revision.body error:error]) {
         return nil;
+    }
+
+    if (![self validateAttachments:revision.attachments]) {
+        CDTLogWarn(
+            CDTDATASTORE_LOG_CONTEXT,
+            @"Attachments dictionary is not keyed by attachment name. "
+             "When accessing attachments on saved revisions they will be keyed by attachment name");
     }
 
     if (![self ensureDatabaseOpen]) {

--- a/CDTDatastoreTests/DatastoreCRUD.m
+++ b/CDTDatastoreTests/DatastoreCRUD.m
@@ -36,6 +36,10 @@
 #import "DBQueryUtils.h"
 #import "CDTAttachment.h"
 
+@interface CDTDatastore ()
+- (BOOL)validateAttachments:(NSDictionary<NSString *, CDTAttachment *> *)attachments;
+@end
+
 @interface DatastoreCRUD : CloudantSyncTests
 
 @property (nonatomic,strong) CDTDatastore *datastore;
@@ -97,6 +101,29 @@
                    error.code,
                    @"Error code should be 400, but was %ld",
                    (long)error.code);
+}
+
+- (void)testAttachmentValidationUnexpectedAttsDictKey
+{
+    CDTUnsavedDataAttachment *dataAttachment = [[CDTUnsavedDataAttachment alloc]
+        initWithData:[@"test" dataUsingEncoding:NSUTF8StringEncoding]
+                name:@"test"
+                type:@"text/plain"];
+    NSDictionary<NSString *, CDTAttachment *> *attachmentsDict =
+        @{ @"not the name" : dataAttachment };
+    XCTAssertFalse([self.datastore validateAttachments:attachmentsDict],
+                   "Attachments dictionary not keyed on attachment name should fail validation");
+}
+
+- (void)testAttachmentValidationCorrectAttsDictKey
+{
+    CDTUnsavedDataAttachment *dataAttachment = [[CDTUnsavedDataAttachment alloc]
+        initWithData:[@"test" dataUsingEncoding:NSUTF8StringEncoding]
+                name:@"test"
+                type:@"text/plain"];
+    NSDictionary<NSString *, CDTAttachment *> *attachmentsDict = @{ @"test" : dataAttachment };
+    XCTAssertTrue([self.datastore validateAttachments:attachmentsDict],
+                  "Attachments dictionary keyed on attachment name should pass validation");
 }
 
 -(void) testDocumentWithNonSerialisableValue {


### PR DESCRIPTION
## What
Validate Attachment Dictionary on CDTDocumentRevision objects to ensure they
are keyed by the attachment name. 

## How
Added a new method in the CDTDatastore class which enumerates over the key value pairs in the dictionary, returning false if one of the entires is not keyed on the attachment name.
To keep API compatibility, this change only logs a message at the "Warning" level. When we are working towards a 2.0.0 release we can then update it to return an error in the event the attachments dictionary is not keyed correctly.

## Issues 

#287 