### PR TITLE
Use Replication Protocol V3

### DIFF
--- a/CDTDatastore/touchdb/TDInternal.h
+++ b/CDTDatastore/touchdb/TDInternal.h
@@ -103,8 +103,14 @@
 
 @interface TD_Database (Replication_Internal)
 - (void)stopAndForgetReplicator:(TDReplicator*)repl;
-- (NSObject*)lastSequenceWithCheckpointID:(NSString*)checkpointID;
-- (void)setLastSequence:(NSObject*)lastSequence withCheckpointID:(NSString*)checkpointID;
+NS_ASSUME_NONNULL_BEGIN
+- (nullable NSDictionary<NSString *, NSObject *> *)checkpointDocumentWithID:
+    (nonnull NSString *)checkpointID;
+- (BOOL)saveCheckpointDocument:(nonnull NSDictionary<NSString *, NSObject *> *)checkpoint
+                         error:(NSError *__autoreleasing *)error;
+- (BOOL)deleteCheckpointDocunemtWithID:(NSString *)checkpointID
+                                 error:(NSError *__autoreleasing *)error;
+NS_ASSUME_NONNULL_END;
 + (NSString*)joinQuotedStrings:(NSArray*)strings;
 @end
 

--- a/CDTDatastore/touchdb/TDInternal.h
+++ b/CDTDatastore/touchdb/TDInternal.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2011 Couchbase, Inc. All rights reserved.
 //
 //  Modifications for this distribution by Cloudant, Inc., Copyright (c) 2014 Cloudant, Inc.
+//  Copyright © 2016 IBM Corporation. All rights reserved.
 //
 
 #import "TD_Database.h"

--- a/CDTDatastore/touchdb/TDReplicator.m
+++ b/CDTDatastore/touchdb/TDReplicator.m
@@ -790,13 +790,19 @@ NSString* TDReplicatorStartedNotification = @"TDReplicatorStarted";
                             NSArray<NSDictionary<NSString*, NSObject*>*>* localHistory =
                                 localCheckpoint[@"history"];
 
+                            if (!localHistory) {
+                                CDTLogInfo(CDTREPLICATION_LOG_CONTEXT,
+                                           @"%@: Local checkpoint doc does not contain history,"
+                                           @" falling back to full replication",
+                                           self);
+                            }
+
                             // This assumes the  history array is ordered (most recent -> least
                             // recent)
                             for (NSDictionary<NSString*, NSObject*>* rHistory in remoteHistory) {
                                 NSString* sessionID = (NSString*)rHistory[@"session_id"];
                                 BOOL found = NO;
-                                for (NSDictionary<NSString*, NSObject*>* lHistory in
-                                         remoteHistory) {
+                                for (NSDictionary<NSString*, NSObject*>* lHistory in localHistory) {
                                     if ([lHistory[@"session_id"] isEqual:sessionID]) {
                                         found = YES;
                                         break;

--- a/CDTDatastore/touchdb/TDReplicator.m
+++ b/CDTDatastore/touchdb/TDReplicator.m
@@ -6,6 +6,7 @@
 //  Copyright (c) 2011 Couchbase, Inc. All rights reserved.
 //
 //  Modifications for this distribution by Cloudant, Inc., Copyright (c) 2014 Cloudant, Inc.
+//  Copyright © 2016 IBM Corporation. All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
 //  except in compliance with the License. You may obtain a copy of the License at

--- a/CDTDatastore/touchdb/TD_Database+Replication.m
+++ b/CDTDatastore/touchdb/TD_Database+Replication.m
@@ -6,6 +6,7 @@
 //  Copyright (c) 2011 Couchbase, Inc. All rights reserved.
 //
 //  Modifications for this distribution by Cloudant, Inc., Copyright (c) 2014 Cloudant, Inc.
+//  Copyright © 2016 IBM Corporation. All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
 //  except in compliance with the License. You may obtain a copy of the License at

--- a/CDTDatastore/touchdb/TD_Database+Replication.m
+++ b/CDTDatastore/touchdb/TD_Database+Replication.m
@@ -96,7 +96,7 @@
     NSParameterAssert(checkpoint.count > 0);
 
     NSString *remote = (NSString *)checkpoint[@"_id"];
-    // 7 is the length of _local/ +1
+    // 7 is the length of _local/
     remote = [remote substringFromIndex:7];
 
     NSData *checkpointData = [TDJSON dataWithJSONObject:checkpoint options:0 error:&error];

--- a/CDTDatastore/touchdb/TD_Database+Replication.m
+++ b/CDTDatastore/touchdb/TD_Database+Replication.m
@@ -96,8 +96,8 @@
     NSParameterAssert(checkpoint.count > 0);
 
     NSString *remote = (NSString *)checkpoint[@"_id"];
-    // 8 is the length of _local/ +1
-    remote = [remote substringFromIndex:8];
+    // 7 is the length of _local/ +1
+    remote = [remote substringFromIndex:7];
 
     NSData *checkpointData = [TDJSON dataWithJSONObject:checkpoint options:0 error:&error];
     if (error) {

--- a/CDTDatastoreReplicationAcceptanceTests/ReplicationAcceptance.m
+++ b/CDTDatastoreReplicationAcceptanceTests/ReplicationAcceptance.m
@@ -3,8 +3,15 @@
 //  ReplicationAcceptance
 //
 //  Created by Michael Rhodes on 29/01/2014.
+//  Copyright © 2016 IBM Corporation. All rights reserved.
 //
-//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
 
 #import "ReplicationAcceptance.h"
 

--- a/CDTDatastoreTests/DatastoreManagerTests.m
+++ b/CDTDatastoreTests/DatastoreManagerTests.m
@@ -4,7 +4,15 @@
 //
 //  Created by Rhys Short on 17/12/2014.
 //
+//  Copyright © 2016 IBM Corporation. All rights reserved.
 //
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
 
 #import <Foundation/Foundation.h>
 #import <CDTDatastore/CloudantSync.h>

--- a/CDTDatastoreTests/DatastoreManagerTests.m
+++ b/CDTDatastoreTests/DatastoreManagerTests.m
@@ -78,8 +78,13 @@
 
     // check that we get back the upgraded sequence numbers
     for (NSString *remote in remotes) {
-        NSObject *sequence = [[store database] lastSequenceWithCheckpointID:remote];
-        XCTAssertNotNil(sequence);
+        __block NSData *lastSequenceJson;
+        [[[store database] fmdbQueue] inDatabase:^(FMDatabase *db) {
+          lastSequenceJson =
+              [db dataForQuery:@"SELECT last_sequence FROM replicators WHERE remote=?", remote];
+        }];
+
+        XCTAssertNotNil(lastSequenceJson);
     }
 }
 


### PR DESCRIPTION
## What

Improve replication performance by being able to identify the last sequence at which CDTDatastore replicated to the remote.
## How
- Change the checkpoint document to match the format of V3 for the replication protocol.
- If the last seq for local and remote don't match for the checkpoint, back track over the history object to identify a seq where they do match.
## Issues

Part of #288
