### PR TITLE
Removed iOS testing from Travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,11 @@ install:
 script:
   - rake travis
 env:
-  - PLATFORM=iOS
-    encrypted=yes
-  - PLATFORM=iOS
+  # Travis hardware is too slow to run the iOS tests as the build exceeds the
+  # allowed time of 50 minutes. Rely on Jenkins coverage for iOS for now.
+  #- PLATFORM=iOS
+  #  encrypted=yes
+  #- PLATFORM=iOS
   - PLATFORM=OSX
   - PLATFORM=OSX
     encrypted=yes


### PR DESCRIPTION
*What*

Removed iOS testing from Travis matrix

*Why/How*

Travis builds have a 50 minute limit. The Travis hardware is too slow for the iOS tests to finish in that time (c.f. Jenkins completing the work in < 3 min using the Mac Mini executors).
Removed the iOS tests from Travis matrix to avoid these timeout failures.

*Testing*

Disables iOS test coverage from Travis, but they are still run on Jenkins. The limitation is for PRs from forked repositories which only run on Travis. For those PRs we may not see some failures until after merges to master.