### PR TITLE
Fix jenkins logging

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -109,7 +109,7 @@ end
 def run_tests(workspace, scheme, destination)
   settings = "GCC_PREPROCESSOR_DEFINITIONS='${inherited} ENCRYPT_DATABASE=1'" unless !ENV["encrypted"]
   # if jenkins passed us a log name, use that, otherwise default to "test.log"
-  logName = (ENV["LOG_NAME"] == nil ? "test.log" : ENV["LOG_NAME"])
+  logName = (ENV["LOG_NAME"] == nil ? "#{scheme}.log" : ENV["LOG_NAME"])
   return system("xcodebuild -verbose -workspace #{workspace} -scheme '#{scheme}' -destination '#{destination}' #{settings} test | tee #{logName} | xcpretty -r junit; exit ${PIPESTATUS[0]}")
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -108,7 +108,7 @@ end
 # Runs `test` target for workspace/scheme/destination
 def run_tests(workspace, scheme, destination)
   settings = "GCC_PREPROCESSOR_DEFINITIONS='${inherited} ENCRYPT_DATABASE=1'" unless !ENV["encrypted"]
-  # if jenkins passed us a log name, use that, otherwise default to "test.log"
+  # if jenkins passed us a log name, use that, otherwise default to "#{scheme}.log"
   logName = (ENV["LOG_NAME"] == nil ? "#{scheme}.log" : ENV["LOG_NAME"])
   return system("xcodebuild -verbose -workspace #{workspace} -scheme '#{scheme}' -destination '#{destination}' #{settings} test | tee #{logName} | xcpretty -r junit; exit ${PIPESTATUS[0]}")
 end

--- a/Rakefile
+++ b/Rakefile
@@ -108,7 +108,8 @@ end
 # Runs `test` target for workspace/scheme/destination
 def run_tests(workspace, scheme, destination)
   settings = "GCC_PREPROCESSOR_DEFINITIONS='${inherited} ENCRYPT_DATABASE=1'" unless !ENV["encrypted"]
-  logName = (ENV["encrypted"] ? "Encrypted" : "") + "#{scheme}.log"
+  # if jenkins passed us a log name, use that, otherwise default to "test.log"
+  logName = (ENV["LOG_NAME"] == nil ? "test.log" : ENV["LOG_NAME"])
   return system("xcodebuild -verbose -workspace #{workspace} -scheme '#{scheme}' -destination '#{destination}' #{settings} test | tee #{logName} | xcpretty -r junit; exit ${PIPESTATUS[0]}")
 end
 


### PR DESCRIPTION
## What

Use a more logical log naming scheme and fix a bug where the docs step tries to archive a log which doesn't exist (and silently fails the whole pipeline).

## How

- Define RA/build/test log names in jenkinsfile and pass to rakefile
- buildDocs step uses "CDTDatastore_buildDocs.log" as log name

## Testing

Jenkins runs, logs are there

## Issues

#396