### PR TITLE
Add test to ensure CDTDatastore filehandles aren't leaked

### DIFF
--- a/CDTDatastoreTests/DatastoreManagerTests.m
+++ b/CDTDatastoreTests/DatastoreManagerTests.m
@@ -20,8 +20,11 @@
 #import "TDInternal.h"
 #import "FMDatabase.h"
 #import "FMDatabaseQueue.h"
-#import <libproc.h>
-#import <sys/proc_info.h>
+// for testDatastoreClosesFilehandles
+#if TARGET_OS_OSX
+    #import <libproc.h>
+    #import <sys/proc_info.h>
+#endif
 @interface DatastoreManagerTests : CloudantSyncTests
 
 @end
@@ -97,6 +100,8 @@
     }
 }
 
+// this can only run on macOS because it uses proc_pidinfo which is not available on iOS
+#if TARGET_OS_OSX
 - (void) testDatastoreClosesFilehandles {
     // repeatedly obtain the same datastore in a loop, adding documents to it and calling
     // ensureIndexed on each iteration, check that we have not excessively leaked filehandles, which
@@ -138,6 +143,7 @@
     }
     XCTAssertEqual([ds documentCount], n);
 }
+#endif
 
 @end
 

--- a/CDTDatastoreTests/DatastoreManagerTests.m
+++ b/CDTDatastoreTests/DatastoreManagerTests.m
@@ -125,6 +125,7 @@
             fdCount = bufferSize / PROC_PIDLISTFD_SIZE;
             // as observed in testing, this should never go above 8, but we'll set a conservative limit of 100 to allow some breathing room
             XCTAssertTrue(fdCount < 100);
+            free(fdInfo);
         }
     }
     XCTAssertEqual([ds documentCount], n);


### PR DESCRIPTION
Note that the aim of this PR has diverged from the original purpose, hence the branch name not reflecting the PR title.

## What

Add a test to ensure that we don't excessively leak filehandles, which is an indication that the `CDTDatastore` and `CDTQIndexManager` objects are not being dealloc'd correctly.

## How

Repeatedly add documents and call `ensureIndexed`. In each loop iteration use `proc_pidinfo` to check number of open filehandles, and assert on this.

## Testing

See added test `testDatastoreClosesFilehandles`.

_Note_ 

This test is currently expected to fail until #428 merges.

_Note_

 This test will fail without the `@autoreleasepool` present. See https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/MemoryMgmt/Articles/mmAutoreleasePools.html for further details.

In particular: "Cocoa always expects code to be executed within an autorelease pool block, otherwise autoreleased objects do not get released and your application leaks memory. (If you send an autorelease message outside of an autorelease pool block, Cocoa logs a suitable error message.) The AppKit and UIKit frameworks process each event-loop iteration (such as a mouse down event or a tap) within an autorelease pool block". 

Because we "are writing a program that is not based on a UI framework, such as a command-line tool", without the `@autoreleasepool`, the `dealloc` methods would only be called all at once at the end of the test (which would also leak file handles).

## Issues

#427
