### PR TITLE
Fix retain cycle between CDTQIndexManager and CDTDatastore

### DIFF
--- a/CDTDatastore.xcodeproj/project.pbxproj
+++ b/CDTDatastore.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		3567DB3346B03BED878BC14F /* CDTDatastore+Replication.m in Sources */ = {isa = PBXBuildFile; fileRef = 3567D4C1BDD33D0148CA9FF2 /* CDTDatastore+Replication.m */; };
 		8836FBAB2706816C58690495 /* Pods_base_CDTDatastoreOSX.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D03C1BA0A7DA75BFAF80CC8 /* Pods_base_CDTDatastoreOSX.framework */; };
 		888D25163DAC0158BEAC19FF /* Pods_base_tests_CDTDatastoreTestsOSX.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 04DFF5124D5BD3161681174C /* Pods_base_tests_CDTDatastoreTestsOSX.framework */; };
+		8E19D00920A9C6BC0012F346 /* CDTQLifecycleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E19D00820A9C6BC0012F346 /* CDTQLifecycleTests.m */; };
+		8E19D00B20A9D0BB0012F346 /* CDTQLifecycleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E19D00820A9C6BC0012F346 /* CDTQLifecycleTests.m */; };
 		8E2DDDF81D1BEFBE00673564 /* CDTReplay429Interceptor.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E2DDDF61D1BEFBE00673564 /* CDTReplay429Interceptor.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8E2DDDF91D1BEFBE00673564 /* CDTReplay429Interceptor.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E2DDDF61D1BEFBE00673564 /* CDTReplay429Interceptor.h */; };
 		8E2DDDFA1D1BEFBE00673564 /* CDTReplay429Interceptor.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E2DDDF71D1BEFBE00673564 /* CDTReplay429Interceptor.m */; };
@@ -760,6 +762,7 @@
 		780DA1CE0B016A2CE9A8458C /* Pods-base-raTests-CDTDatastoreReplicationAcceptanceTestsOSX.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-base-raTests-CDTDatastoreReplicationAcceptanceTestsOSX.debug.xcconfig"; path = "Pods/Target Support Files/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTestsOSX/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTestsOSX.debug.xcconfig"; sourceTree = "<group>"; };
 		85F3ECA4D5FB8EA5B31B14F1 /* Pods-base-CDTDatastoreOSX.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-base-CDTDatastoreOSX.release.xcconfig"; path = "Pods/Target Support Files/Pods-base-CDTDatastoreOSX/Pods-base-CDTDatastoreOSX.release.xcconfig"; sourceTree = "<group>"; };
 		880C1D944A8E097B9021DF85 /* Pods-base-tests-CDTDatastoreTestsOSX.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-base-tests-CDTDatastoreTestsOSX.debug.xcconfig"; path = "Pods/Target Support Files/Pods-base-tests-CDTDatastoreTestsOSX/Pods-base-tests-CDTDatastoreTestsOSX.debug.xcconfig"; sourceTree = "<group>"; };
+		8E19D00820A9C6BC0012F346 /* CDTQLifecycleTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CDTQLifecycleTests.m; sourceTree = "<group>"; };
 		8E2DDDF61D1BEFBE00673564 /* CDTReplay429Interceptor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDTReplay429Interceptor.h; sourceTree = "<group>"; };
 		8E2DDDF71D1BEFBE00673564 /* CDTReplay429Interceptor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTReplay429Interceptor.m; sourceTree = "<group>"; };
 		8E6D540B207B7190006FF35F /* CDTDatastoreTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CDTDatastoreTests-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -1389,6 +1392,7 @@
 				98F77E0E1C44044000515CC3 /* CDTQIndexTests.m */,
 				98F77E0F1C44044000515CC3 /* CDTQIndexUpdaterTests.m */,
 				98F77E101C44044000515CC3 /* CDTQInvalidQuerySyntax.m */,
+				8E19D00820A9C6BC0012F346 /* CDTQLifecycleTests.m */,
 				98F77E111C44044000515CC3 /* CDTQPerformanceTests.m */,
 				98F77E121C44044000515CC3 /* CDTQQueryExecutorTests.m */,
 				98F77E131C44044000515CC3 /* CDTQQuerySortTests.m */,
@@ -3018,6 +3022,7 @@
 				8E6D541220930F4E006FF35F /* CDTQIndexNameTests.m in Sources */,
 				980F228C1CB818530075A843 /* CDTQPerformanceTests.m in Sources */,
 				980F228D1CB818530075A843 /* CDTQQueryExecutorTests.m in Sources */,
+				8E19D00B20A9D0BB0012F346 /* CDTQLifecycleTests.m in Sources */,
 				980F228E1CB818530075A843 /* CDTQQuerySortTests.m in Sources */,
 				980F228F1CB818530075A843 /* CDTQQuerySqlTranslatorTests.m in Sources */,
 				980F22901CB818530075A843 /* CDTQTextSearchTests.m in Sources */,
@@ -3213,6 +3218,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8E19D00920A9C6BC0012F346 /* CDTQLifecycleTests.m in Sources */,
 				980F22711CB818260075A843 /* CDTQFilterFieldsTest.m in Sources */,
 				980F22721CB818260075A843 /* CDTQIndexCreatorTests.m in Sources */,
 				980F22731CB818260075A843 /* CDTQIndexManagerTests.m in Sources */,

--- a/CDTDatastore/query/CDTDatastore+Query.m
+++ b/CDTDatastore/query/CDTDatastore+Query.m
@@ -24,8 +24,13 @@
     {
         if (objc_getAssociatedObject(self, @selector(CDTQManager)) == nil) {
             CDTQIndexManager *m = [CDTQIndexManager managerUsingDatastore:self error:nil];
+            // NB: we make a weak reference here so that we don't
+            // cause retain cycles, since the CDTQIndexManager also
+            // has a reference to us which is passed in when it is
+            // constructed. This association is cleared in
+            // [CDTQIndexManager dealloc].
             objc_setAssociatedObject(self, @selector(CDTQManager), m,
-                                     OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+                                     OBJC_ASSOCIATION_ASSIGN);
         }
     }
 

--- a/CDTDatastore/query/CDTDatastore+Query.m
+++ b/CDTDatastore/query/CDTDatastore+Query.m
@@ -3,6 +3,7 @@
 //
 //  Created by Rhys Short on 19/11/2014.
 //
+//  Copyright © 2018 IBM Corporation. All rights reserved.
 //  Copyright (c) 2014 Cloudant. All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/CDTDatastore/query/CDTQIndexManager.m
+++ b/CDTDatastore/query/CDTQIndexManager.m
@@ -2,6 +2,8 @@
 //  CDTQIndexManager.m
 //
 //  Created by Mike Rhodes on 2014-09-27
+//
+//  Copyright © 2018 IBM Corporation. All rights reserved.
 //  Copyright (c) 2014 Cloudant. All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file

--- a/CDTDatastore/query/CDTQIndexManager.m
+++ b/CDTDatastore/query/CDTQIndexManager.m
@@ -57,6 +57,8 @@
 #import <CloudantSync.h>
 #import <FMDB/FMDB.h>
 
+#import <objc/runtime.h>
+
 NSString *const CDTQIndexManagerErrorDomain = @"CDTIndexManagerErrorDomain";
 
 NSString *const kCDTQIndexTablePrefix = @"_t_cloudant_sync_query_index_";
@@ -124,6 +126,10 @@ static const int VERSION = 2;
 {
     // close the database.
     [self.database close];
+    // remove the datastore's association with us, otherwise it will
+    // become invalid since it's a weak reference
+    objc_setAssociatedObject(self.datastore, @selector(CDTQManager), nil,
+                             OBJC_ASSOCIATION_ASSIGN);
 }
 
 #pragma mark List indexes

--- a/CDTDatastoreTests/CDTQLifecycleTests.m
+++ b/CDTDatastoreTests/CDTQLifecycleTests.m
@@ -33,7 +33,6 @@
     free(tempDirectoryNameCString);
     
     NSError *error;
-    NSError *__autoreleasing *error2;
     CDTDatastoreManager *factory = [[CDTDatastoreManager alloc] initWithDirectory:factoryPath error:&error];
     @autoreleasepool{
         
@@ -68,10 +67,10 @@
     // called when this test method exits).
     @autoreleasepool{
         // delete datastore
-        [factory deleteDatastoreNamed:@"test" error:error2];
-        XCTAssertTrue(error2 == nil);
-        NSArray *contents = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:factoryPath error:error2];
-        XCTAssertTrue(error2 == nil);
+        [factory deleteDatastoreNamed:@"test" error:&error];
+        XCTAssertNil(error);
+        NSArray *contents = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:factoryPath error:&error];
+        XCTAssertNil(error);
         XCTAssertEqual([contents count], 0);
     }
 }

--- a/CDTDatastoreTests/CDTQLifecycleTests.m
+++ b/CDTDatastoreTests/CDTQLifecycleTests.m
@@ -49,9 +49,7 @@
             [datastore createDocumentFromRevision:document
                                             error:&error];
             XCTAssertNil(error);
-        }
-        // multiple invocations of create/get index in tight loop
-        for (int i=0; i<10;i++) {
+            // ensure indexed within loop
             [datastore ensureIndexed:@[@"hello"] withName:@"index"];
         }
         CDTQResultSet *rs = [datastore find:@{@"hello":@"world"}];
@@ -112,9 +110,7 @@
             [datastore createDocumentFromRevision:document
                                             error:&error];
             XCTAssertNil(error);
-        }
-        // multiple invocations of create/get index in tight loop
-        for (int i=0; i<10;i++) {
+            // ensure indexed within loop
             [datastore ensureIndexed:@[@"hello"] withName:@"index"];
         }
         CDTQResultSet *rs = [datastore find:@{@"hello":@"world"}];

--- a/CDTDatastoreTests/CDTQLifecycleTests.m
+++ b/CDTDatastoreTests/CDTQLifecycleTests.m
@@ -5,6 +5,14 @@
 //  Created by tomblench on 14/05/2018.
 //  Copyright © 2018 IBM Corporation. All rights reserved.
 //
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.//  Copyright © 2018 IBM Corporation. All rights reserved.
+//
 
 #import <Foundation/Foundation.h>
 #import <XCTest/XCTest.h>

--- a/CDTDatastoreTests/CDTQLifecycleTests.m
+++ b/CDTDatastoreTests/CDTQLifecycleTests.m
@@ -1,0 +1,137 @@
+//
+//  CDTQLifecycleTests.m
+//  CDTDatastore
+//
+//  Created by tomblench on 14/05/2018.
+//  Copyright © 2018 IBM Corporation. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <XCTest/XCTest.h>
+#import <CDTDatastore/CloudantSync.h>
+
+@interface CDTQLifecycleTests : XCTestCase
+@end
+
+@implementation CDTQLifecycleTests
+
+-(void)testDatastoreDeletesCorrectly
+{
+    NSString *tempDirectoryTemplate = [NSTemporaryDirectory()
+                                       stringByAppendingPathComponent:@"cloudant_sync_ios_tests.XXXXXX"];
+    const char *tempDirectoryTemplateCString =
+    [tempDirectoryTemplate fileSystemRepresentation];
+    char *tempDirectoryNameCString =
+    (char *)malloc(strlen(tempDirectoryTemplateCString) + 1);
+    strcpy(tempDirectoryNameCString, tempDirectoryTemplateCString);
+    
+    char *result = mkdtemp(tempDirectoryNameCString);
+    
+    NSString *factoryPath = [[NSFileManager defaultManager]
+                             stringWithFileSystemRepresentation:tempDirectoryNameCString
+                             length:strlen(result)];
+    free(tempDirectoryNameCString);
+    
+    NSError *error;
+    NSError *__autoreleasing *error2;
+    CDTDatastoreManager *factory = [[CDTDatastoreManager alloc] initWithDirectory:factoryPath error:&error];
+    @autoreleasepool{
+        
+        // create datastore
+        CDTDatastore *datastore = [factory datastoreNamed:@"test" error:&error];
+        XCTAssertNil(error);
+        // create some docs
+        int nDocs = 10;
+        for (int i=0; i<nDocs;i++) {
+            NSMutableDictionary *dict = [@{ @"hello" : @"world" } mutableCopy];
+            CDTDocumentRevision *document = [CDTDocumentRevision revision];
+            document.body = dict;
+            [datastore createDocumentFromRevision:document
+                                            error:&error];
+            XCTAssertNil(error);
+        }
+        // multiple invocations of create/get index in tight loop
+        for (int i=0; i<10;i++) {
+            [datastore ensureIndexed:@[@"hello"] withName:@"index"];
+        }
+        CDTQResultSet *rs = [datastore find:@{@"hello":@"world"}];
+        XCTAssertEqual([[rs documentIds] count], nDocs);
+    }
+    // Now everything in the above autoreleasepool has had dealloc
+    // called on it eventually (we assume) the datastore and the
+    // result set would go out of scope but this forces them to have
+    // dealloc called.  Without the autoreleasepools, the log message
+    // "BUG IN CLIENT OF libsqlite3.dylib: database integrity
+    // compromised by API violation: vnode unlinked while in use:
+    // {filename}" will appear. Although on most platforms the on-disk
+    // deletion will proceed once all filehandles are closed, so in
+    // principle this should not be a problem, as long as dealloc is
+    // called "eventually" (in the case of this test, it would get
+    // called when this test method exits).
+    @autoreleasepool{
+        // delete datastore
+        [factory deleteDatastoreNamed:@"test" error:error2];
+        XCTAssertTrue(error2 == nil);
+        NSArray *contents = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:factoryPath error:error2];
+        XCTAssertTrue(error2 == nil);
+        XCTAssertEqual([contents count], 0);
+    }
+}
+
+-(void)testManagersCloseAndReopen
+{
+    NSString *tempDirectoryTemplate = [NSTemporaryDirectory()
+                                       stringByAppendingPathComponent:@"cloudant_sync_ios_tests.XXXXXX"];
+    const char *tempDirectoryTemplateCString =
+    [tempDirectoryTemplate fileSystemRepresentation];
+    char *tempDirectoryNameCString =
+    (char *)malloc(strlen(tempDirectoryTemplateCString) + 1);
+    strcpy(tempDirectoryNameCString, tempDirectoryTemplateCString);
+    
+    char *result = mkdtemp(tempDirectoryNameCString);
+    
+    NSString *factoryPath = [[NSFileManager defaultManager]
+                             stringWithFileSystemRepresentation:tempDirectoryNameCString
+                             length:strlen(result)];
+    free(tempDirectoryNameCString);
+    
+    NSError *error;
+    int nDocs = 10;
+    @autoreleasepool{
+        // get manager
+        CDTDatastoreManager *factory = [[CDTDatastoreManager alloc] initWithDirectory:factoryPath error:&error];
+        // create datastore
+        CDTDatastore *datastore = [factory datastoreNamed:@"test" error:&error];
+        XCTAssertNil(error);
+        
+        // create some docs
+        for (int i=0; i<nDocs;i++) {
+            NSMutableDictionary *dict = [@{ @"hello" : @"world" } mutableCopy];
+            CDTDocumentRevision *document = [CDTDocumentRevision revision];
+            document.body = dict;
+            [datastore createDocumentFromRevision:document
+                                            error:&error];
+            XCTAssertNil(error);
+        }
+        // multiple invocations of create/get index in tight loop
+        for (int i=0; i<10;i++) {
+            [datastore ensureIndexed:@[@"hello"] withName:@"index"];
+        }
+        CDTQResultSet *rs = [datastore find:@{@"hello":@"world"}];
+        XCTAssertEqual([[rs documentIds] count], nDocs);
+    }
+    @autoreleasepool{
+        // get manager
+        CDTDatastoreManager *factory = [[CDTDatastoreManager alloc] initWithDirectory:factoryPath error:&error];
+        // open existing datastore
+        CDTDatastore *datastore = [factory datastoreNamed:@"test" error:&error];
+        XCTAssertNil(error);
+        // check index exists
+        XCTAssertEqual([[datastore listIndexes] count], 1);
+        // query
+        CDTQResultSet *rs = [datastore find:@{@"hello":@"world"}];
+        XCTAssertEqual([[rs documentIds] count], nDocs);
+    }
+}
+
+@end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CDTDatastore CHANGELOG
 
+## Unreleased
+- [FIXED] Bug which prevented CDTDatastore instances from being closed after calling index/query
+  methods.
+
 ## 2.0.2 (2018-04-30)
 - [FIXED] Bug which prevented `find` queries from executing
   successfully against indexes with certain names.


### PR DESCRIPTION
## What

Fix retain cycle between `CDTQIndexManager` and `CDTDatastore`

## How

Make a weak reference to the associated object from the `CDTDatastore` to the `CDTQIndexManager`. Because it isn't reference counted, the `CDTQIndexManager` instance `dealloc` is correctly called (it didn't before because its reference count never reached 0), at which point the reference is cleared.

## Testing

See added test class `CDTQLifecycleTests`
