### PR TITLE
Enable IAM

### DIFF
--- a/CDTDatastore/CDTReplicator/CDTDatastore+Replication.h
+++ b/CDTDatastore/CDTReplicator/CDTDatastore+Replication.h
@@ -34,6 +34,19 @@ NS_ASSUME_NONNULL_BEGIN
                                             error:(NSError *__autoreleasing *) error;
 
 /**
+ * Creates a push replicator.
+ * @param target The URL of the remote database to push to.
+ * @param delegate An optional delegate for the replication
+ * @param error A pointer to an error that will be set if the replicator could not be created.
+ * @param IAMAPIKey         IAM API Key to authenticate with.
+ * @return A push replicator.
+ */
+- (nullable CDTReplicator*) pushReplicationTarget:(NSURL *)target
+                               IAMAPIKey:(NSString *)IAMAPIKey
+                            withDelegate:(NSObject <CDTReplicatorDelegate> *)delegate
+                                   error:(NSError *__autoreleasing *)error;
+
+/**
  * Creates a pull replicator.
  * @param source The URL of the database from which to pull.
  * @param delegate An optional delegate for the replication.
@@ -47,6 +60,19 @@ NS_ASSUME_NONNULL_BEGIN
                                          password:(nullable NSString*)password
                                      withDelegate:(nullable NSObject<CDTReplicatorDelegate>*)delegate
                                             error:(NSError *__autoreleasing *) error;
+
+/**
+ * Creates a pull replicator.
+ * @param source The URL of the database from which to pull.
+ * @param delegate An optional delegate for the replication.
+ * @param error A pointer to an error that will be set if the replicator could not be created.
+ * @param IAMAPIKey         IAM API Key to authenticate with.
+ * @return A pull replicator.
+ */
+- (nullable CDTReplicator*) pullReplicationSource:(NSURL *)source
+                                        IAMAPIKey:(NSString *)IAMAPIKey
+                                     withDelegate:(NSObject <CDTReplicatorDelegate> *)delegate
+                                            error:(NSError *__autoreleasing *)error;
 
 
 /**
@@ -84,6 +110,17 @@ NS_ASSUME_NONNULL_BEGIN
                  completionHandler:(void (^ __nonnull)(NSError* __nullable)) completionHandler
 NS_SWIFT_NAME(push(to:username:password:completionHandler:));
 
+/**
+ Asynchronously pushes data in this datastore to the server.
+ 
+ @param target            The URL of the remote database to push the data to.
+ @param completionHandler A block to call when the replication completes or errors.
+ @param IAMAPIKey         IAM API Key to authenticate with.
+ */
+- (void) pushReplicationWithTarget:(NSURL *)target
+                        IAMAPIKey:(NSString *)IAMAPIKey
+                completionHandler:(void (^ __nonnull)(NSError *__nullable))completionHandler
+NS_SWIFT_NAME(push(to:IAMAPIKey:completionHandler:));
 
 /**
  Asynchronously pull data from a remote server to this local datastore.
@@ -98,6 +135,18 @@ NS_SWIFT_NAME(push(to:username:password:completionHandler:));
                           password:(nullable NSString*) password
                  completionHandler:(void (^ __nonnull)(NSError* __nullable)) completionHandler
 NS_SWIFT_NAME(pull(from:username:password:completionHandler:));
+
+/**
+ Asynchronously pull data from a remote server to this local datastore.
+ 
+ @param source            The URL of the remote database from which to pull data.
+ @param completionHandler A block to call when the replication completes or errors.
+ @param IAMAPIKey         IAM API Key to authenticate with.
+ */
+- (void) pullReplicationWithSource:(NSURL*) source
+                         IAMAPIKey:(NSString *)IAMAPIKey
+                 completionHandler:(void (^ __nonnull)(NSError* __nullable)) completionHandler
+NS_SWIFT_NAME(pull(from:IAMAPIKey:completionHandler:));
 
 @end
 

--- a/CDTDatastore/CDTReplicator/CDTDatastore+Replication.m
+++ b/CDTDatastore/CDTReplicator/CDTDatastore+Replication.m
@@ -70,6 +70,14 @@
     return [self replicatorWithReplication:push delegate:delegate error:error];
 }
 
+- (CDTReplicator *)pushReplicationTarget:(NSURL *)target
+                               IAMAPIKey:(NSString *)IAMAPIKey
+                            withDelegate:(NSObject <CDTReplicatorDelegate> *)delegate
+                                   error:(NSError *__autoreleasing *)error {
+    CDTPushReplication *push = [CDTPushReplication replicationWithSource:self target:target IAMAPIKey:IAMAPIKey];
+    return [self replicatorWithReplication:push delegate:delegate error:error];
+}
+
 - (CDTReplicator *)pullReplicationSource:(NSURL *)source
                                 username:(NSString*)username
                                 password:(NSString*)password
@@ -78,6 +86,16 @@
 
     CDTPullReplication *pull = [CDTPullReplication replicationWithSource:source target:self username:username password:password];
 
+    return [self replicatorWithReplication:pull delegate:delegate error:error];
+}
+
+- (CDTReplicator *)pullReplicationSource:(NSURL *)source
+                                IAMAPIKey:(NSString *)IAMAPIKey
+                             withDelegate:(NSObject <CDTReplicatorDelegate> *)delegate
+                                   error:(NSError *__autoreleasing *)error {
+    
+    CDTPullReplication *pull = [CDTPullReplication replicationWithSource:source target:self IAMAPIKey:IAMAPIKey];
+    
     return [self replicatorWithReplication:pull delegate:delegate error:error];
 }
 
@@ -118,6 +136,23 @@
     }
 }
 
+- (void)pushReplicationWithTarget:(NSURL *)target
+                        IAMAPIKey:(NSString *)IAMAPIKey
+                completionHandler:(void (^ __nonnull)(NSError *__nullable))completionHandler
+{
+    NSError* error = nil;
+    CDTDatastoreReplicationDelegate* delegate = [[CDTDatastoreReplicationDelegate alloc] initWithCompletionHandler:completionHandler];
+    CDTReplicator* replicator = [self pushReplicationTarget:target
+                                                  IAMAPIKey:IAMAPIKey
+                                               withDelegate:delegate error:&error];
+    if (!error){
+        [replicator startWithError:&error];
+    }
+    
+    if (error) {
+        completionHandler(error);
+    }
+}
 
 - (void) pullReplicationWithSource:(NSURL*) source
                  completionHandler:(void (^ __nonnull)(NSError* __nullable)) completionHandler
@@ -138,6 +173,22 @@
         [replicator startWithError:&error];
     }
 
+    if (error) {
+        completionHandler(error);
+    }
+}
+
+- (void) pullReplicationWithSource:(NSURL *)source
+                         IAMAPIKey:(NSString *)IAMAPIKey
+                 completionHandler:(void (^ __nonnull)(NSError *__nullable))completionHandler
+{
+    NSError* error = nil;
+    CDTDatastoreReplicationDelegate* delegate = [[CDTDatastoreReplicationDelegate alloc] initWithCompletionHandler:completionHandler];
+    CDTReplicator* replicator = [self pullReplicationSource:source IAMAPIKey:IAMAPIKey withDelegate:delegate error:&error];
+    if (!error){
+        [replicator startWithError:&error];
+    }
+    
     if (error) {
         completionHandler(error);
     }

--- a/CDTDatastore/CDTReplicator/CDTPullReplication.h
+++ b/CDTDatastore/CDTReplicator/CDTPullReplication.h
@@ -82,6 +82,21 @@ NS_ASSUME_NONNULL_BEGIN
                              password:(nullable NSString *)password;
 
 /**
+ * All CDTPullReplication objects must have a source and target.
+ *
+ * The CDTPullReplication uses an IAM API key to authenticate - see
+ * https://console.bluemix.net/docs/services/Cloudant/guides/iam.html#ibm-cloud-identity-and-access-management
+ * for more information about IAM.
+ *
+ * @param IAMAPIKey The IAM API key.
+ * @return an initialsed instance of CDTAbstractReplication.
+ */
++ (instancetype)replicationWithSource:(NSURL *)source
+                               target:(CDTDatastore *)target
+                            IAMAPIKey:(NSString *)IAMAPIKey;
+
+
+/**
  @name Accessing the replication source and target
  */
 

--- a/CDTDatastore/CDTReplicator/CDTPullReplication.m
+++ b/CDTDatastore/CDTReplicator/CDTPullReplication.m
@@ -15,6 +15,7 @@
 
 #import "CDTPullReplication.h"
 #import "CDTSessionCookieInterceptor.h"
+#import "CDTIAMSessionCookieInterceptor.h"
 #import "CDTReplay429Interceptor.h"
 #import "CDTDatastore.h"
 #import "CDTLogging.h"
@@ -41,6 +42,13 @@
     return [[self alloc] initWithSource:source target:target username:username password:password];
 }
 
++ (instancetype)replicationWithSource:(NSURL *)source
+                               target:(CDTDatastore *)target
+                            IAMAPIKey:(NSString *)IAMAPIKey
+{
+    return [[self alloc] initWithSource:source target:target IAMAPIKey:IAMAPIKey];
+}
+
 - (instancetype)initWithSource:(NSURL *)source
                         target:(CDTDatastore *)target
                       username:(NSString *)username
@@ -58,6 +66,27 @@
             sourceComponents.user = nil;
             sourceComponents.password = nil;
         }
+        
+        _source = sourceComponents.URL;
+        _target = target;
+    }
+    return self;
+}
+
+- (instancetype)initWithSource:(NSURL *)source
+                        target:(CDTDatastore *)target
+                     IAMAPIKey:(NSString *)IAMAPIKey
+{
+    if (self = [super initWithIAMAPIKey:IAMAPIKey]) {
+        NSURLComponents * sourceComponents = [NSURLComponents componentsWithURL:source resolvingAgainstBaseURL:NO];
+        if(sourceComponents.user && sourceComponents.password){
+            CDTLogWarn(CDTREPLICATION_LOG_CONTEXT, @"Credentials provided via the URL but IAM API key was provided, discarding URL credentials.");
+        }
+        CDTIAMSessionCookieInterceptor * cookieInterceptor = [[CDTIAMSessionCookieInterceptor alloc] initWithAPIKey:IAMAPIKey];
+        [self addInterceptor:cookieInterceptor];
+        
+        sourceComponents.user = nil;
+        sourceComponents.password = nil;
         
         _source = sourceComponents.URL;
         _target = target;

--- a/CDTDatastore/CDTReplicator/CDTPushReplication.h
+++ b/CDTDatastore/CDTReplicator/CDTPushReplication.h
@@ -87,6 +87,21 @@ typedef BOOL (^CDTFilterBlock)(CDTDocumentRevision *__nonnull revision,
                              password:(nullable NSString *)password;
 
 /**
+ * All CDTPushReplication objects must have a source and target.
+ *
+ * The CDTPushReplication uses an IAM API key to authenticate - see
+ * https://console.bluemix.net/docs/services/Cloudant/guides/iam.html#ibm-cloud-identity-and-access-management
+ * for more information about IAM.
+ *
+ * @param IAMAPIKey The IAM API key.
+ * @return an initialsed instance of CDTAbstractReplication.
+ */
++ (instancetype)replicationWithSource:(CDTDatastore *)source
+                               target:(NSURL *)target
+                            IAMAPIKey:(NSString *)IAMAPIKey;
+
+
+/**
  @name Accessing the replication source and target
  */
 

--- a/CDTDatastore/CDTReplicator/CDTPushReplication.m
+++ b/CDTDatastore/CDTReplicator/CDTPushReplication.m
@@ -17,6 +17,7 @@
 #import "CDTPushReplication.h"
 #import "CDTDatastore.h"
 #import "CDTSessionCookieInterceptor.h"
+#import "CDTIAMSessionCookieInterceptor.h"
 #import "CDTReplay429Interceptor.h"
 #import "TDMisc.h"
 #import "CDTLogging.h"
@@ -42,6 +43,13 @@
     return [[self alloc] initWithSource:source target:target username:username password:password];
 }
 
++ (instancetype)replicationWithSource:(CDTDatastore *)source
+                               target:(NSURL *)target
+                            IAMAPIKey:(NSString *)IAMAPIKey
+{
+    return [[self alloc] initWithSource:source target:target IAMAPIKey:IAMAPIKey];
+}
+
 - (instancetype)initWithSource:(CDTDatastore *)source
                         target:(NSURL *)target
                       username:(NSString *)username
@@ -65,6 +73,28 @@
     }
     return self;
 }
+
+- (instancetype)initWithSource:(CDTDatastore *)source
+                        target:(NSURL *)target
+                     IAMAPIKey:(NSString *)IAMAPIKey
+{
+    if (self = [super initWithIAMAPIKey:IAMAPIKey]) {
+        NSURLComponents * targetComponents = [NSURLComponents componentsWithURL:target resolvingAgainstBaseURL:NO];
+        if(targetComponents.user && targetComponents.password){
+            CDTLogWarn(CDTREPLICATION_LOG_CONTEXT, @"Credentials provided via the URL but IAM API key was provided, discarding URL credentials.");
+        }
+        CDTIAMSessionCookieInterceptor * cookieInterceptor = [[CDTIAMSessionCookieInterceptor alloc] initWithAPIKey:IAMAPIKey];
+        [self addInterceptor:cookieInterceptor];
+        
+        targetComponents.user = nil;
+        targetComponents.password = nil;
+        
+        _source = source;
+        _target = targetComponents.URL;
+    }
+    return self;
+}
+
 
 - (instancetype)copyWithZone:(NSZone *)zone
 {

--- a/CDTDatastoreReplicationAcceptanceTests/CloudantReplicationBase+CompareDb.m
+++ b/CDTDatastoreReplicationAcceptanceTests/CloudantReplicationBase+CompareDb.m
@@ -52,7 +52,9 @@
     NSInteger localCount = local.documentCount;
     
     // Check document count in the remote DB
-    NSDictionary* headers = @{@"accept": @"application/json"};
+    NSMutableDictionary *headers = [[NSMutableDictionary alloc] init];
+    headers[@"accept"] = @"application/json";
+
     NSDictionary* json = [[UNIRest get:^(UNISimpleRequest* request) {
         [request setUrl:[databaseUrl absoluteString]];
         [request setHeaders:headers];
@@ -78,7 +80,8 @@
 -(BOOL) compareDocIdsAndCurrentRevs:(CDTDatastore*)local withDatabase:(NSURL*)databaseUrl
 {
     // Remote doc IDs
-    NSDictionary* headers = @{@"accept": @"application/json"};
+    NSMutableDictionary *headers = [[NSMutableDictionary alloc] init];
+    headers[@"accept"] = @"application/json";
     NSURL *all_docs = [databaseUrl URLByAppendingPathComponent:@"_all_docs"];
     NSDictionary* json = [[UNIRest get:^(UNISimpleRequest* request) {
         [request setUrl:[all_docs absoluteString]];
@@ -148,7 +151,8 @@
 
             // Remote revs for this doc
             NSMutableArray *remoteRevIdsAccumulator = [NSMutableArray array];
-            NSDictionary* headers = @{@"accept": @"application/json"};
+            NSMutableDictionary *headers = [[NSMutableDictionary alloc] init];
+            headers[@"accept"] = @"application/json";
             NSURL *docUrl = [databaseUrl URLByAppendingPathComponent:currentRevision.docId];
             NSDictionary* json = [[UNIRest get:^(UNISimpleRequest* request) {
                 [request setUrl:[docUrl absoluteString]];
@@ -192,7 +196,8 @@
          }
          
          // Get the document, including attachments
-         NSDictionary* headers = @{@"accept": @"application/json"};
+         NSMutableDictionary *headers = [[NSMutableDictionary alloc] init];
+         headers[@"accept"] = @"application/json";
          NSURL *docUrl = [databaseUrl URLByAppendingPathComponent:document.docId];
          NSDictionary* json = [[UNIRest get:^(UNISimpleRequest* request) {
              [request setUrl:[docUrl absoluteString]];

--- a/CDTDatastoreReplicationAcceptanceTests/CloudantReplicationBase.h
+++ b/CDTDatastoreReplicationAcceptanceTests/CloudantReplicationBase.h
@@ -7,8 +7,13 @@
 //
 
 #import <XCTest/XCTest.h>
+#import "CDTPushReplication.h"
+
+
 
 @class CDTDatastoreManager;
+@class CDTReplicator;
+@class CDTReplicatorFactory;
 @protocol CDTEncryptionKeyProvider;
 
 @interface CloudantReplicationBase : XCTestCase
@@ -17,11 +22,19 @@
 
 @property (nonatomic,strong) CDTDatastoreManager *factory;
 @property (nonatomic,strong) NSString *factoryPath;
+@property (nonatomic,strong) NSString *iamApiKey;
 
 @property (nonatomic, strong) id<CDTEncryptionKeyProvider> provider;
 
 @property (nonatomic, strong) NSURL *remoteRootURL;
 @property (nonatomic, strong) NSString *remoteDbPrefix;
+
+@property (nonatomic, strong) NSURL *primaryRemoteDatabaseURL;
+@property (nonatomic, strong) CDTDatastore *datastore;
+@property (nonatomic, strong) CDTReplicatorFactory *replicatorFactory;
+
+
+-(NSString*)getIAMBearerToken;
 
 -(void) createRemoteDatabase:(NSString*)name
                  instanceURL:(NSURL*)rootURL;
@@ -43,5 +56,15 @@
 - (NSString*)copyRemoteDocumentWithId:(NSString*)fromId
                                  toId:(NSString*)toId
                           databaseURL:(NSURL*)dbUrl;
+
+-(CDTReplicator *) pullFromRemote;
+
+-(CDTReplicator *) pullFromRemoteWithFilter:(NSString*)filterName params:(NSDictionary*)params;
+
+-(CDTReplicator *) pushToRemote;
+
+-(CDTReplicator *) pushToRemoteWithFilter:(CDTFilterBlock)filter params:(NSDictionary*)params;
+
+
 
 @end

--- a/CDTDatastoreReplicationAcceptanceTests/ReplicationAcceptance+CRUD.m
+++ b/CDTDatastoreReplicationAcceptanceTests/ReplicationAcceptance+CRUD.m
@@ -138,8 +138,10 @@
 
     NSURL *bulk_url = [self.primaryRemoteDatabaseURL URLByAppendingPathComponent:@"_bulk_docs"];
 
-    NSDictionary* headers = @{@"accept": @"application/json",
-                              @"content-type": @"application/json"};
+    NSMutableDictionary *headers = [[NSMutableDictionary alloc] init];
+    headers[@"accept"] = @"application/json";
+    headers[@"content-type"] = @"application/json";
+
     UNIHTTPJsonResponse* response = [[UNIRest postEntity:^(UNIBodyRequest* request) {
         [request setUrl:[bulk_url absoluteString]];
         [request setHeaders:headers];
@@ -147,6 +149,7 @@
                                                          options:0
                                                            error:nil]];
     }] asJson];
+    
     //    NSLog(@"%@", response.body.array);
     XCTAssertTrue([response.body.array count] == count, @"Remote db has wrong number of docs");
 }
@@ -154,7 +157,9 @@
 -(void) createRemoteDocWithId:(NSString*)docId revs:(NSInteger)n_revs
 {
     NSString *revId;
-    NSDictionary* headers;
+    NSMutableDictionary *headers = [[NSMutableDictionary alloc] init];
+    headers[@"accept"] = @"application/json";
+    headers[@"content-type"] = @"application/json";
     UNIHTTPJsonResponse* response;
     NSDictionary *dict = @{@"hello": @"world"};
     NSURL *docURL = [self.primaryRemoteDatabaseURL URLByAppendingPathComponent:docId];
@@ -163,9 +168,7 @@
 
     // Create revisions of document in remote store
     for (long i = 0; i < n_revs-1; i++) {
-        headers = @{@"accept": @"application/json",
-                    @"content-type": @"application/json",
-                    @"If-Match": revId};
+        headers[@"If-Match"] =  revId;
         response = [[UNIRest putEntity:^(UNIBodyRequest* request) {
             [request setUrl:[docURL absoluteString]];
             [request setHeaders:headers];
@@ -183,9 +186,10 @@
 -(NSString*) createRemoteDocWithId:(NSString *)docId body:(NSDictionary*)body
 {
     NSURL *docURL = [self.primaryRemoteDatabaseURL URLByAppendingPathComponent:docId];
-    
-    NSDictionary* headers = @{@"accept": @"application/json",
-                              @"content-type": @"application/json"};
+
+    NSMutableDictionary *headers = [[NSMutableDictionary alloc] init];
+    headers[@"accept"] = @"application/json";
+    headers[ @"content-type"] = @"application/json";
     UNIHTTPJsonResponse* response = [[UNIRest putEntity:^(UNIBodyRequest* request) {
         [request setUrl:[docURL absoluteString]];
         [request setHeaders:headers];
@@ -202,7 +206,8 @@
     NSURL *docURL = [self.primaryRemoteDatabaseURL URLByAppendingPathComponent:docId];
     
     // Get the doc to find its rev
-    NSDictionary* headers = @{@"accept": @"application/json"};
+    NSMutableDictionary *headers = [[NSMutableDictionary alloc] init];
+    headers[@"accept"] = @"application/json";
     NSDictionary* json = [[UNIRest get:^(UNISimpleRequest* request) {
         [request setUrl:[docURL absoluteString]];
         [request setHeaders:headers];;
@@ -212,7 +217,7 @@
     // Delete
     UNIHTTPJsonResponse* response = [[UNIRest delete:^(UNISimpleRequest* request) {
         [request setUrl:[docURL absoluteString]];
-        NSDictionary* headers = @{@"accept": @"application/json", @"If-Match": revId};
+        headers[@"If-Match"] = revId;
         [request setHeaders:headers];
     }] asJson];
     XCTAssertTrue([response.body.object objectForKey:@"ok"] != nil, @"Delete document failed");
@@ -223,7 +228,8 @@
 -(NSDictionary*) remoteDbMetadata
 {
     // Check document count in the remote DB
-    NSDictionary* headers = @{@"accept": @"application/json"};
+    NSMutableDictionary *headers = [[NSMutableDictionary alloc] init];
+    headers[@"accept"] = @"application/json";
     return [[UNIRest get:^(UNISimpleRequest* request) {
         [request setUrl:[self.primaryRemoteDatabaseURL absoluteString]];
         [request setHeaders:headers];

--- a/CDTDatastoreReplicationAcceptanceTests/ReplicationAcceptance.h
+++ b/CDTDatastoreReplicationAcceptanceTests/ReplicationAcceptance.h
@@ -17,9 +17,6 @@
 
 @interface ReplicationAcceptance : CloudantReplicationBase
 
-@property (nonatomic, strong) CDTDatastore *datastore;
-@property (nonatomic, strong) CDTReplicatorFactory *replicatorFactory;
 
-@property (nonatomic, strong) NSURL *primaryRemoteDatabaseURL;
 
 @end

--- a/CDTDatastoreReplicationAcceptanceTests/ReplicationAcceptance.m
+++ b/CDTDatastoreReplicationAcceptanceTests/ReplicationAcceptance.m
@@ -33,6 +33,7 @@
 #import "CDTDatastoreManager.h"
 #import "CDTDatastore.h"
 #import "CDTDocumentRevision.h"
+#import "CDTIAMSessionCookieInterceptor.h"
 #import "CDTPullReplication.h"
 #import "CDTPushReplication.h"
 #import "TDReplicator.h"
@@ -182,76 +183,92 @@
     [super tearDown];
 }
 
-/**
- Create a new replicator, and wait for replication from the remote database to complete.
- */
--(CDTReplicator *) pullFromRemote {
-    return [self pullFromRemoteWithFilter:nil params:nil];
+-(CDTPullReplication *) testPullReplicator:(CDTDatastore *)target {
+    return [self testPullReplicator:nil target:target];
 }
 
--(CDTReplicator *) pullFromRemoteWithFilter:(NSString*)filterName params:(NSDictionary*)params
-{
-    CDTPullReplication *pull = [CDTPullReplication replicationWithSource:self.primaryRemoteDatabaseURL
-                                                                  target:self.datastore];
-    
-    pull.filter = filterName;
-    pull.filterParams = params;
-
-    NSError *error;
-    CDTReplicator *replicator =  [self.replicatorFactory oneWay:pull error:&error];
-    XCTAssertNil(error, @"%@",error);
-    XCTAssertNotNil(replicator, @"CDTReplicator is nil");
-    
-    NSLog(@"Replicating from %@", [pull.source absoluteString]);
-    if (![replicator startWithError:&error]) {
-        XCTFail(@"CDTReplicator -startWithError: %@", error);
-    }
-    
-    while (replicator.isActive) {
-        [NSThread sleepForTimeInterval:1.0f];
-        NSLog(@" -> %@", [CDTReplicator stringForReplicatorState:replicator.state]);
-    }
-
-    return replicator;
-}
-
-/**
- Create a new replicator, and wait for replication from the local database to complete.
- */
--(CDTReplicator *) pushToRemote {
-    return [self pushToRemoteWithFilter:nil params:nil];
-}
-
-/**
- Create a new replicator, and wait for replication from the local database to complete.
- */
--(CDTReplicator *) pushToRemoteWithFilter:(CDTFilterBlock)filter params:(NSDictionary*)params{
-    
-    CDTPushReplication *push = [CDTPushReplication replicationWithSource:self.datastore
-                                                                  target:self.primaryRemoteDatabaseURL];
-    push.filter = filter;
-    push.filterParams = params;
-    
-    NSError *error;
-    CDTReplicator *replicator =  [self.replicatorFactory oneWay:push error:&error];
-    XCTAssertNil(error, @"%@",error);
-    XCTAssertNotNil(replicator, @"CDTReplicator is nil");
-    
-    NSLog(@"Replicating to %@", [self.primaryRemoteDatabaseURL absoluteString]);
-    if (![replicator startWithError:&error]) {
-        XCTFail(@"CDTReplicator -startWithError: %@", error);
-    }
-   
-    while (replicator.isActive) {
+-(CDTPullReplication *) testPullReplicator:(NSURL *)primaryRemoteDatabaseURL
+                                    target:(CDTDatastore *)target {
+    CDTPullReplication *pull = nil;
+    if([self.iamApiKey length] != 0) {
+        if(primaryRemoteDatabaseURL) {
+            pull = [CDTPullReplication replicationWithSource:primaryRemoteDatabaseURL
+                                                      target:target
+                                                   IAMAPIKey:self.iamApiKey];
+        } else {
+            pull = [CDTPullReplication replicationWithSource:self.primaryRemoteDatabaseURL
+                                                      target:target
+                                                   IAMAPIKey:self.iamApiKey];
+        }
+    } else {
+        if(primaryRemoteDatabaseURL) {
+            pull = [CDTPullReplication replicationWithSource:primaryRemoteDatabaseURL
+                                                      target:target];
+        } else {
+            pull = [CDTPullReplication replicationWithSource:self.primaryRemoteDatabaseURL
+                                                      target:target];
+        }
         
-        [[NSRunLoop currentRunLoop] runMode: NSDefaultRunLoopMode
-                                 beforeDate: [NSDate dateWithTimeIntervalSinceNow:0.1]];
-        NSLog(@" -> %@", [CDTReplicator stringForReplicatorState:replicator.state]);
     }
-
-    return replicator;
+    return pull;
 }
 
+-(CDTPushReplication *) testPushReplicator:(CDTDatastore *)source
+                                    target:(NSURL *)primaryRemoteDatabaseURL {
+    CDTPushReplication *push = nil;
+    if([self.iamApiKey length] != 0) {
+        push = [CDTPushReplication replicationWithSource:source
+                                                  target:primaryRemoteDatabaseURL
+                                               IAMAPIKey:self.iamApiKey];
+    } else {
+        push = [CDTPushReplication replicationWithSource:source
+                                                  target:primaryRemoteDatabaseURL];
+    }
+    return push;
+}
+
+-(CDTPushReplication *) testPushReplicator:(CDTDatastore *)source {
+    CDTPushReplication *push = nil;
+    if([self.iamApiKey length] != 0) {
+        push = [CDTPushReplication replicationWithSource:source
+                                                  target:self.primaryRemoteDatabaseURL
+                                               IAMAPIKey:self.iamApiKey];
+    } else {
+        push = [CDTPushReplication replicationWithSource:source
+                                                  target:self.primaryRemoteDatabaseURL];
+    }
+    return push;
+}
+
+- (void) testPullReplicationWithSource:(NSURL*) source
+                 completionHandler:(void (^ __nonnull)(NSError* __nullable)) completionHandler
+{
+    if([self.iamApiKey length] != 0) {
+        [self.datastore pullReplicationWithSource:source IAMAPIKey:self.iamApiKey completionHandler:completionHandler];
+    } else {
+        [self.datastore pullReplicationWithSource:source username:nil password:nil completionHandler:completionHandler];
+    }
+}
+
+- (void) testPushReplicationWithSource:(NSURL*) source
+                     completionHandler:(void (^ __nonnull)(NSError* __nullable)) completionHandler
+{
+    if([self.iamApiKey length] != 0) {
+        [self.datastore pullReplicationWithSource:source IAMAPIKey:self.iamApiKey completionHandler:completionHandler];
+    } else {
+        [self.datastore pullReplicationWithSource:source username:nil password:nil completionHandler:completionHandler];
+    }
+}
+
+- (void) testPushReplicationWithTarget:(NSURL*) target
+                 completionHandler:(void (^ __nonnull)(NSError* __nullable)) completionHandler
+{
+    if([self.iamApiKey length] != 0) {
+        [self.datastore pushReplicationWithTarget:target IAMAPIKey:self.iamApiKey completionHandler:completionHandler];
+    } else {
+        [self.datastore pushReplicationWithTarget:target username:nil password:nil completionHandler:completionHandler];
+    }
+}
 
 #pragma mark - Tests
 
@@ -266,9 +283,7 @@
     [self createRemoteDocs:self.n_docs];
 
     CountingHTTPInterceptor *interceptor = [[CountingHTTPInterceptor alloc] init];
-    CDTPullReplication *pull =
-        [CDTPullReplication replicationWithSource:self.primaryRemoteDatabaseURL
-                                           target:self.datastore];
+    CDTPullReplication *pull = [self testPullReplicator:self.datastore];
     [pull addInterceptor:interceptor];
 
     CDTReplicator *replicator = [self.replicatorFactory oneWay:pull error:nil];
@@ -303,7 +318,8 @@
 
     XCTestExpectation* expectation = [self expectationWithDescription:@"pullReplication"];
     NSLog(@"Replicating from %@", self.primaryRemoteDatabaseURL);
-    [self.datastore pullReplicationWithSource:self.primaryRemoteDatabaseURL completionHandler:^(NSError *error) {
+    
+    [self testPullReplicationWithSource:self.primaryRemoteDatabaseURL completionHandler:^(NSError *error) {
         XCTAssertNil(error);
         [expectation fulfill];
     }];
@@ -318,9 +334,9 @@
     [self createLocalDocs: 10];
 
     XCTestExpectation* expectation = [self expectationWithDescription:@"pullReplication"];
-
+    
     NSLog(@"Replicating to %@", self.primaryRemoteDatabaseURL);
-    [self.datastore pushReplicationWithTarget:self.primaryRemoteDatabaseURL completionHandler:^(NSError *error) {
+    [self testPushReplicationWithTarget:self.primaryRemoteDatabaseURL completionHandler:^(NSError *error) {
         XCTAssertNil(error);
         [expectation fulfill];
     }];
@@ -341,9 +357,7 @@
     TestRequestPiplineInterceptor1 *first = [[TestRequestPiplineInterceptor1 alloc] init];
     TestRequestPiplineInterceptor2 *second = [[TestRequestPiplineInterceptor2 alloc] init];
 
-    CDTPullReplication *pull =
-        [CDTPullReplication replicationWithSource:self.primaryRemoteDatabaseURL
-                                           target:self.datastore];
+    CDTPullReplication *pull = [self testPullReplicator:self.datastore];
     [pull addInterceptors:@[ first, second ]];
 
     CDTReplicator *replicator = [self.replicatorFactory oneWay:pull error:nil];
@@ -370,9 +384,7 @@
     TestResponsePiplineInterceptor1 *first = [[TestResponsePiplineInterceptor1 alloc] init];
     TestResponsePiplineInterceptor2 *second = [[TestResponsePiplineInterceptor2 alloc] init];
 
-    CDTPullReplication *pull =
-        [CDTPullReplication replicationWithSource:self.primaryRemoteDatabaseURL
-                                           target:self.datastore];
+    CDTPullReplication *pull = [self testPullReplicator:self.datastore];
     [pull addInterceptors:@[ first, second ]];
 
     CDTReplicator *replicator = [self.replicatorFactory oneWay:pull error:nil];
@@ -424,8 +436,7 @@
     XCTAssertEqual(self.datastore.documentCount, _n_docs, @"Incorrect number of documents created");
     
     
-    CDTPushReplication *push = [CDTPushReplication replicationWithSource:self.datastore
-                                                                  target:self.primaryRemoteDatabaseURL];
+    CDTPushReplication *push = [self testPushReplicator:self.datastore];
     
     NSError *error;
     CDTReplicator *replicator =  [self.replicatorFactory oneWay:push error:&error];
@@ -470,8 +481,7 @@
     NSLog(@"Creating documents...");
     [self createRemoteDocs:_n_docs];
     
-    CDTPullReplication *pull = [CDTPullReplication replicationWithSource:self.primaryRemoteDatabaseURL
-                                                                  target:self.datastore];
+    CDTPullReplication *pull = [self testPullReplicator:self.datastore];
     
     NSError *error;
     CDTReplicator *replicator =  [self.replicatorFactory oneWay:pull error:&error];
@@ -540,8 +550,7 @@
     
     [self createRemoteDocs:self.n_docs];
     
-    CDTPullReplication *pull = [CDTPullReplication replicationWithSource:self.primaryRemoteDatabaseURL
-                                                                  target:self.datastore];
+    CDTPullReplication *pull = [self testPullReplicator:self.datastore];
     
     NSError *error;
     CDTReplicator *replicator =  [self.replicatorFactory oneWay:pull error:&error];
@@ -602,8 +611,7 @@
     
     [self createLocalDocs:self.n_docs];
     
-    CDTPushReplication *push = [CDTPushReplication replicationWithSource:self.datastore
-                                                                  target:self.primaryRemoteDatabaseURL];
+    CDTPushReplication *push = [self testPushReplicator:self.datastore];
     
     NSError *error;
     CDTReplicator *replicator =  [self.replicatorFactory oneWay:push error:&error];
@@ -678,11 +686,9 @@
     [self createLocalDocs:2000];
     [self createRemoteDocs:2000 suffixFrom:2000];
     
-    CDTPullReplication *pull = [CDTPullReplication replicationWithSource:self.primaryRemoteDatabaseURL
-                                                                  target:self.datastore];
+    CDTPullReplication *pull = [self testPullReplicator:self.datastore];
     CDTReplicator *pullReplicator =  [self.replicatorFactory oneWay:pull error:nil];
-    CDTPushReplication *push = [CDTPushReplication replicationWithSource:self.datastore
-                                                                  target:self.primaryRemoteDatabaseURL];
+    CDTPushReplication *push = [self testPushReplicator:self.datastore];
     CDTReplicator *pushReplicator =  [self.replicatorFactory oneWay:push error:nil];
     
     
@@ -768,11 +774,9 @@
     [self createLocalDocs:nDocs];
     [self createRemoteDocs:nDocs suffixFrom:nDocs];
 
-    CDTPullReplication *pull = [CDTPullReplication replicationWithSource:self.primaryRemoteDatabaseURL
-                                                                  target:self.datastore];
+    CDTPullReplication *pull = [self testPullReplicator:self.datastore];
     CDTReplicator *pullReplicator =  [self.replicatorFactory oneWay:pull error:nil];
-    CDTPushReplication *push = [CDTPushReplication replicationWithSource:self.datastore
-                                                                  target:self.primaryRemoteDatabaseURL];
+    CDTPushReplication *push = [self testPushReplicator:self.datastore];
     CDTReplicator *pushReplicator =  [self.replicatorFactory oneWay:push error:nil];
     
     
@@ -926,8 +930,9 @@
 
     //make sure the remote database has the appropriate document
     NSURL *docURL = [self.primaryRemoteDatabaseURL URLByAppendingPathComponent:@"doc-3"];
-    NSDictionary* headers = @{@"accept": @"application/json",
-                              @"content-type": @"application/json"};
+    NSMutableDictionary *headers = [[NSMutableDictionary alloc] init];
+    headers[@"accept"] = @"application/json";
+    headers[ @"content-type"] = @"application/json";
     UNIHTTPJsonResponse *response = [[UNIRest get:^(UNISimpleRequest* request) {
         [request setUrl:[docURL absoluteString]];
         [request setHeaders:headers];
@@ -962,8 +967,7 @@
     int nlocalDocs = 5000;
     [self createLocalDocs:nlocalDocs];
 
-    CDTPushReplication *push = [CDTPushReplication replicationWithSource:self.datastore
-                                                                  target:self.primaryRemoteDatabaseURL];
+    CDTPushReplication *push = [self testPushReplicator:self.datastore];
     
     CDTReplicator *replicator =  [self.replicatorFactory oneWay:push error:nil];
     
@@ -1023,8 +1027,9 @@
 
     // Check number of revs
     NSURL *docURL = [self.primaryRemoteDatabaseURL URLByAppendingPathComponent:docId];
-    NSDictionary* headers = @{@"accept": @"application/json",
-                              @"content-type": @"application/json"};
+    NSMutableDictionary *headers = [[NSMutableDictionary alloc] init];
+    headers[@"accept"] = @"application/json";
+    headers[ @"content-type"] = @"application/json";
     UNIHTTPJsonResponse *response = [[UNIRest get:^(UNISimpleRequest* request) {
         [request setUrl:[docURL absoluteString]];
         [request setHeaders:headers];
@@ -1100,8 +1105,10 @@
                               deletedDocs:0];
 
     // Check number of revs for all docs is <n_mods>
-    NSDictionary* headers = @{@"accept": @"application/json",
-                              @"content-type": @"application/json"};
+    NSMutableDictionary *headers = [[NSMutableDictionary alloc] init];
+    headers[@"accept"] = @"application/json";
+    headers[@"content-type"] = @"application/json";
+
     for (int i = 1; i < self.n_docs+1; i++) {
         NSString *docId = [NSString stringWithFormat:@"doc-%i", i];
         NSURL *docURL = [self.primaryRemoteDatabaseURL URLByAppendingPathComponent:docId];
@@ -1329,8 +1336,7 @@
 
     NSURL *thirdDatabase = [self.remoteRootURL URLByAppendingPathComponent:thirdDatabaseName];
 
-    CDTPushReplication *push = [CDTPushReplication replicationWithSource:self.datastore
-                                                                  target:thirdDatabase];
+    CDTPushReplication *push = [self testPushReplicator:self.datastore target:thirdDatabase];
     
     CDTReplicator *replicator = [self.replicatorFactory oneWay:push error:nil];
 
@@ -1438,8 +1444,7 @@
 
     NSURL *thirdDatabase = [self.remoteRootURL URLByAppendingPathComponent:thirdDatabaseName];
 
-    CDTPushReplication *push = [CDTPushReplication replicationWithSource:self.datastore
-                                                                  target:thirdDatabase];
+    CDTPushReplication *push = [self testPushReplicator:self.datastore target:thirdDatabase];
     
     CDTReplicator *replicator = [self.replicatorFactory oneWay:push error:nil];
     
@@ -1543,9 +1548,7 @@
     
     [self createRemoteDocs:100];
     
-    CDTPullReplication *pull = [CDTPullReplication replicationWithSource:self.primaryRemoteDatabaseURL
-                                                                  target:self.datastore];
-
+    CDTPullReplication *pull = [self testPullReplicator:self.datastore];
     
     NSString *userAgent = [NSString stringWithFormat:@"%@/testCreateReplicationWithExtraHeaders",
                            [CDTAbstractReplication defaultUserAgentHTTPHeader]];
@@ -1585,15 +1588,13 @@
 // this test is disabled because it causes too many build falures
 -(void) xxxtestMultiThreadedReplication
 {
-    CDTPullReplication *pull = [CDTPullReplication replicationWithSource:self.primaryRemoteDatabaseURL
-                                                                  target:self.datastore];
+    CDTPullReplication *pull = [self testPullReplicator:self.datastore];
     CDTReplicator *firstReplicator =  [self.replicatorFactory oneWay:pull error:nil];
     
     CDTDatastore *secondDatastore = [self.factory datastoreNamed:@"test2"
                                        withEncryptionKeyProvider:self.provider
                                                            error:nil];
-    CDTPullReplication *secondPull = [CDTPullReplication replicationWithSource:self.primaryRemoteDatabaseURL
-                                                                  target:secondDatastore];
+    CDTPullReplication *secondPull = [self testPullReplicator:self.primaryRemoteDatabaseURL target:secondDatastore];
     CDTReplicator *secondReplicator =  [self.replicatorFactory oneWay:secondPull error:nil];
     
     [self createRemoteDocs:2000];
@@ -1674,8 +1675,7 @@
     // not equal it's limit. 
     [self createRemoteDocs:3005];
     
-    CDTPullReplication *pull = [CDTPullReplication replicationWithSource:self.primaryRemoteDatabaseURL
-                                                                  target:self.datastore];
+    CDTPullReplication *pull = [self testPullReplicator:self.datastore];
     CDTReplicator *replicator =  [self.replicatorFactory oneWay:pull error:nil];
     
     [replicator startWithError:nil];
@@ -1693,8 +1693,10 @@
     //make sure the remote database has the appropriate document
     NSString *remoteCheckpointPath = [NSString stringWithFormat:@"_local/%@", checkpointDocId];
     NSURL *docURL = [self.primaryRemoteDatabaseURL URLByAppendingPathComponent:remoteCheckpointPath];
-    NSDictionary* headers = @{@"accept": @"application/json",
-                              @"content-type": @"application/json"};
+    NSMutableDictionary *headers = [[NSMutableDictionary alloc] init];
+    headers[@"accept"] = @"application/json";
+    headers[@"content-type"] = @"application/json";
+
     UNIHTTPJsonResponse *response = [[UNIRest get:^(UNISimpleRequest* request) {
         [request setUrl:[docURL absoluteString]];
         [request setHeaders:headers];
@@ -1715,8 +1717,7 @@
     // not equal it's limit.
     [self createLocalDocs:3005];
     
-    CDTPushReplication *push = [CDTPushReplication replicationWithSource:self.datastore
-                                                                  target:self.primaryRemoteDatabaseURL];
+    CDTPushReplication *push = [self testPushReplicator:self.datastore];
     CDTReplicator *replicator =  [self.replicatorFactory oneWay:push error:nil];
     
     [replicator startWithError:nil];
@@ -1733,8 +1734,10 @@
     //make sure the remote database has the appropriate document
     NSString *remoteCheckpointPath = [NSString stringWithFormat:@"_local/%@", checkpointDocId];
     NSURL *docURL = [self.primaryRemoteDatabaseURL URLByAppendingPathComponent:remoteCheckpointPath];
-    NSDictionary* headers = @{@"accept": @"application/json",
-                              @"content-type": @"application/json"};
+    NSMutableDictionary *headers = [[NSMutableDictionary alloc] init];
+    headers[@"accept"] = @"application/json";
+    headers[@"content-type"] = @"application/json";
+
     UNIHTTPJsonResponse *response = [[UNIRest get:^(UNISimpleRequest* request) {
         [request setUrl:[docURL absoluteString]];
         [request setHeaders:headers];
@@ -1846,7 +1849,15 @@
         XCTFail(@"Should not be called");
     };
 
-    CDTURLSession *session = [[CDTURLSession alloc] init];
+    CDTURLSession *session = nil;
+    if([self.iamApiKey length] != 0) {
+        CDTIAMSessionCookieInterceptor *interceptor =
+        [[CDTIAMSessionCookieInterceptor alloc] initWithAPIKey:self.iamApiKey];
+        
+        session = [[CDTURLSession alloc] initWithCallbackThread:[NSThread currentThread] requestInterceptors:@[interceptor] sessionConfigDelegate: nil];
+    } else {
+        session = [[CDTURLSession alloc] init];
+    }
 
     TDChangeTracker *changeTracker =
         [[TDChangeTracker alloc] initWithDatabaseURL:self.primaryRemoteDatabaseURL
@@ -1955,6 +1966,68 @@
     }
     
     XCTAssertTrue(changeTrackerGotChanges);
+}
+
+-(void) testURLConnectionChangeTrackerWithRealRemoteAndIAMKey
+{
+    if([self.iamApiKey length] != 0) {
+    
+        __block BOOL changeTrackerStopped = NO;
+        __block BOOL changeTrackerGotChanges = NO;
+        unsigned int limitSize = 100;
+        
+        ChangeTrackerDelegate *delegate = [[ChangeTrackerDelegate alloc] init];
+        
+        delegate.changesBlock = ^(NSArray *changes){
+            changeTrackerGotChanges = YES;
+            
+            NSUInteger changeCount = changes.count;
+            XCTAssertTrue(changeCount <= limitSize, @"Too many changes.");
+            //while the test above assures that changeCount > 0,
+            //there's no guarantee this is true in real-life, so
+            //that XCTAssertTrue is not included here.
+            
+            for (NSDictionary* change in changes) {
+                XCTAssertNotNil(change[@"seq"], @"no seq in %@", change);
+            }
+        };
+        
+        delegate.stoppedBlock = ^(TDChangeTracker *tracker) {
+            changeTrackerStopped = YES;
+        };
+        
+        delegate.changeBlock = ^(NSDictionary *change) {
+            XCTFail(@"Should not be called");
+        };
+        
+        CDTIAMSessionCookieInterceptor *interceptor =
+        [[CDTIAMSessionCookieInterceptor alloc] initWithAPIKey:self.iamApiKey];
+        
+        CDTURLSession *session = [[CDTURLSession alloc] initWithCallbackThread:[NSThread currentThread] requestInterceptors:@[interceptor] sessionConfigDelegate: nil];
+
+        TDChangeTracker *changeTracker = [[TDChangeTracker alloc] initWithDatabaseURL:self.primaryRemoteDatabaseURL
+                                                                                 mode:kOneShot
+                                                                            conflicts:YES
+                                                                         lastSequence:nil
+                                                                               client:delegate
+                                                                              session:session];
+        changeTracker.limit = limitSize;
+        
+        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
+            [changeTracker start];
+            while(!changeTrackerStopped) {
+                [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode
+                                         beforeDate:[NSDate distantFuture]];
+            }
+        });
+        
+        while (!changeTrackerStopped) {
+            [[NSRunLoop currentRunLoop] runMode: NSDefaultRunLoopMode
+                                     beforeDate: [NSDate dateWithTimeIntervalSinceNow:0.1]];
+        }
+        
+        XCTAssertTrue(changeTrackerGotChanges);
+    }
 }
 
 -(void) testURLConnectionChangeTrackerWithRealRemoteUsingAuthorizer

--- a/CDTDatastoreReplicationAcceptanceTests/ReplicationSettings.h
+++ b/CDTDatastoreReplicationAcceptanceTests/ReplicationSettings.h
@@ -18,6 +18,8 @@
 
 @property (readonly) NSNumber* largeRevTreeSize;
 
+@property (readonly) NSString* iamApiKey;
+
 /**
  * Note that the symbolic constants from DDLog.h can't be used in the plist file.
  * The following numbers should be used:

--- a/CDTDatastoreReplicationAcceptanceTests/ReplicationSettings.m
+++ b/CDTDatastoreReplicationAcceptanceTests/ReplicationSettings.m
@@ -32,6 +32,11 @@
     return self;
 }
 
+-(NSString *) iamApiKey{
+    
+    return self.replicationSettings[@"TEST_COUCH_IAM_API_KEY"];
+}
+
 
 -(NSString *) host{
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # CDTDatastore CHANGELOG
 
 ## Unreleased
+- [NEW] Added support for authenticating with IAM API keys. See
+[Using with IAM](https://github.com/cloudant/CDTDatastore/blob/master/doc/replication.md#using-with-iam) for more details.
 - [REMOVED] Removed deprecated class `CDTSavedHTTPAttachment` and method `createRevisionFromJson` on `CDTDocumentRevision`.
 
 ## 1.2.2 (2017-09-06)

--- a/README.md
+++ b/README.md
@@ -240,7 +240,8 @@ do {
     print("Encountered an error: \(error)")
 }
 ```
-Read more in [the replication docs](https://github.com/cloudant/CDTDatastore/blob/master/doc/replication.md).
+Read more in [the replication docs](https://github.com/cloudant/CDTDatastore/blob/master/doc/replication.md)
+including how to use IAM authentication instead of username/password.
 
 ### Finding data
 

--- a/doc/replication.md
+++ b/doc/replication.md
@@ -145,6 +145,32 @@ if ([replicator startWithError:&error]){
 }
 ```
 
+### Using with IAM
+
+You can omit a username and password from the source URL of a `CDTPullReplication`
+or the target URL of a `CDTPushReplication` and instead specify an IAM API key. For
+more information about configuring IAM and obtaining IAM API keys refer to the 
+[Cloudant documentation](https://console.bluemix.net/docs/services/Cloudant/guides/iam.html#ibm-cloud-identity-and-access-management).
+
+```objc
+#import <CloudantSync.h>
+NSString *s = @"https://abc123-example-bluemix.cloudant.com.cloudant.com/my_database";
+NSURL *remoteDatabaseURL = [NSURL URLWithString:s];
+CDTDatastore *datastore = [manager datastoreNamed:@"my_datastore"];
+
+// Create a replicator that replicates changes from a remote
+// database to the local one using an IAM API key.
+CDTPullReplication *pullReplication = [CDTPullReplication replicationWithSource:remoteDatabaseURL
+                                                                         target:datastore
+                                                                         IAMAPIKey:@"zxy0987654321"];
+
+// Create a replicator that replicates changes from the local datastore to a
+// remote database with an IAM API key.
+CDTPushReplication *pushReplication = [CDTPushReplication replicationWithSource:datastore
+                                                                         target:remoteDatabaseURL]
+                                                                         IAMAPIKey:@"zxy0987654321"];
+```
+
 ### Using a replication delegate
 
 Once you've created a `CDTReplicator` object, you probably don't want your main


### PR DESCRIPTION
## What

Enable IAM and verify that RA and CDT tests are passing with IAM API Key.

## How

- Revert @tomblench pull request (#370) to add IAM back into replication
- Added IAM key support to: `pushReplicationTarget`, `pullReplicationSource`, `pushReplicationWithTarget`, `pullReplicationWithSource`
- Replication plist: Added `TEST_COUCH_IAM_API_KEY`
- @ricellis added IAM documentation

@tomblench commmon code commit:
- Move pull/push helpers into
  CloudantReplicationBase
- Remove custom setup/teardown code from
  Attachments
- Use push/pull helpers in Attachment, which are
  IAM-aware

## Testing
Added IAM tests `iosIamRAT` and `macosIamRAT` to RA axes in Jenkinsfile.

WIP: `testRemoteLastSequenceValueAfterPushReplication` failing with two errors for iOS and macOS:
```
((localLastSequence) != nil) failed
((localLastSequence[@"source_last_seq"]) equal to (jsonResponse[@"source_last_seq"])) failed: ("(null)") is not equal to ("3005")
```