### PR TITLE
Fix build errors in Xcode 9

### DIFF
--- a/PodFile
+++ b/PodFile
@@ -52,4 +52,9 @@ abstract_target 'base' do
           platform :ios, '7.0'
         end
     end
+
+    post_install do | installer |
+        print "SQLCipher: link Pods/Headers/sqlite3.h"
+        system "mkdir -p Pods/Headers/Private && ln -s ../../SQLCipher/sqlite3.h Pods/Headers/Private"
+    end
 end


### PR DESCRIPTION
## What

Resolve build errors:
```
Implicit declaration of function 'sqlite3_rekey' is invalid in C99
Implicit declaration of function 'sqlite3_key' is invalid in C99
```

## How

From [this comment](https://discuss.zetetic.net/t/ios-11-xcode-issue-implicit-declaration-of-function-sqlite3-key-is-invalid-in-c99/2198/27):
```
This appears to be an issue with CocoaPods with use_framworks!, 
which disables the creation of header links under Pods/Headers. 
This makes it impossible for FMDB to resolve the proper sqlite3.h 
file included with SQLCipher.

In this case you can work around this by using a post_install hook
in your podfile to create a link in Pods/Headers/Private which is 
automatically included in the Header Search Path.
```

## Testing

No new tests.