### PR TITLE
Fix leaks and peak memory usage issue.

### DIFF
--- a/CDTDatastore/CDTReplicator/CDTReplicator.m
+++ b/CDTDatastore/CDTReplicator/CDTReplicator.m
@@ -181,8 +181,8 @@ static NSString *const CDTReplicatorErrorDomain = @"CDTReplicatorErrorDomain";
     {
         // check both self.started and self.state. While unlikely, it is possible for -stop to
         // be called before -startWithTaskGroup:error:. If -stop is called first on a particular
-        // instance, the resulting state will 'stopped' and the object can no longer be started at
-        // that point.
+        // instance, the resulting state will be 'stopped' and the object can no longer be started
+        // at that point.
         if (self.started || self.state != CDTReplicatorStatePending) {
             CDTLogInfo(CDTREPLICATION_LOG_CONTEXT,
                        @"-startWithTaskGroup:error: CDTReplicator can only be started "

--- a/CDTDatastore/HTTP/CDTHTTPInterceptorContext.m
+++ b/CDTDatastore/HTTP/CDTHTTPInterceptorContext.m
@@ -25,7 +25,7 @@
 
 
 -(instancetype)init {
-    NSAssert(NO, @"Call the designated initaliser");
+    NSAssert(NO, @"Call the designated initialiser");
     return nil;
 }
 

--- a/CDTDatastore/HTTP/CDTURLSession.h
+++ b/CDTDatastore/HTTP/CDTURLSession.h
@@ -2,7 +2,7 @@
 //  CDTURLSession.h
 //
 //  Created by Rhys Short.
-//  Copyright © 2015, 2016 IBM Corporation. All rights reserved.
+//  Copyright © 2015, 2016, 2017 IBM Corporation. All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
 //  except in compliance with the License. You may obtain a copy of the License at
@@ -82,6 +82,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)disassociateTask:(NSURLSessionDataTask *)task;
 
 - (void) waitForFreeSlot;
+
+- (void)finishTasksAndInvalidate;
 
 @end
 

--- a/CDTDatastore/HTTP/CDTURLSession.m
+++ b/CDTDatastore/HTTP/CDTURLSession.m
@@ -2,7 +2,7 @@
 //  CDTURLSession.m
 //
 //  Created by Rhys Short.
-//  Copyright © 2015, 2016 IBM Corporation. All rights reserved.
+//  Copyright © 2015, 2016, 2017 IBM Corporation. All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
 //  except in compliance with the License. You may obtain a copy of the License at
@@ -100,7 +100,7 @@ static dispatch_semaphore_t g_asyncTaskMonitor;
     return self;
 }
 
-- (void)dealloc { [self.session finishTasksAndInvalidate]; }
+- (void)finishTasksAndInvalidate { [self.session finishTasksAndInvalidate]; }
 
 - (CDTURLSessionTask *)dataTaskWithRequest:(NSURLRequest *)request
                               taskDelegate:(NSObject<CDTURLSessionTaskDelegate> *)taskDelegate

--- a/CDTDatastore/touchdb/ChangeTracker/TDChangeTracker.h
+++ b/CDTDatastore/touchdb/ChangeTracker/TDChangeTracker.h
@@ -3,6 +3,9 @@
 //  TouchDB
 //
 //  Created by Jens Alfke on 6/20/11.
+//
+//  Copyright © 2017 IBM Corp. All rights reserved.
+//
 //  Copyright 2011 Couchbase, Inc.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
@@ -23,6 +26,7 @@
 - (void)changeTrackerReceivedChange:(NSDictionary*)change;
 - (void)changeTrackerReceivedChanges:(NSArray*)changes;
 - (void)changeTrackerStopped:(TDChangeTracker*)tracker;
+- (NSUInteger)sizeOfChangeQueue;
 @end
 
 typedef enum TDChangeTrackerMode { kOneShot, kLongPoll, kContinuous } TDChangeTrackerMode;

--- a/CDTDatastore/touchdb/ChangeTracker/TDURLConnectionChangeTracker.m
+++ b/CDTDatastore/touchdb/ChangeTracker/TDURLConnectionChangeTracker.m
@@ -3,7 +3,7 @@
 //  
 //
 //  Created by Adam Cox on 1/5/15.
-//  Copyright (c) 2015 IBM.
+//  Copyright © 2015, 2017 IBM Corp. All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
 //  except in compliance with the License. You may obtain a copy of the License at
@@ -40,6 +40,9 @@
 @property (nonatomic, strong) CDTURLSession * session;
 @property (nonatomic, strong) CDTURLSessionTask * task;
 @end
+
+static const int kChangeQueueThreshold = 500;
+static const float kChangeQueuePollingRate = 0.1f;
 
 @implementation TDURLConnectionChangeTracker
 
@@ -281,8 +284,23 @@ didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
     }
     
     [self clearConnection];
-    
-    if (restart){
+
+    if (restart) {
+        // Throttle the rate at which we get the list of changes. If we already have more than
+        // kChangeQueueThreshold changes to be processed, wait until we fall below that threshold
+        // before we get any more. Note that this is not a hard limit, and the number of changes may
+        // exceed kChangeQueueThreshold, but it won't go vastly above the threshold. This saves us
+        // from consuming large amounts of memory by allocating a TDPulledRevision for each
+        // change we are waiting to pull and keeps our peak memory usage much smaller during
+        // pulls of large numbers of changes.
+        if ([_client respondsToSelector:@selector(sizeOfChangeQueue)]) {
+            while ([_client sizeOfChangeQueue] > kChangeQueueThreshold &&
+                   [[NSRunLoop currentRunLoop]
+                          runMode:NSDefaultRunLoopMode
+                       beforeDate:[NSDate dateWithTimeIntervalSinceNow:kChangeQueuePollingRate]])
+                ;
+        }
+
         [self start];  // Next poll...
     } else {
         [self stopped];

--- a/CDTDatastore/touchdb/TDPuller.m
+++ b/CDTDatastore/touchdb/TDPuller.m
@@ -3,6 +3,8 @@
 //  TouchDB
 //
 //  Created by Jens Alfke on 12/2/11.
+//  Copyright © 2017 IBM Corp. All rights reserved.
+//
 //  Copyright (c) 2011 Couchbase, Inc. All rights reserved.
 //
 //  Modifications for this distribution by Cloudant, Inc., Copyright (c) 2014 Cloudant, Inc.
@@ -302,6 +304,7 @@ static NSString* joinQuotedEscaped(NSArray* strings);
     if (!_caughtUp) [self asyncTasksFinished:1];  // balances -asyncTaskStarted in -beginReplicating
 }
 
+- (NSUInteger)sizeOfChangeQueue { return _revsToPull.count; }
 #pragma mark - REVISION CHECKING:
 
 // Process a bunch of remote revisions from the _changes feed at once
@@ -646,6 +649,8 @@ static NSString* joinQuotedEscaped(NSArray* strings);
                 [_pendingSequences removeSequence:fakeSequence];
             }
         }
+
+        [_db clearPendingAttachments];
 
         CDTLogVerbose(CDTREPLICATION_LOG_CONTEXT, @"%@ finished inserting %u revisions", self,
                    (unsigned)downloads.count);

--- a/CDTDatastore/touchdb/TDReplicator.m
+++ b/CDTDatastore/touchdb/TDReplicator.m
@@ -6,7 +6,7 @@
 //  Copyright (c) 2011 Couchbase, Inc. All rights reserved.
 //
 //  Modifications for this distribution by Cloudant, Inc., Copyright (c) 2014 Cloudant, Inc.
-//  Copyright © 2016 IBM Corporation. All rights reserved.
+//  Copyright © 2016, 2017 IBM Corporation. All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
 //  except in compliance with the License. You may obtain a copy of the License at
@@ -309,6 +309,11 @@ NSString* TDReplicatorStartedNotification = @"TDReplicatorStarted";
             dispatch_group_leave(taskGroup);
         }
     }
+
+    [self.session finishTasksAndInvalidate];
+    self.session = nil;
+    self.sessionConfigDelegate = nil;
+    self.interceptors = nil;
 }
 
 

--- a/CDTDatastore/touchdb/TD_Database.h
+++ b/CDTDatastore/touchdb/TD_Database.h
@@ -6,7 +6,15 @@
  *  Copyright (c) 2011 Couchbase, Inc. All rights reserved.
  *
  *  Modifications for this distribution by Cloudant, Inc., Copyright (c) 2014 Cloudant, Inc.
+ *  Copyright © 2017 IBM Corporation. All rights reserved.
  *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ *  except in compliance with the License. You may obtain a copy of the License at
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software distributed under the
+ *  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ *  either express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
  */
 
 #import "TD_Revision.h"
@@ -234,6 +242,8 @@ extern const TDChangesOptions kDefaultTDChangesOptions;
     format ("designdocname/viewname"), it attempts to load the view properties from the
     design document and compile them with the TDViewCompiler. */
 - (TD_View*)compileViewNamed:(NSString*)name status:(TDStatus*)outStatus;
+
+- (void)clearPendingAttachments;
 
 @property (readonly) NSArray* allViews;
 

--- a/CDTDatastore/touchdb/TD_Database.m
+++ b/CDTDatastore/touchdb/TD_Database.m
@@ -8,6 +8,8 @@
 // Modified by Michael Rhodes, 2013
 // Copyright (c) 2013 Cloudant, Inc. All rights reserved.
 //
+// Copyright © 2017 IBM Corporation. All rights reserved.
+//
 //  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
 //  except in compliance with the License. You may obtain a copy of the License at
 //    http://www.apache.org/licenses/LICENSE-2.0
@@ -1538,4 +1540,5 @@ const TDChangesOptions kDefaultTDChangesOptions = {UINT_MAX, 0, NO, NO, YES};
     return queue;
 }
 
+- (void)clearPendingAttachments { _pendingAttachmentsByDigest = nil; }
 @end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CDTDatastore CHANGELOG
 
+## Unreleased
+
+- [IMPROVED] Significant reduction in memory usage during large pull replications.
+
 ## 1.2.0 (2016-12-07)
 
 - [NEW] Warnings are logged if attachments dictionary is not keyed by `attachment.name`.


### PR DESCRIPTION
### What

Fix some memory leaks and a peak memory consumption issue during large pull replications.

### How

Add new method `finishTasksAndInvalidate` to `CDTURLSession`, which calls through to the `finishTasksAndInvalidate` method of the underlying `NSURLSession` and call this method from `TDReplicator` once we've finished the replication. This breaks a retain cycle that caused `CDTURLSession` objects not to be deallocated because the `NSURLSession` was still referencing them.  Although there was a call to `NSURLSession#finishTasksAndInvalidate` in `CDTURLSession#dealloc` it was never called because the `CDTURLSession` was never deallocated due to the retain cycle.

Also fixed a few other memory leaks.

Peak memory usage was going extremely high during large pull replications. This memory was ultimately being deallocated, but could cause the application to crash due to running out of memory. This was tracked down to the fact that during a large pull, hundreds of thousands of `TDPulledRevision`objects were being allocated. To prevent so many `TDPulledRevision` objects being allocated, the rate at which we get the list of changes to be pulled is now throttled so we don't read ahead too far before we actually pull the revisions.

A new method `sizeOfChangeQueue` has been added to the `TDChangeTrackerClient` protocol so that we can evaluate the length of the queue of changes and then not read ahead too far in the list of changes relative to the changes we've actually pulled.  In `TDURLConnectionChangeTracker.m`, we now evaluate the queue length to see if it's greater than 500. If it is, we wait until it falls to 500 or below before we continue to get the list of changes. This means we no longer create hundreds of thousands of `TDPulledRevision` objects and the number at any one time doesn't go much above 500.

The value 500 was picked by experimentation with various large pull replications. It seems to give a good balance of performance without increasing peak memory usage too much. Using too low a threshold can slow performance as we can run out of changes in our list of changes to pull. Using too high a threshold can also slow performance slightly but also increases peak memory usage.

### Testing

No new automated tests have been added. All existing tests pass (including Replication Acceptance Tests).

Various manual tests have been carried out using an app based on the TodoSync example app replicating large data sets. Using one of the data sets containing >400k documents totalling 4.5GB including attachments, peak memory is now approximately 38MB during replication and the replication completes successfully. Previously, peak memory usage continually grew hitting 1.42GB before the app crashed having only replicated about 82k documents.

Fixes #303