### PR TITLE
Add CDTIAMSessionCookieInterceptor

### DIFF
--- a/CDTDatastore.xcodeproj/project.pbxproj
+++ b/CDTDatastore.xcodeproj/project.pbxproj
@@ -19,6 +19,16 @@
 		8E2DDDF91D1BEFBE00673564 /* CDTReplay429Interceptor.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E2DDDF61D1BEFBE00673564 /* CDTReplay429Interceptor.h */; };
 		8E2DDDFA1D1BEFBE00673564 /* CDTReplay429Interceptor.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E2DDDF71D1BEFBE00673564 /* CDTReplay429Interceptor.m */; };
 		8E2DDDFB1D1BEFBE00673564 /* CDTReplay429Interceptor.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E2DDDF71D1BEFBE00673564 /* CDTReplay429Interceptor.m */; };
+		8E705A8B1F0CE58500FF0219 /* CDTIAMSessionCookieInterceptor.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E705A8A1F0CE58500FF0219 /* CDTIAMSessionCookieInterceptor.m */; };
+		8E705A8C1F0CE58500FF0219 /* CDTIAMSessionCookieInterceptor.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E705A8A1F0CE58500FF0219 /* CDTIAMSessionCookieInterceptor.m */; };
+		8E705A8E1F0CE5B200FF0219 /* CDTIAMSessionCookieInterceptor.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E705A8D1F0CE5B200FF0219 /* CDTIAMSessionCookieInterceptor.h */; };
+		8E705A8F1F0CE5B200FF0219 /* CDTIAMSessionCookieInterceptor.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E705A8D1F0CE5B200FF0219 /* CDTIAMSessionCookieInterceptor.h */; };
+		8E705A921F0D360700FF0219 /* CDTSessionCookieInterceptorBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E705A901F0D360700FF0219 /* CDTSessionCookieInterceptorBase.h */; };
+		8E705A931F0D360700FF0219 /* CDTSessionCookieInterceptorBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E705A901F0D360700FF0219 /* CDTSessionCookieInterceptorBase.h */; };
+		8E705A941F0D360700FF0219 /* CDTSessionCookieInterceptorBase.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E705A911F0D360700FF0219 /* CDTSessionCookieInterceptorBase.m */; };
+		8E705A951F0D360700FF0219 /* CDTSessionCookieInterceptorBase.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E705A911F0D360700FF0219 /* CDTSessionCookieInterceptorBase.m */; };
+		8E705A971F0E325200FF0219 /* CDTIAMSessionCookieInterceptorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E705A961F0E325200FF0219 /* CDTIAMSessionCookieInterceptorTests.m */; };
+		8E705A981F0E348F00FF0219 /* CDTIAMSessionCookieInterceptorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E705A961F0E325200FF0219 /* CDTIAMSessionCookieInterceptorTests.m */; };
 		90D44B38BE0B6F0F5E18F462 /* Pods_base_raTests_CDTDatastoreReplicationAcceptanceTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FF78267FE761ABB49CEB76BB /* Pods_base_raTests_CDTDatastoreReplicationAcceptanceTests.framework */; };
 		980F22711CB818260075A843 /* CDTQFilterFieldsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 98F77E0B1C44044000515CC3 /* CDTQFilterFieldsTest.m */; };
 		980F22721CB818260075A843 /* CDTQIndexCreatorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98F77E0C1C44044000515CC3 /* CDTQIndexCreatorTests.m */; };
@@ -750,6 +760,11 @@
 		880C1D944A8E097B9021DF85 /* Pods-base-tests-CDTDatastoreTestsOSX.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-base-tests-CDTDatastoreTestsOSX.debug.xcconfig"; path = "Pods/Target Support Files/Pods-base-tests-CDTDatastoreTestsOSX/Pods-base-tests-CDTDatastoreTestsOSX.debug.xcconfig"; sourceTree = "<group>"; };
 		8E2DDDF61D1BEFBE00673564 /* CDTReplay429Interceptor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDTReplay429Interceptor.h; sourceTree = "<group>"; };
 		8E2DDDF71D1BEFBE00673564 /* CDTReplay429Interceptor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTReplay429Interceptor.m; sourceTree = "<group>"; };
+		8E705A8A1F0CE58500FF0219 /* CDTIAMSessionCookieInterceptor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTIAMSessionCookieInterceptor.m; sourceTree = "<group>"; };
+		8E705A8D1F0CE5B200FF0219 /* CDTIAMSessionCookieInterceptor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDTIAMSessionCookieInterceptor.h; sourceTree = "<group>"; };
+		8E705A901F0D360700FF0219 /* CDTSessionCookieInterceptorBase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDTSessionCookieInterceptorBase.h; sourceTree = "<group>"; };
+		8E705A911F0D360700FF0219 /* CDTSessionCookieInterceptorBase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTSessionCookieInterceptorBase.m; sourceTree = "<group>"; };
+		8E705A961F0E325200FF0219 /* CDTIAMSessionCookieInterceptorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTIAMSessionCookieInterceptorTests.m; sourceTree = "<group>"; };
 		987382FB1C47B1DD00937212 /* CDTHelperFixedKeyProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDTHelperFixedKeyProvider.h; sourceTree = "<group>"; };
 		987382FC1C47B1DD00937212 /* CDTHelperFixedKeyProvider.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTHelperFixedKeyProvider.m; sourceTree = "<group>"; };
 		987382FD1C47B1DD00937212 /* CDTHelperOneUseKeyProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDTHelperOneUseKeyProvider.h; sourceTree = "<group>"; };
@@ -1378,6 +1393,7 @@
 				98F77E171C44044000515CC3 /* CDTQValueExtractorTests.m */,
 				98F77E181C44044000515CC3 /* CDTReplicationTests.m */,
 				98F77E191C44044000515CC3 /* CDTSessionCookieInterceptorTests.m */,
+				8E705A961F0E325200FF0219 /* CDTIAMSessionCookieInterceptorTests.m */,
 				98F77E1A1C44044000515CC3 /* CDTURLSessionTaskTests.m */,
 				98F77E1B1C44044000515CC3 /* CDTURLSessionTests.m */,
 				98F77E1C1C44044000515CC3 /* CloudantSyncTests.h */,
@@ -1535,6 +1551,10 @@
 				98F77BA51C43FCEE00515CC3 /* CDTHTTPInterceptorContext.m */,
 				98F77BA61C43FCEE00515CC3 /* CDTSessionCookieInterceptor.h */,
 				98F77BA71C43FCEE00515CC3 /* CDTSessionCookieInterceptor.m */,
+				8E705A8D1F0CE5B200FF0219 /* CDTIAMSessionCookieInterceptor.h */,
+				8E705A8A1F0CE58500FF0219 /* CDTIAMSessionCookieInterceptor.m */,
+				8E705A901F0D360700FF0219 /* CDTSessionCookieInterceptorBase.h */,
+				8E705A911F0D360700FF0219 /* CDTSessionCookieInterceptorBase.m */,
 				98F77BA81C43FCEE00515CC3 /* CDTURLSession.h */,
 				98F77BA91C43FCEE00515CC3 /* CDTURLSession.m */,
 				98F77BAA1C43FCEE00515CC3 /* CDTURLSessionTask.h */,
@@ -1935,6 +1955,7 @@
 				987383881C47B38800937212 /* CDTQLogging.h in Headers */,
 				987383891C47B38800937212 /* CDTDatastore+Query.h in Headers */,
 				9873838A1C47B38800937212 /* Version.h in Headers */,
+				8E705A8F1F0CE5B200FF0219 /* CDTIAMSessionCookieInterceptor.h in Headers */,
 				9873838B1C47B38800937212 /* TDBlobStore+Internal.h in Headers */,
 				9873838C1C47B38800937212 /* TD_Database+BlobFilenames.h in Headers */,
 				9873838D1C47B38800937212 /* CDTBlobEncryptedData+Internal.h in Headers */,
@@ -1994,6 +2015,7 @@
 				987383C41C47B38800937212 /* TD_Database+Attachments.h in Headers */,
 				987383C51C47B38800937212 /* CDTEncryptionKeychainManager.h in Headers */,
 				987383C61C47B38800937212 /* CloudantSyncEncryption.h in Headers */,
+				8E705A931F0D360700FF0219 /* CDTSessionCookieInterceptorBase.h in Headers */,
 				987383C71C47B38800937212 /* TDReachability.h in Headers */,
 				987383C81C47B38800937212 /* TDBase64.h in Headers */,
 				987383C91C47B38800937212 /* CDTURLSessionTask.h in Headers */,
@@ -2066,6 +2088,7 @@
 				98F77C7C1C43FCEE00515CC3 /* CDTQLogging.h in Headers */,
 				98F77C721C43FCEE00515CC3 /* CDTDatastore+Query.h in Headers */,
 				98F77CDE1C43FCEE00515CC3 /* Version.h in Headers */,
+				8E705A8E1F0CE5B200FF0219 /* CDTIAMSessionCookieInterceptor.h in Headers */,
 				98F77CB11C43FCEE00515CC3 /* TDBlobStore+Internal.h in Headers */,
 				98F77C991C43FCEE00515CC3 /* TD_Database+BlobFilenames.h in Headers */,
 				98F77C441C43FCEE00515CC3 /* CDTBlobEncryptedData+Internal.h in Headers */,
@@ -2125,6 +2148,7 @@
 				98F77C5A1C43FCEE00515CC3 /* CDTEncryptionKeychainManager.h in Headers */,
 				98F77C531C43FCEE00515CC3 /* CloudantSyncEncryption.h in Headers */,
 				98F77CCD1C43FCEE00515CC3 /* TDReachability.h in Headers */,
+				8E705A921F0D360700FF0219 /* CDTSessionCookieInterceptorBase.h in Headers */,
 				98F77CAD1C43FCEE00515CC3 /* TDBase64.h in Headers */,
 				98F77C701C43FCEE00515CC3 /* CDTURLSessionTask.h in Headers */,
 				98F77CD11C43FCEE00515CC3 /* TDReplicator.h in Headers */,
@@ -2799,6 +2823,7 @@
 				987383181C47B38800937212 /* TD_DatabaseManager.m in Sources */,
 				8E2DDDFB1D1BEFBE00673564 /* CDTReplay429Interceptor.m in Sources */,
 				987383191C47B38800937212 /* Test.m in Sources */,
+				8E705A951F0D360700FF0219 /* CDTSessionCookieInterceptorBase.m in Sources */,
 				9873831A1C47B38800937212 /* CDTHTTPInterceptorContext.m in Sources */,
 				9873831B1C47B38800937212 /* TDSequenceMap.m in Sources */,
 				9873831C1C47B38800937212 /* MYStreamUtils.m in Sources */,
@@ -2816,6 +2841,7 @@
 				9873832A1C47B38800937212 /* CDTQIndexCreator.m in Sources */,
 				9873832B1C47B38800937212 /* TDMisc.m in Sources */,
 				9873832C1C47B38800937212 /* CDTChangedDictionary.m in Sources */,
+				8E705A8C1F0CE58500FF0219 /* CDTIAMSessionCookieInterceptor.m in Sources */,
 				9873832D1C47B38800937212 /* CDTAttachment.m in Sources */,
 				9873832E1C47B38800937212 /* CDTEncryptionKeyNilProvider.m in Sources */,
 				9873832F1C47B38800937212 /* TD_Database+Replication.m in Sources */,
@@ -2945,6 +2971,7 @@
 				9873853C1C47B45600937212 /* CDTQMatcherQueryExecutor.m in Sources */,
 				9873853E1C47B45600937212 /* TDMiscTests.m in Sources */,
 				987385401C47B45600937212 /* TD_DatabaseTests.m in Sources */,
+				8E705A981F0E348F00FF0219 /* CDTIAMSessionCookieInterceptorTests.m in Sources */,
 				987385411C47B45600937212 /* DatastoreManagerTests.m in Sources */,
 				987385431C47B45600937212 /* TDMultiStreamWriterTests.m in Sources */,
 				987385441C47B45600937212 /* CDTQEitherMatcher.m in Sources */,
@@ -3026,6 +3053,7 @@
 				98F77CA61C43FCEE00515CC3 /* TD_DatabaseManager.m in Sources */,
 				8E2DDDFA1D1BEFBE00673564 /* CDTReplay429Interceptor.m in Sources */,
 				98F77D271C43FDA700515CC3 /* Test.m in Sources */,
+				8E705A941F0D360700FF0219 /* CDTSessionCookieInterceptorBase.m in Sources */,
 				98F77C6B1C43FCEE00515CC3 /* CDTHTTPInterceptorContext.m in Sources */,
 				98F77CD61C43FCEE00515CC3 /* TDSequenceMap.m in Sources */,
 				98F77D1A1C43FDA700515CC3 /* MYStreamUtils.m in Sources */,
@@ -3043,6 +3071,7 @@
 				98F77C771C43FCEE00515CC3 /* CDTQIndexCreator.m in Sources */,
 				98F77CBC1C43FCEE00515CC3 /* TDMisc.m in Sources */,
 				98F77CDC1C43FCEE00515CC3 /* CDTChangedDictionary.m in Sources */,
+				8E705A8B1F0CE58500FF0219 /* CDTIAMSessionCookieInterceptor.m in Sources */,
 				98F77C1E1C43FCEE00515CC3 /* CDTAttachment.m in Sources */,
 				98F77C4F1C43FCEE00515CC3 /* CDTEncryptionKeyNilProvider.m in Sources */,
 				98F77CA21C43FCEE00515CC3 /* TD_Database+Replication.m in Sources */,
@@ -3117,6 +3146,7 @@
 				980F22761CB818260075A843 /* CDTQInvalidQuerySyntax.m in Sources */,
 				987AF7B61DE7274C00577DAC /* DatastoreEncryptionTests.m in Sources */,
 				980F22771CB818260075A843 /* CDTQPerformanceTests.m in Sources */,
+				8E705A971F0E325200FF0219 /* CDTIAMSessionCookieInterceptorTests.m in Sources */,
 				980F22781CB818260075A843 /* CDTQQueryExecutorTests.m in Sources */,
 				980F22791CB818260075A843 /* CDTQQuerySortTests.m in Sources */,
 				980F227A1CB818260075A843 /* CDTQQuerySqlTranslatorTests.m in Sources */,

--- a/CDTDatastore/CDTReplicator/CDTAbstractReplication.h
+++ b/CDTDatastore/CDTReplicator/CDTAbstractReplication.h
@@ -146,6 +146,16 @@ typedef NS_ENUM(NSInteger, CDTReplicationErrors) {
  * @return an initialsed instance of CDTAbstractReplication.
  */
 - (instancetype)initWithUsername:(nullable NSString*)username password:(nullable NSString*)password;
+
+/**
+ * Initalises the abstract replication, using an IAM API key to authenticate.
+ * See https://console.bluemix.net/docs/services/Cloudant/guides/iam.html#ibm-cloud-identity-and-access-management
+ * for more information about IAM.
+ * @param IAMAPIKey The IAM API key.
+ * @return an initialsed instance of CDTAbstractReplication.
+ */
+- (instancetype)initWithIAMAPIKey:(NSString *)IAMAPIKey;
+
 /**
   Adds an interceptor to the interceptors array.
  @param interceptor the interceptor to append to the interceptors array.

--- a/CDTDatastore/CDTReplicator/CDTAbstractReplication.m
+++ b/CDTDatastore/CDTReplicator/CDTAbstractReplication.m
@@ -27,6 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nullable, readwrite, nonatomic, strong) NSString *username;
 @property (nullable, readwrite, nonatomic, strong) NSString *password;
+@property (nullable, readwrite, nonatomic, strong) NSString *IAMAPIKey;
 
 NS_ASSUME_NONNULL_END
 
@@ -55,6 +56,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     return [self initWithUsername:nil password: nil];
 }
+
 - (instancetype)initWithUsername:(nullable NSString *)username
                         password:(nullable NSString *)password
 {
@@ -63,6 +65,16 @@ NS_ASSUME_NONNULL_BEGIN
         _httpInterceptors = @[];
         _username = username;
         _password = password;
+    }
+    return self;
+}
+
+- (instancetype)initWithIAMAPIKey:(NSString *)IAMAPIKey
+{
+    self = [super init];
+    if (self) {
+        _httpInterceptors = @[];
+        _IAMAPIKey= IAMAPIKey;
     }
     return self;
 }

--- a/CDTDatastore/CDTReplicator/CDTPullReplication.h
+++ b/CDTDatastore/CDTReplicator/CDTPullReplication.h
@@ -82,6 +82,21 @@ NS_ASSUME_NONNULL_BEGIN
                              password:(nullable NSString *)password;
 
 /**
+ * All CDTPullReplication objects must have a source and target.
+ *
+ * The CDTPullReplication uses an IAM API key to authenticate - see
+ * https://console.bluemix.net/docs/services/Cloudant/guides/iam.html#ibm-cloud-identity-and-access-management
+ * for more information about IAM.
+ *
+ * @param IAMAPIKey The IAM API key.
+ * @return an initialsed instance of CDTAbstractReplication.
+ */
++ (instancetype)replicationWithSource:(NSURL *)source
+                               target:(CDTDatastore *)target
+                            IAMAPIKey:(NSString *)IAMAPIKey;
+
+
+/**
  @name Accessing the replication source and target
  */
 

--- a/CDTDatastore/CDTReplicator/CDTPullReplication.m
+++ b/CDTDatastore/CDTReplicator/CDTPullReplication.m
@@ -15,6 +15,7 @@
 
 #import "CDTPullReplication.h"
 #import "CDTSessionCookieInterceptor.h"
+#import "CDTIAMSessionCookieInterceptor.h"
 #import "CDTReplay429Interceptor.h"
 #import "CDTDatastore.h"
 #import "CDTLogging.h"
@@ -41,6 +42,13 @@
     return [[self alloc] initWithSource:source target:target username:username password:password];
 }
 
++ (instancetype)replicationWithSource:(NSURL *)source
+                               target:(CDTDatastore *)target
+                            IAMAPIKey:(NSString *)IAMAPIKey
+{
+    return [[self alloc] initWithSource:source target:target IAMAPIKey:IAMAPIKey];
+}
+
 - (instancetype)initWithSource:(NSURL *)source
                         target:(CDTDatastore *)target
                       username:(NSString *)username
@@ -58,6 +66,27 @@
             sourceComponents.user = nil;
             sourceComponents.password = nil;
         }
+        
+        _source = sourceComponents.URL;
+        _target = target;
+    }
+    return self;
+}
+
+- (instancetype)initWithSource:(NSURL *)source
+                        target:(CDTDatastore *)target
+                     IAMAPIKey:(NSString *)IAMAPIKey
+{
+    if (self = [super initWithIAMAPIKey:IAMAPIKey]) {
+        NSURLComponents * sourceComponents = [NSURLComponents componentsWithURL:source resolvingAgainstBaseURL:NO];
+        if(sourceComponents.user && sourceComponents.password){
+            CDTLogWarn(CDTREPLICATION_LOG_CONTEXT, @"Credentials provided via the URL but IAM API key was provided, discarding URL credentials.");
+        }
+        CDTIAMSessionCookieInterceptor * cookieInterceptor = [[CDTIAMSessionCookieInterceptor alloc] initWithAPIKey:IAMAPIKey];
+        [self addInterceptor:cookieInterceptor];
+        
+        sourceComponents.user = nil;
+        sourceComponents.password = nil;
         
         _source = sourceComponents.URL;
         _target = target;

--- a/CDTDatastore/CDTReplicator/CDTPushReplication.h
+++ b/CDTDatastore/CDTReplicator/CDTPushReplication.h
@@ -87,6 +87,21 @@ typedef BOOL (^CDTFilterBlock)(CDTDocumentRevision *__nonnull revision,
                              password:(nullable NSString *)password;
 
 /**
+ * All CDTPushReplication objects must have a source and target.
+ *
+ * The CDTPushReplication uses an IAM API key to authenticate - see
+ * https://console.bluemix.net/docs/services/Cloudant/guides/iam.html#ibm-cloud-identity-and-access-management
+ * for more information about IAM.
+ *
+ * @param IAMAPIKey The IAM API key.
+ * @return an initialsed instance of CDTAbstractReplication.
+ */
++ (instancetype)replicationWithSource:(CDTDatastore *)source
+                               target:(NSURL *)target
+                            IAMAPIKey:(NSString *)IAMAPIKey;
+
+
+/**
  @name Accessing the replication source and target
  */
 

--- a/CDTDatastore/CDTReplicator/CDTPushReplication.m
+++ b/CDTDatastore/CDTReplicator/CDTPushReplication.m
@@ -17,6 +17,7 @@
 #import "CDTPushReplication.h"
 #import "CDTDatastore.h"
 #import "CDTSessionCookieInterceptor.h"
+#import "CDTIAMSessionCookieInterceptor.h"
 #import "CDTReplay429Interceptor.h"
 #import "TDMisc.h"
 #import "CDTLogging.h"
@@ -42,6 +43,13 @@
     return [[self alloc] initWithSource:source target:target username:username password:password];
 }
 
++ (instancetype)replicationWithSource:(CDTDatastore *)source
+                               target:(NSURL *)target
+                            IAMAPIKey:(NSString *)IAMAPIKey
+{
+    return [[self alloc] initWithSource:source target:target IAMAPIKey:IAMAPIKey];
+}
+
 - (instancetype)initWithSource:(CDTDatastore *)source
                         target:(NSURL *)target
                       username:(NSString *)username
@@ -65,6 +73,28 @@
     }
     return self;
 }
+
+- (instancetype)initWithSource:(CDTDatastore *)source
+                        target:(NSURL *)target
+                     IAMAPIKey:(NSString *)IAMAPIKey
+{
+    if (self = [super initWithIAMAPIKey:IAMAPIKey]) {
+        NSURLComponents * targetComponents = [NSURLComponents componentsWithURL:target resolvingAgainstBaseURL:NO];
+        if(targetComponents.user && targetComponents.password){
+            CDTLogWarn(CDTREPLICATION_LOG_CONTEXT, @"Credentials provided via the URL but IAM API key was provided, discarding URL credentials.");
+        }
+        CDTIAMSessionCookieInterceptor * cookieInterceptor = [[CDTIAMSessionCookieInterceptor alloc] initWithAPIKey:IAMAPIKey];
+        [self addInterceptor:cookieInterceptor];
+        
+        targetComponents.user = nil;
+        targetComponents.password = nil;
+        
+        _source = source;
+        _target = targetComponents.URL;
+    }
+    return self;
+}
+
 
 - (instancetype)copyWithZone:(NSZone *)zone
 {

--- a/CDTDatastore/HTTP/CDTIAMSessionCookieInterceptor.h
+++ b/CDTDatastore/HTTP/CDTIAMSessionCookieInterceptor.h
@@ -1,9 +1,9 @@
 //
-//  CDTSessionCookieInterceptor.h
+//  CDTIAMSessionCookieInterceptor.h
+//  CDTDatastore
 //
-//
-//  Created by Rhys Short on 08/09/2015.
-//  Copyright (c) 2015 IBM Corp.
+//  Created by tomblench on 05/07/2017.
+//  Copyright © 2017 IBM Corporation. All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
 //  except in compliance with the License. You may obtain a copy of the License at
@@ -18,11 +18,10 @@
 #import "CDTSessionCookieInterceptorBase.h"
 #import "CDTMacros.h"
 
-@interface CDTSessionCookieInterceptor : CDTSessionCookieInterceptorBase
+@interface CDTIAMSessionCookieInterceptor :  CDTSessionCookieInterceptorBase
 
 - (nonnull instancetype)init NS_UNAVAILABLE;
 
-- (nonnull instancetype)initWithUsername:(nonnull NSString *)username
-                                password:(nonnull NSString *)password NS_DESIGNATED_INITIALIZER;
+- (nonnull instancetype)initWithAPIKey:(nonnull NSString *)apiKey NS_DESIGNATED_INITIALIZER;
 
 @end

--- a/CDTDatastore/HTTP/CDTIAMSessionCookieInterceptor.m
+++ b/CDTDatastore/HTTP/CDTIAMSessionCookieInterceptor.m
@@ -1,0 +1,156 @@
+//
+//  CDTIAMSessionCookieInterceptor.m
+//  CDTDatastore
+//
+//  Created by tomblench on 05/07/2017.
+//  Copyright © 2017 IBM Corporation. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "CDTIAMSessionCookieInterceptor.h"
+#import "CDTLogging.h"
+
+static const NSInteger CDTIAMSessionCookieRequestTimeout = 600;
+
+
+@interface CDTIAMSessionCookieInterceptor ()
+
+
+@property NSData *IAMSessionRequestBody;
+
+- (NSData *)getBearerToken;
+
+/** NSURLSession to make calls to get IAM bearer token (shouldn't be same one we're intercepting). */
+@property (nonnull, nonatomic, strong) NSURLSession *IAMURLSession;
+
+@property NSURL *IAMTokenURL;
+
+@end
+
+@implementation CDTIAMSessionCookieInterceptor
+
+- (instancetype)initWithAPIKey:(NSString *)apiKey
+{
+    self = [super init];
+    if (self) {
+        // build the request to get the IAM bearer token
+        _IAMSessionRequestBody = [[NSString stringWithFormat:@"grant_type=urn:ibm:params:oauth:grant-type:apikey&response_type=cloud_iam&apikey=%@", [apiKey stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]]] dataUsingEncoding:NSUTF8StringEncoding];
+        
+        NSURLSessionConfiguration *config =
+        [NSURLSessionConfiguration ephemeralSessionConfiguration];
+        // The IAM bearer token endpoint requires a form-encoded request with API key present.
+        // We might as well set that up now.
+        config.HTTPAdditionalHeaders = @{ @"Content-Type" : @"application/x-www-form-urlencoded" };
+        _IAMURLSession = [NSURLSession sessionWithConfiguration:config];
+        [super setShouldMakeSessionRequest:YES];
+        
+        _IAMTokenURL = [NSURL URLWithString:[[NSProcessInfo processInfo]environment][@"CDT_IAM_TOKEN_URL"]];
+        if (_IAMTokenURL == nil) {
+            _IAMTokenURL = [NSURL URLWithString:@"https://iam.bluemix.net/oidc/token"];
+        }
+    }
+    return self;
+}
+
+- (NSURLSessionConfiguration*)customiseSessionConfig:(NSURLSessionConfiguration*)config
+{
+    // We are posting to the _iam_session endpoint using JSON.
+    // We might as well set that up now.
+    [config setHTTPAdditionalHeaders:@{ @"Content-Type" : @"application/json" }];
+    return config;
+}
+
+- (CDTHTTPInterceptorContext *)interceptRequestInContext:(CDTHTTPInterceptorContext *)context
+{
+    if (self.shouldMakeSessionRequest) {
+        if (!self.cookie) {
+            // We don't have a cookie - first get the IAM bearer token
+            NSData *bearerToken = [self getBearerToken];
+            if (bearerToken != nil) {
+                [self setSessionRequestBody:bearerToken];
+                NSURLComponents *components =
+                [NSURLComponents componentsWithURL:context.request.URL resolvingAgainstBaseURL:NO];
+                components.path = @"/_iam_session";
+                NSURL *URL = [components URL];
+                self.cookie = [super startNewSessionAtURL:URL withBody:self.sessionRequestBody session:self.urlSession sessionStartedHandler:^(NSData * data){return [self hasSessionStarted:data];}];
+            }
+        }
+    }
+    [context.request setValue:self.cookie forHTTPHeaderField:@"Cookie"];
+    return context;
+}
+
+- (NSData *)getBearerToken {
+
+    CDTLogDebug(CDTREPLICATION_LOG_CONTEXT, @"Getting bearer token");
+    
+    // TODO allow over-riding of URL
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:_IAMTokenURL];
+    request.HTTPMethod = @"POST";
+    request.HTTPBody = self.IAMSessionRequestBody;
+    
+    dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+    __block NSData *token = nil;
+    NSURLSessionDataTask *task = [self.IAMURLSession
+                                  dataTaskWithRequest:request
+                                  completionHandler:^(NSData *__nullable data, NSURLResponse *__nullable response,
+                                                      NSError *__nullable error) {
+                                      
+                                      NSHTTPURLResponse *httpResp = (NSHTTPURLResponse *)response;
+                                      
+                                      if (httpResp && httpResp.statusCode / 100 == 2) {
+                                          token = data;
+                                      } else if (!httpResp) {
+                                          // Network failure of some kind; often transient. Try again next time.
+                                          CDTLogError(CDTREPLICATION_LOG_CONTEXT, @"Error getting cookie response from the server at %@, error: %@",
+                                                      request.URL,
+                                                      [error localizedDescription]);
+                                      } else if (httpResp.statusCode / 100 == 5) {
+                                          // Server error of some kind; often transient. Try again next time.
+                                          CDTLogError(CDTREPLICATION_LOG_CONTEXT,
+                                                      @"Failed to get cookie from the server at %@, response code was %ld.",
+                                                      request.URL,
+                                                      (long)httpResp.statusCode);
+                                      } else if (httpResp.statusCode == 401) {
+                                          // Credentials are not valid, fail and don't retry.
+                                          CDTLogError(CDTREPLICATION_LOG_CONTEXT, @"Credentials are incorrect for the server at %@, cookie "
+                                                      @"authentication will not be attempted "
+                                                      @"again by this interceptor object",
+                                                      request.URL);
+                                          self.shouldMakeSessionRequest = NO;
+                                      } else {
+                                          // Most other HTTP status codes are non-transient failures; don't retry.
+                                          CDTLogError(CDTREPLICATION_LOG_CONTEXT,
+                                                      @"Failed to get cookie from the server at %@, response code %ld. Cookie "
+                                                      @"authentication will not be attempted again by this interceptor "
+                                                      @"object",
+                                                      request.URL,
+                                                      (long)httpResp.statusCode);
+                                          self.shouldMakeSessionRequest = NO;
+                                      }
+                                      dispatch_semaphore_signal(sema);
+                                      
+                                  }];
+    [task resume];
+    dispatch_semaphore_wait(
+                            sema, dispatch_time(DISPATCH_TIME_NOW, CDTIAMSessionCookieRequestTimeout * NSEC_PER_SEC));
+    return token;
+}
+
+/* this is a no-op for IAM session, we only needed to check the HTTP status code */
+- (BOOL)hasSessionStarted:(nonnull NSData *)data
+{
+    return true;
+}
+
+
+@end

--- a/CDTDatastore/HTTP/CDTSessionCookieInterceptorBase.h
+++ b/CDTDatastore/HTTP/CDTSessionCookieInterceptorBase.h
@@ -1,0 +1,43 @@
+//
+//  CDTSessionCookieInterceptorBase.h
+//  CDTDatastore
+//
+//  Created by tomblench on 05/07/2017.
+//  Copyright © 2017 IBM Corporation. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+#import "CDTHTTPInterceptor.h"
+
+@interface CDTSessionCookieInterceptorBase : NSObject <CDTHTTPInterceptor>
+
+
+/** Form encoded username and password. */
+@property (nonnull, strong, nonatomic) NSData *sessionRequestBody;
+
+/** Whether it looks worthwhile for us to make the session request (no bad failures so far). */
+@property (nonatomic) BOOL shouldMakeSessionRequest;
+
+/** Current session cookie. */
+@property (nullable, strong, nonatomic) NSString *cookie;
+
+/** NSURLSession to make calls to _session using (shouldn't be same one we're intercepting). */
+@property (nonnull, nonatomic, strong) NSURLSession *urlSession;
+
+
+- (nullable NSString *)startNewSessionAtURL:(nonnull NSURL *)url
+                                   withBody:(nonnull NSData *)body
+                                    session:(nonnull NSURLSession *)session
+                      sessionStartedHandler:(BOOL (^_Nonnull)(NSData *_Nonnull data))sessionStartedHandler;
+
+- (nonnull NSURLSessionConfiguration*)customiseSessionConfig:(nonnull NSURLSessionConfiguration*)config;
+
+@end

--- a/CDTDatastore/HTTP/CDTSessionCookieInterceptorBase.m
+++ b/CDTDatastore/HTTP/CDTSessionCookieInterceptorBase.m
@@ -1,0 +1,133 @@
+//
+//  CDTSessionCookieInterceptorBase.m
+//  CDTDatastore
+//
+//  Created by tomblench on 05/07/2017.
+//  Copyright © 2017 IBM Corporation. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#import "CDTSessionCookieInterceptorBase.h"
+#import "CDTLogging.h"
+
+/** Number of seconds to wait for _session to respond. */
+static const NSInteger CDTSessionCookieRequestTimeout = 600;
+
+
+@implementation CDTSessionCookieInterceptorBase
+
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        NSURLSessionConfiguration *config =
+        [NSURLSessionConfiguration ephemeralSessionConfiguration];
+        [self setShouldMakeSessionRequest:YES];
+        // allow sub-classes to set headers etc for the session
+        config = [self customiseSessionConfig:config];
+        [self setUrlSession:[NSURLSession sessionWithConfiguration:config]];
+    }
+    return self;
+}
+
+- (NSURLSessionConfiguration*)customiseSessionConfig:(NSURLSessionConfiguration*)config
+{
+    // sub-classes may wish to over-ride this
+    return config;
+}
+
+
+/**
+ We assume a 401 means that the cookie we applied at request time was rejected. Therefore
+ clear it and tell the HTTP mechanism to retry the request. For all other responses, there's
+ nothing for this interceptor to do.
+ */
+- (CDTHTTPInterceptorContext *)interceptResponseInContext:(CDTHTTPInterceptorContext *)context
+{
+    if (context.response.statusCode == 401 && self.shouldMakeSessionRequest) {
+        self.cookie = nil;
+        context.shouldRetry = YES;
+    }
+
+    return context;
+}
+
+
+/**
+ Handles retrieving a cookie ("logging in") for the credentials this interceptor
+ was initialised with.
+ 
+ If the request fails, this method will also set the `shouldMakeSessionRequest` property
+ to `NO` if the error didn't look transient.
+ */
+- (nullable NSString *)startNewSessionAtURL:(NSURL *)url
+                                   withBody:(NSData *)body
+                                    session:(NSURLSession *)session
+                      sessionStartedHandler:(BOOL (^)(NSData *data))sessionStartedHandler
+{
+    
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
+    request.HTTPMethod = @"POST";
+    request.HTTPBody = body;
+    
+    dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+    __block NSString *cookie = nil;
+    NSURLSessionDataTask *task = [session
+                                  dataTaskWithRequest:request
+                                  completionHandler:^(NSData *__nullable data, NSURLResponse *__nullable response,
+                                                      NSError *__nullable error) {
+                                      
+                                      NSHTTPURLResponse *httpResp = (NSHTTPURLResponse *)response;
+                                      
+                                      if (httpResp && httpResp.statusCode / 100 == 2) {
+                                          // Success! Get the cookie from the header if login succeeded.
+                                          if (data && sessionStartedHandler(data)) {
+                                              NSString *cookieHeader = httpResp.allHeaderFields[@"Set-Cookie"];
+                                              cookie = [cookieHeader componentsSeparatedByString:@";"][0];
+                                          }
+                                      } else if (!httpResp) {
+                                          // Network failure of some kind; often transient. Try again next time.
+                                          CDTLogError(CDTREPLICATION_LOG_CONTEXT, @"Error making cookie response, error:%@",
+                                                      [error localizedDescription]);
+                                      } else if (httpResp.statusCode / 100 == 5) {
+                                          // Server error of some kind; often transient. Try again next time.
+                                          CDTLogError(CDTREPLICATION_LOG_CONTEXT,
+                                                      @"Failed to get cookie from the server at %@, response code was %ld.",
+                                                      url,
+                                                      (long)httpResp.statusCode);
+                                      } else if (httpResp.statusCode == 401) {
+                                          // Credentials are not valid, fail and don't retry.
+                                          CDTLogError(CDTREPLICATION_LOG_CONTEXT, @"Credentials are incorrect, cookie "
+                                                      @"authentication will not be attempted "
+                                                      @"again by this interceptor object");
+                                          self.shouldMakeSessionRequest = NO;
+                                      } else {
+                                          // Most other HTTP status codes are non-transient failures; don't retry.
+                                          CDTLogError(CDTREPLICATION_LOG_CONTEXT,
+                                                      @"Failed to get cookie from the server at %@, response code %ld. Cookie "
+                                                      @"authentication will not be attempted again by this interceptor "
+                                                      @"object",
+                                                      url,
+                                                      (long)httpResp.statusCode);
+                                          self.shouldMakeSessionRequest = NO;
+                                      }
+                                      
+                                      dispatch_semaphore_signal(sema);
+                                      
+                                  }];
+    [task resume];
+    dispatch_semaphore_wait(
+                            sema, dispatch_time(DISPATCH_TIME_NOW, CDTSessionCookieRequestTimeout * NSEC_PER_SEC));
+    
+    return cookie;
+}
+
+@end

--- a/CDTDatastore/HTTP/CDTURLSession.m
+++ b/CDTDatastore/HTTP/CDTURLSession.m
@@ -62,26 +62,30 @@ static dispatch_semaphore_t g_asyncTaskMonitor;
         NSURLSessionConfiguration *config;
         // Create a unique session id using the address of self.
         NSString *sessionId = [NSString stringWithFormat:@"com.cloudant.sync.sessionid.%p", self];
-
-// Only compile this for iOS8.0 and above or OSX 10.10 and above
+        if (getenv("CDT_TEST_ENABLE_OHHTTPSTUBS")) {
+            config = [NSURLSessionConfiguration defaultSessionConfiguration];
+        } else {
+            // Only compile this for iOS8.0 and above or OSX 10.10 and above
 #if (defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 80000) \
  || (defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && __MAC_OS_X_VERSION_MAX_ALLOWED >= 101000)
-        // NSURLSessionConfiguration:backgroundSessionConfigurationWithIdentifier was introduced in iOS 8.0
-        // to replace backgroundSessionConfiguration which was deprecated in iOS 8.0, so use the new version if
-        // available.
-        if ([[NSURLSessionConfiguration class] respondsToSelector:@selector(backgroundSessionConfigurationWithIdentifier:)]) {
-            config = [NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:sessionId];
-        } else {
+            // NSURLSessionConfiguration:backgroundSessionConfigurationWithIdentifier was introduced in iOS 8.0
+            // to replace backgroundSessionConfiguration which was deprecated in iOS 8.0, so use the new version if
+            // available.
+            if ([[NSURLSessionConfiguration class] respondsToSelector:@selector(backgroundSessionConfigurationWithIdentifier:)]) {
+                config = [NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:sessionId];
+            } else {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-            // since the method is only called on platforms where its replacement is missing
-            // we supress the warning
-            config = [NSURLSessionConfiguration backgroundSessionConfiguration:sessionId];
+                // since the method is only called on platforms where its replacement is missing
+                // we supress the warning
+                config = [NSURLSessionConfiguration backgroundSessionConfiguration:sessionId];
 #pragma GCC pop
-        }
+            }
 #else
+        }
         config = [NSURLSessionConfiguration backgroundSessionConfiguration:sessionId];
 #endif
+        }
         [config setTimeoutIntervalForRequest:300];
         [sessionConfigDelegate customiseNSURLSessionConfiguration:config];
 

--- a/CDTDatastoreTests/CDTIAMSessionCookieInterceptorTests.m
+++ b/CDTDatastoreTests/CDTIAMSessionCookieInterceptorTests.m
@@ -1,0 +1,638 @@
+//
+//  CDTIAMSessionCookieInterceptorTests.m
+//  CDTDatastore
+//
+//  Created by tomblench on 06/07/2017.
+//  Copyright © 2017 IBM Corporation. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+
+
+#import <XCTest/XCTest.h>
+#import "CloudantSyncTests.h"
+#import "CDTIamSessionCookieInterceptor.h"
+#import "CDTURLSession.h"
+#import <OHHTTPStubs/OHHTTPStubs.h>
+#import <OHHTTPStubs/OHHTTPStubsResponse+JSON.h>
+#import <OHHTTPStubs/NSURLRequest+HTTPBodyTesting.h>
+#import "CDTLogging.h"
+#import "TDJSON.h"
+
+// expose properties so we can look at them
+@interface CDTIAMSessionCookieInterceptor ()
+
+@property (nonatomic) BOOL shouldMakeSessionRequest;
+@property (nullable, strong, nonatomic) NSString *cookie;
+@property (nonnull, nonatomic, strong) NSURLSession *URLSession;
+
+@property NSURL *IAMTokenURL;
+
+
+@end
+
+static const NSString *testCookieHeaderValue =
+@"AuthSession=a2ltc3RlYmVsOjUxMzRBQTUzOtiY2_IDUIdsTJEVNEjObAbyhrgz";
+
+static const NSString *testCookieHeaderValue2 =
+@"AuthSession=dG9tYmxlbmNoOjU5NTM0QzgyOhqHa60IlqPmGR8vTVIK-tzhopMR";
+
+// helper to sequence a number of stubbed responses
+
+@interface OHHTTPStubsHelper : NSObject
+@property NSMutableArray<OHHTTPStubsResponseBlock> *responses;
+@property int currentResponse;
+
+- (id) init;
+- (void) addResponse:(OHHTTPStubsResponseBlock)responseBlock;
+- (void) doStubsForHost:(NSString*)host;
+@end
+
+@implementation OHHTTPStubsHelper
+
+- (id) init
+{
+    if (self = [super init]) {
+        _currentResponse = 0;
+        _responses = [NSMutableArray array];
+    }
+    return self;
+}
+
+- (void) addResponse:(OHHTTPStubsResponseBlock)responseBlock
+{
+    [_responses addObject:responseBlock];
+}
+- (void) doStubsForHost:(NSString*)host
+{
+    [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *__nonnull request) {
+        return [[request.URL host] isEqualToString:host];
+    } withStubResponse:^OHHTTPStubsResponse *__nonnull(NSURLRequest *__nonnull request) {
+        return [_responses objectAtIndex:_currentResponse++](request);
+    }];
+}
+
+@end
+
+@interface CDTIAMSessionCookieInterceptorTests : CloudantSyncTests
+
+@end
+
+@implementation CDTIAMSessionCookieInterceptorTests
+
+NSDictionary *iamToken1;
+NSDictionary *iamToken2;
+
+- (void)setUp {
+    setenv("CDT_TEST_ENABLE_OHHTTPSTUBS", "1", true);
+    CDTChangeLogLevel(CDTTD_REMOTE_REQUEST_CONTEXT, DDLogLevelDebug);
+    CDTChangeLogLevel(CDTREPLICATION_LOG_CONTEXT, DDLogLevelDebug);
+    [DDLog addLogger:[DDTTYLogger sharedInstance]];
+    
+    iamToken1 =
+    @{
+      @"access_token": @"eyJraWQiOiIyMDE3MDQwMi0wMDowMDowMCIsImFsZyI6IlJTMjU2In0.eyJpYW1faWQiOiJJQk1pZC0yNzAwMDdHRjBEIiwiaWQiOiJJQk1pZC0yNzAwMDdHRjBEIiwicmVhbG1pZCI6IklCTWlkIiwiaWRlbnRpZmllciI6IjI3MDAwN0dGMEQiLCJnaXZlbl9uYW1lIjoiVG9tIiwiZmFtaWx5X25hbWUiOiJCbGVuY2giLCJuYW1lIjoiVG9tIEJsZW5jaCIsImVtYWlsIjoidGJsZW5jaEB1ay5pYm0uY29tIiwic3ViIjoidGJsZW5jaEB1ay5pYm0uY29tIiwiYWNjb3VudCI6eyJic3MiOiI1ZTM1ZTZhMjlmYjJlZWNhNDAwYWU0YzNlMWZhY2Y2MSJ9LCJpYXQiOjE1MDA0NjcxMDIsImV4cCI6MTUwMDQ3MDcwMiwiaXNzIjoiaHR0cHM6Ly9pYW0ubmcuYmx1ZW1peC5uZXQvb2lkYy90b2tlbiIsImdyYW50X3R5cGUiOiJ1cm46aWJtOnBhcmFtczpvYXV0aDpncmFudC10eXBlOmFwaWtleSIsInNjb3BlIjoib3BlbmlkIiwiY2xpZW50X2lkIjoiZGVmYXVsdCJ9.XAPdb5K4n2nYih-JWTWBGoKkxTXM31c1BB1g-Ciauc2LxuoNXVTyz_mNqf1zQL07FUde1Cb_dwrbotjickNcxVPost6byQztfc0mRF1x2S6VR8tn7SGiRmXBjLofkTh1JQq-jutp2MS315XbTG6K6m16uYzL9qfMnRvQHxsZWErzfPiJx-Trg_j7OX-qNFjdNUGnRpU7FmULy0r7RxLd8mhG-M1yxVzRBAZzvM63s0XXfMnk1oLi-BuUUTqVOdrM0KyYMWfD0Q72PTo4Exa17V-R_73Nq8VPCwpOvZcwKRA2sPTVgTMzU34max8b5kpTzVGJ6SXSItTVOUdAygZBng",
+      @"refresh_token": @"MO61FKNvVRWkSa4vmBZqYv_Jt1kkGMUc-XzTcNnR-GnIhVKXHUWxJVV3RddE8Kqh3X_TZRmyK8UySIWKxoJ2t6obUSUalPm90SBpTdoXtaljpNyormqCCYPROnk6JBym72ikSJqKHHEZVQkT0B5ggZCwPMnKagFj0ufs-VIhCF97xhDxDKcIPMWG02xxPuESaSTJJug7e_dUDoak_ZXm9xxBmOTRKwOxn5sTKthNyvVpEYPE7jIHeiRdVDOWhN5LomgCn3TqFCLpMErnqwgNYbyCBd9rNm-alYKDb6Jle4njuIBpXxQPb4euDwLd1osApaSME3nEarFWqRBzhjoqCe1Kv564s_rY7qzD1nHGvKOdpSa0ZkMcfJ0LbXSQPs7gBTSVrBFZqwlg-2F-U3Cto62-9qRR_cEu_K9ZyVwL4jWgOlngKmxV6Ku4L5mHp4KgEJSnY_78_V2nm64E--i2ZA1FhiKwIVHDOivVNhggE9oabxg54vd63glp4GfpNnmZsMOUYG9blJJpH4fDX4Ifjbw-iNBD7S2LRpP8b8vG9pb4WioGzN43lE5CysveKYWrQEZpThznxXlw1snDu_A48JiL3Lrvo1LobLhF3zFV-kQ=",
+      @"token_type": @"Bearer",
+      @"expires_in": @3600,
+      @"expiration": @1500470702
+      };
+    iamToken2 =
+    @{
+      @"access_token": @"eyJraWQiOiIyMDE3MDQwMi0wMDowMDowMCIsImFsZyI6IlJTMjU2In0.eyJpYW1faWQiOiJJQk1pZC0yNzAwMDdHRjBEIiwiaWQiOiJJQk1pZC0yNzAwMDdHRjBEIiwicmVhbG1pZCI6IklCTWlkIiwiaWRlbnRpZmllciI6IjI3MDAwN0dGMEQiLCJnaXZlbl9uYW1lIjoiVG9tIiwiZmFtaWx5X25hbWUiOiJCbGVuY2giLCJuYW1lIjoiVG9tIEJsZW5jaCIsImVtYWlsIjoidGJsZW5jaEB1ay5pYm0uY29tIiwic3ViIjoidGJsZW5jaEB1ay5pYm0uY29tIiwiYWNjb3VudCI6eyJic3MiOiI1ZTM1ZTZhMjlmYjJlZWNhNDAwYWU0YzNlMWZhY2Y2MSJ9LCJpYXQiOjE1MDA0NjcxMTEsImV4cCI6MTUwMDQ3MDcxMSwiaXNzIjoiaHR0cHM6Ly9pYW0ubmcuYmx1ZW1peC5uZXQvb2lkYy90b2tlbiIsImdyYW50X3R5cGUiOiJ1cm46aWJtOnBhcmFtczpvYXV0aDpncmFudC10eXBlOmFwaWtleSIsInNjb3BlIjoib3BlbmlkIiwiY2xpZW50X2lkIjoiZGVmYXVsdCJ9.wJ5Glsvee3xRbfxr847pNgVj-U_ZLLzOiScHcjkrHk0jQdg8D4KurAV1QGa_MwWzd_QxS55lNqCzi6HV1p3kSyjcdJSGe-l-B3_xjw-7Q3BMoPjcO-X1mNYsKQyCtSAJsuByCYQVPoNKuBifsQcds65mKh87gUtc00vP5J-vzdYpzkrjncFO3lzJJwYSnbqFaAPtNnEYwEEIpS0n9H4mgHiLqletzYs9acggssxZpUl2wdkUaQ_diuTJg-u2o6Oy3aVJCWV78DIc3NVwgQCuJ40as6QpFPWluXJmfgdW5lFkQ_etieI9JDgXk_HQUpYcj0Droec6wTXEGUYWjukhsw",
+      @"refresh_token": @"M0oCn5XLXUWAFUSqC7FRv1d83-SOfPvYmKKRdZpT33C81KsTaZx3Y3jMXRGkR1sIAohEm-gkpwGQcm1I_lfs5zlqwaKlsLOv4jvjvjiaPFwoU7QP62bHWGsq0j-RNN-_kHXsp3G1R7AtndZL0XQ4se4Jlgt68Cw3_YyEcxS6E65iTv1hZ9lg1EjJqzFLd4ArQVT6gFCpSaRaH2ilie4hat5ZFI2JALHPzVnBlRBqeIUferQOL6Yw2b_Z9TvYa6AaqOsQzI5ma2yIQTw6tzjrc5xXqnqnkH566pNlY8pKvETvCsdLgEclMoa8zoe9SAXDFEIl7svNMRG9FsoR7G4rwojs2BawDPPwkEcm6aC1K5azX23GbnekhvNfXloASWc2ETerN2RxYRZNnFnO4f0enCNReMhoPCUBObgO6iq0a56VslRTT-BHYBCax_YklBz9acbhJnF-C9PWjyrYwZHFajMhpFjOmY3hlrQXVXtjOqKs5WbMhpQ8BWN5KBUDYY7F7OMvv4bYTF7kfu5Uc_ge9_Nj4EGvPwA6vehvZjSj-0td6D32p2zMDmu_yoTLRpv6N7u5BRA5_PmhH_hsffXSKX5fDNL_CqGaNvcI5tVBry8=",
+      @"token_type": @"Bearer",
+      @"expires_in": @3600,
+      @"expiration": @1500470711
+      };
+}
+
+- (void)tearDown {
+    unsetenv("CDT_TEST_ENABLE_OHHTTPSTUBS");
+    [OHHTTPStubs removeAllStubs];
+}
+
+/**
+ * Test normal IAM token and IAM session request path by calling interceptRequestInContext directly
+ */
+- (void)testIAMTokenAndCookieSuccessful
+{
+    
+    [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *__nonnull request) {
+        return [[request.URL host] isEqualToString:@"iam.bluemix.net"];
+    }
+                        withStubResponse:^OHHTTPStubsResponse *__nonnull(NSURLRequest *__nonnull request) {
+                            if ([request.HTTPMethod isEqualToString:@"POST"]) {
+                                return [OHHTTPStubsResponse
+                                        responseWithJSONObject:iamToken1
+                                        statusCode:200
+                                        headers:@{}];
+                            } else {
+                                XCTFail(@"Unexpected HTTP Method");
+                                return [OHHTTPStubsResponse responseWithJSONObject:@{} statusCode:400 headers:@{}];
+                            }
+                            
+                            
+                        }];
+    
+    [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *__nonnull request) {
+        return [[request.URL host] isEqualToString:@"username.cloudant.com"];
+    }
+                        withStubResponse:^OHHTTPStubsResponse *__nonnull(NSURLRequest *__nonnull request) {
+                            
+                            if ([request.HTTPMethod isEqualToString:@"POST"]) {
+                                XCTAssert([[TDJSON JSONObjectWithData:request.OHHTTPStubs_HTTPBody options:0 error:nil][@"access_token"] isEqualToString:iamToken1[@"access_token"]]);
+                                XCTAssert([request.URL.lastPathComponent isEqualToString:@"_iam_session"]);
+                                XCTAssert([request.allHTTPHeaderFields[@"Content-Type"] isEqualToString:@"application/json"]);
+                                
+                                return [OHHTTPStubsResponse
+                                        responseWithJSONObject:@{
+                                                                 @"ok" : @(YES),
+                                                                 @"name" : @"username",
+                                                                 @"roles" : @[ @"_admin" ]
+                                                                 }
+                                        statusCode:200
+                                        headers:@{
+                                                  @"Set-Cookie" : [NSString
+                                                                   stringWithFormat:@"%@; Version=1; Path=/; HttpOnly",
+                                                                   testCookieHeaderValue]
+                                                  }];
+                            } else if ([request.HTTPMethod isEqualToString:@"GET"]) {
+                                return [OHHTTPStubsResponse responseWithJSONObject:@{} statusCode:200 headers:@{}];
+                            } else if ([request.HTTPMethod isEqualToString:@"DELETE"]) {
+                                return [OHHTTPStubsResponse responseWithJSONObject:@{} statusCode:200 headers:@{}];
+                            } else {
+                                XCTFail(@"Unexpected HTTP Method");
+                                return [OHHTTPStubsResponse responseWithJSONObject:@{} statusCode:400 headers:@{}];
+                            }
+                            
+                        }];
+    
+    CDTIAMSessionCookieInterceptor *interceptor =
+    [[CDTIAMSessionCookieInterceptor alloc] initWithAPIKey:@"apikey"];
+    // create a context with a request which we can use
+    NSURL *url = [NSURL URLWithString:@"http://username.cloudant.com"];
+    NSURLRequest *request = [NSURLRequest requestWithURL:url];
+    
+    CDTHTTPInterceptorContext *context =
+    [[CDTHTTPInterceptorContext alloc] initWithRequest:[request mutableCopy]
+                                                 state:[NSMutableDictionary dictionary]];
+    
+    context = [interceptor interceptRequestInContext:context];
+    
+    XCTAssertEqualObjects(interceptor.cookie, testCookieHeaderValue);
+    XCTAssertEqual(interceptor.shouldMakeSessionRequest, YES);
+    XCTAssertEqualObjects([context.request valueForHTTPHeaderField:@"Cookie"],
+                          testCookieHeaderValue);
+}
+
+/**
+ * Test IAM token and cookie flow, where session expires and is successfully renewed:
+ * - GET a resource on the cloudant server
+ * - Cookie jar empty, so get IAM token followed by session cookie
+ * - GET now proceeds as normal, expected cookie value is sent in header
+ * - second GET on cloudant server, re-using session cookie
+ * - third GET on cloudant server, cookie expired, get IAM token and session cookie and replay
+ *   request
+ */
+- (void)testIAMTokenAndCookieWithExpirySuccessful
+{
+    OHHTTPStubsHelper *IAMTokenHelper = [[OHHTTPStubsHelper alloc] init];
+    
+    // first token
+    [IAMTokenHelper addResponse:^OHHTTPStubsResponse *__nonnull(NSURLRequest *__nonnull request) {
+        if ([request.HTTPMethod isEqualToString:@"POST"]) {
+            return [OHHTTPStubsResponse
+                    responseWithJSONObject:iamToken1
+                    statusCode:200
+                    headers:@{}];
+        } else {
+            XCTFail(@"Unexpected HTTP Method");
+            return [OHHTTPStubsResponse responseWithJSONObject:@{} statusCode:400 headers:@{}];
+        }
+    }];
+    
+    // second token
+    [IAMTokenHelper addResponse:^OHHTTPStubsResponse *__nonnull(NSURLRequest *__nonnull request) {
+        if ([request.HTTPMethod isEqualToString:@"POST"]) {
+            return [OHHTTPStubsResponse
+                    responseWithJSONObject:iamToken2
+                    statusCode:200
+                    headers:@{}];
+        } else {
+            XCTFail(@"Unexpected HTTP Method");
+            return [OHHTTPStubsResponse responseWithJSONObject:@{} statusCode:400 headers:@{}];
+        }
+    }];
+    [IAMTokenHelper doStubsForHost:@"iam.bluemix.net"];
+    
+    OHHTTPStubsHelper *helper = [[OHHTTPStubsHelper alloc] init];
+    
+    // call to _iam_session endpoint, return cookie in header
+    [helper addResponse:^OHHTTPStubsResponse *__nonnull(NSURLRequest *__nonnull request) {
+        
+        XCTAssert([request.HTTPMethod isEqualToString:@"POST"]);
+        XCTAssert([[TDJSON JSONObjectWithData:request.OHHTTPStubs_HTTPBody options:0 error:nil][@"access_token"] isEqualToString:iamToken1[@"access_token"]]);
+        XCTAssert([request.URL.lastPathComponent isEqualToString:@"_iam_session"]);
+        XCTAssert([request.allHTTPHeaderFields[@"Content-Type"] isEqualToString:@"application/json"]);
+
+        return [OHHTTPStubsResponse
+                responseWithJSONObject:@{
+                                         @"ok" : @(YES),
+                                         @"name" : @"username",
+                                         @"roles" : @[ @"_admin" ]
+                                         }
+                statusCode:200
+                headers:@{
+                          @"Set-Cookie" : [NSString
+                                           stringWithFormat:@"%@; Version=1; Path=/; HttpOnly",
+                                           testCookieHeaderValue]
+                          }];
+    }];
+    
+    // get resource successfully using cookie
+    [helper addResponse:^OHHTTPStubsResponse *__nonnull(NSURLRequest *__nonnull request) {
+        // TODO assert on the cookie passed in
+        XCTAssert([request.HTTPMethod isEqualToString:@"GET"]);
+        // TODO a more realistic object
+        return [OHHTTPStubsResponse responseWithJSONObject:@{} statusCode:200 headers:@{}];
+    }];
+    
+    // 2nd get resource successfully using cookie
+    [helper addResponse:^OHHTTPStubsResponse *__nonnull(NSURLRequest *__nonnull request) {
+        // TODO assert on the cookie passed in
+        XCTAssert([request.HTTPMethod isEqualToString:@"GET"]);
+        // TODO a more realistic object
+        return [OHHTTPStubsResponse responseWithJSONObject:@{} statusCode:200 headers:@{}];
+    }];
+    
+    // 3nd get resource fails, cookie expired
+    [helper addResponse:^OHHTTPStubsResponse *__nonnull(NSURLRequest *__nonnull request) {
+        // TODO assert on the cookie passed in
+        XCTAssert([request.HTTPMethod isEqualToString:@"GET"]);
+        return [OHHTTPStubsResponse responseWithJSONObject:@{@"error":@"credentials_expired"} statusCode:401 headers:@{}];
+    }];
+    
+    // call to _iam_session endpoint to refresh cookie
+    [helper addResponse:^OHHTTPStubsResponse *__nonnull(NSURLRequest *__nonnull request) {
+        XCTAssert([request.HTTPMethod isEqualToString:@"POST"]);
+        XCTAssert([[TDJSON JSONObjectWithData:request.OHHTTPStubs_HTTPBody options:0 error:nil][@"access_token"] isEqualToString:iamToken2[@"access_token"]]);
+        XCTAssert([request.URL.lastPathComponent isEqualToString:@"_iam_session"]);
+        XCTAssert([request.allHTTPHeaderFields[@"Content-Type"] isEqualToString:@"application/json"]);
+
+        return [OHHTTPStubsResponse
+                responseWithJSONObject:@{
+                                         @"ok" : @(YES),
+                                         @"name" : @"username",
+                                         @"roles" : @[ @"_admin" ]
+                                         }
+                statusCode:200
+                headers:@{
+                          @"Set-Cookie" : [NSString
+                                           stringWithFormat:@"%@; Version=1; Path=/; HttpOnly",
+                                           testCookieHeaderValue2]
+                          }];
+    }];
+    // replay of 3rd get resource succeeds with new cookie
+    [helper addResponse:^OHHTTPStubsResponse *__nonnull(NSURLRequest *__nonnull request) {
+        // TODO assert on the cookie passed in
+        XCTAssert([request.HTTPMethod isEqualToString:@"GET"]);
+        // TODO a more realistic object
+        return [OHHTTPStubsResponse responseWithJSONObject:@{} statusCode:200 headers:@{}];
+        
+    }];
+    [helper doStubsForHost:@"username1.cloudant.com"];
+    
+    CDTIAMSessionCookieInterceptor *interceptor =
+    [[CDTIAMSessionCookieInterceptor alloc] initWithAPIKey:@"apikey"];
+    // create a context with a request which we can use
+    NSURL *url = [NSURL URLWithString:@"http://username1.cloudant.com/animaldb"];
+    NSURLRequest *request = [NSURLRequest requestWithURL:url];
+    
+    CDTHTTPInterceptorContext *context =
+    [[CDTHTTPInterceptorContext alloc] initWithRequest:[request mutableCopy]
+                                                 state:[NSMutableDictionary dictionary]];
+    
+    CDTURLSession *session = [[CDTURLSession alloc] initWithCallbackThread:[NSThread currentThread] requestInterceptors:@[interceptor] sessionConfigDelegate:nil];
+    
+    CDTURLSessionTask *task = [session dataTaskWithRequest:request taskDelegate:nil];
+    [task resume];
+    while ([task state] != NSURLSessionTaskStateCompleted) {
+        [NSThread sleepForTimeInterval:1.0];
+    }
+    
+    XCTAssertEqualObjects(interceptor.cookie, testCookieHeaderValue);
+    
+    CDTURLSessionTask *task2 = [session dataTaskWithRequest:request taskDelegate:nil];
+    [task2 resume];
+    while ([task2 state] != NSURLSessionTaskStateCompleted) {
+        [NSThread sleepForTimeInterval:1.0];
+    }
+
+    XCTAssertEqualObjects(interceptor.cookie, testCookieHeaderValue);
+    
+    CDTURLSessionTask *task3 = [session dataTaskWithRequest:request taskDelegate:nil];
+    [task3 resume];
+    while ([task3 state] != NSURLSessionTaskStateCompleted) {
+        [NSThread sleepForTimeInterval:1.0];
+    }
+    
+    XCTAssertEqualObjects(interceptor.cookie, testCookieHeaderValue2);
+    XCTAssert([IAMTokenHelper currentResponse] == 2);
+    XCTAssert([helper currentResponse] == 6);
+}
+
+
+/**
+ * Test IAM token and cookie flow, where session expires and subsequent IAM token fails:
+ * - GET a resource on the cloudant server
+ * - Cookie jar empty, so get IAM token followed by session cookie
+ * - GET now proceeds as normal, expected cookie value is sent in header
+ * - second GET on cloudant server, re-using session cookie
+ * - third GET on cloudant server, cookie expired, subsequent IAM token fails, no more requests
+ *   are made
+ */
+
+- (void)testIAMRenewalFailureOnIamToken
+{
+    OHHTTPStubsHelper *IAMTokenHelper = [[OHHTTPStubsHelper alloc] init];
+    
+    // first one succeeds
+    [IAMTokenHelper addResponse:^OHHTTPStubsResponse *__nonnull(NSURLRequest *__nonnull request) {
+        if ([request.HTTPMethod isEqualToString:@"POST"]) {
+            return [OHHTTPStubsResponse
+                    responseWithJSONObject:iamToken1
+                    statusCode:200
+                    headers:@{}];
+        } else {
+            XCTFail(@"Unexpected HTTP Method");
+            return [OHHTTPStubsResponse responseWithJSONObject:@{} statusCode:400 headers:@{}];
+        }
+    }];
+    
+    // IAM goes down - could be anything non 200
+    [IAMTokenHelper addResponse:^OHHTTPStubsResponse *__nonnull(NSURLRequest *__nonnull request) {
+        if ([request.HTTPMethod isEqualToString:@"POST"]) {
+            return [OHHTTPStubsResponse
+                    responseWithJSONObject:@{@"error" : @"error"}
+                    statusCode:401
+                    headers:@{}];
+        } else {
+            XCTFail(@"Unexpected HTTP Method");
+            return [OHHTTPStubsResponse responseWithJSONObject:@{} statusCode:400 headers:@{}];
+        }
+    }];
+    
+    [IAMTokenHelper doStubsForHost:@"iam.bluemix.net"];
+    
+    OHHTTPStubsHelper *helper = [[OHHTTPStubsHelper alloc] init];
+    
+    // call to _iam_session endpoint, return cookie in header
+    [helper addResponse:^OHHTTPStubsResponse *__nonnull(NSURLRequest *__nonnull request) {
+        
+        XCTAssert([request.HTTPMethod isEqualToString:@"POST"]);
+        XCTAssert([[TDJSON JSONObjectWithData:request.OHHTTPStubs_HTTPBody options:0 error:nil][@"access_token"] isEqualToString:iamToken1[@"access_token"]]);
+        XCTAssert([request.URL.lastPathComponent isEqualToString:@"_iam_session"]);
+        XCTAssert([request.allHTTPHeaderFields[@"Content-Type"] isEqualToString:@"application/json"]);
+        
+        return [OHHTTPStubsResponse
+                responseWithJSONObject:@{
+                                         @"ok" : @(YES),
+                                         @"name" : @"username",
+                                         @"roles" : @[ @"_admin" ]
+                                         }
+                statusCode:200
+                headers:@{
+                          @"Set-Cookie" : [NSString
+                                           stringWithFormat:@"%@; Version=1; Path=/; HttpOnly",
+                                           testCookieHeaderValue]
+                          }];
+    }];
+    
+    // get resource successfully using cookie
+    [helper addResponse:^OHHTTPStubsResponse *__nonnull(NSURLRequest *__nonnull request) {
+        // TODO assert on the cookie passed in
+        XCTAssert([request.HTTPMethod isEqualToString:@"GET"]);
+        // TODO a more realistic object
+        return [OHHTTPStubsResponse responseWithJSONObject:@{} statusCode:200 headers:@{}];
+    }];
+    
+    // 2nd get resource successfully using cookie
+    [helper addResponse:^OHHTTPStubsResponse *__nonnull(NSURLRequest *__nonnull request) {
+        // TODO assert on the cookie passed in
+        XCTAssert([request.HTTPMethod isEqualToString:@"GET"]);
+        // TODO a more realistic object
+        return [OHHTTPStubsResponse responseWithJSONObject:@{} statusCode:200 headers:@{}];
+    }];
+    
+    // 3rd get resource fails, cookie expired
+    [helper addResponse:^OHHTTPStubsResponse *__nonnull(NSURLRequest *__nonnull request) {
+        // TODO assert on the cookie passed in
+        XCTAssert([request.HTTPMethod isEqualToString:@"GET"]);
+        return [OHHTTPStubsResponse responseWithJSONObject:@{@"error":@"credentials_expired"} statusCode:401 headers:@{}];
+    }];
+    
+    // 3rd get is re-attempted but will fail - request interceptors can't stop "in flight" requests
+    // but we didn't manage to get the IAM token so we don't have a valid cookie
+    [helper addResponse:^OHHTTPStubsResponse *__nonnull(NSURLRequest *__nonnull request) {
+        // TODO assert on the cookie passed in
+        XCTAssert([request.HTTPMethod isEqualToString:@"GET"]);
+        XCTAssert(request.allHTTPHeaderFields[@"Cookie"] == nil);
+        return [OHHTTPStubsResponse responseWithJSONObject:@{@"error":@"credentials_expired"} statusCode:401 headers:@{}];
+    }];
+    
+    [helper doStubsForHost:@"username1.cloudant.com"];
+    
+    CDTIAMSessionCookieInterceptor *interceptor =
+    [[CDTIAMSessionCookieInterceptor alloc] initWithAPIKey:@"apikey"];
+    // create a context with a request which we can use
+    NSURL *url = [NSURL URLWithString:@"http://username1.cloudant.com/animaldb"];
+    NSURLRequest *request = [NSURLRequest requestWithURL:url];
+    
+    CDTURLSession *session = [[CDTURLSession alloc] initWithCallbackThread:[NSThread currentThread] requestInterceptors:@[interceptor] sessionConfigDelegate:nil];
+    
+    CDTURLSessionTask *task = [session dataTaskWithRequest:request taskDelegate:nil];
+    [task resume];
+    while ([task state] != NSURLSessionTaskStateCompleted) {
+        [NSThread sleepForTimeInterval:1.0];
+    }
+
+    XCTAssertEqualObjects(interceptor.cookie, testCookieHeaderValue);
+    
+    CDTURLSessionTask *task2 = [session dataTaskWithRequest:request taskDelegate:nil];
+    [task2 resume];
+    while ([task2 state] != NSURLSessionTaskStateCompleted) {
+        [NSThread sleepForTimeInterval:1.0];
+    }
+
+    XCTAssertEqualObjects(interceptor.cookie, testCookieHeaderValue);
+    
+    CDTURLSessionTask *task3 = [session dataTaskWithRequest:request taskDelegate:nil];
+    [task3 resume];
+    while ([task3 state] != NSURLSessionTaskStateCompleted) {
+        [NSThread sleepForTimeInterval:1.0];
+    }
+    
+    XCTAssertNil(interceptor.cookie);
+    XCTAssert([IAMTokenHelper currentResponse] == 2);
+    XCTAssert([helper currentResponse] == 5);
+}
+
+/**
+ * Test IAM token and cookie flow, where session expires and subsequent session cookie fails:
+ * - GET a resource on the cloudant server
+ * - Cookie jar empty, so get IAM token followed by session cookie
+ * - GET now proceeds as normal, expected cookie value is sent in header
+ * - second GET on cloudant server, re-using session cookie
+ * - third GET on cloudant server, cookie expired, get IAM token, subsequent session cookie
+ *   request fails, no more requests are made
+ */
+
+- (void) testIAMRenewalFailureOnSessionCookie
+{
+    
+    OHHTTPStubsHelper *IAMTokenHelper = [[OHHTTPStubsHelper alloc] init];
+    
+    // first IAM token
+    [IAMTokenHelper addResponse:^OHHTTPStubsResponse *__nonnull(NSURLRequest *__nonnull request) {
+        if ([request.HTTPMethod isEqualToString:@"POST"]) {
+            return [OHHTTPStubsResponse
+                    responseWithJSONObject:iamToken1
+                    statusCode:200
+                    headers:@{}];
+        } else {
+            XCTFail(@"Unexpected HTTP Method");
+            return [OHHTTPStubsResponse responseWithJSONObject:@{} statusCode:400 headers:@{}];
+        }
+    }];
+    
+    // second IAM token
+    [IAMTokenHelper addResponse:^OHHTTPStubsResponse *__nonnull(NSURLRequest *__nonnull request) {
+        if ([request.HTTPMethod isEqualToString:@"POST"]) {
+            return [OHHTTPStubsResponse
+                    responseWithJSONObject:iamToken2
+                    statusCode:200
+                    headers:@{}];
+        } else {
+            XCTFail(@"Unexpected HTTP Method");
+            return [OHHTTPStubsResponse responseWithJSONObject:@{} statusCode:400 headers:@{}];
+        }
+    }];
+    
+    [IAMTokenHelper doStubsForHost:@"iam.bluemix.net"];
+    
+    OHHTTPStubsHelper *helper = [[OHHTTPStubsHelper alloc] init];
+    
+    // call to _iam_session endpoint, return cookie in header
+    [helper addResponse:^OHHTTPStubsResponse *__nonnull(NSURLRequest *__nonnull request) {
+        
+        XCTAssert([request.HTTPMethod isEqualToString:@"POST"]);
+        XCTAssert([[TDJSON JSONObjectWithData:request.OHHTTPStubs_HTTPBody options:0 error:nil][@"access_token"] isEqualToString:iamToken1[@"access_token"]]);
+        XCTAssert([request.URL.lastPathComponent isEqualToString:@"_iam_session"]);
+        XCTAssert([request.allHTTPHeaderFields[@"Content-Type"] isEqualToString:@"application/json"]);
+        
+        return [OHHTTPStubsResponse
+                responseWithJSONObject:@{
+                                         @"ok" : @(YES),
+                                         @"name" : @"username",
+                                         @"roles" : @[ @"_admin" ]
+                                         }
+                statusCode:200
+                headers:@{
+                          @"Set-Cookie" : [NSString
+                                           stringWithFormat:@"%@; Version=1; Path=/; HttpOnly",
+                                           testCookieHeaderValue]
+                          }];
+    }];
+    
+    // get resource successfully using cookie
+    [helper addResponse:^OHHTTPStubsResponse *__nonnull(NSURLRequest *__nonnull request) {
+        // TODO assert on the cookie passed in
+        XCTAssert([request.HTTPMethod isEqualToString:@"GET"]);
+        // TODO a more realistic object
+        return [OHHTTPStubsResponse responseWithJSONObject:@{} statusCode:200 headers:@{}];
+    }];
+    
+    // 2nd get resource successfully using cookie
+    [helper addResponse:^OHHTTPStubsResponse *__nonnull(NSURLRequest *__nonnull request) {
+        // TODO assert on the cookie passed in
+        XCTAssert([request.HTTPMethod isEqualToString:@"GET"]);
+        // TODO a more realistic object
+        return [OHHTTPStubsResponse responseWithJSONObject:@{} statusCode:200 headers:@{}];
+    }];
+    
+    // 3rd get resource fails, cookie expired
+    [helper addResponse:^OHHTTPStubsResponse *__nonnull(NSURLRequest *__nonnull request) {
+        // TODO assert on the cookie passed in
+        XCTAssert([request.HTTPMethod isEqualToString:@"GET"]);
+        return [OHHTTPStubsResponse responseWithJSONObject:@{@"error":@"credentials_expired"} statusCode:401 headers:@{}];
+    }];
+    
+    // call to _iam_session endpoint with updated token fails
+    [helper addResponse:^OHHTTPStubsResponse *__nonnull(NSURLRequest *__nonnull request) {
+        
+        XCTAssert([request.HTTPMethod isEqualToString:@"POST"]);
+        XCTAssert([[TDJSON JSONObjectWithData:request.OHHTTPStubs_HTTPBody options:0 error:nil][@"access_token"] isEqualToString:iamToken2[@"access_token"]]);
+        XCTAssert([request.URL.lastPathComponent isEqualToString:@"_iam_session"]);
+        XCTAssert([request.allHTTPHeaderFields[@"Content-Type"] isEqualToString:@"application/json"]);
+
+        return [OHHTTPStubsResponse responseWithJSONObject:@{@"error":@"credentials_expired"} statusCode:401 headers:@{}];
+    }];
+    
+    // 3rd get is re-attempted but will fail - request interceptors can't stop "in flight" requests
+    // but we didn't manage to get the IAM token so we don't have a valid cookie
+    [helper addResponse:^OHHTTPStubsResponse *__nonnull(NSURLRequest *__nonnull request) {
+        // TODO assert on the cookie passed in
+        XCTAssert([request.HTTPMethod isEqualToString:@"GET"]);
+        XCTAssert(request.allHTTPHeaderFields[@"Cookie"] == nil);
+        return [OHHTTPStubsResponse responseWithJSONObject:@{@"error":@"credentials_expired"} statusCode:401 headers:@{}];
+    }];
+    
+    
+    [helper doStubsForHost:@"username1.cloudant.com"];
+    
+    CDTIAMSessionCookieInterceptor *interceptor =
+    [[CDTIAMSessionCookieInterceptor alloc] initWithAPIKey:@"apikey"];
+    // create a context with a request which we can use
+    NSURL *url = [NSURL URLWithString:@"http://username1.cloudant.com/animaldb"];
+    NSURLRequest *request = [NSURLRequest requestWithURL:url];
+    
+    CDTURLSession *session = [[CDTURLSession alloc] initWithCallbackThread:[NSThread currentThread] requestInterceptors:@[interceptor] sessionConfigDelegate:nil];
+    
+    CDTURLSessionTask *task = [session dataTaskWithRequest:request taskDelegate:nil];
+    [task resume];
+    while ([task state] != NSURLSessionTaskStateCompleted) {
+        [NSThread sleepForTimeInterval:1.0];
+    }
+
+    XCTAssertEqualObjects(interceptor.cookie, testCookieHeaderValue);
+
+    CDTURLSessionTask *task2 = [session dataTaskWithRequest:request taskDelegate:nil];
+    [task2 resume];
+    while ([task2 state] != NSURLSessionTaskStateCompleted) {
+        [NSThread sleepForTimeInterval:1.0];
+    }
+
+    XCTAssertEqualObjects(interceptor.cookie, testCookieHeaderValue);
+    
+    CDTURLSessionTask *task3 = [session dataTaskWithRequest:request taskDelegate:nil];
+    [task3 resume];
+    while ([task3 state] != NSURLSessionTaskStateCompleted) {
+        [NSThread sleepForTimeInterval:1.0];
+    }
+    
+    XCTAssertNil(interceptor.cookie);
+    XCTAssert([IAMTokenHelper currentResponse] == 2);
+    XCTAssert([helper currentResponse] == 6);
+    
+}
+
+@end


### PR DESCRIPTION
Work to support IAM API key authentication using IAM tokens and the IAM session endpoint.

- Refactor existing cookie interceptor classes and add CDTSessionCookieInterceptorBase for shared functionality
- Add options on {Pull,Push}Replication to set IAM API key and therefore use new interceptor
- Add new environment variable to allow stub HTTP testing by forcing network requests onto a foreground session
- Add new tests for interceptor using stubbed responses
