### PR TITLE
Remove IAM-flavour methods for obtain replications

### DIFF
--- a/CDTDatastore/CDTReplicator/CDTPullReplication.h
+++ b/CDTDatastore/CDTReplicator/CDTPullReplication.h
@@ -82,21 +82,6 @@ NS_ASSUME_NONNULL_BEGIN
                              password:(nullable NSString *)password;
 
 /**
- * All CDTPullReplication objects must have a source and target.
- *
- * The CDTPullReplication uses an IAM API key to authenticate - see
- * https://console.bluemix.net/docs/services/Cloudant/guides/iam.html#ibm-cloud-identity-and-access-management
- * for more information about IAM.
- *
- * @param IAMAPIKey The IAM API key.
- * @return an initialsed instance of CDTAbstractReplication.
- */
-+ (instancetype)replicationWithSource:(NSURL *)source
-                               target:(CDTDatastore *)target
-                            IAMAPIKey:(NSString *)IAMAPIKey;
-
-
-/**
  @name Accessing the replication source and target
  */
 

--- a/CDTDatastore/CDTReplicator/CDTPullReplication.m
+++ b/CDTDatastore/CDTReplicator/CDTPullReplication.m
@@ -15,7 +15,6 @@
 
 #import "CDTPullReplication.h"
 #import "CDTSessionCookieInterceptor.h"
-#import "CDTIAMSessionCookieInterceptor.h"
 #import "CDTReplay429Interceptor.h"
 #import "CDTDatastore.h"
 #import "CDTLogging.h"
@@ -42,13 +41,6 @@
     return [[self alloc] initWithSource:source target:target username:username password:password];
 }
 
-+ (instancetype)replicationWithSource:(NSURL *)source
-                               target:(CDTDatastore *)target
-                            IAMAPIKey:(NSString *)IAMAPIKey
-{
-    return [[self alloc] initWithSource:source target:target IAMAPIKey:IAMAPIKey];
-}
-
 - (instancetype)initWithSource:(NSURL *)source
                         target:(CDTDatastore *)target
                       username:(NSString *)username
@@ -66,27 +58,6 @@
             sourceComponents.user = nil;
             sourceComponents.password = nil;
         }
-        
-        _source = sourceComponents.URL;
-        _target = target;
-    }
-    return self;
-}
-
-- (instancetype)initWithSource:(NSURL *)source
-                        target:(CDTDatastore *)target
-                     IAMAPIKey:(NSString *)IAMAPIKey
-{
-    if (self = [super initWithIAMAPIKey:IAMAPIKey]) {
-        NSURLComponents * sourceComponents = [NSURLComponents componentsWithURL:source resolvingAgainstBaseURL:NO];
-        if(sourceComponents.user && sourceComponents.password){
-            CDTLogWarn(CDTREPLICATION_LOG_CONTEXT, @"Credentials provided via the URL but IAM API key was provided, discarding URL credentials.");
-        }
-        CDTIAMSessionCookieInterceptor * cookieInterceptor = [[CDTIAMSessionCookieInterceptor alloc] initWithAPIKey:IAMAPIKey];
-        [self addInterceptor:cookieInterceptor];
-        
-        sourceComponents.user = nil;
-        sourceComponents.password = nil;
         
         _source = sourceComponents.URL;
         _target = target;

--- a/CDTDatastore/CDTReplicator/CDTPushReplication.h
+++ b/CDTDatastore/CDTReplicator/CDTPushReplication.h
@@ -87,21 +87,6 @@ typedef BOOL (^CDTFilterBlock)(CDTDocumentRevision *__nonnull revision,
                              password:(nullable NSString *)password;
 
 /**
- * All CDTPushReplication objects must have a source and target.
- *
- * The CDTPushReplication uses an IAM API key to authenticate - see
- * https://console.bluemix.net/docs/services/Cloudant/guides/iam.html#ibm-cloud-identity-and-access-management
- * for more information about IAM.
- *
- * @param IAMAPIKey The IAM API key.
- * @return an initialsed instance of CDTAbstractReplication.
- */
-+ (instancetype)replicationWithSource:(CDTDatastore *)source
-                               target:(NSURL *)target
-                            IAMAPIKey:(NSString *)IAMAPIKey;
-
-
-/**
  @name Accessing the replication source and target
  */
 

--- a/CDTDatastore/CDTReplicator/CDTPushReplication.m
+++ b/CDTDatastore/CDTReplicator/CDTPushReplication.m
@@ -17,7 +17,6 @@
 #import "CDTPushReplication.h"
 #import "CDTDatastore.h"
 #import "CDTSessionCookieInterceptor.h"
-#import "CDTIAMSessionCookieInterceptor.h"
 #import "CDTReplay429Interceptor.h"
 #import "TDMisc.h"
 #import "CDTLogging.h"
@@ -43,13 +42,6 @@
     return [[self alloc] initWithSource:source target:target username:username password:password];
 }
 
-+ (instancetype)replicationWithSource:(CDTDatastore *)source
-                               target:(NSURL *)target
-                            IAMAPIKey:(NSString *)IAMAPIKey
-{
-    return [[self alloc] initWithSource:source target:target IAMAPIKey:IAMAPIKey];
-}
-
 - (instancetype)initWithSource:(CDTDatastore *)source
                         target:(NSURL *)target
                       username:(NSString *)username
@@ -73,28 +65,6 @@
     }
     return self;
 }
-
-- (instancetype)initWithSource:(CDTDatastore *)source
-                        target:(NSURL *)target
-                     IAMAPIKey:(NSString *)IAMAPIKey
-{
-    if (self = [super initWithIAMAPIKey:IAMAPIKey]) {
-        NSURLComponents * targetComponents = [NSURLComponents componentsWithURL:target resolvingAgainstBaseURL:NO];
-        if(targetComponents.user && targetComponents.password){
-            CDTLogWarn(CDTREPLICATION_LOG_CONTEXT, @"Credentials provided via the URL but IAM API key was provided, discarding URL credentials.");
-        }
-        CDTIAMSessionCookieInterceptor * cookieInterceptor = [[CDTIAMSessionCookieInterceptor alloc] initWithAPIKey:IAMAPIKey];
-        [self addInterceptor:cookieInterceptor];
-        
-        targetComponents.user = nil;
-        targetComponents.password = nil;
-        
-        _source = source;
-        _target = targetComponents.URL;
-    }
-    return self;
-}
-
 
 - (instancetype)copyWithZone:(NSZone *)zone
 {


### PR DESCRIPTION
This commit is to temporarily backout the public API part of the IAM cookie interceptors, and can
be reversed once IAM is ready.
