### PR TITLE
Fix threading issues

### DIFF
--- a/CDTDatastoreReplicationAcceptanceTests/ReplicationAcceptance+CRUD.h
+++ b/CDTDatastoreReplicationAcceptanceTests/ReplicationAcceptance+CRUD.h
@@ -27,6 +27,7 @@
 -(void) createRemoteDocs:(NSInteger)count suffixFrom:(NSInteger)start;
 -(void) createRemoteDocWithId:(NSString*)docId revs:(NSInteger)n_revs;
 -(NSString*) createRemoteDocWithId:(NSString *)ddocid body:(NSDictionary*)ddocbody;
+-(void) createRemoteDocs:(NSInteger)count at:(NSURL*)url revs:(NSInteger)n_revs;
 
 -(NSString*) deleteRemoteDocWithId:(NSString *)docId;
 


### PR DESCRIPTION
_What_

Fixes for threading issues encountered when running and stopping multiple pull replications simultaneously.

_How_

Fixes to ensure that internal state variables are modified in a consistent manner, inside `synchronized` blocks where required. (See commit message for more details).

_Testing_

Added tests `testMultithreadedPullCancelHalfSmallWithConflicts` and `testMultithreadedPullCancelHalfLargeNoConflicts`.

Ran a "soak-test" of `testMultithreadedPullCancelHalfLargeNoConflicts` repeatedly with no failures for approx 1 hour

_Fixes_

#383, #384 