### PR TITLE
Fix common crypto includes for Xcode 10

### DIFF
--- a/CDTDatastore/touchdb/TDBlobStore.h
+++ b/CDTDatastore/touchdb/TDBlobStore.h
@@ -10,13 +10,7 @@
 
 #import <FMDB/FMDB.h>
 
-#ifdef GNUSTEP
-#import <openssl/md5.h>
-#import <openssl/sha.h>
-#else
-#define COMMON_DIGEST_FOR_OPENSSL
 #import <CommonCrypto/CommonDigest.h>
-#endif
 
 #import "CDTEncryptionKeyProvider.h"
 #import "CDTBlobReader.h"
@@ -31,7 +25,7 @@ typedef NS_ENUM(NSInteger, CDTBlobStoreError) {
 /** Key identifying a data blob. This happens to be a SHA-1 digest. */
 typedef struct TDBlobKey
 {
-    uint8_t bytes[SHA_DIGEST_LENGTH];
+    uint8_t bytes[CC_SHA1_DIGEST_LENGTH];
 } TDBlobKey;
 
 /** A persistent content-addressable store for arbitrary-size data blobs.
@@ -109,7 +103,7 @@ typedef struct TDBlobKey
 
 typedef struct
 {
-    uint8_t bytes[MD5_DIGEST_LENGTH];
+    uint8_t bytes[CC_MD5_DIGEST_LENGTH];
 } TDMD5Key;
 
 /** Lets you stream a large attachment to a TDBlobStore asynchronously, e.g. from a network
@@ -120,8 +114,8 @@ typedef struct
     NSString* _tempPath;
     id<CDTBlobWriter> _blobWriter;
     UInt64 _length;
-    SHA_CTX _shaCtx;
-    MD5_CTX _md5Ctx;
+    CC_SHA1_CTX _shaCtx;
+    CC_MD5_CTX _md5Ctx;
     TDBlobKey _blobKey;
     TDMD5Key _MD5Digest;
 }

--- a/CDTDatastore/touchdb/TDBlobStore.h
+++ b/CDTDatastore/touchdb/TDBlobStore.h
@@ -4,6 +4,15 @@
 //
 //  Created by Jens Alfke on 12/10/11.
 //  Copyright (c) 2011 Couchbase, Inc. All rights reserved.
+//  Copyright © 2018 IBM Corporation. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//  except in compliance with the License. You may obtain a copy of the License at
+//    http://www.apache.org/licenses/LICENSE-2.0
+//  Unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
 //
 
 #import <Foundation/Foundation.h>

--- a/CDTDatastore/touchdb/TDBlobStore.m
+++ b/CDTDatastore/touchdb/TDBlobStore.m
@@ -81,10 +81,10 @@ NSString *const CDTBlobStoreErrorDomain = @"CDTBlobStoreErrorDomain";
     NSCParameterAssert(blob);
 
     TDBlobKey key;
-    SHA_CTX ctx;
-    SHA1_Init(&ctx);
-    SHA1_Update(&ctx, blob.bytes, blob.length);
-    SHA1_Final(key.bytes, &ctx);
+    CC_SHA1_CTX ctx;
+    CC_SHA1_Init(&ctx);
+    CC_SHA1_Update(&ctx, blob.bytes, blob.length);
+    CC_SHA1_Final(key.bytes, &ctx);
 
     return key;
 }
@@ -289,8 +289,8 @@ NSString *const CDTBlobStoreErrorDomain = @"CDTBlobStoreErrorDomain";
     self = [super init];
     if (self) {
         _store = store;
-        SHA1_Init(&_shaCtx);
-        MD5_Init(&_md5Ctx);
+        CC_SHA1_Init(&_shaCtx);
+        CC_MD5_Init(&_md5Ctx);
 
         // Open a temporary file in the store's temporary directory:
         NSString* filename = [TDCreateUUID() stringByAppendingPathExtension:@"blobtmp"];
@@ -312,8 +312,8 @@ NSString *const CDTBlobStoreErrorDomain = @"CDTBlobStoreErrorDomain";
     [_blobWriter appendData:data];
     NSUInteger dataLen = data.length;
     _length += dataLen;
-    SHA1_Update(&_shaCtx, data.bytes, dataLen);
-    MD5_Update(&_md5Ctx, data.bytes, dataLen);
+    CC_SHA1_Update(&_shaCtx, data.bytes, dataLen);
+    CC_MD5_Update(&_md5Ctx, data.bytes, dataLen);
 }
 
 - (void)closeFile
@@ -326,8 +326,8 @@ NSString *const CDTBlobStoreErrorDomain = @"CDTBlobStoreErrorDomain";
 {
     Assert(_blobWriter, @"Already finished");
     [self closeFile];
-    SHA1_Final(_blobKey.bytes, &_shaCtx);
-    MD5_Final(_MD5Digest.bytes, &_md5Ctx);
+    CC_SHA1_Final(_blobKey.bytes, &_shaCtx);
+    CC_MD5_Final(_MD5Digest.bytes, &_md5Ctx);
 }
 
 - (NSString*)MD5DigestString

--- a/CDTDatastore/touchdb/TDBlobStore.m
+++ b/CDTDatastore/touchdb/TDBlobStore.m
@@ -6,6 +6,7 @@
 //  Copyright (c) 2011 Couchbase, Inc. All rights reserved.
 //
 //  Modifications for this distribution by Cloudant, Inc., Copyright (c) 2014 Cloudant, Inc.
+//  Copyright © 2018 IBM Corporation. All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
 //  except in compliance with the License. You may obtain a copy of the License at

--- a/CDTDatastore/touchdb/TDMisc.m
+++ b/CDTDatastore/touchdb/TDMisc.m
@@ -4,6 +4,7 @@
 //
 //  Created by Jens Alfke on 1/13/12.
 //  Copyright (c) 2012 Couchbase, Inc. All rights reserved.
+//  Copyright © 2018 IBM Corporation. All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
 //  except in compliance with the License. You may obtain a copy of the License at

--- a/CDTDatastore/touchdb/TDMisc.m
+++ b/CDTDatastore/touchdb/TDMisc.m
@@ -20,14 +20,8 @@
 #import "CollectionUtils.h"
 #import <errno.h>
 
-#ifdef GNUSTEP
-#import <openssl/sha.h>
-#import <uuid/uuid.h>  // requires installing "uuid-dev" package on Ubuntu
-#else
-#define COMMON_DIGEST_FOR_OPENSSL
 #import <CommonCrypto/CommonDigest.h>
 #import <CommonCrypto/CommonHMAC.h>
-#endif
 
 NSString* TDCreateUUID()
 {
@@ -54,31 +48,31 @@ NSString* TDCreateUUID()
 
 NSData* TDSHA1Digest(NSData* input)
 {
-    unsigned char digest[SHA_DIGEST_LENGTH];
-    SHA_CTX ctx;
-    SHA1_Init(&ctx);
-    SHA1_Update(&ctx, input.bytes, input.length);
-    SHA1_Final(digest, &ctx);
+    unsigned char digest[CC_SHA1_DIGEST_LENGTH];
+    CC_SHA1_CTX ctx;
+    CC_SHA1_Init(&ctx);
+    CC_SHA1_Update(&ctx, input.bytes, input.length);
+    CC_SHA1_Final(digest, &ctx);
     return [NSData dataWithBytes:&digest length:sizeof(digest)];
 }
 
 NSData* TDSHA256Digest(NSData* input)
 {
-    unsigned char digest[SHA256_DIGEST_LENGTH];
-    SHA256_CTX ctx;
-    SHA256_Init(&ctx);
-    SHA256_Update(&ctx, input.bytes, input.length);
-    SHA256_Final(digest, &ctx);
+    unsigned char digest[CC_SHA256_DIGEST_LENGTH];
+    CC_SHA256_CTX ctx;
+    CC_SHA256_Init(&ctx);
+    CC_SHA256_Update(&ctx, input.bytes, input.length);
+    CC_SHA256_Final(digest, &ctx);
     return [NSData dataWithBytes:&digest length:sizeof(digest)];
 }
 
 NSString* TDHexSHA1Digest(NSData* input)
 {
-    unsigned char digest[SHA_DIGEST_LENGTH];
-    SHA_CTX ctx;
-    SHA1_Init(&ctx);
-    SHA1_Update(&ctx, input.bytes, input.length);
-    SHA1_Final(digest, &ctx);
+    unsigned char digest[CC_SHA1_DIGEST_LENGTH];
+    CC_SHA1_CTX ctx;
+    CC_SHA1_Init(&ctx);
+    CC_SHA1_Update(&ctx, input.bytes, input.length);
+    CC_SHA1_Final(digest, &ctx);
     return TDHexFromBytes(&digest, sizeof(digest));
 }
 
@@ -93,14 +87,14 @@ NSString* TDHexFromBytes(const void* bytes, size_t length)
 
 NSData* TDHMACSHA1(NSData* key, NSData* data)
 {
-    UInt8 hmac[SHA_DIGEST_LENGTH];
+    UInt8 hmac[CC_SHA1_DIGEST_LENGTH];
     CCHmac(kCCHmacAlgSHA1, key.bytes, key.length, data.bytes, data.length, &hmac);
     return [NSData dataWithBytes:hmac length:sizeof(hmac)];
 }
 
 NSData* TDHMACSHA256(NSData* key, NSData* data)
 {
-    UInt8 hmac[SHA256_DIGEST_LENGTH];
+    UInt8 hmac[CC_SHA256_DIGEST_LENGTH];
     CCHmac(kCCHmacAlgSHA256, key.bytes, key.length, data.bytes, data.length, &hmac);
     return [NSData dataWithBytes:hmac length:sizeof(hmac)];
 }

--- a/CDTDatastore/touchdb/TD_Database+BlobFilenames.m
+++ b/CDTDatastore/touchdb/TD_Database+BlobFilenames.m
@@ -118,7 +118,7 @@ NSString *const TDDatabaseBlobFilenamesFileExtension = @"blob";
             NSData *keyData = dataFromHexadecimalString(hexKey);
 
             TDBlobKey key;
-            [keyData getBytes:key.bytes length:SHA_DIGEST_LENGTH];
+            [keyData getBytes:key.bytes length:CC_SHA1_DIGEST_LENGTH];
 
             NSString *blobFilename = [r stringForColumn:TDDatabaseBlobFilenamesColumnFilename];
 
@@ -204,8 +204,8 @@ NSString *const TDDatabaseBlobFilenamesFileExtension = @"blob";
 
 + (NSString *)generateRandomBlobFilename
 {
-    uint8_t randBytes[SHA_DIGEST_LENGTH];
-    arc4random_buf(randBytes, SHA_DIGEST_LENGTH);
+    uint8_t randBytes[CC_SHA1_DIGEST_LENGTH];
+    arc4random_buf(randBytes, CC_SHA1_DIGEST_LENGTH);
     
     NSString *randStr = TDHexFromBytes(randBytes, sizeof(randBytes));
     

--- a/CDTDatastore/touchdb/TD_Database+BlobFilenames.m
+++ b/CDTDatastore/touchdb/TD_Database+BlobFilenames.m
@@ -4,6 +4,7 @@
 //
 //  Created by Enrique de la Torre Fernandez on 29/05/2015.
 //  Copyright (c) 2015 IBM Cloudant. All rights reserved.
+//  Copyright © 2018 IBM Corporation. All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
 //  except in compliance with the License. You may obtain a copy of the License at

--- a/CDTDatastore/touchdb/TD_Database+Insertion.m
+++ b/CDTDatastore/touchdb/TD_Database+Insertion.m
@@ -6,6 +6,7 @@
 //  Copyright (c) 2011 Couchbase, Inc. All rights reserved.
 //
 //  Modifications for this distribution by Cloudant, Inc., Copyright (c) 2014 Cloudant, Inc.
+//  Copyright © 2018 IBM Corporation. All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
 //  except in compliance with the License. You may obtain a copy of the License at

--- a/CDTDatastoreTests/Attachments/AttachmentCRUD.m
+++ b/CDTDatastoreTests/Attachments/AttachmentCRUD.m
@@ -143,7 +143,7 @@
         NSData *data = dataFromHexadecimalString(@"D55F9AC778BAF2256FA4DE87AAC61F590EBE66E0");
         
         TDBlobKey key;
-        [data getBytes:key.bytes length:SHA_DIGEST_LENGTH];
+        [data getBytes:key.bytes length:CC_SHA1_DIGEST_LENGTH];
 
         filename = [TD_Database filenameForKey:key inBlobFilenamesTableInDatabase:db];
     }];
@@ -215,7 +215,7 @@
         NSData *data = dataFromHexadecimalString(@"D55F9AC778BAF2256FA4DE87AAC61F590EBE66E0");
         
         TDBlobKey key;
-        [data getBytes:key.bytes length:SHA_DIGEST_LENGTH];
+        [data getBytes:key.bytes length:CC_SHA1_DIGEST_LENGTH];
 
         filename = [TD_Database filenameForKey:key inBlobFilenamesTableInDatabase:db];
     }];
@@ -275,7 +275,7 @@
         NSData *data = dataFromHexadecimalString(@"D55F9AC778BAF2256FA4DE87AAC61F590EBE66E0");
         
         TDBlobKey key;
-        [data getBytes:key.bytes length:SHA_DIGEST_LENGTH];
+        [data getBytes:key.bytes length:CC_SHA1_DIGEST_LENGTH];
 
         filename = [TD_Database filenameForKey:key inBlobFilenamesTableInDatabase:db];
     }];
@@ -377,13 +377,13 @@
         NSData *data = dataFromHexadecimalString(@"D55F9AC778BAF2256FA4DE87AAC61F590EBE66E0");
         
         TDBlobKey key;
-        [data getBytes:key.bytes length:SHA_DIGEST_LENGTH];
+        [data getBytes:key.bytes length:CC_SHA1_DIGEST_LENGTH];
 
         filenameImage = [TD_Database filenameForKey:key inBlobFilenamesTableInDatabase:db];
         
         data = dataFromHexadecimalString(@"3FF2989BCCF52150BBA806BAE1DB2E0B06AD6F88");
 
-        [data getBytes:key.bytes length:SHA_DIGEST_LENGTH];
+        [data getBytes:key.bytes length:CC_SHA1_DIGEST_LENGTH];
 
         filenameText = [TD_Database filenameForKey:key inBlobFilenamesTableInDatabase:db];
     }];
@@ -475,13 +475,13 @@
         NSData *data = dataFromHexadecimalString(@"D55F9AC778BAF2256FA4DE87AAC61F590EBE66E0");
         
         TDBlobKey key;
-        [data getBytes:key.bytes length:SHA_DIGEST_LENGTH];
+        [data getBytes:key.bytes length:CC_SHA1_DIGEST_LENGTH];
 
         filenameImage = [TD_Database filenameForKey:key inBlobFilenamesTableInDatabase:db];
         
         data = dataFromHexadecimalString(@"3FF2989BCCF52150BBA806BAE1DB2E0B06AD6F88");
 
-        [data getBytes:key.bytes length:SHA_DIGEST_LENGTH];
+        [data getBytes:key.bytes length:CC_SHA1_DIGEST_LENGTH];
 
         filenameText = [TD_Database filenameForKey:key inBlobFilenamesTableInDatabase:db];
     }];
@@ -610,13 +610,13 @@
         NSData *data = dataFromHexadecimalString(@"D55F9AC778BAF2256FA4DE87AAC61F590EBE66E0");
         
         TDBlobKey key;
-        [data getBytes:key.bytes length:SHA_DIGEST_LENGTH];
+        [data getBytes:key.bytes length:CC_SHA1_DIGEST_LENGTH];
 
         filenameImage = [TD_Database filenameForKey:key inBlobFilenamesTableInDatabase:db];
         
         data = dataFromHexadecimalString(@"3FF2989BCCF52150BBA806BAE1DB2E0B06AD6F88");
 
-        [data getBytes:key.bytes length:SHA_DIGEST_LENGTH];
+        [data getBytes:key.bytes length:CC_SHA1_DIGEST_LENGTH];
 
         filenameText = [TD_Database filenameForKey:key inBlobFilenamesTableInDatabase:db];
     }];
@@ -699,7 +699,7 @@
         NSData *data = dataFromHexadecimalString(@"D55F9AC778BAF2256FA4DE87AAC61F590EBE66E0");
         
         TDBlobKey key;
-        [data getBytes:key.bytes length:SHA_DIGEST_LENGTH];
+        [data getBytes:key.bytes length:CC_SHA1_DIGEST_LENGTH];
 
         filename = [TD_Database filenameForKey:key inBlobFilenamesTableInDatabase:db];
     }];
@@ -774,7 +774,7 @@
         NSData *data = dataFromHexadecimalString(@"D55F9AC778BAF2256FA4DE87AAC61F590EBE66E0");
         
         TDBlobKey key;
-        [data getBytes:key.bytes length:SHA_DIGEST_LENGTH];
+        [data getBytes:key.bytes length:CC_SHA1_DIGEST_LENGTH];
 
         filename = [TD_Database filenameForKey:key inBlobFilenamesTableInDatabase:db];
     }];

--- a/CDTDatastoreTests/Encryption/TDBlobStoreEncryptionTests.m
+++ b/CDTDatastoreTests/Encryption/TDBlobStoreEncryptionTests.m
@@ -286,7 +286,7 @@
       NSData *data = dataFromHexadecimalString(TDBLOBSTOREENCRYPTIONTESTS_LOREM_SHA1DIGEST);
 
       TDBlobKey key;
-      [data getBytes:key.bytes length:SHA_DIGEST_LENGTH];
+      [data getBytes:key.bytes length:CC_SHA1_DIGEST_LENGTH];
 
       reader = [_blobStore blobForKey:key withDatabase:db];
     }];

--- a/CDTDatastoreTests/TD_DatabaseBlobFilenamesTests.m
+++ b/CDTDatastoreTests/TD_DatabaseBlobFilenamesTests.m
@@ -164,7 +164,7 @@
       NSData *data = dataFromHexadecimalString(TDDATABASEBLOBFILENAMESTESTS_SHA1DIGEST_01);
 
       TDBlobKey key;
-      [data getBytes:key.bytes length:SHA_DIGEST_LENGTH];
+      [data getBytes:key.bytes length:CC_SHA1_DIGEST_LENGTH];
 
       filename =
           [TD_Database generateAndInsertFilenameBasedOnKey:key intoBlobFilenamesTableInDatabase:db];
@@ -183,7 +183,7 @@
       NSData *data = dataFromHexadecimalString(TDDATABASEBLOBFILENAMESTESTS_SHA1DIGEST_01);
 
       TDBlobKey key;
-      [data getBytes:key.bytes length:SHA_DIGEST_LENGTH];
+      [data getBytes:key.bytes length:CC_SHA1_DIGEST_LENGTH];
 
       filename = [TD_Database generateAndInsertRandomFilenameBasedOnKey:key
                                        intoBlobFilenamesTableInDatabase:db];
@@ -204,7 +204,7 @@
       NSData *data = dataFromHexadecimalString(TDDATABASEBLOBFILENAMESTESTS_SHA1DIGEST_03);
 
       TDBlobKey key;
-      [data getBytes:key.bytes length:SHA_DIGEST_LENGTH];
+      [data getBytes:key.bytes length:CC_SHA1_DIGEST_LENGTH];
 
       resultFirstInsert =
           [TD_Database insertFilename:filename withKey:key intoBlobFilenamesTableInDatabase:db];
@@ -215,7 +215,7 @@
       NSData *data = dataFromHexadecimalString(TDDATABASEBLOBFILENAMESTESTS_SHA1DIGEST_04);
 
       TDBlobKey key;
-      [data getBytes:key.bytes length:SHA_DIGEST_LENGTH];
+      [data getBytes:key.bytes length:CC_SHA1_DIGEST_LENGTH];
 
       resultSecondInsert =
           [TD_Database insertFilename:filename withKey:key intoBlobFilenamesTableInDatabase:db];

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CDTDatastore CHANGELOG
 
+## 2.1.1 (Unreleased)
+- [FIXED] Unknown type and undeclared identifier issues with common crypto includes.
+
 ## 2.1.0 (2018-07-10)
 - [NEW] Add method `-closeDatastoreNamed:` on `CDTDatastoreManager`.
 - [FIXED] Fix issue where repeated calls to `-datastoreNamed:error:` on `CDTDatastoreManager` for


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

In theory, the COMMON_DIGEST_FOR_OPENSSL #define should work, which means that we can use the openssl (non-"CC"-prefixed) symbols. For reasons, I still can't get to the bottom of, this breaks on Xcode 10.

However, now that compatibility with GNUstep is no longer required, we can just drop the whole
openssl thing and use the CommonCrypto ("CC") symbols directly.

This also makes the old touchdb code more consistent with later CDTDatastore/Encryption code which doesn't #define COMMON_DIGEST_FOR_OPENSSL.

See #441 

## Approach

Use `CC_` prefixed symbols and remove `#ifdef GNUSTEP` stanzas.

## Schema & API Changes

"No change"

## Security and Privacy

"No change"

## Testing

No functional change, existing tests pass.

## Monitoring and Logging

"No change"
