### PR TITLE
Fix attachment key dangling reference

### DIFF
--- a/CDTDatastore/Attachments/CDTDatastore+Attachments.m
+++ b/CDTDatastore/Attachments/CDTDatastore+Attachments.m
@@ -142,7 +142,7 @@ static NSString *const CDTAttachmentsErrorDomain = @"CDTAttachmentsErrorDomain";
                                                                          size:size
                                                                        revpos:revpos
                                                                      sequence:sequence
-                                                                          key:keyData
+                                                                          key:[keyData copy]
                                                                      encoding:encoding];
 
     return attachment;


### PR DESCRIPTION
On line 125, a reference to the "key" column's data is created which was not properly copied when stored in the CDTSavedAttachment instance on line 145. This leads to FMDB re-using the memory if there is more than one attachment and in the "best" case leads to all attachments having the same key and in the worst case crashes the application with a segfault when working with the "key" attribute.
