### PR TITLE
Set error state when network offline

### DIFF
--- a/CDTDatastore/touchdb/TDReplicator.m
+++ b/CDTDatastore/touchdb/TDReplicator.m
@@ -493,6 +493,11 @@ NSString* TDReplicatorStartedNotification = @"TDReplicatorStarted";
     if (!_online) return NO;
     CDTLogInfo(CDTREPLICATION_LOG_CONTEXT, @"%@: Going offline", self);
     _online = NO;
+    NSString *msg = @"Replication stopped because the reachability tracker determined the device was offline.";
+    NSDictionary *userInfo = @{NSLocalizedDescriptionKey: NSLocalizedString(msg, nil)};
+    self.error = [NSError errorWithDomain:TDInternalErrorDomain
+                                                      code:TDReplicatorErrorNetworkOffline
+                                                  userInfo:userInfo];
     [self stopRemoteRequests];
     [self postProgressChanged];
     return YES;

--- a/CDTDatastore/touchdb/TDStatus.h
+++ b/CDTDatastore/touchdb/TDStatus.h
@@ -14,7 +14,8 @@ typedef NS_ENUM(NSInteger, TDInternalErrors) {
     /**
      * TDReplicator: local database deleted during replication
      */
-    TDReplicatorErrorLocalDatabaseDeleted  = 1001
+    TDReplicatorErrorLocalDatabaseDeleted  = 1001,
+    TDReplicatorErrorNetworkOffline = 1002
 };
 
 /** TouchDB internal status/error codes. Superset of HTTP status codes. */

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@
   the
   [`UIApplicationDidEnterBackgroundNotification`](https://developer.apple.com/documentation/uikit/uiapplicationdidenterbackgroundnotification?language=objc) notification,
   and call `stop` on the replicator.
+- [FIXED] Added status code `TDReplicatorErrorNetworkOffline` -
+  replicators will go into an error state with this error code if the
+  network goes offline, instead of appearing to complete normally.
 
 ## 1.2.2 (2017-09-06)
 - [IMPROVED] Added pre-emptive session renewal when within 5 minutes of expiry.


### PR DESCRIPTION
## What

When the network is offline as determined by `TDReachability`, set an appropriate error condition before stopping.

## How

Add symbolic constant `TDReplicatorErrorNetworkOffline`, and set an `NSError` object with this code before calling `[self postProgressChanged]` in `goOffline`.

## Testing

Added `testPullLotsOfOneRevDocumentsGoesOffline`.

## Issues

See #400 - currently when the network goes offline it looks like the replication has completely successfully.