### PR TITLE
Fix Replication Acceptance warnings

### DIFF
--- a/CDTDatastore/HTTP/CDTHTTPInterceptorContext.h
+++ b/CDTDatastore/HTTP/CDTHTTPInterceptorContext.h
@@ -27,6 +27,12 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nullable, readwrite, nonatomic, strong) NSHTTPURLResponse *response;
 
 /**
+ * An immutable copy of the state dictionary for this context.
+ * This is useful when subclassing.
+ */
+@property (nonnull, readonly, nonatomic) NSDictionary *state;
+
+/**
  *  Unavaiable, use -initWithRequest
  *
  *  Calling this method from your code will result in

--- a/CDTDatastore/HTTP/CDTHTTPInterceptorContext.m
+++ b/CDTDatastore/HTTP/CDTHTTPInterceptorContext.m
@@ -18,7 +18,7 @@
 #import "CDTHTTPInterceptorContext.h"
 
 @interface CDTHTTPInterceptorContext ()
-@property NSMutableDictionary<NSString*, NSObject*> *state;
+@property NSMutableDictionary<NSString *, NSObject *> *internalState;
 @end
 
 @implementation CDTHTTPInterceptorContext
@@ -41,19 +41,19 @@
     if (self) {
         _request = request;
         _shouldRetry = NO;
-        _state = state;
+        _internalState = state;
     }
     return self;
 }
 
 - (NSObject*)stateForKey:(NSString*)key {
-    return _state[key];
+    return self.internalState[key];
 }
 
 - (void)setState:(NSObject*)value
           forKey:(NSObject*)key {
-    [_state setValue:value forKey:key];
+    [self.internalState setValue:value forKey:key];
 }
 
-
+- (NSDictionary *)state { return [self.internalState copy]; }
 @end

--- a/CDTDatastoreReplicationAcceptanceTests/CDTRATestContext.m
+++ b/CDTDatastoreReplicationAcceptanceTests/CDTRATestContext.m
@@ -19,7 +19,7 @@
 
 - (instancetype)initWithContext:(CDTHTTPInterceptorContext *)context
 {
-    self = [super initWithRequest:context.request];
+    self = [super initWithRequest:context.request state:[context.state mutableCopy]];
     if (self) {
         self.response = context.response;
     }

--- a/Rakefile
+++ b/Rakefile
@@ -19,7 +19,7 @@ SAMPLE_IOS = "Project"
 
 
 # Destinations
-IPHONE_DEST = 'platform=iOS Simulator,OS=latest,name=iPhone 4S'
+IPHONE_DEST = 'platform=iOS Simulator,OS=latest,name=iPhone 5'
 OSX_DEST = 'platform=OS X'
 
 #


### PR DESCRIPTION
## What

Fix warnings in replication acceptance tests

## How
- Fix the public API for CDTHTTPInterceptorContext
- Expose state dictionary via the state property, which creates a immutable copy
of the state dictionary.

- Rename the internal state dictionary from state to internalState. Also access this
via the property rather than the iVar.

- Update Rakefile to use `iphone 5` for iOS tests now that the iPhone 4S does not support iOS 10

## Issues 

Fixes #313