### PR TITLE
Don't stop replicator when backgrounded

### DIFF
--- a/CDTDatastore/touchdb/TDReplicator.m
+++ b/CDTDatastore/touchdb/TDReplicator.m
@@ -376,14 +376,6 @@ NSString* TDReplicatorStartedNotification = @"TDReplicatorStarted";
     [[NSNotificationCenter defaultCenter] postNotificationName:TDReplicatorStartedNotification
                                                         object:self];
 
-#if TARGET_OS_IPHONE
-    // Register for foreground/background transition notifications, on iOS:
-    [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(appBackgrounding:)
-                                                 name:UIApplicationDidEnterBackgroundNotification
-                                               object:nil];
-#endif
-
     _online = NO;
 
     // Start reachability checks. (This creates another ref cycle, because
@@ -411,12 +403,6 @@ NSString* TDReplicatorStartedNotification = @"TDReplicatorStarted";
         CDTLogInfo(CDTREPLICATION_LOG_CONTEXT, @"%@ STOPPING...", self);
         [_batcher flushAll];
         _continuous = NO;
-    #if TARGET_OS_IPHONE
-        // Unregister for background transition notifications, on iOS:
-        [[NSNotificationCenter defaultCenter] removeObserver:self
-                                                        name:UIApplicationDidEnterBackgroundNotification
-                                                      object:nil];
-    #endif
         [self stopRemoteRequests];
 
         [NSObject cancelPreviousPerformRequestsWithTarget: self
@@ -538,15 +524,6 @@ NSString* TDReplicatorStartedNotification = @"TDReplicatorStarted";
     else if (host.reachabilityKnown)
         [self goOffline];
 }
-
-#if TARGET_OS_IPHONE
-- (void)appBackgrounding:(NSNotification*)n
-{
-    CDTLogInfo(CDTREPLICATION_LOG_CONTEXT, @"%@: App going into background", self);
-    // Danger: This is called on the main thread!
-    [self performSelector:@selector(stop) onThread:_thread withObject:nil waitUntilDone:NO];
-}
-#endif
 
 - (void)updateActive
 {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - [FIXED] Threading issues in replicators.
 - [REMOVED] Removed deprecated class `CDTSavedHTTPAttachment` and method
   `createRevisionFromJson` on `CDTDocumentRevision`.
-- [BREAKING] On iOS, replicators no longer stop when the app is
+- [BREAKING CHANGE] On iOS, replicators no longer stop when the app is
   backgrounded. To revert to the existing behaviour, your app should
   over-ride
   the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@
 - [FIXED] Threading issues in replicators.
 - [REMOVED] Removed deprecated class `CDTSavedHTTPAttachment` and method
   `createRevisionFromJson` on `CDTDocumentRevision`.
+- [BREAKING] On iOS, replicators no longer stop when the app is
+  backgrounded. To revert to the existing behaviour, your app should
+  over-ride
+  the
+  [`applicationDidEnterBackground`](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1622997-applicationdidenterbackground?language=objc) method
+  or register for
+  the
+  [`UIApplicationDidEnterBackgroundNotification`](https://developer.apple.com/documentation/uikit/uiapplicationdidenterbackgroundnotification?language=objc) notification,
+  and call `stop` on the replicator.
 
 ## 1.2.2 (2017-09-06)
 - [IMPROVED] Added pre-emptive session renewal when within 5 minutes of expiry.


### PR DESCRIPTION
## What

Don't stop the replicator when iOS apps enter the background.

## How

Remove registration/de-registration for `UIApplicationDidEnterBackgroundNotification` event.

Remove `appBackgrounding` method.

## Testing

Existing tests pass.

## Issues / Discussion

See #400, some customers want replications to continue when the app is backgrounded, and should have control over whether this happens or not. Also, current behaviour breaks "replication policy" style execution.
