### PR TITLE
Threading and Jenkins test improvements

### DIFF
--- a/CDTDatastore/touchdb/TD_Database+Replication.m
+++ b/CDTDatastore/touchdb/TD_Database+Replication.m
@@ -100,22 +100,19 @@
     // 7 is the length of _local/
     remote = [remote substringFromIndex:7];
 
-    NSData *checkpointData = [TDJSON dataWithJSONObject:checkpoint options:0 error:&error];
-    if (error) {
+    NSData *checkpointData = [TDJSON dataWithJSONObject:checkpoint options:0 error:error];
+    if (!checkpointData) {
         return NO;
     }
 
+    __block bool result;
     [self.fmdbQueue inDatabase:^(FMDatabase *db) {
-      [db executeUpdate:@"INSERT OR REPLACE INTO replicators (remote, push, "
+      result = [db executeUpdate:@"INSERT OR REPLACE INTO replicators (remote, push, "
                         @"last_sequence) VALUES (?, -1, ?)"
           withErrorAndBindings:error, remote, checkpointData];
     }];
 
-    if (error) {
-        return NO;
-    } else {
-        return YES;
-    }
+    return result;
 }
 
 + (NSString *)joinQuotedStrings:(NSArray *)strings

--- a/CDTDatastoreReplicationAcceptanceTests/ReplicationSettings.h
+++ b/CDTDatastoreReplicationAcceptanceTests/ReplicationSettings.h
@@ -20,6 +20,8 @@
 
 @property (readonly) NSString* iamApiKey;
 
+@property (readonly) NSNumber* raSmall;
+
 /**
  * Note that the symbolic constants from DDLog.h can't be used in the plist file.
  * The following numbers should be used:

--- a/CDTDatastoreReplicationAcceptanceTests/ReplicationSettings.m
+++ b/CDTDatastoreReplicationAcceptanceTests/ReplicationSettings.m
@@ -32,11 +32,13 @@
     return self;
 }
 
--(NSString *) iamApiKey{
-    
-    return self.replicationSettings[@"TEST_COUCH_IAM_API_KEY"];
+-(NSString *) iamApiKey {
+    NSString *key = self.replicationSettings[@"TEST_COUCH_IAM_API_KEY"];
+    if (key == nil || [key length] == 0) {
+        return nil;
+    }
+    return key;
 }
-
 
 -(NSString *) host{
 
@@ -69,6 +71,10 @@
 
 -(NSNumber *) loggingLevel {
     return self.replicationSettings[@"TEST_COUCH_LOGGING_LEVEL"];
+}
+
+-(NSNumber *) raSmall {
+    return self.replicationSettings[@"TEST_COUCH_RA_SMALL"];
 }
 
 -(NSString *) serverURI {

--- a/CDTDatastoreReplicationAcceptanceTests/ReplicationSettings.plist
+++ b/CDTDatastoreReplicationAcceptanceTests/ReplicationSettings.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>TEST_COUCH_IAM_API_KEY</key>
+	<string></string>
+	<key>TEST_COUCH_RA_SMALL</key>
+	<false/>
 	<key>TEST_COUCH_USERNAME</key>
 	<string></string>
 	<key>TEST_COUCH_PASSWORD</key>


### PR DESCRIPTION
## What

Threading and Jenkins test improvements.

Threading improvements increase overall robustness of replicators when they are started/stopped in a manner which exposes previous race conditions.

Jenkins improvements allow us to see that replication acceptance (RA) tests have passed before merging from master, by executing them with a smaller set of documents and excluding some large tests.

### Threading fixes

- Use a busy-wait loop in `_bulk_get` probe, because blocking on a
  semaphore blocks the run-loop which causes a deadlock when waiting
  on completion handlers for tests like
  `test{Pull,Push}ReplicationUsingOneLiner`.

- Handle error in server response in `saveLastSequence`.

- Execute the final call to `saveLastSequence` synchronously, to
  ensure the sequence number is correct when replication has
  finished. Previously this was the cause of two subtle threading
  errors: i) the `_db` field could be set to `nil` before the response
  callback fired, so the sequence wasn't persisted to the database;
  ii) the response callback never fires because the application or
  test executor exits before this can occur.

- (Related to above) post "stopped" notification after checkpoint
  save. This was a timing bug causing
  `testRemoteLastSequenceValueAfter{Pull,Push}Replication` to
  occasionally fail.

- Synchronise `TDURLConnectionChangeTracker` `start`/`stop`.
  Previously this could cause a crash at the line
  `self.inputBuffer = [NSMutableData dataWithCapacity:0];` because of
  a race condition when stopping soon after starting. The crash
  occurred because the object's state had become invalid after `stop`
  was called, but `start` was still executing.

- Only run `[TDPuller stopped]` once - if it runs more than once we
  could send messages to garbage/nil objects.

- Only run `[TDReplicator stopped]` once - fixes a race condition
  where stopped could run twice and reset `_db` to `nil` before the
  sequence can be saved.

- Add extra logging for `saveLastSequence` success and failure paths.

### Jenkins fixes

- Run 'small' RA tests (fewer documents and some tests excluded) for
  non-master branches.

- Append to logfiles (some configrations like IAM/non-IAM will result
  in the same file name).

- Fix error handling in `saveCheckpointDocument` - error pointer was
  incorrectly passed in and return codes were not being checked.

## Test fixes

- Add default values for IAM and small-RA to plist - they need to be
  present even if they are over-ridden

- `[ReplicationSettings iamApiKey]` returns nil if it's present but
  blank

## Testing

`test{Pull,Push}ReplicationUsingOneLiner` pass, were previously failing on master.

