### PR TITLE
Fix warnings

### DIFF
--- a/CDTDatastore/Attachments/CDTDatastore+Attachments.m
+++ b/CDTDatastore/Attachments/CDTDatastore+Attachments.m
@@ -251,8 +251,7 @@ static NSString *const CDTAttachmentsErrorDomain = @"CDTAttachmentsErrorDomain";
     };
 
     // insert new record
-    success = success =
-        [db executeUpdate:[SQL_INSERT_ATTACHMENT_ROW copy] withParameterDictionary:params];
+    success = [db executeUpdate:[SQL_INSERT_ATTACHMENT_ROW copy] withParameterDictionary:params];
 
     // We don't remove the blob from the store on !success because
     // it could be referenced from another attachment (as files are

--- a/CDTDatastore/Attachments/CDTDatastore+Attachments.m
+++ b/CDTDatastore/Attachments/CDTDatastore+Attachments.m
@@ -4,6 +4,7 @@
 //
 //  Created by Michael Rhodes on 24/03/2014.
 //  Copyright (c) 2014 Cloudant. All rights reserved.
+//  Copyright © 2016 IBM Corporation. All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
 //  except in compliance with the License. You may obtain a copy of the License at

--- a/CDTDatastore/Encryption/CDTEncryptionKey.h
+++ b/CDTDatastore/Encryption/CDTEncryptionKey.h
@@ -4,6 +4,7 @@
 //
 //  Created by Enrique de la Torre Fernandez on 12/05/2015.
 //  Copyright (c) 2015 IBM Cloudant. All rights reserved.
+//  Copyright © 2016 IBM Corporation. All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
 //  except in compliance with the License. You may obtain a copy of the License at

--- a/CDTDatastore/Encryption/CDTEncryptionKey.h
+++ b/CDTDatastore/Encryption/CDTEncryptionKey.h
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  CDTENCRYPTIONKEY_KEYSIZE bytes buffer with the DPK
  */
-@property (nonnull, strong, nonatomic, readonly) NSData *data;
+@property (strong, nonatomic, readonly) NSData *data;
 
 - (instancetype)init UNAVAILABLE_ATTRIBUTE;
 
@@ -44,11 +44,11 @@ NS_ASSUME_NONNULL_BEGIN
  
  @warning If data.length is not CDTENCRYPTIONKEY_KEYSIZE, init will return nil
  */
-- (nullable instancetype)initWithData:(nonnull NSData *)data NS_DESIGNATED_INITIALIZER;
+- (nullable instancetype)initWithData:(NSData *)data NS_DESIGNATED_INITIALIZER;
 
-- (BOOL)isEqualToEncryptionKey:(nonnull CDTEncryptionKey *)encryptionKey;
+- (BOOL)isEqualToEncryptionKey:(CDTEncryptionKey *)encryptionKey;
 
-+ (nullable instancetype)encryptionKeyWithData:(nonnull NSData *)data;
++ (nullable instancetype)encryptionKeyWithData:(NSData *)data;
 
 @end
 NS_ASSUME_NONNULL_END

--- a/CDTDatastore/Encryption/CDTEncryptionKey.h
+++ b/CDTDatastore/Encryption/CDTEncryptionKey.h
@@ -27,6 +27,7 @@
 // Size (bytes) of the DPK (Data Protection Key)
 #define CDTENCRYPTIONKEY_KEYSIZE 32
 
+NS_ASSUME_NONNULL_BEGIN
 @interface CDTEncryptionKey : NSObject
 
 /**
@@ -34,7 +35,7 @@
  */
 @property (nonnull, strong, nonatomic, readonly) NSData *data;
 
-- (nullable instancetype)init UNAVAILABLE_ATTRIBUTE;
+- (instancetype)init UNAVAILABLE_ATTRIBUTE;
 
 /**
  Initialise an encryption key with a buffer.
@@ -50,3 +51,4 @@
 + (nullable instancetype)encryptionKeyWithData:(nonnull NSData *)data;
 
 @end
+NS_ASSUME_NONNULL_END

--- a/CDTDatastore/Encryption/CDTEncryptionKey.m
+++ b/CDTDatastore/Encryption/CDTEncryptionKey.m
@@ -4,6 +4,7 @@
 //
 //  Created by Enrique de la Torre Fernandez on 12/05/2015.
 //  Copyright (c) 2015 IBM Cloudant. All rights reserved.
+//  Copyright © 2016 IBM Corporation. All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
 //  except in compliance with the License. You may obtain a copy of the License at

--- a/CDTDatastore/Encryption/CDTEncryptionKey.m
+++ b/CDTDatastore/Encryption/CDTEncryptionKey.m
@@ -34,6 +34,7 @@
 #pragma mark - Init object
 - (instancetype)init
 {
+    NSAssert(NO, @"Use designated initializer");
     return nil;
 }
 

--- a/CDTDatastore/Encryption/CDTEncryptionKeySimpleProvider.h
+++ b/CDTDatastore/Encryption/CDTEncryptionKeySimpleProvider.h
@@ -32,9 +32,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)init UNAVAILABLE_ATTRIBUTE;
 
-- (nullable instancetype)initWithKey:(nonnull NSData *)key NS_DESIGNATED_INITIALIZER;
+- (nullable instancetype)initWithKey:(NSData *)key NS_DESIGNATED_INITIALIZER;
 
-+ (nullable instancetype)providerWithKey:(nonnull NSData *)key;
++ (nullable instancetype)providerWithKey:(NSData *)key;
 
 @end
 NS_ASSUME_NONNULL_END

--- a/CDTDatastore/Encryption/CDTEncryptionKeySimpleProvider.h
+++ b/CDTDatastore/Encryption/CDTEncryptionKeySimpleProvider.h
@@ -4,6 +4,7 @@
 //
 //  Created by Enrique de la Torre Fernandez on 26/05/2015.
 //  Copyright (c) 2015 IBM Cloudant. All rights reserved.
+//  Copyright © 2016 IBM Corporation. All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
 //  except in compliance with the License. You may obtain a copy of the License at

--- a/CDTDatastore/Encryption/CDTEncryptionKeySimpleProvider.h
+++ b/CDTDatastore/Encryption/CDTEncryptionKeySimpleProvider.h
@@ -27,12 +27,14 @@
  @see CDTEncryptionKeyProvider
  @see CDTEncryptionKey
  */
+NS_ASSUME_NONNULL_BEGIN
 @interface CDTEncryptionKeySimpleProvider : NSObject <CDTEncryptionKeyProvider>
 
-- (nullable instancetype)init UNAVAILABLE_ATTRIBUTE;
+- (instancetype)init UNAVAILABLE_ATTRIBUTE;
 
 - (nullable instancetype)initWithKey:(nonnull NSData *)key NS_DESIGNATED_INITIALIZER;
 
 + (nullable instancetype)providerWithKey:(nonnull NSData *)key;
 
 @end
+NS_ASSUME_NONNULL_END

--- a/CDTDatastore/Encryption/CDTEncryptionKeySimpleProvider.m
+++ b/CDTDatastore/Encryption/CDTEncryptionKeySimpleProvider.m
@@ -28,6 +28,7 @@
 
 - (instancetype)init
 {
+    NSAssert(NO, @"Use designated initializer");
     return nil;
 }
 

--- a/CDTDatastore/Encryption/CDTEncryptionKeySimpleProvider.m
+++ b/CDTDatastore/Encryption/CDTEncryptionKeySimpleProvider.m
@@ -4,6 +4,7 @@
 //
 //  Created by Enrique de la Torre Fernandez on 26/05/2015.
 //  Copyright (c) 2015 IBM Cloudant. All rights reserved.
+//  Copyright © 2016 IBM Corporation. All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
 //  except in compliance with the License. You may obtain a copy of the License at

--- a/CDTDatastore/HTTP/CDTHTTPInterceptorContext.h
+++ b/CDTDatastore/HTTP/CDTHTTPInterceptorContext.h
@@ -3,7 +3,7 @@
 //  
 //
 //  Created by Rhys Short on 17/08/2015.
-//  Copyright © 2016 IBM Corporation. All rights reserved.
+//  Copyright © 2015, 2016 IBM Corporation. All rights reserved.
 //
 //
 //  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/CDTDatastore/HTTP/CDTHTTPInterceptorContext.h
+++ b/CDTDatastore/HTTP/CDTHTTPInterceptorContext.h
@@ -78,9 +78,8 @@ NS_ASSUME_NONNULL_BEGIN
  * @param value the value to store
  * @param key the key with which the value is associated
  */
-                                                   
-- (void)setState:(NSObject*)value
-          forKey:(NSObject*)key;
+
+- (void)setState:(NSObject *)value forKey:(NSString *)key;
 
 @end
 

--- a/CDTDatastore/HTTP/CDTHTTPInterceptorContext.h
+++ b/CDTDatastore/HTTP/CDTHTTPInterceptorContext.h
@@ -3,7 +3,7 @@
 //  
 //
 //  Created by Rhys Short on 17/08/2015.
-//  Copyright (c) 2015 IBM Corp.
+//  Copyright © 2016 IBM Corporation. All rights reserved.
 //
 //
 //  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/CDTDatastore/HTTP/CDTHTTPInterceptorContext.m
+++ b/CDTDatastore/HTTP/CDTHTTPInterceptorContext.m
@@ -3,7 +3,7 @@
 //  
 //
 //  Created by Rhys Short on 17/08/2015.
-//  Copyright © 2016 IBM Corporation. All rights reserved.
+//  Copyright © 2015, 2016 IBM Corporation. All rights reserved.
 //
 //
 //  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/CDTDatastore/HTTP/CDTHTTPInterceptorContext.m
+++ b/CDTDatastore/HTTP/CDTHTTPInterceptorContext.m
@@ -49,9 +49,8 @@
 - (NSObject*)stateForKey:(NSString*)key {
     return self.internalState[key];
 }
-
-- (void)setState:(NSObject*)value
-          forKey:(NSObject*)key {
+- (void)setState:(NSObject *)value forKey:(NSString *)key
+{
     [self.internalState setValue:value forKey:key];
 }
 

--- a/CDTDatastore/HTTP/CDTHTTPInterceptorContext.m
+++ b/CDTDatastore/HTTP/CDTHTTPInterceptorContext.m
@@ -3,7 +3,7 @@
 //  
 //
 //  Created by Rhys Short on 17/08/2015.
-//  Copyright (c) 2015 IBM Corp.
+//  Copyright © 2016 IBM Corporation. All rights reserved.
 //
 //
 //  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/CDTDatastore/HTTP/CDTURLSession.h
+++ b/CDTDatastore/HTTP/CDTURLSession.h
@@ -2,7 +2,7 @@
 //  CDTURLSession.h
 //
 //  Created by Rhys Short.
-//  Copyright (c) 2015 IBM Corp.
+//  Copyright © 2016 IBM Corporation. All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
 //  except in compliance with the License. You may obtain a copy of the License at

--- a/CDTDatastore/HTTP/CDTURLSession.h
+++ b/CDTDatastore/HTTP/CDTURLSession.h
@@ -2,7 +2,7 @@
 //  CDTURLSession.h
 //
 //  Created by Rhys Short.
-//  Copyright © 2016 IBM Corporation. All rights reserved.
+//  Copyright © 2015, 2016 IBM Corporation. All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
 //  except in compliance with the License. You may obtain a copy of the License at

--- a/CDTDatastore/HTTP/CDTURLSession.m
+++ b/CDTDatastore/HTTP/CDTURLSession.m
@@ -2,7 +2,7 @@
 //  CDTURLSession.m
 //
 //  Created by Rhys Short.
-//  Copyright © 2016 IBM Corporation. All rights reserved.
+//  Copyright © 2015, 2016 IBM Corporation. All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
 //  except in compliance with the License. You may obtain a copy of the License at

--- a/CDTDatastore/HTTP/CDTURLSession.m
+++ b/CDTDatastore/HTTP/CDTURLSession.m
@@ -2,7 +2,7 @@
 //  CDTURLSession.m
 //
 //  Created by Rhys Short.
-//  Copyright (c) 2015 IBM Corp.
+//  Copyright © 2016 IBM Corporation. All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
 //  except in compliance with the License. You may obtain a copy of the License at

--- a/CDTDatastore/HTTP/CDTURLSessionTask.h
+++ b/CDTDatastore/HTTP/CDTURLSessionTask.h
@@ -39,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Don't call this initialiser; it will throw an exception.
  */
-- (nullable instancetype)init UNAVAILABLE_ATTRIBUTE;
+- (instancetype)init UNAVAILABLE_ATTRIBUTE;
 
 /*
  * Initalises an instance of CDTURLSessionTask

--- a/CDTDatastore/HTTP/CDTURLSessionTask.m
+++ b/CDTDatastore/HTTP/CDTURLSessionTask.m
@@ -57,7 +57,7 @@
 
 @implementation CDTURLSessionTask
 
-- (nullable instancetype)init
+- (instancetype)init
 {
     NSAssert(NO, @"Use designated initializer");
     return nil;


### PR DESCRIPTION
## What

Fix warnings for nullability, pointer mismatch and double variable assignment.
## How
- Correct nullability annotations for `init` methods and use `NSAssert` to stop users calling the method dynamically in debug builds.
- Remove second assignment of `success`
- Correct the parameter types for `setState:forKey:`
## Testing
- No new tests
##  Issues

Fixes #329 
