### PR TITLE
Remove support for SQLCipher encryption

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,4 @@ env:
   # Travis hardware is too slow to run the iOS tests as the build exceeds the
   # allowed time of 50 minutes. Rely on Jenkins coverage for iOS for now.
   #- PLATFORM=iOS
-  #  encrypted=yes
-  #- PLATFORM=iOS
   - PLATFORM=OSX
-  - PLATFORM=OSX
-    encrypted=yes

--- a/CDTDatastore.podspec
+++ b/CDTDatastore.podspec
@@ -34,34 +34,14 @@ Pod::Spec.new do |s|
 
   s.default_subspec = 'standard'
 
-  ['standard', 'SQLCipher'].each do |subspec_label|
-      s.subspec subspec_label do |sp|
-
-        sp.prefix_header_contents = '#import "CollectionUtils.h"', '#import "Logging.h"', '#import "Test.h"', '#import "CDTMacros.h"'
-        sp.private_header_files = 'CDTDatastore/touchdb/*.h'
-
-        sp.source_files = 'CDTDatastore/**/*.{h,m}'
-
-        sp.exclude_files = 'CDTDatastore/vendor/MYUtilities/*.{h,m}'
-
-        sp.dependency 'CDTDatastore/common-dependencies'
-
-        if subspec_label == 'standard'
-          sp.library = 'sqlite3', 'z'
-          sp.dependency 'FMDB', '= 2.6'
-        else
-          sp.xcconfig = { 'OTHER_CFLAGS' => '$(inherited) -DENCRYPT_DATABASE' }
-          sp.library = 'z'
-          sp.dependency 'FMDB/SQLCipher', '= 2.6'
-
-          # Some CDTDatastore classes use SQLite functions, therefore we have
-          # to include 'SQLCipher' although 'FMDB/SQLCipher' also depends on it
-          # or they will not compile (linker will not find some symbols).
-          # Also, we have to force cocoapods to configure SQLCipher with support
-          # for FTS.
-          sp.dependency 'SQLCipher/fts', '~> 3.1.0'
-        end
-    end
+  s.subspec 'standard' do |sp|
+    sp.prefix_header_contents = '#import "CollectionUtils.h"', '#import "Logging.h"', '#import "Test.h"', '#import "CDTMacros.h"'
+    sp.private_header_files = 'CDTDatastore/touchdb/*.h'
+    sp.source_files = 'CDTDatastore/**/*.{h,m}'
+    sp.exclude_files = 'CDTDatastore/vendor/MYUtilities/*.{h,m}'
+    sp.library = 'sqlite3', 'z'
+    sp.dependency 'CDTDatastore/common-dependencies'
+    sp.dependency 'FMDB', '= 2.6'
   end
 
   s.subspec 'common-dependencies' do |sp|

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,7 @@ def podfile(podfileDir) {
     }
 }
 
-def buildAndTest(nodeLabel, target, rakeEnv, encrypted, testIam='no') {
+def buildAndTest(nodeLabel, target, rakeEnv, testIam='no') {
     node(nodeLabel) {
         // Clean the directory before un-stashing (removes old logs)
         deleteDir()
@@ -38,11 +38,8 @@ def buildAndTest(nodeLabel, target, rakeEnv, encrypted, testIam='no') {
         // Unstash the source on this node
         unstash name: 'source'
 
-        // log name is based on whether we're encrypted and what the target is
+        // log name is based on what the target is
         def logName = "CDTDatastore"
-        if (encrypted == "yes") {
-            logName += "Encrypted"
-        }
         if (testIam == "yes") {
             logName += "Iam"
         }
@@ -72,9 +69,6 @@ def buildAndTest(nodeLabel, target, rakeEnv, encrypted, testIam='no') {
                 credsId = 'couchdb'
                 credsUser = 'TEST_COUCH_USERNAME'
                 credsPass = 'TEST_COUCH_PASSWORD'
-            }
-            if (encrypted == 'yes') {
-                envVariables.add('encrypted=yes')
             }
             withEnv(envVariables) {
                 withCredentials([usernamePassword(credentialsId: credsId, usernameVariable: credsUser, passwordVariable: credsPass), string(credentialsId: 'clientlibs-test-iam', variable: credsIam)]) {
@@ -138,38 +132,26 @@ stage('Checkout') {
 stage('BuildAndTest') {
     def axes = [
             ios: {
-                buildAndTest('ios', 'testios', 'IPHONE_DEST', 'no')
-                buildAndTest('ios', 'sample', 'IPHONE_DEST', 'no')
-            },
-            iosEncrypted: {
-                buildAndTest('ios', 'testios', 'IPHONE_DEST', 'yes')
+                buildAndTest('ios', 'testios', 'IPHONE_DEST')
+                buildAndTest('ios', 'sample', 'IPHONE_DEST')
             },
             macos: {
-                buildAndTest('macos', 'testosx', 'OSX_DEST', 'no')
-            },
-            macosEncrypted: {
-                buildAndTest('macos', 'testosx', 'OSX_DEST', 'yes')
+                buildAndTest('macos', 'testosx', 'OSX_DEST')
             },
             macosBuildDocs: {
                 buildDocs()
             },
             iosRAT: {
-                buildAndTest('ios', 'replicationacceptanceios', 'IPHONE_DEST', 'no')
-            },
-            iosRATEncrypted: {
-                buildAndTest('ios', 'replicationacceptanceios', 'IPHONE_DEST', 'yes')
+                buildAndTest('ios', 'replicationacceptanceios', 'IPHONE_DEST')
             },
             macosRAT: {
-                buildAndTest('macos', 'replicationacceptanceosx', 'OSX_DEST', 'no')
+                buildAndTest('macos', 'replicationacceptanceosx', 'OSX_DEST')
             },
-            macosRATEncrypted: {
-                buildAndTest('macos', 'replicationacceptanceosx', 'OSX_DEST', 'yes')
-            },                
             iosIamRAT: {
-                buildAndTest('ios', 'replicationacceptanceios', 'IPHONE_DEST', 'no', 'yes')
+                buildAndTest('ios', 'replicationacceptanceios', 'IPHONE_DEST', 'yes')
             },
             macosIamRAT: {
-                buildAndTest('macos', 'replicationacceptanceosx', 'OSX_DEST', 'no', 'yes')
+                buildAndTest('macos', 'replicationacceptanceosx', 'OSX_DEST', 'yes')
             }
     ]
     parallel(axes)

--- a/PodFile
+++ b/PodFile
@@ -1,8 +1,7 @@
 use_frameworks!
 
 if ENV["encrypted"]
-    MRDatabaseContentChecker = "MRDatabaseContentChecker/SQLCipher"
-    FMDB = "FMDB/SQLCipher"
+    raise 'Encryption is not supported. Please unset the "encrypted" environment variable'
 else
     MRDatabaseContentChecker = "MRDatabaseContentChecker"
     FMDB = "FMDB"
@@ -11,7 +10,6 @@ end
 abstract_target 'base' do
     pod FMDB, '= 2.6'
     pod 'CocoaLumberjack', '~> 2.0'
-    pod 'SQLCipher/fts', '~> 3.1.0' if ENV["encrypted"]
     pod 'GoogleToolboxForMac/NSData+zlib', '~> 2.1.1'
 
     target :CDTDatastore do
@@ -51,10 +49,5 @@ abstract_target 'base' do
         target :CDTDatastoreReplicationAcceptanceTests do
           platform :ios, '7.0'
         end
-    end
-
-    post_install do | installer |
-        print "SQLCipher: link Pods/Headers/sqlite3.h"
-        system "mkdir -p Pods/Headers/Private && ln -s ../../SQLCipher/sqlite3.h Pods/Headers/Private"
     end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -100,14 +100,12 @@ end
 
 # Runs `build` target for workspace/scheme/destination
 def run_build(workspace, scheme, destination)
-  settings = "GCC_PREPROCESSOR_DEFINITIONS='${inherited} ENCRYPT_DATABASE=1'" unless !ENV["encrypted"]
   # build using xcpretty as otherwise it's very verbose when running tests
   return system("xcodebuild -workspace #{workspace} -scheme '#{scheme}' -destination '#{destination}' #{settings} build | xcpretty; exit ${PIPESTATUS[0]}")
 end
 
 # Runs `test` target for workspace/scheme/destination
 def run_tests(workspace, scheme, destination)
-  settings = "GCC_PREPROCESSOR_DEFINITIONS='${inherited} ENCRYPT_DATABASE=1'" unless !ENV["encrypted"]
   # if jenkins passed us a log name, use that, otherwise default to "#{scheme}.log"
   logName = (ENV["LOG_NAME"] == nil ? "#{scheme}.log" : ENV["LOG_NAME"])
   return system("xcodebuild -verbose -workspace #{workspace} -scheme '#{scheme}' -destination '#{destination}' #{settings} test | tee #{logName} | xcpretty -r junit; exit ${PIPESTATUS[0]}")

--- a/Rakefile
+++ b/Rakefile
@@ -101,14 +101,14 @@ end
 # Runs `build` target for workspace/scheme/destination
 def run_build(workspace, scheme, destination)
   # build using xcpretty as otherwise it's very verbose when running tests
-  return system("xcodebuild -workspace #{workspace} -scheme '#{scheme}' -destination '#{destination}' #{settings} build | xcpretty; exit ${PIPESTATUS[0]}")
+  return system("xcodebuild -workspace #{workspace} -scheme '#{scheme}' -destination '#{destination}' build | xcpretty; exit ${PIPESTATUS[0]}")
 end
 
 # Runs `test` target for workspace/scheme/destination
 def run_tests(workspace, scheme, destination)
   # if jenkins passed us a log name, use that, otherwise default to "#{scheme}.log"
   logName = (ENV["LOG_NAME"] == nil ? "#{scheme}.log" : ENV["LOG_NAME"])
-  return system("xcodebuild -verbose -workspace #{workspace} -scheme '#{scheme}' -destination '#{destination}' #{settings} test | tee #{logName} | xcpretty -r junit; exit ${PIPESTATUS[0]}")
+  return system("xcodebuild -verbose -workspace #{workspace} -scheme '#{scheme}' -destination '#{destination}' test | tee #{logName} | xcpretty -r junit; exit ${PIPESTATUS[0]}")
 end
 
 def test(workspace, scheme, destination)


### PR DESCRIPTION
## What

Remove support for SQLCipher encryption in build, CocoaPods, CI.

Note that the core functionality and associated tests have not been removed from the code base.

## Issues

See https://github.com/CocoaPods/CocoaPods/issues/7232 , 
https://github.com/ccgus/fmdb/issues/612 ,
https://discuss.zetetic.net/t/ios-11-xcode-issue-implicit-declaration-of-function-sqlite3-key-is-invalid-in-c99/2198/27 ,
