### PR TITLE
371 check 403 credentials expired

### DIFF
--- a/CDTDatastore/HTTP/CDTHTTPInterceptorContext.h
+++ b/CDTDatastore/HTTP/CDTHTTPInterceptorContext.h
@@ -25,6 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readwrite, nonatomic, strong) NSMutableURLRequest *request;
 @property (nonatomic) BOOL shouldRetry;
 @property (nullable, readwrite, nonatomic, strong) NSHTTPURLResponse *response;
+@property (nullable, nonatomic, strong) NSData *responseData;
 
 /**
  * An immutable copy of the state dictionary for this context.

--- a/CDTDatastore/HTTP/CDTURLSessionTask.m
+++ b/CDTDatastore/HTTP/CDTURLSessionTask.m
@@ -51,7 +51,7 @@
 #pragma mark properties for the current request
 @property (nullable, nonatomic, strong) NSHTTPURLResponse *response;
 @property (nullable, nonatomic, strong) NSError * requestError;
-@property (nullable, nonatomic, strong) NSData * requestData;
+@property (nullable, nonatomic, strong) NSData * responseData;
 
 @end
 
@@ -125,7 +125,7 @@
     self.finished = NO;
     self.response = nil;
     self.requestError = nil;
-    self.requestData = nil;
+    self.responseData = nil;
     __block CDTHTTPInterceptorContext *ctx =
         [[CDTHTTPInterceptorContext alloc] initWithRequest:[self.request mutableCopy]
                                                      state:self.contextState];
@@ -181,7 +181,7 @@
 }
 
 - (void)processData:(NSData*)data {
-    self.requestData = data;
+    self.responseData = data;
 }
 
 - (void)processResponse:(NSURLResponse *)response onThread:(NSThread *)thread
@@ -200,6 +200,7 @@
     [[CDTHTTPInterceptorContext alloc] initWithRequest:[self.request mutableCopy]
                                                  state:self.contextState];
     ctx.response = self.response;
+    ctx.responseData = self.responseData;
     
     
     for (NSObject<CDTHTTPInterceptor> *obj in self.responseInterceptors) {
@@ -225,7 +226,7 @@
                              waitUntilDone:NO];
             [self.delegate performSelector:@selector(receivedData:)
                                   onThread:thread
-                                withObject:self.requestData
+                                withObject:self.responseData
                              waitUntilDone:NO];
         }
         self.finished = YES;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - [IMPROVED] Added pre-emptive session renewal when within 5 minutes of expiry.
+- [FIXED] Issue where cookie interceptor did not check for 403 HTTP response case.
 - [FIXED] Replaced the GoogleToolboxForMac files with the CocoaPod subspec.
 
 ## 1.2.1 (2017-04-07)


### PR DESCRIPTION
## What

Check for 403 HTTP `credentials_expired` case.

## How

- When 403 `credentials_expired` error occurs, call `session` endpoint and renew cookie.

## Testing
- Test case for 403 `credentials_expired`:  get resource and response returns 403, then call session endpoint and get a new cookie.
- Test case for 403 non-expiry: get resource and response returns 403, don't call session and keep existing cookie.
- Test case with cookie flow design similar to java-cloudant's `basic403Test` method

## Issues

fixes #371 