### PR TITLE
398 update doc links

### DIFF
--- a/CDTDatastore/CDTReplicator/CDTPullReplication.h
+++ b/CDTDatastore/CDTReplicator/CDTPullReplication.h
@@ -127,11 +127,11 @@ NS_ASSUME_NONNULL_BEGIN
  See the Cloudant/CouchDB documentation on replication and filter functions.
 
  *
- [http://docs.cloudant.com/guides/replication/replication.html#filtered-replication](http://docs.cloudant.com/guides/replication/replication.html#filtered-replication)
+ [Cloudant filtered replication](https://console.bluemix.net/docs/services/Cloudant/api/advanced_replication.html#filtered-replication)
  *
- [http://docs.couchdb.org/en/latest/couchapp/ddocs.html#filter-functions](http://docs.couchdb.org/en/latest/couchapp/ddocs.html#filter-functions)
+ [CouchDB filter functions](http://docs.couchdb.org/en/latest/ddocs/ddocs.html#filter-functions)
  *
- [http://docs.couchdb.org/en/latest/json-structure.html#replication-settings](http://docs.couchdb.org/en/latest/json-structure.html#replication-settings)
+ [CouchDB replication settings](http://docs.couchdb.org/en/latest/json-structure.html#replication-settings)
 
  Filter functions in Cloudant/CouchDB are passed two arguments: a document revision and a
  request header.

--- a/CDTDatastore/CDTReplicator/CDTReplicator.m
+++ b/CDTDatastore/CDTReplicator/CDTReplicator.m
@@ -331,10 +331,10 @@ static NSString *const CDTReplicatorErrorDomain = @"CDTReplicatorErrorDomain";
     }
     
     //Set default value for reset to NO
-    //More details: http://docs.couchdb.org/en/1.6.1/query-server/protocol.html
+    //More details: http://docs.couchdb.org/en/latest/query-server/protocol.html
     repl.reset = NO;
     //Cloudant's default value is no heartbeat
-    //More details: https://docs.cloudant.com/database.html
+    //More details: https://console.bluemix.net/docs/services/Cloudant/api/replication.html#replication
     repl.heartbeat = nil;
     
     // Headers are validated before being put in properties

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [NEW] Added API for upcoming IBM Cloud Identity and Access
   Management support for Cloudant on IBM Cloud. Note: IAM API key
   support is not yet enabled in the service.
+- [IMPROVED] Updated documentation by replacing deprecated Cloudant links with the latest bluemix.net links.
 - [FIXED] Crash when stopping replicators.
 - [FIXED] Threading issues in replicators.
 - [REMOVED] Removed deprecated class `CDTSavedHTTPAttachment` and method

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -87,6 +87,23 @@ def buildAndTest(nodeLabel, target, rakeEnv, encrypted, testIam='no') {
     }
 }
 
+def buildDocs() {
+    node('macos') {
+        // Clean the directory before un-stashing (removes old logs)
+        deleteDir()
+
+        // Unstash the source on this node
+        unstash name: 'source'
+
+        try {
+          sh "rake docs"
+        } finally {
+            // Archive the complete log in case more debugging needed
+            archiveArtifacts artifacts: '*CDTDatastore*.log'
+        }
+    }
+}
+
 @NonCPS
 def getVersion(versionFile) {
   def versionMatcher = versionFile =~ /#define CLOUDANT_SYNC_VERSION "(.*)"/
@@ -119,6 +136,9 @@ stage('BuildAndTest') {
             },
             macosEncrypted: {
                 buildAndTest('macos', 'testosx', 'OSX_DEST', 'yes')
+            },
+            macosBuildDocs: {
+                buildDocs()
             },
             iosRAT: {
                 buildAndTest('ios', 'replicationacceptanceios', 'IPHONE_DEST', 'no')

--- a/Rakefile
+++ b/Rakefile
@@ -91,7 +91,7 @@ end
 
 desc "Build docs and install to Xcode"
 task :docs do
-  system("appledoc --keep-intermediate-files --project-name CDTDatastore --project-company Cloudant -o build/docs --company-id com.cloudant -i Classes/vendor -i Classes/common/touchdb Classes/")
+  system("appledoc --keep-intermediate-files --project-name CDTDatastore --project-company Cloudant -o build/docs --company-id com.cloudant -i CDTDatastore/vendor/ -i CDTDatastore/touchdb/ CDTDatastore")
 end
 
 #

--- a/doc/query-migration.md
+++ b/doc/query-migration.md
@@ -82,7 +82,7 @@ To:
 
 - Query options like `offset`, `limit`, and `sort` are now handled by `-find:skip:limit:fields:sort:`.  `offset` is now known as `skip` and a new query option to perform field projection is now also available.
 
-[2]: https://docs.cloudant.com/api.html#cloudant-query
+[2]: https://console.bluemix.net/docs/services/Cloudant/api/cloudant_query.html#query
 [3]: http://docs.mongodb.org/manual/tutorial/query-documents/
 
 ## Migration Path

--- a/doc/query.md
+++ b/doc/query.md
@@ -250,7 +250,7 @@ Query documents using `NSDictionary` objects. These use the [Cloudant Query `sel
 syntax. Several features of Cloudant Query are not yet supported in this implementation.
 See below for more details.
 
-[sel]: https://docs.cloudant.com/api/cloudant-query.html#selector-syntax
+[sel]: https://console.bluemix.net/docs/services/Cloudant/api/cloudant_query.html#selector-syntax
 
 #### Equality and comparisons
 


### PR DESCRIPTION
## What

Fix appledoc command for `rake docs`.
Update deprecated Cloudant doc links.

## How

- Replaced deprecated docs.cloudant.com links to the latest Bluemix links
- Updated CouchDB links
- Updated appledoc command in Rakefile

## Testing

No new tests.
Tested appledoc and `rake docs` commands locally.

## Issues

fixes #398 