### PR TITLE
372 cookie expiry

### DIFF
--- a/CDTDatastore.xcodeproj/project.pbxproj
+++ b/CDTDatastore.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		00049C35D4C6DF8171AF9AC8 /* Pods_base_tests_CDTDatastoreTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 992FED8F2AA3E2ADD7599045 /* Pods_base_tests_CDTDatastoreTests.framework */; };
 		1399B6CAACAB8F75EE125480 /* Pods_base_raTests_CDTDatastoreReplicationAcceptanceTestsOSX.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3809563FA5BF431C4EC8D3B5 /* Pods_base_raTests_CDTDatastoreReplicationAcceptanceTestsOSX.framework */; };
+		2E25F68D1F4C6DB900177ABA /* OHHTTPStubsHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 2E25F68C1F4C6DB900177ABA /* OHHTTPStubsHelper.m */; };
+		2E25F68E1F4C6E3D00177ABA /* OHHTTPStubsHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 2E25F68C1F4C6DB900177ABA /* OHHTTPStubsHelper.m */; };
 		3567D22135DB02790BD939BA /* CDTDatastore+Replication.h in Headers */ = {isa = PBXBuildFile; fileRef = 3567D9F9C835096137DC8EF2 /* CDTDatastore+Replication.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3567D43713667ABFE05C08F2 /* CDTDatastore+Replication.h in Headers */ = {isa = PBXBuildFile; fileRef = 3567D9F9C835096137DC8EF2 /* CDTDatastore+Replication.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3567DA2E9930DA1BFABB6617 /* CDTDatastore+Replication.m in Sources */ = {isa = PBXBuildFile; fileRef = 3567D4C1BDD33D0148CA9FF2 /* CDTDatastore+Replication.m */; };
@@ -741,6 +743,8 @@
 		1053749380E7A10A270B91E4 /* Pods-base-CDTDatastoreOSX.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-base-CDTDatastoreOSX.debug.xcconfig"; path = "Pods/Target Support Files/Pods-base-CDTDatastoreOSX/Pods-base-CDTDatastoreOSX.debug.xcconfig"; sourceTree = "<group>"; };
 		11828F46DDB99AC94990EF7B /* Pods-base-raTests-CDTDatastoreReplicationAcceptanceTestsOSX.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-base-raTests-CDTDatastoreReplicationAcceptanceTestsOSX.release.xcconfig"; path = "Pods/Target Support Files/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTestsOSX/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTestsOSX.release.xcconfig"; sourceTree = "<group>"; };
 		1970EE2354D3B1A67BBEE47B /* Pods-base-raTests-CDTDatastoreReplicationAcceptanceTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-base-raTests-CDTDatastoreReplicationAcceptanceTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTests/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTests.release.xcconfig"; sourceTree = "<group>"; };
+		2E25F68B1F4C6DB900177ABA /* OHHTTPStubsHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OHHTTPStubsHelper.h; sourceTree = "<group>"; };
+		2E25F68C1F4C6DB900177ABA /* OHHTTPStubsHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OHHTTPStubsHelper.m; sourceTree = "<group>"; };
 		3567D4C1BDD33D0148CA9FF2 /* CDTDatastore+Replication.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "CDTDatastore+Replication.m"; sourceTree = "<group>"; };
 		3567D9F9C835096137DC8EF2 /* CDTDatastore+Replication.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "CDTDatastore+Replication.h"; sourceTree = "<group>"; };
 		3809563FA5BF431C4EC8D3B5 /* Pods_base_raTests_CDTDatastoreReplicationAcceptanceTestsOSX.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_base_raTests_CDTDatastoreReplicationAcceptanceTestsOSX.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1363,6 +1367,8 @@
 		98F77B441C43FC9F00515CC3 /* CDTDatastoreTests */ = {
 			isa = PBXGroup;
 			children = (
+				2E25F68B1F4C6DB900177ABA /* OHHTTPStubsHelper.h */,
+				2E25F68C1F4C6DB900177ABA /* OHHTTPStubsHelper.m */,
 				987382FA1C47B1DD00937212 /* Helpers */,
 				98F77DFF1C44044000515CC3 /* Assets */,
 				98F77E061C44044000515CC3 /* Attachments */,
@@ -3037,6 +3043,7 @@
 				987385511C47B45600937212 /* CloudantSyncTests.m in Sources */,
 				987385521C47B45600937212 /* Tests.m in Sources */,
 				987385531C47B45600937212 /* CDTQSQLOnlyQueryExecutor.m in Sources */,
+				2E25F68E1F4C6E3D00177ABA /* OHHTTPStubsHelper.m in Sources */,
 				987385541C47B45600937212 /* CDTFetchChangesTests.m in Sources */,
 				987385561C47B45600937212 /* TDPusherTests.m in Sources */,
 				987385581C47B45600937212 /* CDTQQueryMatcher.m in Sources */,
@@ -3194,6 +3201,7 @@
 				980F22741CB818260075A843 /* CDTQIndexTests.m in Sources */,
 				980F22751CB818260075A843 /* CDTQIndexUpdaterTests.m in Sources */,
 				980F22761CB818260075A843 /* CDTQInvalidQuerySyntax.m in Sources */,
+				2E25F68D1F4C6DB900177ABA /* OHHTTPStubsHelper.m in Sources */,
 				987AF7B61DE7274C00577DAC /* DatastoreEncryptionTests.m in Sources */,
 				980F22771CB818260075A843 /* CDTQPerformanceTests.m in Sources */,
 				8E705A971F0E325200FF0219 /* CDTIAMSessionCookieInterceptorTests.m in Sources */,

--- a/CDTDatastore/HTTP/CDTSessionCookieInterceptorBase.h
+++ b/CDTDatastore/HTTP/CDTSessionCookieInterceptorBase.h
@@ -26,18 +26,18 @@
 /** Whether it looks worthwhile for us to make the session request (no bad failures so far). */
 @property (nonatomic) BOOL shouldMakeSessionRequest;
 
-/** Current session cookie. */
-@property (nullable, strong, nonatomic) NSString *cookie;
-
-/** NSURLSession to make calls to _session using (shouldn't be same one we're intercepting). */
+/** NSURLSession to use to make calls to _session or _iam_session (shouldn't be same one we're intercepting). */
 @property (nonnull, nonatomic, strong) NSURLSession *urlSession;
 
+/** Current session cookie. */
+@property (nullable, nonatomic, strong) NSArray<NSHTTPCookie *> *cookies;
 
-- (nullable NSString *)startNewSessionAtURL:(nonnull NSURL *)url
+- (nullable NSArray<NSHTTPCookie *> *)startNewSessionAtURL:(nonnull NSURL *)url
                                    withBody:(nonnull NSData *)body
                                     session:(nonnull NSURLSession *)session
                       sessionStartedHandler:(BOOL (^_Nonnull)(NSData *_Nonnull data))sessionStartedHandler;
 
 - (nonnull NSURLSessionConfiguration*)customiseSessionConfig:(nonnull NSURLSessionConfiguration*)config;
 
+- (BOOL)hasValidCookieWithName:(nonnull NSString*)cookieName forRequestURL:(nonnull NSURL*)requestUrl;
 @end

--- a/CDTDatastoreTests/CDTIAMSessionCookieInterceptorTests.m
+++ b/CDTDatastoreTests/CDTIAMSessionCookieInterceptorTests.m
@@ -24,6 +24,7 @@
 #import <OHHTTPStubs/OHHTTPStubs.h>
 #import <OHHTTPStubs/OHHTTPStubsResponse+JSON.h>
 #import <OHHTTPStubs/NSURLRequest+HTTPBodyTesting.h>
+#import "OHHTTPStubsHelper.h"
 #import "CDTLogging.h"
 #import "TDJSON.h"
 
@@ -44,54 +45,6 @@ static const NSString *testCookieHeaderValue =
 
 static const NSString *testCookieHeaderValue2 =
 @"IAMSession=dG9tYmxlbmNoOjU5NTM0QzgyOhqHa60IlqPmGR8vTVIK-tzhopMR";
-
-// helper to sequence a number of stubbed responses
-
-@interface OHHTTPStubsHelper : NSObject
-@property NSMutableArray<OHHTTPStubsResponseBlock> *responses;
-@property int currentResponse;
-
-- (id) init;
-- (void) addResponse:(OHHTTPStubsResponseBlock)responseBlock;
-- (void) doStubsForHost:(NSString*)host;
-@end
-
-@implementation OHHTTPStubsHelper
-
-- (id) init
-{
-    if (self = [super init]) {
-        _currentResponse = 0;
-        _responses = [NSMutableArray array];
-    }
-    return self;
-}
-
-- (void) addResponse:(OHHTTPStubsResponseBlock)responseBlock
-{
-    [_responses addObject:responseBlock];
-}
-- (void) doStubsForHost:(NSString*)host
-{
-    [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *__nonnull request) {
-        return [[request.URL host] isEqualToString:host];
-    } withStubResponse:^OHHTTPStubsResponse *__nonnull(NSURLRequest *__nonnull request) {
-        if (_currentResponse < _responses.count) {
-            return [_responses objectAtIndex:_currentResponse++](request);
-        } else {
-            return [OHHTTPStubsResponse
-                    responseWithJSONObject:@{
-                                             @"error" : @"Failed",
-                                             @"reason" : @"More requests were made than expected by the tests."
-                                             }
-                    statusCode:555
-                    headers:@{}
-                    ];
-        }
-    }];
-}
-
-@end
 
 @interface CDTIAMSessionCookieInterceptorTests : CloudantSyncTests
 
@@ -184,8 +137,7 @@ NSDictionary *iamToken2;
     [helper addResponse:^OHHTTPStubsResponse *__nonnull(NSURLRequest *__nonnull request) {
         XCTAssert([testCookieHeaderValue isEqualToString: request.allHTTPHeaderFields[@"Cookie"]]);
         XCTAssert([request.HTTPMethod isEqualToString:@"GET"]);
-        // TODO a more realistic object
-        return [OHHTTPStubsResponse responseWithJSONObject:@{} statusCode:200 headers:@{}];
+        return [OHHTTPStubsResponse responseWithJSONObject:@{@"ok" : @(YES)} statusCode:200 headers:@{}];
     }];
     
     [helper doStubsForHost:@"username.cloudant.com"];
@@ -275,16 +227,14 @@ NSDictionary *iamToken2;
     [helper addResponse:^OHHTTPStubsResponse *__nonnull(NSURLRequest *__nonnull request) {
         XCTAssert([testCookieHeaderValue isEqualToString: request.allHTTPHeaderFields[@"Cookie"]]);
         XCTAssert([request.HTTPMethod isEqualToString:@"GET"]);
-        // TODO a more realistic object
-        return [OHHTTPStubsResponse responseWithJSONObject:@{} statusCode:200 headers:@{}];
+        return [OHHTTPStubsResponse responseWithJSONObject:@{@"ok" : @(YES)} statusCode:200 headers:@{}];
     }];
     
     // 2nd get resource successfully using cookie
     [helper addResponse:^OHHTTPStubsResponse *__nonnull(NSURLRequest *__nonnull request) {
         XCTAssert([testCookieHeaderValue isEqualToString: request.allHTTPHeaderFields[@"Cookie"]]);
         XCTAssert([request.HTTPMethod isEqualToString:@"GET"]);
-        // TODO a more realistic object
-        return [OHHTTPStubsResponse responseWithJSONObject:@{} statusCode:200 headers:@{}];
+        return [OHHTTPStubsResponse responseWithJSONObject:@{@"ok" : @(YES)} statusCode:200 headers:@{}];
     }];
     
     // 3nd get resource fails, pretend cookie invalid by returning 401
@@ -318,8 +268,7 @@ NSDictionary *iamToken2;
     [helper addResponse:^OHHTTPStubsResponse *__nonnull(NSURLRequest *__nonnull request) {
         XCTAssert([testCookieHeaderValue2 isEqualToString: request.allHTTPHeaderFields[@"Cookie"]]);
         XCTAssert([request.HTTPMethod isEqualToString:@"GET"]);
-        // TODO a more realistic object
-        return [OHHTTPStubsResponse responseWithJSONObject:@{} statusCode:200 headers:@{}];
+        return [OHHTTPStubsResponse responseWithJSONObject:@{@"ok" : @(YES)} statusCode:200 headers:@{}];
         
     }];
     [helper doStubsForHost:@"username1.cloudant.com"];
@@ -425,16 +374,14 @@ NSDictionary *iamToken2;
     [helper addResponse:^OHHTTPStubsResponse *__nonnull(NSURLRequest *__nonnull request) {
         XCTAssert([testCookieHeaderValue isEqualToString: request.allHTTPHeaderFields[@"Cookie"]]);
         XCTAssert([request.HTTPMethod isEqualToString:@"GET"]);
-        // TODO a more realistic object
-        return [OHHTTPStubsResponse responseWithJSONObject:@{} statusCode:200 headers:@{}];
+        return [OHHTTPStubsResponse responseWithJSONObject:@{@"ok" : @(YES)} statusCode:200 headers:@{}];
     }];
     
     // 2nd get resource successfully using cookie
     [helper addResponse:^OHHTTPStubsResponse *__nonnull(NSURLRequest *__nonnull request) {
         XCTAssert([testCookieHeaderValue isEqualToString: request.allHTTPHeaderFields[@"Cookie"]]);
         XCTAssert([request.HTTPMethod isEqualToString:@"GET"]);
-        // TODO a more realistic object
-        return [OHHTTPStubsResponse responseWithJSONObject:@{} statusCode:200 headers:@{}];
+        return [OHHTTPStubsResponse responseWithJSONObject:@{@"ok" : @(YES)} statusCode:200 headers:@{}];
     }];
     
     // 3rd get resource fails, pretend cookie invalid by returning 401
@@ -557,16 +504,14 @@ NSDictionary *iamToken2;
     [helper addResponse:^OHHTTPStubsResponse *__nonnull(NSURLRequest *__nonnull request) {
         XCTAssert([testCookieHeaderValue isEqualToString: request.allHTTPHeaderFields[@"Cookie"]]);
         XCTAssert([request.HTTPMethod isEqualToString:@"GET"]);
-        // TODO a more realistic object
-        return [OHHTTPStubsResponse responseWithJSONObject:@{} statusCode:200 headers:@{}];
+        return [OHHTTPStubsResponse responseWithJSONObject:@{@"ok" : @(YES)} statusCode:200 headers:@{}];
     }];
     
     // 2nd get resource successfully using cookie
     [helper addResponse:^OHHTTPStubsResponse *__nonnull(NSURLRequest *__nonnull request) {
         XCTAssert([testCookieHeaderValue isEqualToString: request.allHTTPHeaderFields[@"Cookie"]]);
         XCTAssert([request.HTTPMethod isEqualToString:@"GET"]);
-        // TODO a more realistic object
-        return [OHHTTPStubsResponse responseWithJSONObject:@{} statusCode:200 headers:@{}];
+        return [OHHTTPStubsResponse responseWithJSONObject:@{@"ok" : @(YES)} statusCode:200 headers:@{}];
     }];
     
     // 3rd get resource fails, cookie expired
@@ -629,6 +574,148 @@ NSDictionary *iamToken2;
     XCTAssert([IAMTokenHelper currentResponse] == 2);
     XCTAssert([helper currentResponse] == 6);
     
+}
+
+/**
+ * Test IAM token and cookie flow, where session is nearly expired and we pre-emptively renew.
+ * - GET a resource on the cloudant server
+ * - Cookie jar empty, so get IAM token followed by session cookie with short expiry time
+ * - GET now proceeds as normal, expected cookie value is sent in header
+ * - second GET on cloudant server, cookie is nearly expired so should renew
+ * - IAM token followed by session cookie, followed by replay of request with new cookie.
+ * - third GET on cloudant server with new valid cookie.
+ */
+
+- (void)testIAMInterceptorRenewsEarly
+{
+    OHHTTPStubsHelper *IAMTokenHelper = [[OHHTTPStubsHelper alloc] init];
+    
+    // IAM token
+    [IAMTokenHelper addResponse:^OHHTTPStubsResponse *__nonnull(NSURLRequest *__nonnull request) {
+        if ([request.HTTPMethod isEqualToString:@"POST"]) {
+            return [OHHTTPStubsResponse
+                    responseWithJSONObject:iamToken1
+                    statusCode:200
+                    headers:@{}];
+        } else {
+            XCTFail(@"Unexpected HTTP Method");
+            return [OHHTTPStubsResponse responseWithJSONObject:@{@"ok" : @(YES)} statusCode:400 headers:@{}];
+        }
+    }];
+    
+    // IAM token renewal
+    [IAMTokenHelper addResponse:^OHHTTPStubsResponse *__nonnull(NSURLRequest *__nonnull request) {
+        if ([request.HTTPMethod isEqualToString:@"POST"]) {
+            return [OHHTTPStubsResponse
+                    responseWithJSONObject:iamToken2
+                    statusCode:200
+                    headers:@{}];
+        } else {
+            XCTFail(@"Unexpected HTTP Method");
+            return [OHHTTPStubsResponse responseWithJSONObject:@{@"ok" : @(YES)} statusCode:400 headers:@{}];
+        }
+    }];
+    
+    [IAMTokenHelper doStubsForHost:@"iam.bluemix.net"];
+    
+    OHHTTPStubsHelper *helper = [[OHHTTPStubsHelper alloc] init];
+    
+    // call to _iam_session endpoint, return cookie in header with 1 minute life
+    [helper addResponse:^OHHTTPStubsResponse *__nonnull(NSURLRequest *__nonnull request) {
+        
+        XCTAssert([request.HTTPMethod isEqualToString:@"POST"]);
+        XCTAssert([[TDJSON JSONObjectWithData:request.OHHTTPStubs_HTTPBody options:0 error:nil][@"access_token"] isEqualToString:iamToken1[@"access_token"]]);
+        XCTAssert([request.URL.lastPathComponent isEqualToString:@"_iam_session"]);
+        XCTAssert([request.allHTTPHeaderFields[@"Content-Type"] isEqualToString:@"application/json"]);
+        return [OHHTTPStubsResponse
+                responseWithJSONObject:@{
+                                         @"ok" : @(YES),
+                                         @"name" : @"username",
+                                         @"roles" : @[ @"_admin" ]
+                                         }
+                statusCode:200
+                headers:@{
+                          @"Set-Cookie" : [NSString
+                                           stringWithFormat:@"%@; Version=1; Path=/; HttpOnly; Max-Age=60",
+                                           testCookieHeaderValue]
+                          }];
+    }];
+    
+    // get resource successfully using cookie
+    [helper addResponse:^OHHTTPStubsResponse *__nonnull(NSURLRequest *__nonnull request) {
+        XCTAssert([testCookieHeaderValue isEqualToString: request.allHTTPHeaderFields[@"Cookie"]]);
+        XCTAssert([request.HTTPMethod isEqualToString:@"GET"]);
+        return [OHHTTPStubsResponse responseWithJSONObject:@{@"ok" : @(YES)} statusCode:200 headers:@{}];
+    }];
+    
+    // renewal call to _iam_session endpoint, return cookie in header with 1 day life
+    [helper addResponse:^OHHTTPStubsResponse *__nonnull(NSURLRequest *__nonnull request) {
+        
+        XCTAssert([request.HTTPMethod isEqualToString:@"POST"]);
+        XCTAssert([[TDJSON JSONObjectWithData:request.OHHTTPStubs_HTTPBody options:0 error:nil][@"access_token"] isEqualToString:iamToken2[@"access_token"]]);
+        XCTAssert([request.URL.lastPathComponent isEqualToString:@"_iam_session"]);
+        XCTAssert([request.allHTTPHeaderFields[@"Content-Type"] isEqualToString:@"application/json"]);
+        return [OHHTTPStubsResponse
+                responseWithJSONObject:@{
+                                         @"ok" : @(YES),
+                                         @"name" : @"username",
+                                         @"roles" : @[ @"_admin" ]
+                                         }
+                statusCode:200
+                headers:@{
+                          @"Set-Cookie" : [NSString
+                                           stringWithFormat:@"%@; Version=1; Path=/; HttpOnly; Max-Age=86400",
+                                           testCookieHeaderValue2]
+                          }];
+    }];
+    
+    // get resource successfully using new cookie
+    [helper addResponse:^OHHTTPStubsResponse *__nonnull(NSURLRequest *__nonnull request) {
+        XCTAssert([testCookieHeaderValue2 isEqualToString: request.allHTTPHeaderFields[@"Cookie"]]);
+        XCTAssert([request.HTTPMethod isEqualToString:@"GET"]);
+        return [OHHTTPStubsResponse responseWithJSONObject:@{@"ok" : @(YES)} statusCode:200 headers:@{}];
+    }];
+    
+    // get another resource successfully using new cookie
+    [helper addResponse:^OHHTTPStubsResponse *__nonnull(NSURLRequest *__nonnull request) {
+        XCTAssert([testCookieHeaderValue2 isEqualToString: request.allHTTPHeaderFields[@"Cookie"]]);
+        XCTAssert([request.HTTPMethod isEqualToString:@"GET"]);
+        return [OHHTTPStubsResponse responseWithJSONObject:@{@"ok" : @(YES)} statusCode:200 headers:@{}];
+    }];
+    
+    [helper doStubsForHost:@"username.cloudant.com"];
+    
+    CDTIAMSessionCookieInterceptor *interceptor =
+    [[CDTIAMSessionCookieInterceptor alloc] initWithAPIKey:@"apikey"];
+    // create a context with a request which we can use
+    NSURL *url = [NSURL URLWithString:@"http://username.cloudant.com"];
+    NSURLRequest *request = [NSURLRequest requestWithURL:url];
+    
+    CDTURLSession *session = [[CDTURLSession alloc] initWithCallbackThread:[NSThread currentThread] requestInterceptors:@[interceptor] sessionConfigDelegate: nil];
+    
+    // Initial GET will get a cookie and resource
+    CDTURLSessionTask *task = [session dataTaskWithRequest:request taskDelegate:nil];
+    [task resume];
+    while ([task state] != NSURLSessionTaskStateCompleted) {
+        [NSThread sleepForTimeInterval:1.0];
+    }
+    
+    // Second GET should renew cookie and get resource
+    CDTURLSessionTask *task2 = [session dataTaskWithRequest:request taskDelegate:nil];
+    [task2 resume];
+    while ([task2 state] != NSURLSessionTaskStateCompleted) {
+        [NSThread sleepForTimeInterval:1.0];
+    }
+    
+    // Third GET should just GET resource
+    CDTURLSessionTask *task3 = [session dataTaskWithRequest:request taskDelegate:nil];
+    [task3 resume];
+    while ([task3 state] != NSURLSessionTaskStateCompleted) {
+        [NSThread sleepForTimeInterval:1.0];
+    }
+    
+    XCTAssert([IAMTokenHelper currentResponse] == 2);
+    XCTAssert([helper currentResponse] == 5);
 }
 
 @end

--- a/CDTDatastoreTests/CDTSessionCookieInterceptorTests.m
+++ b/CDTDatastoreTests/CDTSessionCookieInterceptorTests.m
@@ -92,7 +92,8 @@ static const NSString *testCookieHeaderValue =
 
     context = [interceptor interceptRequestInContext:context];
 
-    XCTAssertEqualObjects(interceptor.cookie, testCookieHeaderValue);
+    NSString *cookieString = [NSString stringWithFormat:@"%@=%@", interceptor.cookies[0].name, interceptor.cookies[0].value];
+    XCTAssertEqualObjects(cookieString, testCookieHeaderValue);
     XCTAssertEqual(interceptor.shouldMakeSessionRequest, YES);
     XCTAssertEqualObjects([context.request valueForHTTPHeaderField:@"Cookie"],
                           testCookieHeaderValue);
@@ -113,7 +114,7 @@ static const NSString *testCookieHeaderValue =
 
     context = [interceptor interceptRequestInContext:context];
 
-    XCTAssertNil(interceptor.cookie);
+    XCTAssertNil(interceptor.cookies);
     XCTAssertEqual(interceptor.shouldMakeSessionRequest, NO);
     XCTAssertNil([context.request valueForHTTPHeaderField:@"Cookie"]);
 }

--- a/CDTDatastoreTests/CDTSessionCookieInterceptorTests.m
+++ b/CDTDatastoreTests/CDTSessionCookieInterceptorTests.m
@@ -16,9 +16,14 @@
 
 #import <XCTest/XCTest.h>
 #import "CloudantSyncTests.h"
+#import "CDTLogging.h"
 #import "CDTSessionCookieInterceptor.h"
+#import "CDTURLSession.h"
 #import <OHHTTPStubs/OHHTTPStubs.h>
 #import <OHHTTPStubs/OHHTTPStubsResponse+JSON.h>
+#import <OHHTTPStubs/NSURLRequest+HTTPBodyTesting.h>
+#import "OHHTTPStubsHelper.h"
+
 // expose properties so we can look at them
 @interface CDTSessionCookieInterceptor ()
 
@@ -31,6 +36,9 @@
 static const NSString *testCookieHeaderValue =
     @"AuthSession=cm9vdDo1MEJCRkYwMjq0LO0ylOIwShrgt8y-UkhI-c6BGw";
 
+static const NSString *testCookieHeaderValue2 =
+    @"AuthSession=dn0weEp2NFKDSlZxNkr1MP1zmPJxTishs9z-VliJ-d7CHx";
+
 @interface CDTSessionCookieInterceptorTests : CloudantSyncTests
 
 @end
@@ -39,6 +47,11 @@ static const NSString *testCookieHeaderValue =
 
 - (void)setUp
 {
+    setenv("CDT_TEST_ENABLE_OHHTTPSTUBS", "1", true);
+    CDTChangeLogLevel(CDTTD_REMOTE_REQUEST_CONTEXT, DDLogLevelDebug);
+    CDTChangeLogLevel(CDTREPLICATION_LOG_CONTEXT, DDLogLevelDebug);
+    [DDLog addLogger:[DDTTYLogger sharedInstance]];
+    
     [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *__nonnull request) {
       return [[request.URL host] isEqualToString:@"username1.cloudant.com"];
     }
@@ -76,7 +89,11 @@ static const NSString *testCookieHeaderValue =
         }];
 }
 
-- (void)tearDown { [OHHTTPStubs removeAllStubs]; }
+- (void)tearDown {
+    unsetenv("CDT_TEST_ENABLE_OHHTTPSTUBS");
+    [OHHTTPStubs removeAllStubs];
+}
+
 - (void)testCookieInterceptorSuccessfullyGetsCookie
 {
     CDTSessionCookieInterceptor *interceptor =
@@ -117,6 +134,194 @@ static const NSString *testCookieHeaderValue =
     XCTAssertNil(interceptor.cookies);
     XCTAssertEqual(interceptor.shouldMakeSessionRequest, NO);
     XCTAssertNil([context.request valueForHTTPHeaderField:@"Cookie"]);
+}
+
+/**
+ * Test cookie flow, where a Set-Cookie header on a (non _session) response
+ * pre-emptively renews the cookie.
+ * - GET a resource on the cloudant server
+ * - Cookie jar empty, so get session cookie with short expiry time
+ * - GET now proceeds as normal, expected cookie value is sent in header
+ * - Longer lived cookie is sent in Set-Cookie header on this GET response
+ * - second GET on cloudant server longer lived Cookie should be in place so
+ * no renewal and successful GET with new cookie.
+ */
+- (void)testCookieInterceptorAcceptsSetCookieOnResponse
+{
+    OHHTTPStubsHelper *helper = [[OHHTTPStubsHelper alloc] init];
+    
+    // call to _session endpoint, return cookie in header with 1 minute life
+    [helper addResponse:^OHHTTPStubsResponse *__nonnull(NSURLRequest *__nonnull request) {
+        XCTAssert([request.HTTPMethod isEqualToString:@"POST"]);
+        XCTAssert([request.URL.lastPathComponent isEqualToString:@"_session"]);
+        XCTAssert([request.allHTTPHeaderFields[@"Content-Type"] isEqualToString:@"application/x-www-form-urlencoded"]);
+        XCTAssert([[[NSString alloc] initWithData: request.OHHTTPStubs_HTTPBody encoding:NSUTF8StringEncoding] isEqualToString:@"name=username&password=password"]);
+        return [OHHTTPStubsResponse
+                responseWithJSONObject:@{
+                                         @"ok" : @(YES),
+                                         @"name" : @"username",
+                                         @"roles" : @[ @"_admin" ]
+                                         }
+                statusCode:200
+                headers:@{
+                          @"Set-Cookie" : [NSString
+                                           stringWithFormat:@"%@; Version=1; Path=/; HttpOnly; Max-Age=60",
+                                           testCookieHeaderValue]
+                          }];
+    }];
+    
+    // get resource successfully using cookie, return longer cookie
+    [helper addResponse:^OHHTTPStubsResponse *__nonnull(NSURLRequest *__nonnull request) {
+        XCTAssert([testCookieHeaderValue isEqualToString: request.allHTTPHeaderFields[@"Cookie"]]);
+        XCTAssert([request.HTTPMethod isEqualToString:@"GET"]);
+        return [OHHTTPStubsResponse responseWithJSONObject:@{@"ok" : @(YES)} statusCode:200 headers:@{
+                                                                                                      @"Set-Cookie" : [NSString
+                                                                                                               stringWithFormat:@"%@; Version=1; Path=/; HttpOnly; Max-Age=86400",
+                                                                                                               testCookieHeaderValue2]
+                                                                                                      }];
+    }];
+    
+    // get resource successfully using new cookie
+    [helper addResponse:^OHHTTPStubsResponse *__nonnull(NSURLRequest *__nonnull request) {
+        XCTAssert([testCookieHeaderValue2 isEqualToString: request.allHTTPHeaderFields[@"Cookie"]]);
+        XCTAssert([request.HTTPMethod isEqualToString:@"GET"]);
+        return [OHHTTPStubsResponse responseWithJSONObject:@{@"ok" : @(YES)} statusCode:200 headers:@{}];
+    }];
+    
+    [helper doStubsForHost:@"username2.cloudant.com"];
+    
+    CDTSessionCookieInterceptor *interceptor =
+    [[CDTSessionCookieInterceptor alloc] initWithUsername:@"username" password:@"password"];
+    // create a context with a request which we can use
+    NSURL *url = [NSURL URLWithString:@"http://username2.cloudant.com/somedb"];
+    NSURLRequest *request = [NSURLRequest requestWithURL:url];
+    
+    CDTURLSession *session = [[CDTURLSession alloc] initWithCallbackThread:[NSThread currentThread] requestInterceptors:@[interceptor] sessionConfigDelegate: nil];
+    
+    // Initial GET will get a cookie and resource and update with a longer lived cookie
+    CDTURLSessionTask *task = [session dataTaskWithRequest:request taskDelegate:nil];
+    [task resume];
+    while ([task state] != NSURLSessionTaskStateCompleted) {
+        [NSThread sleepForTimeInterval:1.0];
+    }
+    
+    // Second GET should use new cookie
+    CDTURLSessionTask *task2 = [session dataTaskWithRequest:request taskDelegate:nil];
+    [task2 resume];
+    while ([task2 state] != NSURLSessionTaskStateCompleted) {
+        [NSThread sleepForTimeInterval:1.0];
+    }
+    
+    XCTAssert([helper currentResponse] == 3);
+}
+
+/**
+ * Test cookie flow, where session is nearly expired and we pre-emptively renew.
+ * - GET a resource on the cloudant server
+ * - Cookie jar empty, so get session cookie with short expiry time
+ * - GET now proceeds as normal, expected cookie value is sent in header
+ * - second GET on cloudant server, cookie is nearly expired so should renew
+ * - session cookie requested, followed by replay of request with new cookie.
+ * - third GET on cloudant server with new valid cookie.
+ */
+
+- (void)testCookieInterceptorRenewsEarly
+{
+    OHHTTPStubsHelper *helper = [[OHHTTPStubsHelper alloc] init];
+    
+    // call to _session endpoint, return cookie in header with 1 minute life
+    [helper addResponse:^OHHTTPStubsResponse *__nonnull(NSURLRequest *__nonnull request) {
+        XCTAssert([request.HTTPMethod isEqualToString:@"POST"]);
+        XCTAssert([request.URL.lastPathComponent isEqualToString:@"_session"]);
+        XCTAssert([request.allHTTPHeaderFields[@"Content-Type"] isEqualToString:@"application/x-www-form-urlencoded"]);
+        XCTAssert([[[NSString alloc] initWithData: request.OHHTTPStubs_HTTPBody encoding:NSUTF8StringEncoding] isEqualToString:@"name=username&password=password"]);
+        return [OHHTTPStubsResponse
+                responseWithJSONObject:@{
+                                         @"ok" : @(YES),
+                                         @"name" : @"username",
+                                         @"roles" : @[ @"_admin" ]
+                                         }
+                statusCode:200
+                headers:@{
+                          @"Set-Cookie" : [NSString
+                                           stringWithFormat:@"%@; Version=1; Path=/; HttpOnly; Max-Age=60",
+                                           testCookieHeaderValue]
+                          }];
+    }];
+    
+    // get resource successfully using cookie
+    [helper addResponse:^OHHTTPStubsResponse *__nonnull(NSURLRequest *__nonnull request) {
+        XCTAssert([testCookieHeaderValue isEqualToString: request.allHTTPHeaderFields[@"Cookie"]]);
+        XCTAssert([request.HTTPMethod isEqualToString:@"GET"]);
+        return [OHHTTPStubsResponse responseWithJSONObject:@{@"ok" : @(YES)} statusCode:200 headers:@{}];
+    }];
+    
+    // renewal call to _session endpoint, return cookie in header with 1 day life
+    [helper addResponse:^OHHTTPStubsResponse *__nonnull(NSURLRequest *__nonnull request) {
+        XCTAssert([request.HTTPMethod isEqualToString:@"POST"]);
+        XCTAssert([request.URL.lastPathComponent isEqualToString:@"_session"]);
+        XCTAssert([request.allHTTPHeaderFields[@"Content-Type"] isEqualToString:@"application/x-www-form-urlencoded"]);
+        XCTAssert([[[NSString alloc] initWithData: request.OHHTTPStubs_HTTPBody encoding:NSUTF8StringEncoding] isEqualToString:@"name=username&password=password"]);
+        return [OHHTTPStubsResponse
+                responseWithJSONObject:@{
+                                         @"ok" : @(YES),
+                                         @"name" : @"username",
+                                         @"roles" : @[ @"_admin" ]
+                                         }
+                statusCode:200
+                headers:@{
+                          @"Set-Cookie" : [NSString
+                                           stringWithFormat:@"%@; Version=1; Path=/; HttpOnly; Max-Age=86400",
+                                           testCookieHeaderValue2]
+                          }];
+    }];
+    
+    // get resource successfully using new cookie
+    [helper addResponse:^OHHTTPStubsResponse *__nonnull(NSURLRequest *__nonnull request) {
+        XCTAssert([testCookieHeaderValue2 isEqualToString: request.allHTTPHeaderFields[@"Cookie"]]);
+        XCTAssert([request.HTTPMethod isEqualToString:@"GET"]);
+        return [OHHTTPStubsResponse responseWithJSONObject:@{@"ok" : @(YES)} statusCode:200 headers:@{}];
+    }];
+    
+    // get another resource successfully using new cookie
+    [helper addResponse:^OHHTTPStubsResponse *__nonnull(NSURLRequest *__nonnull request) {
+        XCTAssert([testCookieHeaderValue2 isEqualToString: request.allHTTPHeaderFields[@"Cookie"]]);
+        XCTAssert([request.HTTPMethod isEqualToString:@"GET"]);
+        return [OHHTTPStubsResponse responseWithJSONObject:@{@"ok" : @(YES)} statusCode:200 headers:@{}];
+    }];
+    
+    [helper doStubsForHost:@"username2.cloudant.com"];
+    
+    CDTSessionCookieInterceptor *interceptor =
+    [[CDTSessionCookieInterceptor alloc] initWithUsername:@"username" password:@"password"];
+    // create a context with a request which we can use
+    NSURL *url = [NSURL URLWithString:@"http://username2.cloudant.com/somedb"];
+    NSURLRequest *request = [NSURLRequest requestWithURL:url];
+    
+    CDTURLSession *session = [[CDTURLSession alloc] initWithCallbackThread:[NSThread currentThread] requestInterceptors:@[interceptor] sessionConfigDelegate: nil];
+    
+    // Initial GET will get a cookie and resource
+    CDTURLSessionTask *task = [session dataTaskWithRequest:request taskDelegate:nil];
+    [task resume];
+    while ([task state] != NSURLSessionTaskStateCompleted) {
+        [NSThread sleepForTimeInterval:1.0];
+    }
+    
+    // Second GET should renew cookie and get resource
+    CDTURLSessionTask *task2 = [session dataTaskWithRequest:request taskDelegate:nil];
+    [task2 resume];
+    while ([task2 state] != NSURLSessionTaskStateCompleted) {
+        [NSThread sleepForTimeInterval:1.0];
+    }
+    
+    // Third GET should just GET resource
+    CDTURLSessionTask *task3 = [session dataTaskWithRequest:request taskDelegate:nil];
+    [task3 resume];
+    while ([task3 state] != NSURLSessionTaskStateCompleted) {
+        [NSThread sleepForTimeInterval:1.0];
+    }
+    
+    XCTAssert([helper currentResponse] == 5);
 }
 
 @end

--- a/CDTDatastoreTests/OHHTTPStubsHelper.h
+++ b/CDTDatastoreTests/OHHTTPStubsHelper.h
@@ -1,0 +1,26 @@
+//
+//  OHHTTPStubsHelper.h
+//
+//  Copyright © 2017 IBM Corporation. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+// helper to sequence a number of stubbed responses
+
+#import <OHHTTPStubs/OHHTTPStubs.h>
+#import <OHHTTPStubs/OHHTTPStubsResponse+JSON.h>
+
+@interface OHHTTPStubsHelper : NSObject
+@property NSMutableArray<OHHTTPStubsResponseBlock> *responses;
+@property int currentResponse;
+
+- (id) init;
+- (void) addResponse:(OHHTTPStubsResponseBlock)responseBlock;
+- (void) doStubsForHost:(NSString*)host;
+@end

--- a/CDTDatastoreTests/OHHTTPStubsHelper.m
+++ b/CDTDatastoreTests/OHHTTPStubsHelper.m
@@ -1,0 +1,53 @@
+//
+//  OHHTTPStubsHelper.m
+//
+//  Copyright © 2017 IBM Corporation. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+// helper to sequence a number of stubbed responses
+
+#import "OHHTTPStubsHelper.h"
+
+@implementation OHHTTPStubsHelper
+
+- (id) init
+{
+    if (self = [super init]) {
+        _currentResponse = 0;
+        _responses = [NSMutableArray array];
+    }
+    return self;
+}
+
+- (void) addResponse:(OHHTTPStubsResponseBlock)responseBlock
+{
+    [_responses addObject:responseBlock];
+}
+- (void) doStubsForHost:(NSString*)host
+{
+    [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *__nonnull request) {
+        return [[request.URL host] isEqualToString:host];
+    } withStubResponse:^OHHTTPStubsResponse *__nonnull(NSURLRequest *__nonnull request) {
+        if (_currentResponse < _responses.count) {
+            return [_responses objectAtIndex:_currentResponse++](request);
+        } else {
+            return [OHHTTPStubsResponse
+                    responseWithJSONObject:@{
+                                             @"error" : @"Failed",
+                                             @"reason" : @"More requests were made than expected by the tests."
+                                             }
+                    statusCode:555
+                    headers:@{}
+                    ];
+        }
+    }];
+}
+
+@end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CDTDatastore CHANGELOG
 
 ## Unreleased
+- [IMPROVED] Added pre-emptive session renewal when within 5 minutes of expiry.
 - [FIXED] Replaced the GoogleToolboxForMac files with the CocoaPod subspec.
 
 ## 1.2.1 (2017-04-07)


### PR DESCRIPTION
## What

Added preemptive re-authentication for session cookies.

## How

Added session expiry checks to cookie handling:
* Stored an array of `NSHTTPCookie` instead of just a string of one cookie value.
* Removed handling of `Set-Cookie` and `Cookie` headers in our code, use `NSMutableURLRequest` and `NSHTTPCookie` utilities instead.
* Disabled built-in cookie handling on `_session` and `_iam_session` requests.
* Added `hasValidCookieWithName` method to check for existence of a cookie with more than 5 minutes until expiry for the request URL.
* Added check for `Set-Cookie` header on responses to skip `_session` round trip where the server operates a sliding window.

## Testing

* Added tests for preemptive renewal for _session and _iam_session.
* Added test for Set-Cookie header on a non-session response.
* Shared OHHTTPStubsHelper between both session tests.
 * Corrected cookie name in `CDTIAMSessionCookieInterceptorTests`.
* Stopped tests crashing when more requests were made than mock stubs (fail with 555 instead). * Refactored `_session` success test to also use stub requests.
* Refactored test assertions for new code and to check Cookie headers where possible and removed TODOs.
* Added Max-Age to mock cookies

## Issues

Fixes #372

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://github.com/cloudant/CDTDatastore/blob/master/DCO1.1.txt)
- [x] You have added tests for any code changes
- [x] You have updated the [CHANGELOG.md](https://github.com/cloudant/CDTDatastore/blob/master/CHANGELOG.md)
- [x] You have completed the PR template below: