### PR TITLE
Set `latest=true` when fetching remote document revisions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 
 language: objective-c
-osx_image: xcode8
+osx_image: xcode10.2
 
 before_install:
   - export LANG=en_US.UTF-8

--- a/CDTDatastore.xcodeproj/project.pbxproj
+++ b/CDTDatastore.xcodeproj/project.pbxproj
@@ -2395,7 +2395,7 @@
 					};
 					98F77B3F1C43FC9F00515CC3 = {
 						CreatedOnToolsVersion = 7.2;
-						LastSwiftMigration = 0930;
+						LastSwiftMigration = "";
 					};
 					98F77D2B1C44028700515CC3 = {
 						CreatedOnToolsVersion = 7.2;
@@ -3379,7 +3379,7 @@
 				SDKROOT = macosx;
 				SWIFT_OBJC_BRIDGING_HEADER = "CDTDatastoreTests/CDTDatastoreTestsOSX-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -3396,7 +3396,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 				SWIFT_OBJC_BRIDGING_HEADER = "CDTDatastoreTests/CDTDatastoreTestsOSX-Bridging-Header.h";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};
@@ -3633,7 +3633,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "CDTDatastoreTests/CDTDatastoreTests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -3647,7 +3647,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.cloudant.CDTDatastoreTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "CDTDatastoreTests/CDTDatastoreTests-Bridging-Header.h";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};

--- a/CDTDatastore/touchdb/TDPuller.m
+++ b/CDTDatastore/touchdb/TDPuller.m
@@ -3,7 +3,7 @@
 //  TouchDB
 //
 //  Created by Jens Alfke on 12/2/11.
-//  Copyright © 2017 IBM Corp. All rights reserved.
+//  Copyright © 2017, 2019 IBM Corp. All rights reserved.
 //
 //  Copyright (c) 2011 Couchbase, Inc. All rights reserved.
 //
@@ -434,7 +434,7 @@ static NSString* joinQuotedEscaped(NSArray* strings);
     // been added since the latest revisions we have locally.
     // See: http://wiki.apache.org/couchdb/HTTP_Document_API#GET
     // See: http://wiki.apache.org/couchdb/HTTP_Document_API#Getting_Attachments_With_a_Document
-    NSString* path = $sprintf(@"%@?rev=%@&revs=true&attachments=true", TDEscapeID(rev.docID),
+    NSString* path = $sprintf(@"%@?rev=%@&latest=true&revs=true&attachments=true", TDEscapeID(rev.docID),
                               TDEscapeID(rev.revID));
     NSArray* knownRevs = [_db getPossibleAncestorRevisionIDs:rev limit:kMaxNumberOfAttsSince];
     if (knownRevs.count > 0)
@@ -504,7 +504,7 @@ static NSString* joinQuotedEscaped(NSArray* strings);
     __weak TDPuller* weakSelf = self;
 
     [self sendAsyncRequest:@"POST"
-                      path:@"_bulk_get?revs=true&attachments=true"
+                      path:@"_bulk_get?latest=true&revs=true&attachments=true"
                       body:requestBody
               onCompletion:^(id result, NSError* error) {
                   __strong TDPuller* strongSelf = weakSelf;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CDTDatastore CHANGELOG
 
 ## Unreleased
+- [FIXED] Set latest=true when fetching remote document revisions.
 - [UPGRADED] iOS target platform to 8.0
 
 ## 2.1.1 (2018-09-19)


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description
By adding `latest` we should never receive a "missing" response from the
server. A descendant of the revision requested will be returned even if it has
been deleted.

Fixes #454.

<!--
Provide a short description; saving the detail for the `Approach` section

Also EITHER:
Link to issue this PR is resolving, use the Fixes #nnn form so that the
issue closes automatically when the PR merges e.g.:

Fixes #23

OR

For PRs without an associated issue and/or test/build issues

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue
### 2. What you expected to happen
### 3. What actually happened
-->

## Schema & API Changes
No change.
<!--
EITHER:

- "No change"

OR

For public API (as opposed to internal) changes

- "Fixing bug in API, will change x in such-and-such way"
-->

## Security and Privacy
No change.
<!--
EITHER:

- "No change"

OR

"Making changes in e.g. auth|https|encryption|io
need to be careful about..."

-->

## Testing
No change.
<!--
EITHER:

- Added new tests:
    - test x
    - test y
    - test z

OR

- Modified existing tests because ...

OR

- N/A build or packaging only changes

OR

In exceptional circumstances there may be a good reason we can't add automated
tests, for example if a specific device is required to reproduce a problem.

- No new tests because...
-->

## Monitoring and Logging
No change.
<!--
EITHER:

- "No change"

OR

- "Added new log line X..."
-->
