### PR TITLE
Added per node host locking for pod file

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,6 +16,11 @@
 
 def podfile(podfileDir) {
     // Lock the pod repo and update the pod
+
+    // Note that each macOS host has a podfile so there is one Jenkins lock
+    // available per host. Nodes are named as nodeHost-executorEnv so we use the
+    // part of the node name before the - to identify the pod lock.
+
     lock("${env.NODE_NAME.split('-')[0]}pod") {
         if(fileExists('Podfile.lock')) {
             sh "cd ${podfileDir} && pod update --verbose"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@
 
 def podfile(podfileDir) {
     // Lock the pod repo and update the pod
-    lock('pod') {
+    lock("${env.NODE_NAME.split('-')[0]}pod") {
         if(fileExists('Podfile.lock')) {
             sh "cd ${podfileDir} && pod update --verbose"
         } else {


### PR DESCRIPTION
*What*

Added per node host locking for pod file

*How*

Previously we used a single Jenkins lock to prevent clashing pod updates since we only had one host. Now there are multiple hosts so we should lock per host instead of globally to avoid contention.
Split the `NODE_NAME` on the `-` and prefix that part (the host) to `pod` to get the name of the lock for the node.

Note: the old `pod` lock will be deleted when this merges so other branches using the old lock won't be able to clash, but they will have to update to the new `Jenkinsfile` to pass.

*Testing*

Build change, no new tests, ran correctly obtaining new locks.