### PR TITLE
Fix bug where index table name was not quoted

### DIFF
--- a/CDTDatastore.xcodeproj/project.pbxproj
+++ b/CDTDatastore.xcodeproj/project.pbxproj
@@ -23,6 +23,8 @@
 		8E2DDDFB1D1BEFBE00673564 /* CDTReplay429Interceptor.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E2DDDF71D1BEFBE00673564 /* CDTReplay429Interceptor.m */; };
 		8E6D540E207B7191006FF35F /* SwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E6D540D207B7191006FF35F /* SwiftTests.swift */; };
 		8E6D540F207B7191006FF35F /* SwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E6D540D207B7191006FF35F /* SwiftTests.swift */; };
+		8E6D541120930F00006FF35F /* CDTQIndexNameTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E6D541020930F00006FF35F /* CDTQIndexNameTests.m */; };
+		8E6D541220930F4E006FF35F /* CDTQIndexNameTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E6D541020930F00006FF35F /* CDTQIndexNameTests.m */; };
 		8E705A8B1F0CE58500FF0219 /* CDTIAMSessionCookieInterceptor.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E705A8A1F0CE58500FF0219 /* CDTIAMSessionCookieInterceptor.m */; };
 		8E705A8C1F0CE58500FF0219 /* CDTIAMSessionCookieInterceptor.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E705A8A1F0CE58500FF0219 /* CDTIAMSessionCookieInterceptor.m */; };
 		8E705A8E1F0CE5B200FF0219 /* CDTIAMSessionCookieInterceptor.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E705A8D1F0CE5B200FF0219 /* CDTIAMSessionCookieInterceptor.h */; };
@@ -763,6 +765,7 @@
 		8E6D540B207B7190006FF35F /* CDTDatastoreTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CDTDatastoreTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		8E6D540C207B7190006FF35F /* CDTDatastoreTestsOSX-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CDTDatastoreTestsOSX-Bridging-Header.h"; sourceTree = "<group>"; };
 		8E6D540D207B7191006FF35F /* SwiftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftTests.swift; sourceTree = "<group>"; };
+		8E6D541020930F00006FF35F /* CDTQIndexNameTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CDTQIndexNameTests.m; sourceTree = "<group>"; };
 		8E705A8A1F0CE58500FF0219 /* CDTIAMSessionCookieInterceptor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTIAMSessionCookieInterceptor.m; sourceTree = "<group>"; };
 		8E705A8D1F0CE5B200FF0219 /* CDTIAMSessionCookieInterceptor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDTIAMSessionCookieInterceptor.h; sourceTree = "<group>"; };
 		8E705A901F0D360700FF0219 /* CDTSessionCookieInterceptorBase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDTSessionCookieInterceptorBase.h; sourceTree = "<group>"; };
@@ -1382,6 +1385,7 @@
 				98F77E0B1C44044000515CC3 /* CDTQFilterFieldsTest.m */,
 				98F77E0C1C44044000515CC3 /* CDTQIndexCreatorTests.m */,
 				98F77E0D1C44044000515CC3 /* CDTQIndexManagerTests.m */,
+				8E6D541020930F00006FF35F /* CDTQIndexNameTests.m */,
 				98F77E0E1C44044000515CC3 /* CDTQIndexTests.m */,
 				98F77E0F1C44044000515CC3 /* CDTQIndexUpdaterTests.m */,
 				98F77E101C44044000515CC3 /* CDTQInvalidQuerySyntax.m */,
@@ -3011,6 +3015,7 @@
 				980F22891CB818530075A843 /* CDTQIndexTests.m in Sources */,
 				980F228A1CB818530075A843 /* CDTQIndexUpdaterTests.m in Sources */,
 				980F228B1CB818530075A843 /* CDTQInvalidQuerySyntax.m in Sources */,
+				8E6D541220930F4E006FF35F /* CDTQIndexNameTests.m in Sources */,
 				980F228C1CB818530075A843 /* CDTQPerformanceTests.m in Sources */,
 				980F228D1CB818530075A843 /* CDTQQueryExecutorTests.m in Sources */,
 				980F228E1CB818530075A843 /* CDTQQuerySortTests.m in Sources */,
@@ -3251,6 +3256,7 @@
 				987AF7B91DE7274C00577DAC /* TD_DatabaseEncryptionTests.m in Sources */,
 				98F77EAA1C44044000515CC3 /* CDTQMatcherQueryExecutor.m in Sources */,
 				98F77EB61C44044000515CC3 /* TDMiscTests.m in Sources */,
+				8E6D541120930F00006FF35F /* CDTQIndexNameTests.m in Sources */,
 				98F77EB21C44044000515CC3 /* TD_DatabaseTests.m in Sources */,
 				98F77E911C44044000515CC3 /* DatastoreManagerTests.m in Sources */,
 				98F77EBA1C44044000515CC3 /* TDMultiStreamWriterTests.m in Sources */,

--- a/CDTDatastore/query/CDTQQueryExecutor.m
+++ b/CDTDatastore/query/CDTQQueryExecutor.m
@@ -2,6 +2,7 @@
 //  CDTQQueryExecutor.m
 //
 //  Created by Mike Rhodes on 2014-09-29
+//  Copyright © 2018 IBM Corporation. All rights reserved.
 //  Copyright (c) 2014 Cloudant. All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
@@ -395,7 +396,7 @@ const NSUInteger kSmallResultSetSizeThreshold = 500;
     }
 
     NSString *sql =
-        [NSString stringWithFormat:@"SELECT DISTINCT _id FROM %@ %@ ORDER BY %@;", indexTable,
+        [NSString stringWithFormat:@"SELECT DISTINCT _id FROM \"%@\" %@ ORDER BY %@;", indexTable,
                                    whereClause, [orderClauses componentsJoinedByString:@", "]];
     return [CDTQSqlParts partsForSql:sql parameters:parameters];
 }

--- a/CDTDatastoreTests/CDTQIndexNameTests.m
+++ b/CDTDatastoreTests/CDTQIndexNameTests.m
@@ -1,0 +1,91 @@
+//
+//  CDTQIndexNameTests.m
+//  CDTDatastoreTests
+//
+//  Created by tomblench on 27/04/2018.
+//  Copyright © 2018 IBM Corporation. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+
+#import <Foundation/Foundation.h>
+#import <XCTest/XCTest.h>
+#import "CloudantSyncTests.h"
+#import "CDTDatastore.h"
+#import "CDTDatastore+Query.h"
+#import "CDTDatastoreManager.h"
+#import "CDTDocumentRevision.h"
+#import "CDTQResultSet.h"
+
+// tests for "unusual" index names
+@interface CDTQIndexNameTests : CloudantSyncTests
+@end
+
+@implementation CDTQIndexNameTests
+
+// regression test for bug seen by customer when index name contains dashes and numbers
+- (void)testDashesAndNumbersInIndexName {
+    NSString *dbName = @"db";
+    NSString *indexName = @"zyx-zz0123-20180426-abc-def";
+    NSError *error;
+    CDTDatastore *ds = [self.factory datastoreNamed:dbName error:&error];
+    XCTAssertNil(error);
+    [ds ensureIndexed:@[@"type", @"number", @"name"] withName:indexName];
+    CDTDocumentRevision *rev = [CDTDocumentRevision revision];
+    rev.body = [NSMutableDictionary dictionaryWithDictionary:@{@"type":@"temp", @"number": @0, @"name": @"abc0"}];
+    [ds createDocumentFromRevision:rev error:&error];
+    XCTAssertNil(error);
+    CDTQResultSet *rs = [ds find:@{@"type":@"temp"} skip:0 limit:1000 fields:nil sort:@[@{@"number": @"desc"}]];
+    __block int resultCount = 0;
+    [rs enumerateObjectsUsingBlock:^(CDTDocumentRevision *rev, NSUInteger idx, BOOL *stop) {
+        resultCount++;
+    }];
+    XCTAssertTrue(resultCount == 1);
+}
+
+// test that we can use unicode in index names
+- (void)testUnicodeIndexName {
+    NSString *dbName = @"db";
+    NSString *indexName = @"日本";
+    NSError *error;
+    CDTDatastore *ds = [self.factory datastoreNamed:dbName error:&error];
+    XCTAssertNil(error);
+    [ds ensureIndexed:@[@"type", @"number", @"name"] withName:indexName];
+    CDTDocumentRevision *rev = [CDTDocumentRevision revision];
+    rev.body = [NSMutableDictionary dictionaryWithDictionary:@{@"type":@"temp", @"number": @0, @"name": @"abc0"}];
+    [ds createDocumentFromRevision:rev error:&error];
+    XCTAssertNil(error);
+    CDTQResultSet *rs = [ds find:@{@"type":@"temp"} skip:0 limit:1000 fields:nil sort:@[@{@"number": @"desc"}]];
+    __block int resultCount = 0;
+    [rs enumerateObjectsUsingBlock:^(CDTDocumentRevision *rev, NSUInteger idx, BOOL *stop) {
+        resultCount++;
+    }];
+    XCTAssertTrue(resultCount == 1);
+}
+
+// test that we can use unicode in index fields
+- (void)testUnicodeIndexField {
+    NSString *dbName = @"db";
+    NSString *indexName = @"index";
+    NSError *error;
+    CDTDatastore *ds = [self.factory datastoreNamed:dbName error:&error];
+    XCTAssertNil(error);
+    [ds ensureIndexed:@[@"type", @"number", @"日本"] withName:indexName];
+    CDTDocumentRevision *rev = [CDTDocumentRevision revision];
+    rev.body = [NSMutableDictionary dictionaryWithDictionary:@{@"type":@"temp", @"number": @0, @"日本": @"abc0"}];
+    [ds createDocumentFromRevision:rev error:&error];
+    XCTAssertNil(error);
+    CDTQResultSet *rs = [ds find:@{@"日本":@"abc0"} skip:0 limit:1000 fields:nil sort:@[@{@"number": @"desc"}]];
+    __block int resultCount = 0;
+    [rs enumerateObjectsUsingBlock:^(CDTDocumentRevision *rev, NSUInteger idx, BOOL *stop) {
+        resultCount++;
+    }];
+    XCTAssertTrue(resultCount == 1);
+}
+
+@end

--- a/CDTDatastoreTests/CDTQQuerySortTests.m
+++ b/CDTDatastoreTests/CDTQQuerySortTests.m
@@ -164,7 +164,7 @@ SpecBegin(CDTQQueryExecutorSorting)
                                                                    usingOrder:order
                                                                       indexes:indexes];
 
-                        NSString *sql = @"SELECT DISTINCT _id FROM _t_cloudant_sync_query_index_a "
+                        NSString *sql = @"SELECT DISTINCT _id FROM \"_t_cloudant_sync_query_index_a\" "
                                         @"WHERE _id IN (?, ?) ORDER BY \"name\" ASC;";
                         expect(parts.sqlWithPlaceholders).to.equal(sql);
                         expect(parts.placeholderValues).to.equal([smallDocIdSet allObjects]);
@@ -176,7 +176,7 @@ SpecBegin(CDTQQueryExecutorSorting)
                                                                    usingOrder:order
                                                                       indexes:indexes];
 
-                        NSString *sql = @"SELECT DISTINCT _id FROM _t_cloudant_sync_query_index_b "
+                        NSString *sql = @"SELECT DISTINCT _id FROM \"_t_cloudant_sync_query_index_b\" "
                                         @"WHERE _id IN (?, ?) ORDER BY \"y\" DESC;";
                         expect(parts.sqlWithPlaceholders).to.equal(sql);
                         expect(parts.placeholderValues).to.equal([smallDocIdSet allObjects]);
@@ -192,7 +192,7 @@ SpecBegin(CDTQQueryExecutorSorting)
                                                                    usingOrder:order
                                                                       indexes:indexes];
 
-                        NSString *sql = @"SELECT DISTINCT _id FROM _t_cloudant_sync_query_index_b "
+                        NSString *sql = @"SELECT DISTINCT _id FROM \"_t_cloudant_sync_query_index_b\" "
                                         @"WHERE _id IN (?, ?) ORDER BY \"y\" ASC, \"x\" ASC;";
                         expect(parts.sqlWithPlaceholders).to.equal(sql);
                         expect(parts.placeholderValues).to.equal([smallDocIdSet allObjects]);
@@ -204,7 +204,7 @@ SpecBegin(CDTQQueryExecutorSorting)
                                                                    usingOrder:order
                                                                       indexes:indexes];
 
-                        NSString *sql = @"SELECT DISTINCT _id FROM _t_cloudant_sync_query_index_b "
+                        NSString *sql = @"SELECT DISTINCT _id FROM \"_t_cloudant_sync_query_index_b\" "
                                         @"WHERE _id IN (?, ?) ORDER BY \"y\" DESC, \"x\" DESC;";
                         expect(parts.sqlWithPlaceholders).to.equal(sql);
                         expect(parts.placeholderValues).to.equal([smallDocIdSet allObjects]);
@@ -216,7 +216,7 @@ SpecBegin(CDTQQueryExecutorSorting)
                                                                    usingOrder:order
                                                                       indexes:indexes];
 
-                        NSString *sql = @"SELECT DISTINCT _id FROM _t_cloudant_sync_query_index_b "
+                        NSString *sql = @"SELECT DISTINCT _id FROM \"_t_cloudant_sync_query_index_b\" "
                                         @"WHERE _id IN (?, ?) ORDER BY \"y\" DESC, \"x\" ASC;";
                         expect(parts.sqlWithPlaceholders).to.equal(sql);
                         expect(parts.placeholderValues).to.equal([smallDocIdSet allObjects]);
@@ -236,7 +236,7 @@ SpecBegin(CDTQQueryExecutorSorting)
                                                                    usingOrder:order
                                                                       indexes:indexes];
 
-                        NSString *sql = @"SELECT DISTINCT _id FROM _t_cloudant_sync_query_index_a  "
+                        NSString *sql = @"SELECT DISTINCT _id FROM \"_t_cloudant_sync_query_index_a\"  "
                                         @"ORDER BY \"name\" ASC;";
                         expect(parts.sqlWithPlaceholders).to.equal(sql);
                         expect(parts.placeholderValues).to.equal(@[]);
@@ -248,7 +248,7 @@ SpecBegin(CDTQQueryExecutorSorting)
                                                                    usingOrder:order
                                                                       indexes:indexes];
 
-                        NSString *sql = @"SELECT DISTINCT _id FROM _t_cloudant_sync_query_index_b  "
+                        NSString *sql = @"SELECT DISTINCT _id FROM \"_t_cloudant_sync_query_index_b\"  "
                                         @"ORDER BY \"y\" DESC;";
                         expect(parts.sqlWithPlaceholders).to.equal(sql);
                         expect(parts.placeholderValues).to.equal(@[]);
@@ -264,7 +264,7 @@ SpecBegin(CDTQQueryExecutorSorting)
                                                                    usingOrder:order
                                                                       indexes:indexes];
 
-                        NSString *sql = @"SELECT DISTINCT _id FROM _t_cloudant_sync_query_index_b  "
+                        NSString *sql = @"SELECT DISTINCT _id FROM \"_t_cloudant_sync_query_index_b\"  "
                                         @"ORDER BY \"y\" ASC, \"x\" ASC;";
                         expect(parts.sqlWithPlaceholders).to.equal(sql);
                         expect(parts.placeholderValues).to.equal(@[]);
@@ -276,7 +276,7 @@ SpecBegin(CDTQQueryExecutorSorting)
                                                                    usingOrder:order
                                                                       indexes:indexes];
 
-                        NSString *sql = @"SELECT DISTINCT _id FROM _t_cloudant_sync_query_index_b  "
+                        NSString *sql = @"SELECT DISTINCT _id FROM \"_t_cloudant_sync_query_index_b\"  "
                                         @"ORDER BY \"y\" DESC, \"x\" DESC;";
                         expect(parts.sqlWithPlaceholders).to.equal(sql);
                         expect(parts.placeholderValues).to.equal(@[]);
@@ -288,7 +288,7 @@ SpecBegin(CDTQQueryExecutorSorting)
                                                                    usingOrder:order
                                                                       indexes:indexes];
 
-                        NSString *sql = @"SELECT DISTINCT _id FROM _t_cloudant_sync_query_index_b  "
+                        NSString *sql = @"SELECT DISTINCT _id FROM \"_t_cloudant_sync_query_index_b\"  "
                                         @"ORDER BY \"y\" DESC, \"x\" ASC;";
                         expect(parts.sqlWithPlaceholders).to.equal(sql);
                         expect(parts.placeholderValues).to.equal(@[]);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CDTDatastore CHANGELOG
 
+## Unreleased
+- [FIXED] Bug which prevented `find` queries from executing
+  successfully against indexes with certain names.
+
 ## 2.0.1 (2018-04-12)
 - [FIXED] Header declaration of `listIndexes()`. This prevented this
   method from being called from Swift code.


### PR DESCRIPTION
## What

Fix bug where index table name was not quoted

## How

Add quote marks around table name in `sql` in `[CDTQQueryExecutor sqlToSortIds]`

## Testing

See added tests in CDTQIndexNameTests.m

## Issues

Customer reported issue