### PR TITLE
Jenkinsfile enable rat

### DIFF
--- a/CDTDatastoreReplicationAcceptanceTests/CloudantReplicationBase.m
+++ b/CDTDatastoreReplicationAcceptanceTests/CloudantReplicationBase.m
@@ -30,7 +30,13 @@
     XCTAssertNil(error, @"CDTDatastoreManager had error");
     XCTAssertNotNil(self.factory, @"Factory is nil");
 
-    self.remoteRootURL = [NSURL URLWithString:[[ReplicationSettings alloc] init].serverURI];
+    ReplicationSettings *settings = [[ReplicationSettings alloc] init];
+    self.remoteRootURL = [NSURL URLWithString:settings.serverURI];
+    
+    // Configure BasicAuth header for UNIRest requests
+    if (settings.authorization != nil) {
+        [UNIRest defaultHeader:@"Authorization" value: settings.authorization];
+    }
     
 #ifdef USE_ENCRYPTION
     self.remoteDbPrefix = @"replication-acceptance-with-encryption";

--- a/CDTDatastoreReplicationAcceptanceTests/ReplicationSettings.h
+++ b/CDTDatastoreReplicationAcceptanceTests/ReplicationSettings.h
@@ -12,6 +12,8 @@
 
 @property (readonly) NSString* serverURI;
 
+@property (readonly) NSString* authorization;
+
 @property (readonly) NSNumber* nDocs;
 
 @property (readonly) NSNumber* largeRevTreeSize;

--- a/CDTDatastoreReplicationAcceptanceTests/ReplicationSettings.m
+++ b/CDTDatastoreReplicationAcceptanceTests/ReplicationSettings.m
@@ -84,4 +84,13 @@
     return server;
 }
 
+-(NSString *) authorization {
+    NSString *base64Creds;
+    if (self.username != nil && ![self.username isEqualToString:@""] ){
+        NSData *creds = [[NSString stringWithFormat:@"%@:%@", self.username, self.password]dataUsingEncoding:NSUTF8StringEncoding];
+        base64Creds = [NSString stringWithFormat:@"Basic %@", [creds base64EncodedStringWithOptions:0]];
+    }
+    return base64Creds;
+}
+
 @end

--- a/Rakefile
+++ b/Rakefile
@@ -82,7 +82,7 @@ end
 
 desc "Run the replication acceptance tests for iOS"
 task :replicationacceptanceios do
-  test(CDTDATASTORE_WS, REPLICATION_ACCEPTANCE_IOS, IOS_DEST)
+  test(CDTDATASTORE_WS, REPLICATION_ACCEPTANCE_IOS, IPHONE_DEST)
 end
 
 #


### PR DESCRIPTION
*What*

Enable the replication acceptance tests in the Jenkinsfile

*How*

* Fixed the destination in the `Rakefile`.
* Added additional axes to builds of `master` in the `Jenkinsfile`.
* Improved log collection:
    * Deleted the directory before `unstash` to remove old log files.
    * Expanded the match of the log collector to pick up RAT logs.
    * Disabled log collection for the `sample` build since there aren't any.
* Added credentials reference to the `Jenkinsfile` for the test server.
* Added auth to `UNIRest` requests to fix test setup for servers with credentials
    * Added `authorization` function to `ReplicationSettings` to get Basic auth creds
    * Augmented `CloudantReplicationBase` to add Basic auth header to all `UNIRest` requests. 

*Testing*

All the changes are related to testing. The RATs ran through cleanly with these changes.