### PR TITLE
CDTQIndexManager has weak reference to CDTDatastore

### DIFF
--- a/CDTDatastore.xcodeproj/project.pbxproj
+++ b/CDTDatastore.xcodeproj/project.pbxproj
@@ -37,6 +37,8 @@
 		8E705A951F0D360700FF0219 /* CDTSessionCookieInterceptorBase.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E705A911F0D360700FF0219 /* CDTSessionCookieInterceptorBase.m */; };
 		8E705A971F0E325200FF0219 /* CDTIAMSessionCookieInterceptorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E705A961F0E325200FF0219 /* CDTIAMSessionCookieInterceptorTests.m */; };
 		8E705A981F0E348F00FF0219 /* CDTIAMSessionCookieInterceptorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E705A961F0E325200FF0219 /* CDTIAMSessionCookieInterceptorTests.m */; };
+		8EFE944220E3A58F00B1C9F5 /* CDTLifecycleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8EFE944120E3A58F00B1C9F5 /* CDTLifecycleTests.m */; };
+		8EFE944320E3A58F00B1C9F5 /* CDTLifecycleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8EFE944120E3A58F00B1C9F5 /* CDTLifecycleTests.m */; };
 		90D44B38BE0B6F0F5E18F462 /* Pods_base_raTests_CDTDatastoreReplicationAcceptanceTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FF78267FE761ABB49CEB76BB /* Pods_base_raTests_CDTDatastoreReplicationAcceptanceTests.framework */; };
 		980F22711CB818260075A843 /* CDTQFilterFieldsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 98F77E0B1C44044000515CC3 /* CDTQFilterFieldsTest.m */; };
 		980F22721CB818260075A843 /* CDTQIndexCreatorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98F77E0C1C44044000515CC3 /* CDTQIndexCreatorTests.m */; };
@@ -774,6 +776,7 @@
 		8E705A901F0D360700FF0219 /* CDTSessionCookieInterceptorBase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDTSessionCookieInterceptorBase.h; sourceTree = "<group>"; };
 		8E705A911F0D360700FF0219 /* CDTSessionCookieInterceptorBase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTSessionCookieInterceptorBase.m; sourceTree = "<group>"; };
 		8E705A961F0E325200FF0219 /* CDTIAMSessionCookieInterceptorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTIAMSessionCookieInterceptorTests.m; sourceTree = "<group>"; };
+		8EFE944120E3A58F00B1C9F5 /* CDTLifecycleTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CDTLifecycleTests.m; sourceTree = "<group>"; };
 		987382FB1C47B1DD00937212 /* CDTHelperFixedKeyProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDTHelperFixedKeyProvider.h; sourceTree = "<group>"; };
 		987382FC1C47B1DD00937212 /* CDTHelperFixedKeyProvider.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTHelperFixedKeyProvider.m; sourceTree = "<group>"; };
 		987382FD1C47B1DD00937212 /* CDTHelperOneUseKeyProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDTHelperOneUseKeyProvider.h; sourceTree = "<group>"; };
@@ -1448,6 +1451,7 @@
 				8E6D540D207B7191006FF35F /* SwiftTests.swift */,
 				8E6D540B207B7190006FF35F /* CDTDatastoreTests-Bridging-Header.h */,
 				8E6D540C207B7190006FF35F /* CDTDatastoreTestsOSX-Bridging-Header.h */,
+				8EFE944120E3A58F00B1C9F5 /* CDTLifecycleTests.m */,
 			);
 			path = CDTDatastoreTests;
 			sourceTree = "<group>";
@@ -2195,7 +2199,6 @@
 				987383681C47B38800937212 /* Frameworks */,
 				9873836C1C47B38800937212 /* Headers */,
 				987383E81C47B38800937212 /* Resources */,
-				AAAFAA23FD102B2DE14164E5 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -2216,7 +2219,6 @@
 				9888EC061C512CA500E58783 /* Set Replication Settings */,
 				987385171C47B45300937212 /* Resources */,
 				AAFAB4E1487C11AE991A84B6 /* [CP] Embed Pods Frameworks */,
-				E4372A7365929208FED58858 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -2236,7 +2238,6 @@
 				987385641C47B45600937212 /* Frameworks */,
 				987385681C47B45600937212 /* Resources */,
 				7F8DF32603F19F1A42B0D9AA /* [CP] Embed Pods Frameworks */,
-				3DA143B09B058961AC58AD47 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -2309,7 +2310,6 @@
 				98F77B321C43FC9F00515CC3 /* Frameworks */,
 				98F77B331C43FC9F00515CC3 /* Headers */,
 				98F77B341C43FC9F00515CC3 /* Resources */,
-				74DB0EF2149B218BDE20C6D5 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -2330,7 +2330,6 @@
 				98F77B3E1C43FC9F00515CC3 /* Resources */,
 				987385FB1C49657A00937212 /* CopyFiles */,
 				46CB91A9A17B58E6709D1B46 /* [CP] Embed Pods Frameworks */,
-				DB896BECD3E80D5E28DA1622 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 				987385FA1C49655000937212 /* PBXBuildRule */,
@@ -2353,7 +2352,6 @@
 				9888EC091C512CF800E58783 /* Set Replication Settings */,
 				98F77D2A1C44028700515CC3 /* Resources */,
 				1037323DDF182E4A373CC77F /* [CP] Embed Pods Frameworks */,
-				FCFFBE629E5DB7844595CA06 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -2589,21 +2587,6 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTests/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		3DA143B09B058961AC58AD47 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-base-tests-CDTDatastoreTestsOSX/Pods-base-tests-CDTDatastoreTestsOSX-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		46CB91A9A17B58E6709D1B46 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -2618,6 +2601,7 @@
 				"${BUILT_PRODUCTS_DIR}/MRDatabaseContentChecker-iOS/MRDatabaseContentChecker.framework",
 				"${BUILT_PRODUCTS_DIR}/OCMock-iOS/OCMock.framework",
 				"${BUILT_PRODUCTS_DIR}/OHHTTPStubs-iOS/OHHTTPStubs.framework",
+				"${BUILT_PRODUCTS_DIR}/RSSwizzle-iOS/RSSwizzle.framework",
 				"${BUILT_PRODUCTS_DIR}/Specta-iOS/Specta.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
@@ -2629,26 +2613,12 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MRDatabaseContentChecker.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OCMock.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OHHTTPStubs.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RSSwizzle.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Specta.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-base-tests-CDTDatastoreTests/Pods-base-tests-CDTDatastoreTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		74DB0EF2149B218BDE20C6D5 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-base-CDTDatastore/Pods-base-CDTDatastore-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		754C5939D1D74685677B9518 /* [CP] Check Pods Manifest.lock */ = {
@@ -2683,6 +2653,7 @@
 				"${BUILT_PRODUCTS_DIR}/MRDatabaseContentChecker-macOS/MRDatabaseContentChecker.framework",
 				"${BUILT_PRODUCTS_DIR}/OCMock-macOS/OCMock.framework",
 				"${BUILT_PRODUCTS_DIR}/OHHTTPStubs-macOS/OHHTTPStubs.framework",
+				"${BUILT_PRODUCTS_DIR}/RSSwizzle-macOS/RSSwizzle.framework",
 				"${BUILT_PRODUCTS_DIR}/Specta-macOS/Specta.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
@@ -2694,6 +2665,7 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MRDatabaseContentChecker.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OCMock.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OHHTTPStubs.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RSSwizzle.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Specta.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2765,21 +2737,6 @@
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/buildplist.sh\"";
 		};
-		AAAFAA23FD102B2DE14164E5 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-base-CDTDatastoreOSX/Pods-base-CDTDatastoreOSX-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		AAFAB4E1487C11AE991A84B6 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -2808,21 +2765,6 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTestsOSX/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTestsOSX-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		DB896BECD3E80D5E28DA1622 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-base-tests-CDTDatastoreTests/Pods-base-tests-CDTDatastoreTests-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		DE64C5C18FA0A3DCA885795D /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -2839,36 +2781,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		E4372A7365929208FED58858 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTestsOSX/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTestsOSX-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		FCFFBE629E5DB7844595CA06 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTests/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -3046,6 +2958,7 @@
 				987385371C47B45600937212 /* CDTQMatcherIndexManager.m in Sources */,
 				987385381C47B45600937212 /* TDMultipartWriterTests.m in Sources */,
 				987385391C47B45600937212 /* TD_DatabaseManagerTests.m in Sources */,
+				8EFE944320E3A58F00B1C9F5 /* CDTLifecycleTests.m in Sources */,
 				9873853B1C47B45600937212 /* TDCollateJSONTests.m in Sources */,
 				9873853C1C47B45600937212 /* CDTQMatcherQueryExecutor.m in Sources */,
 				9873853E1C47B45600937212 /* TDMiscTests.m in Sources */,
@@ -3266,6 +3179,7 @@
 				98F77EB21C44044000515CC3 /* TD_DatabaseTests.m in Sources */,
 				98F77E911C44044000515CC3 /* DatastoreManagerTests.m in Sources */,
 				98F77EBA1C44044000515CC3 /* TDMultiStreamWriterTests.m in Sources */,
+				8EFE944220E3A58F00B1C9F5 /* CDTLifecycleTests.m in Sources */,
 				987AF7B51DE7274C00577DAC /* CloudantTests+EncryptionTests.m in Sources */,
 				98F77EA71C44044000515CC3 /* CDTQEitherMatcher.m in Sources */,
 				98F77E901C44044000515CC3 /* DatastoreCRUD.m in Sources */,

--- a/CDTDatastore/CDTDatastore.m
+++ b/CDTDatastore/CDTDatastore.m
@@ -4,6 +4,7 @@
 //
 //  Created by Michael Rhodes on 02/07/2013.
 //  Copyright (c) 2013 Cloudant. All rights reserved.
+//  Copyright © 2018 IBM Corporation. All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
 //  except in compliance with the License. You may obtain a copy of the License at
@@ -42,7 +43,7 @@ NSString *const CDTDatastoreChangeNotification = @"CDTDatastoreChangeNotificatio
 
 @property (nonatomic, strong, readonly) id<CDTEncryptionKeyProvider> keyProvider;
 
-@property (readonly) CDTDatastoreManager *manager;
+@property (readonly, weak) CDTDatastoreManager *manager;
 - (void)TDdbChanged:(NSNotification *)n;
 - (BOOL)validateBodyDictionary:(NSDictionary *)body error:(NSError *__autoreleasing *)error;
 
@@ -93,7 +94,11 @@ NSString *const CDTDatastoreChangeNotification = @"CDTDatastoreChangeNotificatio
     return self;
 }
 
-- (void)dealloc { [[NSNotificationCenter defaultCenter] removeObserver:self]; }
+- (void)dealloc {
+    _database = nil;
+    NSLog(@"dealloc CDTDatastore");
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
 
 #pragma mark Properties
 

--- a/CDTDatastore/CDTDatastore.m
+++ b/CDTDatastore/CDTDatastore.m
@@ -96,7 +96,7 @@ NSString *const CDTDatastoreChangeNotification = @"CDTDatastoreChangeNotificatio
 
 - (void)dealloc {
     _database = nil;
-    NSLog(@"dealloc CDTDatastore");
+    CDTLogDebug(CDTDATASTORE_LOG_CONTEXT, @"-dealloc CDTDatastore %@", self);
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 

--- a/CDTDatastore/CDTDatastoreManager.h
+++ b/CDTDatastore/CDTDatastoreManager.h
@@ -4,6 +4,7 @@
 //
 //  Created by Michael Rhodes on 04/07/2013.
 //  Copyright (c) 2013 Cloudant. All rights reserved.
+//  Copyright © 2018 IBM Corporation. All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
 //  except in compliance with the License. You may obtain a copy of the License at
@@ -60,6 +61,7 @@ extern NSString *__nonnull const CDTDatastoreErrorDomain;
 
  */
 - (BOOL)deleteDatastoreNamed:(nonnull NSString *)name error:(NSError *__autoreleasing __nullable * __nullable)error;
+- (void)closeDatastoreNamed:(nonnull NSString *)name;
 
 /**
  

--- a/CDTDatastore/CDTDatastoreManager.m
+++ b/CDTDatastore/CDTDatastoreManager.m
@@ -138,7 +138,7 @@ NSString *const CDTExtensionsDirName = @"_extensions";
             // delete any cloudant extensions
             // remove the open datastore: this ensures that any associated index manager has -dealloc
             // called on it _before_ we attempt to delete its underlying database
-            NSLog(@"calling close from delete %@", name);
+            CDTLogDebug(CDTDATASTORE_LOG_CONTEXT, @"calling close from delete %@", name);
             [_openDatastores removeObjectForKey:name];
             NSString *dbPath = [self.manager pathForName:name];;
             NSString *extPath = [dbPath stringByDeletingLastPathComponent];

--- a/CDTDatastore/CDTDatastoreManager.m
+++ b/CDTDatastore/CDTDatastoreManager.m
@@ -113,10 +113,6 @@ NSString *const CDTExtensionsDirName = @"_extensions";
 
 - (void)dealloc {
     CDTLogDebug(CDTDATASTORE_LOG_CONTEXT, @"-dealloc CDTDatastoreManager %@", self);
-    /*
-    for (CDTDatastore *ds in _openDatastores) {
-        [[ds database] close];
-    }*/
     [_openDatastores removeAllObjects];
     _manager = nil;
 }

--- a/CDTDatastore/CDTDatastoreManager.m
+++ b/CDTDatastore/CDTDatastoreManager.m
@@ -16,8 +16,8 @@
 
 #import "CDTDatastoreManager.h"
 #import "CDTDatastore+EncryptionKey.h"
-
 #import "CDTEncryptionKeyNilProvider.h"
+#import "CDTLogging.h"
 
 #import "TD_DatabaseManager.h"
 #import "TD_Database.h"
@@ -62,10 +62,10 @@ NSString *const CDTExtensionsDirName = @"_extensions";
     @synchronized (self) {
         CDTDatastore *datastore = _openDatastores[name];
         if (datastore != nil) {
-            NSLog(@"returning already open CDTDatastore %@", name);
+            CDTLogDebug(CDTDATASTORE_LOG_CONTEXT, @"returning already open CDTDatastore %@", name);
             return datastore;
         }
-        NSLog(@"opening new CDTDatastore %@", name);
+        CDTLogDebug(CDTDATASTORE_LOG_CONTEXT, @"opening new CDTDatastore %@", name);
 
         
         NSString *errorReason = nil;
@@ -99,11 +99,11 @@ NSString *const CDTExtensionsDirName = @"_extensions";
 
 - (void)closeDatastoreNamed:(NSString *)name {
     @synchronized (self) {
-        NSLog(@"closing CDTDatastore %@", name);
+        CDTLogDebug(CDTDATASTORE_LOG_CONTEXT, @"closing CDTDatastore %@", name);
         CDTDatastore *ds = _openDatastores[name];
         if (ds == nil) {
             // this may not be an issue if delete was already called and it was removed there
-            NSLog(@"warning can't find CDTDatastore to close %@", name);
+            CDTLogWarn(CDTDATASTORE_LOG_CONTEXT, @"can't find CDTDatastore to close %@", name);
             return;
         }
         [[ds database] close];
@@ -112,7 +112,7 @@ NSString *const CDTExtensionsDirName = @"_extensions";
 }
 
 - (void)dealloc {
-    NSLog(@"dealloc CDTDatastoreManager");
+    CDTLogDebug(CDTDATASTORE_LOG_CONTEXT, @"-dealloc CDTDatastoreManager %@", self);
     /*
     for (CDTDatastore *ds in _openDatastores) {
         [[ds database] close];

--- a/CDTDatastore/query/CDTDatastore+Query.m
+++ b/CDTDatastore/query/CDTDatastore+Query.m
@@ -25,17 +25,12 @@
     {
         if (objc_getAssociatedObject(self, @selector(CDTQManager)) == nil) {
             CDTQIndexManager *m = [CDTQIndexManager managerUsingDatastore:self error:nil];
-            // NB: we make a weak reference here so that we don't
-            // cause retain cycles, since the CDTQIndexManager also
-            // has a reference to us which is passed in when it is
-            // constructed. This association is cleared in
-            // [CDTQIndexManager dealloc].
+            
             objc_setAssociatedObject(self, @selector(CDTQManager), m,
-                                     OBJC_ASSOCIATION_ASSIGN);
+                                     OBJC_ASSOCIATION_RETAIN);
         }
+        return objc_getAssociatedObject(self, @selector(CDTQManager));
     }
-
-    return objc_getAssociatedObject(self, @selector(CDTQManager));
 }
 
 - (BOOL)isTextSearchEnabled

--- a/CDTDatastore/query/CDTQIndexManager.h
+++ b/CDTDatastore/query/CDTQIndexManager.h
@@ -3,6 +3,7 @@
 //
 //  Created by Mike Rhodes on 2014-09-27
 //  Copyright (c) 2014 Cloudant. All rights reserved.
+//  Copyright © 2018 IBM Corporation. All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
 //  except in compliance with the License. You may obtain a copy of the License at
@@ -85,7 +86,7 @@ typedef NS_ENUM(NSInteger, CDTQQueryError) {
  */
 @interface CDTQIndexManager : NSObject
 
-@property (nonatomic, strong) CDTDatastore *datastore;
+@property (nonatomic, weak) CDTDatastore *datastore;
 @property (nonatomic, strong) FMDatabaseQueue *database;
 @property (nonatomic, readonly, getter = isTextSearchEnabled) BOOL textSearchEnabled;
 

--- a/CDTDatastore/query/CDTQIndexManager.h
+++ b/CDTDatastore/query/CDTQIndexManager.h
@@ -13,6 +13,9 @@
 //  either express or implied. See the License for the specific language governing permissions
 //  and limitations under the License.
 
+// NB: These methods are for internal use only. For index and query functionality, use the methods
+// available in the CDTDatastore Query category, by importing the CDTDatastore+Query.h header.
+
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/CDTDatastore/query/CDTQIndexManager.m
+++ b/CDTDatastore/query/CDTQIndexManager.m
@@ -14,6 +14,9 @@
 //  either express or implied. See the License for the specific language governing permissions
 //  and limitations under the License.
 
+// NB: These methods are for internal use only. For index and query functionality, use the methods
+// available in the CDTDatastore Query category, by importing the CDTDatastore+Query.h header.
+
 //
 // The metadata for an index is represented in the database table as follows:
 //

--- a/CDTDatastore/query/CDTQIndexManager.m
+++ b/CDTDatastore/query/CDTQIndexManager.m
@@ -127,7 +127,7 @@ static const int VERSION = 2;
 - (void)dealloc
 {
     // close the database.
-    NSLog(@"dealloc CDTQIndexManager");
+    CDTLogDebug(CDTQ_LOGGING_CONTEXT, @"-dealloc CDTQIndexManager %@", self);
     [self.database close];
 }
 

--- a/CDTDatastore/query/CDTQIndexManager.m
+++ b/CDTDatastore/query/CDTQIndexManager.m
@@ -127,11 +127,8 @@ static const int VERSION = 2;
 - (void)dealloc
 {
     // close the database.
+    NSLog(@"dealloc CDTQIndexManager");
     [self.database close];
-    // remove the datastore's association with us, otherwise it will
-    // become invalid since it's a weak reference
-    objc_setAssociatedObject(self.datastore, @selector(CDTQManager), nil,
-                             OBJC_ASSOCIATION_ASSIGN);
 }
 
 #pragma mark List indexes

--- a/CDTDatastore/touchdb/TDInternal.h
+++ b/CDTDatastore/touchdb/TDInternal.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2011 Couchbase, Inc. All rights reserved.
 //
 //  Modifications for this distribution by Cloudant, Inc., Copyright (c) 2014 Cloudant, Inc.
-//  Copyright © 2016 IBM Corporation. All rights reserved.
+//  Copyright © 2016, 2018 IBM Corporation. All rights reserved.
 //
 
 #import "TD_Database.h"
@@ -72,9 +72,7 @@
 
 @interface TD_Database (Attachments_Internal)
 - (void)rememberAttachmentWritersForDigests:(NSDictionary*)writersByDigests;
-#if DEBUG
 - (id)attachmentWriterForAttachment:(NSDictionary*)attachment;
-#endif
 
 - (NSUInteger)blobCount;
 - (id<CDTBlobReader>)blobForKey:(TDBlobKey)key;

--- a/CDTDatastore/touchdb/TDMultiStreamWriter.h
+++ b/CDTDatastore/touchdb/TDMultiStreamWriter.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2012 Couchbase, Inc. All rights reserved.
 //
 //  Modifications for this distribution by Cloudant, Inc., Copyright(c) 2014 Cloudant, Inc.
+//  Copyright © 2018 IBM Corporation. All rights reserved.
 
 #import <Foundation/Foundation.h>
 
@@ -64,9 +65,7 @@
 - (void)addInput:(id)input length:(UInt64)length;
 - (void)opened;
 
-#if DEBUG
 - (id)initWithBufferSize:(NSUInteger)
     bufferSize;  // added to public interface for testing. Adam Cox (Cloudant) 2014-1-17
-#endif
 
 @end

--- a/CDTDatastore/touchdb/TDMultipartReader.h
+++ b/CDTDatastore/touchdb/TDMultipartReader.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2012 Couchbase, Inc. All rights reserved.
 //
 //  Modifications for this distribution by Cloudant, Inc., Copyright(c) 2014 Cloudant, Inc.
+//  Copyright © 2018 IBM Corporation. All rights reserved.
 
 #import <Foundation/Foundation.h>
 @protocol TDMultipartReaderDelegate;
@@ -41,10 +42,8 @@
     You can call this from your -appendToPart and/or -finishedPart overrides. */
 @property (readonly) NSDictionary* headers;
 
-#if DEBUG
 - (NSData*)
     boundary;  // made public to be used in external test framework. Adam Cox (Cloudant) 2014-1-17
-#endif
 
 @end
 

--- a/CDTDatastore/touchdb/TDMultipartReader.m
+++ b/CDTDatastore/touchdb/TDMultipartReader.m
@@ -4,6 +4,7 @@
 //
 //  Created by Jens Alfke on 1/30/12.
 //  Copyright (c) 2012 Couchbase, Inc. All rights reserved.
+//  Copyright © 2018 IBM Corporation. All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
 //  except in compliance with the License. You may obtain a copy of the License at
@@ -238,8 +239,6 @@ static NSData* kCRLFCRLF;
 
 - (BOOL)finished { return _state == kAtEnd; }
 
-#if DEBUG
 - (NSData*)boundary { return _boundary; }
-#endif
 
 @end

--- a/CDTDatastore/touchdb/TD_Database+Attachments.m
+++ b/CDTDatastore/touchdb/TD_Database+Attachments.m
@@ -6,6 +6,7 @@
 //  Copyright (c) 2011 Couchbase, Inc. All rights reserved.
 //
 //  Modifications for this distribution by Cloudant, Inc., Copyright (c) 2014 Cloudant, Inc.
+//  Copyright © 2018 IBM Corporation. All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
 //  except in compliance with the License. You may obtain a copy of the License at
@@ -79,14 +80,12 @@
 }
 
 // This is ONLY FOR TESTS (see TDMultipartDownloader.m)
-#if DEBUG
 - (id)attachmentWriterForAttachment:(NSDictionary*)attachment
 {
     NSString* digest = $castIf(NSString, attachment[@"digest"]);
     if (!digest) return nil;
     return _pendingAttachmentsByDigest[digest];
 }
-#endif
 
 /**
  Pulls a "follows" attachment from the writer's pending store

--- a/CDTDatastore/touchdb/TD_Database.m
+++ b/CDTDatastore/touchdb/TD_Database.m
@@ -8,7 +8,7 @@
 // Modified by Michael Rhodes, 2013
 // Copyright (c) 2013 Cloudant, Inc. All rights reserved.
 //
-// Copyright © 2017 IBM Corporation. All rights reserved.
+// Copyright © 2017, 2018 IBM Corporation. All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
 //  except in compliance with the License. You may obtain a copy of the License at
@@ -642,6 +642,7 @@ static BOOL removeItemIfExists(NSString* path, NSError** outError)
 
 - (void)dealloc
 {
+    NSLog(@"dealloc td_database");
     if (self.isOpen) {
         // Warn(@"%@ dealloced without being closed first!", self);
         [self close];

--- a/CDTDatastore/touchdb/TD_Database.m
+++ b/CDTDatastore/touchdb/TD_Database.m
@@ -642,9 +642,9 @@ static BOOL removeItemIfExists(NSString* path, NSError** outError)
 
 - (void)dealloc
 {
-    NSLog(@"dealloc td_database");
+    CDTLogDebug(CDTDATASTORE_LOG_CONTEXT, @"-dealloc TD_Database %@", self);
     if (self.isOpen) {
-        // Warn(@"%@ dealloced without being closed first!", self);
+        CDTLogWarn(CDTDATASTORE_LOG_CONTEXT, @"dealloced without being closed first! %@", self);
         [self close];
     }
     [[NSNotificationCenter defaultCenter] removeObserver:self];

--- a/CDTDatastore/touchdb/TD_DatabaseManager.h
+++ b/CDTDatastore/touchdb/TD_DatabaseManager.h
@@ -64,9 +64,9 @@ extern NSUInteger const kTD_DatabaseManagerErrorCodeInvalidName;
 - (void)close;
 
 
-#if DEBUG  // made public for testing (Adam Cox, Cloudant. 2014-1-20)
+// made public for testing (Adam Cox, Cloudant. 2014-1-20)
 + (TD_DatabaseManager*)createEmptyAtPath:(NSString*)path;
 + (TD_DatabaseManager*)createEmptyAtTemporaryPath:(NSString*)name;
-#endif
+
 
 @end

--- a/CDTDatastore/touchdb/TD_DatabaseManager.m
+++ b/CDTDatastore/touchdb/TD_DatabaseManager.m
@@ -50,7 +50,6 @@ static NSCharacterSet* kIllegalNameChars;
     }
 }
 
-#if DEBUG
 + (TD_DatabaseManager*)createEmptyAtPath:(NSString*)path
 {
     [[NSFileManager defaultManager] removeItemAtPath:path error:NULL];
@@ -65,7 +64,6 @@ static NSCharacterSet* kIllegalNameChars;
 {
     return [self createEmptyAtPath:[NSTemporaryDirectory() stringByAppendingPathComponent:name]];
 }
-#endif
 
 - (id)initWithDirectory:(NSString*)dirPath
                 options:(const TD_DatabaseManagerOptions*)options

--- a/CDTDatastoreTests/CDTLifecycleTests.m
+++ b/CDTDatastoreTests/CDTLifecycleTests.m
@@ -247,10 +247,10 @@ static int cdtqIndexManagerInitCount;
 
     // duplicate stderr fd so we can re-use it later
     int stderr_orig = dup(2);
-    // redirect stderr to temporary file
+    // reassign stderr to temporary file
     char *stderr_redir_filename;
     asprintf(&stderr_redir_filename, "%s/%s", tempDirectoryNameCString, "stderr.redirect.txt");
-    FILE *stderr_redir = freopen(stderr_redir_filename, "w", stderr);
+    stderr = fopen (stderr_redir_filename, "w");
 
     NSString *factoryPath = [[NSFileManager defaultManager]
                              stringWithFileSystemRepresentation:tempDirectoryNameCString
@@ -273,7 +273,6 @@ static int cdtqIndexManagerInitCount;
     // - under some circumstances (in release mode), mmap can fail on an empty file
     fprintf(stderr, "testDeletingDatastoreDeletesIndexManagerAfterClosingFilehandle\n");
     fflush(stderr);
-    fclose (stderr_redir);
     // reassign stderr to correct fd for subsequent tests
     stderr = fdopen(stderr_orig, "a");
     // mmap the redirected file to search for string

--- a/CDTDatastoreTests/CDTLifecycleTests.m
+++ b/CDTDatastoreTests/CDTLifecycleTests.m
@@ -18,6 +18,7 @@
 #import "FMDatabaseQueue.h"
 
 #include <sys/stat.h>
+#include <sys/mman.h>
 
 @protocol CDTEncryptionKeyProvider;
 

--- a/CDTDatastoreTests/CDTLifecycleTests.m
+++ b/CDTDatastoreTests/CDTLifecycleTests.m
@@ -1,0 +1,278 @@
+//
+//  CDTLifecycleTests.m
+//  CDTDatastore
+//
+//  Created by tomblench on 27/06/2018.
+//  Copyright © 2018 IBM Corporation. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#import <Foundation/Foundation.h>
+#import <XCTest/XCTest.h>
+#import <CDTDatastore/CloudantSync.h>
+#import <objc/runtime.h>
+#import <RSSwizzle/RSSwizzle.h>
+#import "TD_Database.h"
+#import "FMDatabase.h"
+#import "FMDatabaseQueue.h"
+
+@protocol CDTEncryptionKeyProvider;
+
+static int cdtDatastoreDeallocCount;
+static int cdtqIndexManagerDeallocCount;
+static int cdtDatastoreManagerDeallocCount;
+
+static int cdtDatastoreInitCount;
+static int cdtqIndexManagerInitCount;
+static int cdtDatastoreManagerInitCount;
+
+
+@interface CDTLifecycleTests : XCTestCase
+@end
+
+@implementation CDTLifecycleTests
+
+-(void)setUp {
+    cdtDatastoreDeallocCount = 0;
+    cdtqIndexManagerDeallocCount = 0;
+    cdtDatastoreManagerDeallocCount = 0;
+
+    cdtDatastoreInitCount = 0;
+    cdtqIndexManagerInitCount = 0;
+    cdtDatastoreManagerInitCount = 0;
+}
+
++(void)setUp
+{
+    // "swizzle" dealloc for these classes by incrementing our counter and then calling the original method:
+    // - CDTDatastore
+    // - CDTQIndexManager
+    // - CDTDatastoreManager
+    RSSwizzleInstanceMethod(CDTDatastore,
+                            NSSelectorFromString(@"dealloc"),
+                            RSSWReturnType(void),
+                            RSSWArguments(),
+                            RSSWReplacement({
+        // increment
+        cdtDatastoreDeallocCount++;
+        RSSWCallOriginal();
+    }), 0, NULL);
+    RSSwizzleInstanceMethod(CDTQIndexManager,
+                            NSSelectorFromString(@"dealloc"),
+                            RSSWReturnType(void),
+                            RSSWArguments(),
+                            RSSWReplacement({
+        // increment
+        cdtqIndexManagerDeallocCount++;
+        RSSWCallOriginal();
+    }), 0, NULL);
+    RSSwizzleInstanceMethod(CDTDatastoreManager,
+                            NSSelectorFromString(@"dealloc"),
+                            RSSWReturnType(void),
+                            RSSWArguments(),
+                            RSSWReplacement({
+        // increment
+        cdtDatastoreManagerDeallocCount++;
+        RSSWCallOriginal();
+    }), 0, NULL);
+
+    RSSwizzleInstanceMethod(CDTDatastore,
+                            NSSelectorFromString(@"initWithManager:database:encryptionKeyProvider:"),
+                            RSSWReturnType(id),
+                            RSSWArguments(CDTDatastoreManager *manager, TD_Database *database, id<CDTEncryptionKeyProvider> provider),
+                            RSSWReplacement({
+        // increment
+        cdtDatastoreInitCount++;
+        return RSSWCallOriginal(manager, database, provider);
+    }), 0, NULL);
+
+    RSSwizzleInstanceMethod(CDTQIndexManager,
+                            NSSelectorFromString(@"initUsingDatastore:error:"),
+                            RSSWReturnType(id),
+                            RSSWArguments(CDTDatastore *datastore, NSError *__autoreleasing __nullable *__nullable error),
+                            RSSWReplacement({
+        // increment
+        cdtqIndexManagerInitCount++;
+        return RSSWCallOriginal(datastore, error);
+    }), 0, NULL);
+}
+
+// check that the same datastore instance is obtained each time
+-(void)testSameDatastoreInstance
+{
+    @autoreleasepool {
+        NSString *tempDirectoryTemplate = [NSTemporaryDirectory()
+                                           stringByAppendingPathComponent:@"cloudant_sync_ios_tests.XXXXXX"];
+        const char *tempDirectoryTemplateCString =
+        [tempDirectoryTemplate fileSystemRepresentation];
+        char *tempDirectoryNameCString =
+        (char *)malloc(strlen(tempDirectoryTemplateCString) + 1);
+        strcpy(tempDirectoryNameCString, tempDirectoryTemplateCString);
+        
+        char *result = mkdtemp(tempDirectoryNameCString);
+        
+        NSString *factoryPath = [[NSFileManager defaultManager]
+                                 stringWithFileSystemRepresentation:tempDirectoryNameCString
+                                 length:strlen(result)];
+        free(tempDirectoryNameCString);
+        
+        NSError *error;
+        CDTDatastoreManager *factory = [[CDTDatastoreManager alloc] initWithDirectory:factoryPath error:&error];
+        CDTDatastore *ds1 = [factory datastoreNamed:@"test" error:&error];
+        XCTAssertNil(error);
+        CDTDatastore *ds2 = [factory datastoreNamed:@"test" error:&error];
+        XCTAssertNil(error);
+        XCTAssertEqual(ds1, ds2);
+    }
+}
+
+// check that the same index manager instance is obtained each time
+-(void)testSameIndexManagerInstance
+{
+    @autoreleasepool {
+        NSString *tempDirectoryTemplate = [NSTemporaryDirectory()
+                                           stringByAppendingPathComponent:@"cloudant_sync_ios_tests.XXXXXX"];
+        const char *tempDirectoryTemplateCString =
+        [tempDirectoryTemplate fileSystemRepresentation];
+        char *tempDirectoryNameCString =
+        (char *)malloc(strlen(tempDirectoryTemplateCString) + 1);
+        strcpy(tempDirectoryNameCString, tempDirectoryTemplateCString);
+        
+        char *result = mkdtemp(tempDirectoryNameCString);
+        
+        NSString *factoryPath = [[NSFileManager defaultManager]
+                                 stringWithFileSystemRepresentation:tempDirectoryNameCString
+                                 length:strlen(result)];
+        free(tempDirectoryNameCString);
+        
+        NSError *error;
+        
+        
+        CDTDatastoreManager *factory = [[CDTDatastoreManager alloc] initWithDirectory:factoryPath error:&error];
+        [[factory datastoreNamed:@"test" error:&error] updateAllIndexes];
+        [[factory datastoreNamed:@"test" error:&error] updateAllIndexes];
+    }
+    // only one index manager was inited, proving that the instance was reused
+    XCTAssertEqual(cdtqIndexManagerInitCount, 1);
+}
+
+// check that index manager was deallocated when datastore was deallocated
+-(void)testIndexManagerDeallocsWhenDatastoreDeallocs
+{
+    @autoreleasepool {
+        NSString *tempDirectoryTemplate = [NSTemporaryDirectory()
+                                           stringByAppendingPathComponent:@"cloudant_sync_ios_tests.XXXXXX"];
+        const char *tempDirectoryTemplateCString =
+        [tempDirectoryTemplate fileSystemRepresentation];
+        char *tempDirectoryNameCString =
+        (char *)malloc(strlen(tempDirectoryTemplateCString) + 1);
+        strcpy(tempDirectoryNameCString, tempDirectoryTemplateCString);
+        
+        char *result = mkdtemp(tempDirectoryNameCString);
+        
+        NSString *factoryPath = [[NSFileManager defaultManager]
+                                 stringWithFileSystemRepresentation:tempDirectoryNameCString
+                                 length:strlen(result)];
+        free(tempDirectoryNameCString);
+        
+        NSError *error;
+        CDTDatastoreManager *factory = [[CDTDatastoreManager alloc] initWithDirectory:factoryPath error:&error];
+        CDTDatastore *ds1 = [factory datastoreNamed:@"test" error:&error];
+        [ds1 updateAllIndexes];
+        XCTAssertNil(error);
+    }
+    // index manager was deallocated when datastore was deallocated
+    XCTAssertEqual(cdtqIndexManagerDeallocCount, 1);
+}
+
+// check that datastore was deallocated when manager was deallocated
+-(void)testDatastoreDeallocsWhenManagerDeallocs
+{
+    @autoreleasepool {
+        NSString *tempDirectoryTemplate = [NSTemporaryDirectory()
+                                           stringByAppendingPathComponent:@"cloudant_sync_ios_tests.XXXXXX"];
+        const char *tempDirectoryTemplateCString =
+        [tempDirectoryTemplate fileSystemRepresentation];
+        char *tempDirectoryNameCString =
+        (char *)malloc(strlen(tempDirectoryTemplateCString) + 1);
+        strcpy(tempDirectoryNameCString, tempDirectoryTemplateCString);
+        
+        char *result = mkdtemp(tempDirectoryNameCString);
+        
+        NSString *factoryPath = [[NSFileManager defaultManager]
+                                 stringWithFileSystemRepresentation:tempDirectoryNameCString
+                                 length:strlen(result)];
+        free(tempDirectoryNameCString);
+        
+        NSError *error;
+        CDTDatastoreManager *factory = [[CDTDatastoreManager alloc] initWithDirectory:factoryPath error:&error];
+        CDTDatastore *ds1 = [factory datastoreNamed:@"test" error:&error];
+        XCTAssertNil(error);
+    }
+    // datastore was deallocated when manager was deallocated
+    XCTAssertEqual(cdtDatastoreDeallocCount, 1);
+}
+
+// check that explicitly closing datastore deallocates it, despite still holding a pointer to manager
+-(void)testExplicitCloseDeallocs
+{
+    NSString *tempDirectoryTemplate = [NSTemporaryDirectory()
+                                       stringByAppendingPathComponent:@"cloudant_sync_ios_tests.XXXXXX"];
+    const char *tempDirectoryTemplateCString =
+    [tempDirectoryTemplate fileSystemRepresentation];
+    char *tempDirectoryNameCString =
+    (char *)malloc(strlen(tempDirectoryTemplateCString) + 1);
+    strcpy(tempDirectoryNameCString, tempDirectoryTemplateCString);
+    
+    char *result = mkdtemp(tempDirectoryNameCString);
+    
+    NSString *factoryPath = [[NSFileManager defaultManager]
+                             stringWithFileSystemRepresentation:tempDirectoryNameCString
+                             length:strlen(result)];
+    free(tempDirectoryNameCString);
+    
+    NSError *error;
+    CDTDatastoreManager *factory = [[CDTDatastoreManager alloc] initWithDirectory:factoryPath error:&error];
+    // assign to ds1 inside an autoreleasepool so our pointer doesn't hang on to it
+    @autoreleasepool {
+        CDTDatastore *ds1 = [factory datastoreNamed:@"test" error:&error];
+        XCTAssertNil(error);
+        [factory closeDatastoreNamed:@"test"];
+    }
+    XCTAssertEqual(cdtDatastoreInitCount, 1);
+    XCTAssertEqual(cdtDatastoreDeallocCount, 1);
+}
+
+// ensure that we don't have the filehandle open to the index manager before trying to delete it
+-(void)testDeletingDatastoreDeletesIndexManagerAfterClosingFilehandle
+{
+    NSString *tempDirectoryTemplate = [NSTemporaryDirectory()
+                                       stringByAppendingPathComponent:@"cloudant_sync_ios_tests.XXXXXX"];
+    const char *tempDirectoryTemplateCString =
+    [tempDirectoryTemplate fileSystemRepresentation];
+    char *tempDirectoryNameCString =
+    (char *)malloc(strlen(tempDirectoryTemplateCString) + 1);
+    strcpy(tempDirectoryNameCString, tempDirectoryTemplateCString);
+    
+    char *result = mkdtemp(tempDirectoryNameCString);
+    
+    NSString *factoryPath = [[NSFileManager defaultManager]
+                             stringWithFileSystemRepresentation:tempDirectoryNameCString
+                             length:strlen(result)];
+    free(tempDirectoryNameCString);
+    
+    NSError *error;
+    CDTDatastoreManager *factory = [[CDTDatastoreManager alloc] initWithDirectory:factoryPath error:&error];
+    // assign to ds1 inside an autoreleasepool so our pointer doesn't hang on to it
+    @autoreleasepool {
+        CDTDatastore *ds1 = [factory datastoreNamed:@"test" error:&error];
+        XCTAssertNil(error);
+        [ds1 updateAllIndexes];
+    }
+    // currently there is no way to assert on this - watch the log and check that the following message is not output:
+    // "BUG IN CLIENT OF libsqlite3.dylib: database integrity compromised by API violation: vnode unlinked while in use"
+    [factory deleteDatastoreNamed:@"test" error:&error];
+}
+
+@end

--- a/CDTDatastoreTests/CDTLifecycleTests.m
+++ b/CDTDatastoreTests/CDTLifecycleTests.m
@@ -21,12 +21,9 @@
 
 static int cdtDatastoreDeallocCount;
 static int cdtqIndexManagerDeallocCount;
-static int cdtDatastoreManagerDeallocCount;
 
 static int cdtDatastoreInitCount;
 static int cdtqIndexManagerInitCount;
-static int cdtDatastoreManagerInitCount;
-
 
 @interface CDTLifecycleTests : XCTestCase
 @end
@@ -36,11 +33,9 @@ static int cdtDatastoreManagerInitCount;
 -(void)setUp {
     cdtDatastoreDeallocCount = 0;
     cdtqIndexManagerDeallocCount = 0;
-    cdtDatastoreManagerDeallocCount = 0;
 
     cdtDatastoreInitCount = 0;
     cdtqIndexManagerInitCount = 0;
-    cdtDatastoreManagerInitCount = 0;
 }
 
 +(void)setUp
@@ -48,7 +43,6 @@ static int cdtDatastoreManagerInitCount;
     // "swizzle" dealloc for these classes by incrementing our counter and then calling the original method:
     // - CDTDatastore
     // - CDTQIndexManager
-    // - CDTDatastoreManager
     RSSwizzleInstanceMethod(CDTDatastore,
                             NSSelectorFromString(@"dealloc"),
                             RSSWReturnType(void),
@@ -65,15 +59,6 @@ static int cdtDatastoreManagerInitCount;
                             RSSWReplacement({
         // increment
         cdtqIndexManagerDeallocCount++;
-        RSSWCallOriginal();
-    }), 0, NULL);
-    RSSwizzleInstanceMethod(CDTDatastoreManager,
-                            NSSelectorFromString(@"dealloc"),
-                            RSSWReturnType(void),
-                            RSSWArguments(),
-                            RSSWReplacement({
-        // increment
-        cdtDatastoreManagerDeallocCount++;
         RSSWCallOriginal();
     }), 0, NULL);
 

--- a/CDTDatastoreTests/Encryption/DatastoreManagerEncryptionTests.m
+++ b/CDTDatastoreTests/Encryption/DatastoreManagerEncryptionTests.m
@@ -4,6 +4,7 @@
 //
 //  Created by Enrique de la Torre Fernandez on 13/03/2015.
 //  Copyright (c) 2015 Cloudant. All rights reserved.
+//  Copyright © 2018 IBM Corporation. All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
 //  except in compliance with the License. You may obtain a copy of the License at
@@ -116,6 +117,9 @@
 
     NSString *dbName = @"testdatastoremanager_alreadyopen";
     [self.factory datastoreNamed:dbName withEncryptionKeyProvider:nilProvider error:nil];
+    
+    // Close
+    [self.factory closeDatastoreNamed:dbName];
 
     // Test
     XCTAssertThrows([self.factory datastoreNamed:dbName withEncryptionKeyProvider:nil error:nil],
@@ -130,6 +134,9 @@
 
     NSString *dbName = @"testdatastoremanager_alreadyopennonencryptdb";
     [self.factory datastoreNamed:dbName withEncryptionKeyProvider:nilProvider error:nil];
+    
+    // Close
+    [self.factory closeDatastoreNamed:dbName];
 
     // Get datastore
     CDTHelperFixedKeyProvider *fixedProvider = [CDTHelperFixedKeyProvider provider];
@@ -175,6 +182,9 @@
     NSString *dbName = @"testdatastoremanager_alreadyopenencryptdb";
     [self.factory datastoreNamed:dbName withEncryptionKeyProvider:fixedProvider error:nil];
 
+    // Close
+    [self.factory closeDatastoreNamed:dbName];
+    
     // Get datastore
     CDTEncryptionKeyNilProvider *nilProvider = [CDTEncryptionKeyNilProvider provider];
 
@@ -195,6 +205,9 @@
     NSString *dbName = @"testdatastoremanager_encryptdbwrongkey_again";
     [self.factory datastoreNamed:dbName withEncryptionKeyProvider:fixedProvider error:nil];
 
+    // Close
+    [self.factory closeDatastoreNamed:dbName];
+    
     // Get datastore
     CDTHelperFixedKeyProvider *otherProvider = [fixedProvider negatedProvider];
 

--- a/CDTDatastoreTests/SwiftTests.swift
+++ b/CDTDatastoreTests/SwiftTests.swift
@@ -21,6 +21,7 @@ public class SwiftTests : CloudantSyncTests {
 
     // test that the result of listIndexes() is correctly bridged from obj-c to swift
     public func testListIndexes() {
+        autoreleasepool { () -> Void in
         do {
             let store = try factory.datastoreNamed("my_ds")
             let rev = CDTDocumentRevision()
@@ -32,9 +33,13 @@ public class SwiftTests : CloudantSyncTests {
             XCTAssertTrue((indexes["index"]!["fields"] as! Array<String>).contains("_id"))
             XCTAssertTrue((indexes["index"]!["fields"] as! Array<String>).contains("_rev"))
             XCTAssertTrue((indexes["index"]!["fields"] as! Array<String>).contains("hello"))
-        } catch {
+            }
+
+         catch {
             XCTFail("Test failed with \(error)")
         }
+        }
+        print("done")
     }
     
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CDTDatastore CHANGELOG
 
+## Unreleased
+- [NEW] Add method `-closeDatastoreNamed:` on `CDTDatastoreManager`.
+- [FIXED] Fix issue where repeated calls to `-datastoreNamed:error:` on `CDTDatastoreManager` for
+  the same datastore could cause crashes or failures.
+
 ## 2.0.3 (2018-05-17)
 - [FIXED] Bug which prevented CDTDatastore instances from being closed after calling index/query
   methods.

--- a/PodFile
+++ b/PodFile
@@ -27,6 +27,7 @@ abstract_target 'base' do
         pod 'Expecta'
         pod 'OCMock'
         pod 'OHHTTPStubs'
+        pod 'RSSwizzle'
         pod MRDatabaseContentChecker, :git => 'https://github.com/rhyshort/MRDatabaseContentChecker.git'
 
         target :CDTDatastoreTests do

--- a/Project/Project/CDTAppDelegate.m
+++ b/Project/Project/CDTAppDelegate.m
@@ -22,6 +22,8 @@
 
 - (CDTDatastore*)create_datastore;
 
+@property CDTDatastoreManager *manager;
+
 @end
 
 @implementation CDTAppDelegate
@@ -78,7 +80,13 @@
 - (void)applicationWillTerminate:(UIApplication *)application
 {
     // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
-
+    
+    // Explicitly close the Datastore. For the purposes of our application, this is not strictly
+    // necessary since the Datastore Manager will automatically close all datastores when it is
+    // deallocated. In applications which open large numbers of Datastores it may be necessary to
+    // explicitly close Datastores after use to avoid exhaustion of file handles and other native
+    // resources.
+    [self.manager closeDatastoreNamed:@"todo_items"];
 }
 
 /**
@@ -118,7 +126,7 @@
     
     NSString *path = [storeURL path];
     
-    CDTDatastoreManager *manager = [[CDTDatastoreManager alloc] initWithDirectory:path
+    self.manager = [[CDTDatastoreManager alloc] initWithDirectory:path
                                                                             error:&outError];
     
     if (nil != outError) {
@@ -126,7 +134,7 @@
         exit(1);
     }
 
-    CDTDatastore *datastore = [manager datastoreNamed:@"todo_items" error:&outError];
+    CDTDatastore *datastore = [self.manager datastoreNamed:@"todo_items" error:&outError];
 
     if (nil != outError) {
         NSLog(@"Error creating datastore: %@", outError);

--- a/Rakefile
+++ b/Rakefile
@@ -110,7 +110,7 @@ end
 def run_build(workspace, scheme, destination)
   settings = "GCC_PREPROCESSOR_DEFINITIONS='${inherited} ENCRYPT_DATABASE=1'" unless !ENV["encrypted"]
   # build using xcpretty as otherwise it's very verbose when running tests
-  return system("xcodebuild -workspace #{workspace} -scheme '#{scheme}' -destination '#{destination}' #{settings} build | xcpretty; exit ${PIPESTATUS[0]}")
+  return system("xcodebuild -configuration Release -workspace #{workspace} -scheme '#{scheme}' -destination '#{destination}' #{settings} build | xcpretty; exit ${PIPESTATUS[0]}")
 end
 
 # Runs `test` target for workspace/scheme/destination
@@ -118,7 +118,7 @@ def run_tests(workspace, scheme, destination)
   settings = "GCC_PREPROCESSOR_DEFINITIONS='${inherited} ENCRYPT_DATABASE=1'" unless !ENV["encrypted"]
   # if jenkins passed us a log name, use that, otherwise default to "#{scheme}.log"
   logName = (ENV["LOG_NAME"] == nil ? "#{scheme}.log" : ENV["LOG_NAME"])
-  return system("xcodebuild -verbose -workspace #{workspace} -scheme '#{scheme}' -destination '#{destination}' #{settings} test | tee #{logName} | xcpretty -r junit; exit ${PIPESTATUS[0]}")
+  return system("xcodebuild -configuration Release -verbose -workspace #{workspace} -scheme '#{scheme}' -destination '#{destination}' #{settings} test | tee #{logName} | xcpretty -r junit; exit ${PIPESTATUS[0]}")
 end
 
 def test(workspace, scheme, destination)

--- a/doc/query.md
+++ b/doc/query.md
@@ -399,9 +399,8 @@ both over thirty _and_ named `mike`:
 
 ### Executing queries
 
-To find documents matching a query, use the `CDTQIndexManager` objects `-find:`
-function. Use the returned object's `-enumerateObjectsUsingBlock:` method to iterate
-over the results:
+To find documents matching a query, use the `-find:` method. Use the returned object's
+`-enumerateObjectsUsingBlock:` method to iterate over the results:
 
 ```objc
 CDTQResultSet *result = [ds find:query];


### PR DESCRIPTION
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

Fix lifecycle issues regarding proper opening and closing of resources across `CDTDatastore`, `CDTQIndexManager`, `CDTDatastoreManager`.

Note that the primary motivator here is that the associated object relationship between `CDTDatastore` and `CDTQIndexManager` is currently incorrect when facading through index/query methods, and that it is currently possible to obtain multiple `CDTQIndexManager` instances for the same underlying SQLite database, which leads to incorrect behaviour.

For more details see "Approach" which gives an overview of the design issues.

Fixes #435

## Approach

### Lifecycle of key objects

#### `CDTDatastore` -> `CDTQIndexManager`

1-to-1 relationship, strong reference via `objc_{get,set}AssociatedObject` in
`CDTDatastore+Query.m`.

Each index manager is constructed on demand.

#### `CDTQIndexManager` -> `CDTDatastore`

1-to-1 relationship, weak reference via property `datastore`, therefore no retain cycles. Because
reference to `CDTQIndexManager` can't 'leak' (all methods facade through `CDTDatastore+Query`), this
reference will always be valid.

Note that if `CDTQIndexManager` is constructed using `+managerUsingDatastore` or
`-initUsingDatastore`, the above doesn't hold and it is possible for the reference to `datastore` to
be invalid. Even worse, a user could then use a mixture of API calls through the constructed index
manager and facaded through the datastore. Therefore this usage is discouraged (all of our current
documentation shows index/query usage facaded through datastore).

For the above reason, add a comment in `CDTQIndexManager` to clarify that it's not public API.

#### `CDTDatastoreManager` -> `CDTDatastore`

1-to-many relationship, strong references via the `openDatastores` property, which is a map whose
keys are the datastore name, and values the datastore itself.

Note that the only way of obtaining a new or existing datastore instance is through the manager.

This is a change to existing functionality and guarantees users will obtain the same reference when
multiple calls to `-datastoreNamed` are made. This is essential for the `CDTDatastore` ->
`CDTQIndexManager` to work properly. As of now, this is not the case, and multiple calls to
`-datastoreNamed` will result in a new and different `CDTDatastore` to be constructed each time
(although they all point to the same underlying `TD_Database`). This causes errors as the different
index managers will all try to simultaneously open the same underlying sqlite database.

Note that a user could still have a 'dangling' reference to a `CDTDatastore`, that is they can
assign the pointer of a previously constructed datastore, then `dealloc` its manager. Now they have
a datastore they can't delete (they need the manager for this), and worse, they can now obtain a
different pointer for the same underlying datastore by constructing a new manager and calling
`-datastoreNamed`. I think we have to be pragmatic and decide we can't protect users from this API
abuse.

#### `CDTDatastore` -> `CDTDatastoreManager`

1-to-1 relationship. This is currently held as a strong reference via the property `_manager`, but
will cause retain cycles when combined with the relationship described in the above para. Is not
currently used so can be downgraded to a weak reference or removed.

## Schema & API Changes

Add new method `closeDatastoreNamed` on `CDTDatastoreManager` to allow users with many datastores open to avoid resource (file handle) starvation.

## Security and Privacy

No change.

## Testing

See added test class `CDTLifecycleTests`. Test approach as follows:

### New instances

- Calls to `CDTDatastore+Query.m` methods should always obtain the same `CDTQIndexManager` instance
  for a given `CDTDatastore` instance.
- Calls to `CDTDatastoreManager` `-datastoreNamed` should always obtain the same `CDTDatastore`
  instance for a given datastore name.

### Retain count reaching zero

- When `dealloc` is called on `CDTDatastore`, `dealloc` should be called on the `CDTQIndexManager`
  held as an associated object.
- When `dealloc` is called on `CDTDatastoreManager`, `dealloc` should be called on all
  `CDTDatastores` in `openDatastores`.
- Should we have tests for `TD_Database` retain count?

### Explicit close

- Explicit close supported and tested via new method call on  `CDTDatastoreManager`

### Explicit delete

- When deleting extensions, `dealloc` should be called on `CDTQIndexManager` to allow it to close
  its underlying database for the extensions directory is deleted. (In `deleteDatastoreNamed` call
  `[_openDatastores removeObjectForKey:name]` first). Note that not doing this is the cause of the
  following message, as reported by customer:

### Other test changes

Updated some existing tests which now need an explicit close before re-opening database to reproduce expected behaviour.

Tests run via `Rake` now run in `release` mode, as the original bug report shows certain failure modes are only exhibited when run in `release` (as opposed to `debug`) mode.

Removed some `#ifdef(DEBUG)` guards to allow test code to compile in `release` mode.

## Monitoring and Logging

TODO - some debug `NSLog`s have been left in, these need to be evaluated and turned into "proper" log statements if necessary.