### PR TITLE
Feature/encryption at rest

### DIFF
--- a/CDTDatastore.podspec
+++ b/CDTDatastore.podspec
@@ -14,7 +14,7 @@ EOT
 
 Pod::Spec.new do |s|
   s.name         = "CDTDatastore"
-  s.version      = "2.1.2-SNAPSHOT"
+  s.version      = "0.0.1"
   s.summary      = "CDTDatastore is a document datastore which syncs."
   s.description  = <<-DESC
                     CDTDatastore is a JSON document datastore which speaks the
@@ -25,14 +25,14 @@ Pod::Spec.new do |s|
   s.homepage     = "http://github.com/cloudant/CDTDatastore"
   s.license      = {:type => 'Apache, Version 2.0', :text => license}
   s.author       = { "Cloudant, Inc." => "support@cloudant.com" }
-  s.source       = { :git => "https://github.com/cloudant/CDTDatastore.git", :tag => s.version.to_s }
+  s.source       = { :git => "https://github.com/HippocratesTech/CDTDatastore", :tag => s.version }
 
-  s.ios.deployment_target = '8.0'
-  s.osx.deployment_target = '10.9'
-
+  s.ios.deployment_target = '9.0'
+  s.osx.deployment_target = '10.5'
   s.requires_arc = true
 
   s.default_subspec = 'standard'
+  s.dependency 'OTFToolBox/Core'
 
   ['standard', 'SQLCipher'].each do |subspec_label|
       s.subspec subspec_label do |sp|

--- a/CDTDatastore.xcodeproj/project.pbxproj
+++ b/CDTDatastore.xcodeproj/project.pbxproj
@@ -8,15 +8,12 @@
 
 /* Begin PBXBuildFile section */
 		00049C35D4C6DF8171AF9AC8 /* Pods_base_tests_CDTDatastoreTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 992FED8F2AA3E2ADD7599045 /* Pods_base_tests_CDTDatastoreTests.framework */; };
-		1399B6CAACAB8F75EE125480 /* Pods_base_raTests_CDTDatastoreReplicationAcceptanceTestsOSX.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3809563FA5BF431C4EC8D3B5 /* Pods_base_raTests_CDTDatastoreReplicationAcceptanceTestsOSX.framework */; };
 		2E25F68D1F4C6DB900177ABA /* OHHTTPStubsHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 2E25F68C1F4C6DB900177ABA /* OHHTTPStubsHelper.m */; };
 		2E25F68E1F4C6E3D00177ABA /* OHHTTPStubsHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 2E25F68C1F4C6DB900177ABA /* OHHTTPStubsHelper.m */; };
 		3567D22135DB02790BD939BA /* CDTDatastore+Replication.h in Headers */ = {isa = PBXBuildFile; fileRef = 3567D9F9C835096137DC8EF2 /* CDTDatastore+Replication.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3567D43713667ABFE05C08F2 /* CDTDatastore+Replication.h in Headers */ = {isa = PBXBuildFile; fileRef = 3567D9F9C835096137DC8EF2 /* CDTDatastore+Replication.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3567DA2E9930DA1BFABB6617 /* CDTDatastore+Replication.m in Sources */ = {isa = PBXBuildFile; fileRef = 3567D4C1BDD33D0148CA9FF2 /* CDTDatastore+Replication.m */; };
 		3567DB3346B03BED878BC14F /* CDTDatastore+Replication.m in Sources */ = {isa = PBXBuildFile; fileRef = 3567D4C1BDD33D0148CA9FF2 /* CDTDatastore+Replication.m */; };
-		8836FBAB2706816C58690495 /* Pods_base_CDTDatastoreOSX.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D03C1BA0A7DA75BFAF80CC8 /* Pods_base_CDTDatastoreOSX.framework */; };
-		888D25163DAC0158BEAC19FF /* Pods_base_tests_CDTDatastoreTestsOSX.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 04DFF5124D5BD3161681174C /* Pods_base_tests_CDTDatastoreTestsOSX.framework */; };
 		8E19D00920A9C6BC0012F346 /* CDTQLifecycleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E19D00820A9C6BC0012F346 /* CDTQLifecycleTests.m */; };
 		8E19D00B20A9D0BB0012F346 /* CDTQLifecycleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E19D00820A9C6BC0012F346 /* CDTQLifecycleTests.m */; };
 		8E2DDDF81D1BEFBE00673564 /* CDTReplay429Interceptor.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E2DDDF61D1BEFBE00673564 /* CDTReplay429Interceptor.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -687,6 +684,8 @@
 			isa = PBXBuildRule;
 			compilerSpec = com.apple.compilers.proxy.script;
 			fileType = pattern.proxy;
+			inputFiles = (
+			);
 			isEditable = 1;
 			outputFiles = (
 			);
@@ -747,23 +746,14 @@
 
 /* Begin PBXFileReference section */
 		00A609A6C10F2A6835BF22B3 /* Pods-base-tests-CDTDatastoreTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-base-tests-CDTDatastoreTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-base-tests-CDTDatastoreTests/Pods-base-tests-CDTDatastoreTests.release.xcconfig"; sourceTree = "<group>"; };
-		04DFF5124D5BD3161681174C /* Pods_base_tests_CDTDatastoreTestsOSX.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_base_tests_CDTDatastoreTestsOSX.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		1053749380E7A10A270B91E4 /* Pods-base-CDTDatastoreOSX.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-base-CDTDatastoreOSX.debug.xcconfig"; path = "Pods/Target Support Files/Pods-base-CDTDatastoreOSX/Pods-base-CDTDatastoreOSX.debug.xcconfig"; sourceTree = "<group>"; };
-		11828F46DDB99AC94990EF7B /* Pods-base-raTests-CDTDatastoreReplicationAcceptanceTestsOSX.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-base-raTests-CDTDatastoreReplicationAcceptanceTestsOSX.release.xcconfig"; path = "Pods/Target Support Files/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTestsOSX/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTestsOSX.release.xcconfig"; sourceTree = "<group>"; };
 		1970EE2354D3B1A67BBEE47B /* Pods-base-raTests-CDTDatastoreReplicationAcceptanceTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-base-raTests-CDTDatastoreReplicationAcceptanceTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTests/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTests.release.xcconfig"; sourceTree = "<group>"; };
 		2E25F68B1F4C6DB900177ABA /* OHHTTPStubsHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OHHTTPStubsHelper.h; sourceTree = "<group>"; };
 		2E25F68C1F4C6DB900177ABA /* OHHTTPStubsHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OHHTTPStubsHelper.m; sourceTree = "<group>"; };
 		3567D4C1BDD33D0148CA9FF2 /* CDTDatastore+Replication.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "CDTDatastore+Replication.m"; sourceTree = "<group>"; };
 		3567D9F9C835096137DC8EF2 /* CDTDatastore+Replication.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "CDTDatastore+Replication.h"; sourceTree = "<group>"; };
-		3809563FA5BF431C4EC8D3B5 /* Pods_base_raTests_CDTDatastoreReplicationAcceptanceTestsOSX.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_base_raTests_CDTDatastoreReplicationAcceptanceTestsOSX.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		3D03C1BA0A7DA75BFAF80CC8 /* Pods_base_CDTDatastoreOSX.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_base_CDTDatastoreOSX.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		417460C5FAE995A062206A58 /* Pods_base_CDTDatastore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_base_CDTDatastore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4CE55C521AD1A3F630DFA051 /* Pods-base-raTests-CDTDatastoreReplicationAcceptanceTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-base-raTests-CDTDatastoreReplicationAcceptanceTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTests/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTests.debug.xcconfig"; sourceTree = "<group>"; };
-		58D9EAB81B994FD15D5FBCE4 /* Pods-base-tests-CDTDatastoreTestsOSX.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-base-tests-CDTDatastoreTestsOSX.release.xcconfig"; path = "Pods/Target Support Files/Pods-base-tests-CDTDatastoreTestsOSX/Pods-base-tests-CDTDatastoreTestsOSX.release.xcconfig"; sourceTree = "<group>"; };
 		6A9F55827AB3ACE50E9D41A0 /* Pods-base-CDTDatastore.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-base-CDTDatastore.debug.xcconfig"; path = "Pods/Target Support Files/Pods-base-CDTDatastore/Pods-base-CDTDatastore.debug.xcconfig"; sourceTree = "<group>"; };
-		780DA1CE0B016A2CE9A8458C /* Pods-base-raTests-CDTDatastoreReplicationAcceptanceTestsOSX.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-base-raTests-CDTDatastoreReplicationAcceptanceTestsOSX.debug.xcconfig"; path = "Pods/Target Support Files/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTestsOSX/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTestsOSX.debug.xcconfig"; sourceTree = "<group>"; };
-		85F3ECA4D5FB8EA5B31B14F1 /* Pods-base-CDTDatastoreOSX.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-base-CDTDatastoreOSX.release.xcconfig"; path = "Pods/Target Support Files/Pods-base-CDTDatastoreOSX/Pods-base-CDTDatastoreOSX.release.xcconfig"; sourceTree = "<group>"; };
-		880C1D944A8E097B9021DF85 /* Pods-base-tests-CDTDatastoreTestsOSX.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-base-tests-CDTDatastoreTestsOSX.debug.xcconfig"; path = "Pods/Target Support Files/Pods-base-tests-CDTDatastoreTestsOSX/Pods-base-tests-CDTDatastoreTestsOSX.debug.xcconfig"; sourceTree = "<group>"; };
 		8E19D00820A9C6BC0012F346 /* CDTQLifecycleTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CDTQLifecycleTests.m; sourceTree = "<group>"; };
 		8E2DDDF61D1BEFBE00673564 /* CDTReplay429Interceptor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDTReplay429Interceptor.h; sourceTree = "<group>"; };
 		8E2DDDF71D1BEFBE00673564 /* CDTReplay429Interceptor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDTReplay429Interceptor.m; sourceTree = "<group>"; };
@@ -1150,6 +1140,7 @@
 		992FED8F2AA3E2ADD7599045 /* Pods_base_tests_CDTDatastoreTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_base_tests_CDTDatastoreTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C5AF64D41C76000C007E2551 /* CDTNSURLSessionConfigurationDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDTNSURLSessionConfigurationDelegate.h; sourceTree = "<group>"; };
 		C5D893F16D9AE1D27F28C6F6 /* Pods-base-tests-CDTDatastoreTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-base-tests-CDTDatastoreTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-base-tests-CDTDatastoreTests/Pods-base-tests-CDTDatastoreTests.debug.xcconfig"; sourceTree = "<group>"; };
+		CE9CF3BC264A937D00CEDB56 /* CDTDatastore.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = CDTDatastore.podspec; sourceTree = "<group>"; };
 		F75FD09E8A7B9DB591B81C72 /* Pods-base-CDTDatastore.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-base-CDTDatastore.release.xcconfig"; path = "Pods/Target Support Files/Pods-base-CDTDatastore/Pods-base-CDTDatastore.release.xcconfig"; sourceTree = "<group>"; };
 		FF78267FE761ABB49CEB76BB /* Pods_base_raTests_CDTDatastoreReplicationAcceptanceTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_base_raTests_CDTDatastoreReplicationAcceptanceTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -1161,7 +1152,6 @@
 			files = (
 				987383691C47B38800937212 /* libz.tbd in Frameworks */,
 				9873836A1C47B38800937212 /* libsqlite3.tbd in Frameworks */,
-				8836FBAB2706816C58690495 /* Pods_base_CDTDatastoreOSX.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1170,7 +1160,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				987385791C47B48F00937212 /* CDTDatastoreOSX.framework in Frameworks */,
-				1399B6CAACAB8F75EE125480 /* Pods_base_raTests_CDTDatastoreReplicationAcceptanceTestsOSX.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1181,7 +1170,6 @@
 				987386001C4D497A00937212 /* libz.tbd in Frameworks */,
 				9873857A1C47B49800937212 /* CDTDatastoreOSX.framework in Frameworks */,
 				987385651C47B45600937212 /* libsqlite3.tbd in Frameworks */,
-				888D25163DAC0158BEAC19FF /* Pods_base_tests_CDTDatastoreTestsOSX.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1245,11 +1233,8 @@
 				98F77F0B1C45189600515CC3 /* libz.tbd */,
 				98F77F091C45163300515CC3 /* libsqlite3.tbd */,
 				417460C5FAE995A062206A58 /* Pods_base_CDTDatastore.framework */,
-				3D03C1BA0A7DA75BFAF80CC8 /* Pods_base_CDTDatastoreOSX.framework */,
 				FF78267FE761ABB49CEB76BB /* Pods_base_raTests_CDTDatastoreReplicationAcceptanceTests.framework */,
-				3809563FA5BF431C4EC8D3B5 /* Pods_base_raTests_CDTDatastoreReplicationAcceptanceTestsOSX.framework */,
 				992FED8F2AA3E2ADD7599045 /* Pods_base_tests_CDTDatastoreTests.framework */,
-				04DFF5124D5BD3161681174C /* Pods_base_tests_CDTDatastoreTestsOSX.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -1310,6 +1295,7 @@
 		98F77B2C1C43FC9F00515CC3 = {
 			isa = PBXGroup;
 			children = (
+				CE9CF3BC264A937D00CEDB56 /* CDTDatastore.podspec */,
 				98F77B381C43FC9F00515CC3 /* CDTDatastore */,
 				98F77B441C43FC9F00515CC3 /* CDTDatastoreTests */,
 				98F77D2D1C44028700515CC3 /* CDTDatastoreReplicationAcceptanceTests */,
@@ -1908,16 +1894,10 @@
 			children = (
 				6A9F55827AB3ACE50E9D41A0 /* Pods-base-CDTDatastore.debug.xcconfig */,
 				F75FD09E8A7B9DB591B81C72 /* Pods-base-CDTDatastore.release.xcconfig */,
-				1053749380E7A10A270B91E4 /* Pods-base-CDTDatastoreOSX.debug.xcconfig */,
-				85F3ECA4D5FB8EA5B31B14F1 /* Pods-base-CDTDatastoreOSX.release.xcconfig */,
 				4CE55C521AD1A3F630DFA051 /* Pods-base-raTests-CDTDatastoreReplicationAcceptanceTests.debug.xcconfig */,
 				1970EE2354D3B1A67BBEE47B /* Pods-base-raTests-CDTDatastoreReplicationAcceptanceTests.release.xcconfig */,
-				780DA1CE0B016A2CE9A8458C /* Pods-base-raTests-CDTDatastoreReplicationAcceptanceTestsOSX.debug.xcconfig */,
-				11828F46DDB99AC94990EF7B /* Pods-base-raTests-CDTDatastoreReplicationAcceptanceTestsOSX.release.xcconfig */,
 				C5D893F16D9AE1D27F28C6F6 /* Pods-base-tests-CDTDatastoreTests.debug.xcconfig */,
 				00A609A6C10F2A6835BF22B3 /* Pods-base-tests-CDTDatastoreTests.release.xcconfig */,
-				880C1D944A8E097B9021DF85 /* Pods-base-tests-CDTDatastoreTestsOSX.debug.xcconfig */,
-				58D9EAB81B994FD15D5FBCE4 /* Pods-base-tests-CDTDatastoreTestsOSX.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -2194,7 +2174,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 987383EA1C47B38800937212 /* Build configuration list for PBXNativeTarget "CDTDatastoreOSX" */;
 			buildPhases = (
-				754C5939D1D74685677B9518 /* [CP] Check Pods Manifest.lock */,
 				987383031C47B38800937212 /* Sources */,
 				987383681C47B38800937212 /* Frameworks */,
 				9873836C1C47B38800937212 /* Headers */,
@@ -2213,12 +2192,10 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 9873851D1C47B45300937212 /* Build configuration list for PBXNativeTarget "CDTDatastoreReplicationAcceptanceTestsOSX" */;
 			buildPhases = (
-				05C7FB7C68AD518220643360 /* [CP] Check Pods Manifest.lock */,
 				987385061C47B45300937212 /* Sources */,
 				987385141C47B45300937212 /* Frameworks */,
 				9888EC061C512CA500E58783 /* Set Replication Settings */,
 				987385171C47B45300937212 /* Resources */,
-				AAFAB4E1487C11AE991A84B6 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -2233,11 +2210,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 987385731C47B45600937212 /* Build configuration list for PBXNativeTarget "CDTDatastoreTestsOSX" */;
 			buildPhases = (
-				8FC98010A5F17C9CB6C14A62 /* [CP] Check Pods Manifest.lock */,
 				987385261C47B45600937212 /* Sources */,
 				987385641C47B45600937212 /* Frameworks */,
 				987385681C47B45600937212 /* Resources */,
-				7F8DF32603F19F1A42B0D9AA /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -2408,6 +2383,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -2541,24 +2517,6 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		05C7FB7C68AD518220643360 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTestsOSX-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
 		1037323DDF182E4A373CC77F /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -2566,18 +2524,20 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTests/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTests-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/CocoaLumberjack-iOS/CocoaLumberjack.framework",
-				"${BUILT_PRODUCTS_DIR}/FMDB-iOS/FMDB.framework",
-				"${BUILT_PRODUCTS_DIR}/GoogleToolboxForMac-iOS/GoogleToolboxForMac.framework",
-				"${BUILT_PRODUCTS_DIR}/NSData+Base64-iOS/NSData_Base64.framework",
-				"${BUILT_PRODUCTS_DIR}/TRVSMonitor-iOS/TRVSMonitor.framework",
-				"${BUILT_PRODUCTS_DIR}/Unirest-iOS/Unirest.framework",
+				"${BUILT_PRODUCTS_DIR}/CocoaLumberjack/CocoaLumberjack.framework",
+				"${BUILT_PRODUCTS_DIR}/FMDB/FMDB.framework",
+				"${BUILT_PRODUCTS_DIR}/GoogleToolboxForMac/GoogleToolboxForMac.framework",
+				"${BUILT_PRODUCTS_DIR}/OTFToolBoxCore/OTFToolBoxCore.framework",
+				"${BUILT_PRODUCTS_DIR}/NSData+Base64/NSData_Base64.framework",
+				"${BUILT_PRODUCTS_DIR}/TRVSMonitor/TRVSMonitor.framework",
+				"${BUILT_PRODUCTS_DIR}/Unirest/Unirest.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CocoaLumberjack.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FMDB.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleToolboxForMac.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OTFToolBoxCore.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/NSData_Base64.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/TRVSMonitor.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Unirest.framework",
@@ -2594,21 +2554,23 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-base-tests-CDTDatastoreTests/Pods-base-tests-CDTDatastoreTests-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/CocoaLumberjack-iOS/CocoaLumberjack.framework",
-				"${BUILT_PRODUCTS_DIR}/FMDB-iOS/FMDB.framework",
-				"${BUILT_PRODUCTS_DIR}/GoogleToolboxForMac-iOS/GoogleToolboxForMac.framework",
-				"${BUILT_PRODUCTS_DIR}/Expecta-iOS/Expecta.framework",
-				"${BUILT_PRODUCTS_DIR}/MRDatabaseContentChecker-iOS/MRDatabaseContentChecker.framework",
-				"${BUILT_PRODUCTS_DIR}/OCMock-iOS/OCMock.framework",
-				"${BUILT_PRODUCTS_DIR}/OHHTTPStubs-iOS/OHHTTPStubs.framework",
-				"${BUILT_PRODUCTS_DIR}/RSSwizzle-iOS/RSSwizzle.framework",
-				"${BUILT_PRODUCTS_DIR}/Specta-iOS/Specta.framework",
+				"${BUILT_PRODUCTS_DIR}/CocoaLumberjack/CocoaLumberjack.framework",
+				"${BUILT_PRODUCTS_DIR}/FMDB/FMDB.framework",
+				"${BUILT_PRODUCTS_DIR}/GoogleToolboxForMac/GoogleToolboxForMac.framework",
+				"${BUILT_PRODUCTS_DIR}/OTFToolBoxCore/OTFToolBoxCore.framework",
+				"${BUILT_PRODUCTS_DIR}/Expecta/Expecta.framework",
+				"${BUILT_PRODUCTS_DIR}/MRDatabaseContentChecker/MRDatabaseContentChecker.framework",
+				"${BUILT_PRODUCTS_DIR}/OCMock/OCMock.framework",
+				"${BUILT_PRODUCTS_DIR}/OHHTTPStubs/OHHTTPStubs.framework",
+				"${BUILT_PRODUCTS_DIR}/RSSwizzle/RSSwizzle.framework",
+				"${BUILT_PRODUCTS_DIR}/Specta/Specta.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CocoaLumberjack.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FMDB.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleToolboxForMac.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OTFToolBoxCore.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Expecta.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MRDatabaseContentChecker.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OCMock.framework",
@@ -2619,76 +2581,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-base-tests-CDTDatastoreTests/Pods-base-tests-CDTDatastoreTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		754C5939D1D74685677B9518 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-base-CDTDatastoreOSX-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		7F8DF32603F19F1A42B0D9AA /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-base-tests-CDTDatastoreTestsOSX/Pods-base-tests-CDTDatastoreTestsOSX-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/CocoaLumberjack-macOS/CocoaLumberjack.framework",
-				"${BUILT_PRODUCTS_DIR}/FMDB-macOS/FMDB.framework",
-				"${BUILT_PRODUCTS_DIR}/GoogleToolboxForMac-macOS/GoogleToolboxForMac.framework",
-				"${BUILT_PRODUCTS_DIR}/Expecta-macOS/Expecta.framework",
-				"${BUILT_PRODUCTS_DIR}/MRDatabaseContentChecker-macOS/MRDatabaseContentChecker.framework",
-				"${BUILT_PRODUCTS_DIR}/OCMock-macOS/OCMock.framework",
-				"${BUILT_PRODUCTS_DIR}/OHHTTPStubs-macOS/OHHTTPStubs.framework",
-				"${BUILT_PRODUCTS_DIR}/RSSwizzle-macOS/RSSwizzle.framework",
-				"${BUILT_PRODUCTS_DIR}/Specta-macOS/Specta.framework",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CocoaLumberjack.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FMDB.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleToolboxForMac.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Expecta.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MRDatabaseContentChecker.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OCMock.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OHHTTPStubs.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RSSwizzle.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Specta.framework",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-base-tests-CDTDatastoreTestsOSX/Pods-base-tests-CDTDatastoreTestsOSX-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		8FC98010A5F17C9CB6C14A62 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-base-tests-CDTDatastoreTestsOSX-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 		92D05D0D610105627EDBEE52 /* [CP] Check Pods Manifest.lock */ = {
@@ -2736,34 +2628,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/buildplist.sh\"";
-		};
-		AAFAB4E1487C11AE991A84B6 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTestsOSX/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTestsOSX-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/CocoaLumberjack-macOS/CocoaLumberjack.framework",
-				"${BUILT_PRODUCTS_DIR}/FMDB-macOS/FMDB.framework",
-				"${BUILT_PRODUCTS_DIR}/GoogleToolboxForMac-macOS/GoogleToolboxForMac.framework",
-				"${BUILT_PRODUCTS_DIR}/NSData+Base64-macOS/NSData_Base64.framework",
-				"${BUILT_PRODUCTS_DIR}/TRVSMonitor-macOS/TRVSMonitor.framework",
-				"${BUILT_PRODUCTS_DIR}/Unirest-macOS/Unirest.framework",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CocoaLumberjack.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FMDB.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleToolboxForMac.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/NSData_Base64.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/TRVSMonitor.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Unirest.framework",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTestsOSX/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTestsOSX-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
 		};
 		DE64C5C18FA0A3DCA885795D /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -3297,7 +3161,6 @@
 /* Begin XCBuildConfiguration section */
 		987383EB1C47B38800937212 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 1053749380E7A10A270B91E4 /* Pods-base-CDTDatastoreOSX.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
 				COMBINE_HIDPI_IMAGES = YES;
@@ -3318,7 +3181,6 @@
 		};
 		987383EC1C47B38800937212 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 85F3ECA4D5FB8EA5B31B14F1 /* Pods-base-CDTDatastoreOSX.release.xcconfig */;
 			buildSettings = {
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
 				COMBINE_HIDPI_IMAGES = YES;
@@ -3339,7 +3201,6 @@
 		};
 		9873851E1C47B45300937212 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 780DA1CE0B016A2CE9A8458C /* Pods-base-raTests-CDTDatastoreReplicationAcceptanceTestsOSX.debug.xcconfig */;
 			buildSettings = {
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = CDTDatastoreReplicationAcceptanceTests/Info.plist;
@@ -3353,7 +3214,6 @@
 		};
 		9873851F1C47B45300937212 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 11828F46DDB99AC94990EF7B /* Pods-base-raTests-CDTDatastoreReplicationAcceptanceTestsOSX.release.xcconfig */;
 			buildSettings = {
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = CDTDatastoreReplicationAcceptanceTests/Info.plist;
@@ -3367,7 +3227,6 @@
 		};
 		987385741C47B45600937212 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 880C1D944A8E097B9021DF85 /* Pods-base-tests-CDTDatastoreTestsOSX.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				COMBINE_HIDPI_IMAGES = YES;
@@ -3385,7 +3244,6 @@
 		};
 		987385751C47B45600937212 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 58D9EAB81B994FD15D5FBCE4 /* Pods-base-tests-CDTDatastoreTestsOSX.release.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				COMBINE_HIDPI_IMAGES = YES;
@@ -3588,6 +3446,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 6A9F55827AB3ACE50E9D41A0 /* Pods-base-CDTDatastore.debug.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
@@ -3607,6 +3466,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = F75FD09E8A7B9DB591B81C72 /* Pods-base-CDTDatastore.release.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;

--- a/CDTDatastore.xcodeproj/project.pbxproj
+++ b/CDTDatastore.xcodeproj/project.pbxproj
@@ -2565,7 +2565,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTests/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTests-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTests/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTests-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/CocoaLumberjack-iOS/CocoaLumberjack.framework",
 				"${BUILT_PRODUCTS_DIR}/FMDB-iOS/FMDB.framework",
 				"${BUILT_PRODUCTS_DIR}/GoogleToolboxForMac-iOS/GoogleToolboxForMac.framework",
@@ -2584,7 +2584,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTests/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTests-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTests/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		46CB91A9A17B58E6709D1B46 /* [CP] Embed Pods Frameworks */ = {
@@ -2593,7 +2593,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-base-tests-CDTDatastoreTests/Pods-base-tests-CDTDatastoreTests-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-base-tests-CDTDatastoreTests/Pods-base-tests-CDTDatastoreTests-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/CocoaLumberjack-iOS/CocoaLumberjack.framework",
 				"${BUILT_PRODUCTS_DIR}/FMDB-iOS/FMDB.framework",
 				"${BUILT_PRODUCTS_DIR}/GoogleToolboxForMac-iOS/GoogleToolboxForMac.framework",
@@ -2618,7 +2618,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-base-tests-CDTDatastoreTests/Pods-base-tests-CDTDatastoreTests-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-base-tests-CDTDatastoreTests/Pods-base-tests-CDTDatastoreTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		754C5939D1D74685677B9518 /* [CP] Check Pods Manifest.lock */ = {
@@ -2645,7 +2645,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-base-tests-CDTDatastoreTestsOSX/Pods-base-tests-CDTDatastoreTestsOSX-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-base-tests-CDTDatastoreTestsOSX/Pods-base-tests-CDTDatastoreTestsOSX-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/CocoaLumberjack-macOS/CocoaLumberjack.framework",
 				"${BUILT_PRODUCTS_DIR}/FMDB-macOS/FMDB.framework",
 				"${BUILT_PRODUCTS_DIR}/GoogleToolboxForMac-macOS/GoogleToolboxForMac.framework",
@@ -2670,7 +2670,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-base-tests-CDTDatastoreTestsOSX/Pods-base-tests-CDTDatastoreTestsOSX-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-base-tests-CDTDatastoreTestsOSX/Pods-base-tests-CDTDatastoreTestsOSX-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		8FC98010A5F17C9CB6C14A62 /* [CP] Check Pods Manifest.lock */ = {
@@ -2743,7 +2743,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTestsOSX/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTestsOSX-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTestsOSX/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTestsOSX-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/CocoaLumberjack-macOS/CocoaLumberjack.framework",
 				"${BUILT_PRODUCTS_DIR}/FMDB-macOS/FMDB.framework",
 				"${BUILT_PRODUCTS_DIR}/GoogleToolboxForMac-macOS/GoogleToolboxForMac.framework",
@@ -2762,7 +2762,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTestsOSX/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTestsOSX-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTestsOSX/Pods-base-raTests-CDTDatastoreReplicationAcceptanceTestsOSX-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		DE64C5C18FA0A3DCA885795D /* [CP] Check Pods Manifest.lock */ = {

--- a/CDTDatastore.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/CDTDatastore.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/CDTDatastore.xcworkspace/contents.xcworkspacedata
+++ b/CDTDatastore.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:CDTDatastore.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/CDTDatastore.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/CDTDatastore.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/CDTDatastore/CDTDatastore.h
+++ b/CDTDatastore/CDTDatastore.h
@@ -15,6 +15,7 @@
 
 #import <Foundation/Foundation.h>
 #import "CDTDatastoreManager.h"
+#import "CDTNSURLSessionConfigurationDelegate.h"
 
 @class CDTDocumentRevision;
 @class FMDatabase;
@@ -57,12 +58,6 @@ extern NSString * __nonnull const CDTDatastoreChangeNotification;
  * @see CDTDocumentRevision
  *
  */
-
-@protocol DatastoreDelegate <NSObject>
-@optional
-- (void)didRecieveResponseWith:(NSError*_Nullable)error datastore: (CDTDatastore*_Nullable)store;
-@end
-
 @interface CDTDatastore : NSObject
 
 @property (nonnull, nonatomic, strong, readonly) TD_Database *database;
@@ -70,7 +65,6 @@ extern NSString * __nonnull const CDTDatastoreChangeNotification;
 + (nonnull NSString *)versionString;
 
 @property (nonnull, strong) NSString *directory;
-@property (nonatomic, weak) id <DatastoreDelegate> _Nullable delegate;
 
 
 
@@ -78,18 +72,18 @@ extern NSString * __nonnull const CDTDatastoreChangeNotification;
 /**
  * Encryption Modes allowed at present.
  *
- * @param mode1  Apps are guaranteed to complete syncing within 10 seconds, it will set NSFileProtectionType to CompleteUnlessOpen till 10 seconds finishes. After 10 seconds it will be change to NSFileProtectionType to Complete automatically and any running syncing won't be able to access Files if application is in background.
+ * @param RunToCompletionWithin10Seconds Apps are guaranteed to complete syncing within 10 seconds, it will set NSFileProtectionType to CompleteUnlessOpen till 10 seconds finishes. After 10 seconds it will be change to NSFileProtectionType to Complete automatically and any running syncing won't be able to access Files if application is in background.
  *
- * @param mode2  Apps cannot complete syncing within 10 seconds and need more time, Mode2 will give 20 seconds timeframe to finish any running syncing. After 20 seconds it will be change to NSFileProtectionType to Complete automatically and any running syncing won't be able to access Files if application is in background.
+ * @param RunToCompletionBeyond10Seconds Apps cannot complete syncing within 10 seconds and need more time, RunToCompletionBeyond10Seconds will give 20 seconds timeframe to finish any running syncing. After 20 seconds it will be change to NSFileProtectionType to Complete automatically and any running syncing won't be able to access Files if application is in background.
  *
- * @param Background Apps need to periodically run in the background to do things such as automatic syncs. It will give 30 seconds timeframe to finish any operation  in the background. After 30 seconds it will be change to NSFileProtectionType to Complete automatically and any running operation won't be able to access Files because application is in background.
+ * @param BackgroundMode Apps need to periodically run in the background to do things such as automatic syncs. It will give 30 seconds timeframe to finish any operation  in the background. After 30 seconds it will be change to NSFileProtectionType to Complete automatically and any running operation won't be able to access Files because application is in background.
  *
 */
 
 typedef NS_ENUM(NSUInteger, OTFProtectionLevel) {
-    mode1 = 1,
-    mode2 = 2,
-    background = 3
+    RunToCompletionWithin10Seconds = 1,
+    RunToCompletionBeyond10Seconds = 2,
+    BackgroundMode = 3
 };
 
 /**
@@ -280,6 +274,20 @@ typedef NS_ENUM(NSUInteger, OTFProtectionLevel) {
 
 /// This funtion will return the current applied file protection policy on files.
 - (NSFileProtectionType _Nullable)appliedProtectionPolicyOnDb;
+
+/**
+ * Set the delegate for handling customisation of the NSURLSession
+ * used during replication.
+ *
+ * This allows the setting of specific options on the NSURLSessionConfiguration
+ * to control the replication - e.g. replication only when on Wifi would be
+ * achieved by setting the NSURLSessionConfiguration's allowsCellularAccess
+ * attribute to 'NO'.
+ *
+ * @see CDTNSURLSessionConfigurationDelegate
+ */
+
+@property (nullable, nonatomic, weak) NSObject<CDTNSURLSessionConfigurationDelegate> *sessionConfigDelegate;
 
 /// These below two functionsare being used internally only to manage tasks pool.
 /// This function will increase the runningProcess variable count by 1. runningProcess is an internal Integer variable declared in CDTDatastore.m class, we're using it to check if we've any running process at the time when we're moving app to background. If we have any ongoing process that could

--- a/CDTDatastore/CDTDatastore.h
+++ b/CDTDatastore/CDTDatastore.h
@@ -57,11 +57,20 @@ extern NSString * __nonnull const CDTDatastoreChangeNotification;
  * @see CDTDocumentRevision
  *
  */
+
+@protocol DatastoreDelegate <NSObject>
+@optional
+- (void)didRecieveResponseWith:(NSError*_Nullable)error datastore: (CDTDatastore*_Nullable)store;
+@end
+
 @interface CDTDatastore : NSObject
 
 @property (nonnull, nonatomic, strong, readonly) TD_Database *database;
 
 + (nonnull NSString *)versionString;
+
+@property (nonnull, strong) NSString *directory;
+@property (nonatomic, weak) id <DatastoreDelegate> _Nullable _Nullable delegate;
 
 /**
  *
@@ -71,8 +80,8 @@ extern NSString * __nonnull const CDTDatastoreChangeNotification;
  * @param database the database where this datastore should save documents.
  *
  */
-- (nullable instancetype)initWithManager:(nonnull CDTDatastoreManager *)manager database:(nonnull TD_Database *)database;
-
+//- (nullable instancetype)initWithManager:(nonnull CDTDatastoreManager *)manager database:(nonnull TD_Database *)database;
+- (nullable instancetype)initWithManager:(nonnull CDTDatastoreManager *)manager database:(nonnull TD_Database *)database directory: (nonnull NSString *)directory;
 /**
  * The number of document in the datastore.
  */
@@ -240,4 +249,21 @@ extern NSString * __nonnull const CDTDatastoreChangeNotification;
  * @param error will point to an NSError object in the case of an error
  */
 - (BOOL)compactWithError:(NSError *__autoreleasing __nullable * __nullable)error;
+
+/**
+ *
+ * This function will be used to set default encryption policy before starting any operation and after finishing an operation on DB. Eg. - Default policy we've set is before starting an operation on DB NSFileProtectionCompleteUnlessOpen before starting any operation on DB and we set NSFileProtectionComplete after finishing the operation on DB.
+ * @param before Policy that should be set BEFORE starting an operation on DB
+ * @param after Policy that should be set AFTER finishing an operation on DB
+ *
+ */
+//-(void)setEncryptionBeforeStartingProcess: (NSFileProtectionType _Nonnull )before afterFinishProcess: (NSFileProtectionType _Nullable )after;
+
+-(void)encryptFile: (NSFileProtectionType _Nonnull)type;
+
+- (NSFileProtectionType _Nullable)appliedProtectionPolicyOnDb;
+
+-(void)addNewTask;
+
+-(void)removeOneTask;
 @end

--- a/CDTDatastore/CDTDatastore.h
+++ b/CDTDatastore/CDTDatastore.h
@@ -70,7 +70,32 @@ extern NSString * __nonnull const CDTDatastoreChangeNotification;
 + (nonnull NSString *)versionString;
 
 @property (nonnull, strong) NSString *directory;
-@property (nonatomic, weak) id <DatastoreDelegate> _Nullable _Nullable delegate;
+@property (nonatomic, weak) id <DatastoreDelegate> _Nullable delegate;
+
+
+
+
+/**
+ * Encryption Modes allowed at present.
+ *
+ * @param mode1  Apps are guaranteed to complete syncing within 10 seconds, it will set NSFileProtectionType to CompleteUnlessOpen till 10 seconds finishes. After 10 seconds it will be change to NSFileProtectionType to Complete automatically and any running syncing won't be able to access Files if application is in background.
+ *
+ * @param mode2  Apps cannot complete syncing within 10 seconds and need more time, Mode2 will give 20 seconds timeframe to finish any running syncing. After 20 seconds it will be change to NSFileProtectionType to Complete automatically and any running syncing won't be able to access Files if application is in background.
+ *
+ * @param Background Apps need to periodically run in the background to do things such as automatic syncs. It will give 30 seconds timeframe to finish any operation  in the background. After 30 seconds it will be change to NSFileProtectionType to Complete automatically and any running operation won't be able to access Files because application is in background.
+ *
+*/
+//enum EncryptionModes {
+//    mode1,
+//    mode2,
+//    background
+//};
+
+typedef NS_ENUM(NSUInteger, EncryptionModes) {
+    mode1 = 1,
+    mode2 = 2,
+    background = 3
+};
 
 /**
  *
@@ -250,20 +275,22 @@ extern NSString * __nonnull const CDTDatastoreChangeNotification;
  */
 - (BOOL)compactWithError:(NSError *__autoreleasing __nullable * __nullable)error;
 
-/**
- *
- * This function will be used to set default encryption policy before starting any operation and after finishing an operation on DB. Eg. - Default policy we've set is before starting an operation on DB NSFileProtectionCompleteUnlessOpen before starting any operation on DB and we set NSFileProtectionComplete after finishing the operation on DB.
- * @param before Policy that should be set BEFORE starting an operation on DB
- * @param after Policy that should be set AFTER finishing an operation on DB
- *
- */
-//-(void)setEncryptionBeforeStartingProcess: (NSFileProtectionType _Nonnull )before afterFinishProcess: (NSFileProtectionType _Nullable )after;
-
+/// This function will help to set FILE Protection manually by users.
+/// @param type Its FileProtection Type Enum provided by Apple, user can pass any Protection case whatever they need to set on there files.
 -(void)encryptFile: (NSFileProtectionType _Nonnull)type;
 
+///  This function will help to set Encryption MODE. Set a mode according to your need.
+/// @param mode - It's a ENUM value that users can set from predefined enum cases.
+-(void)setEncryptionMode: (EncryptionModes)mode;
+
+/// This funtion will return the current applied file protection policy on files.
 - (NSFileProtectionType _Nullable)appliedProtectionPolicyOnDb;
 
+/// These below two functionsare being used internally only to manage tasks pool.
+/// This function will increase the runningProcess variable count by 1. runningProcess is an internal Integer variable declared in CDTDatastore.m class, we're using it to check if we've any running process at the time when we're moving app to background. If we have any ongoing process that could
+/*
 -(void)addNewTask;
 
 -(void)removeOneTask;
+ */
 @end

--- a/CDTDatastore/CDTDatastore.h
+++ b/CDTDatastore/CDTDatastore.h
@@ -85,13 +85,8 @@ extern NSString * __nonnull const CDTDatastoreChangeNotification;
  * @param Background Apps need to periodically run in the background to do things such as automatic syncs. It will give 30 seconds timeframe to finish any operation  in the background. After 30 seconds it will be change to NSFileProtectionType to Complete automatically and any running operation won't be able to access Files because application is in background.
  *
 */
-//enum EncryptionModes {
-//    mode1,
-//    mode2,
-//    background
-//};
 
-typedef NS_ENUM(NSUInteger, EncryptionModes) {
+typedef NS_ENUM(NSUInteger, OTFProtectionLevel) {
     mode1 = 1,
     mode2 = 2,
     background = 3
@@ -279,9 +274,9 @@ typedef NS_ENUM(NSUInteger, EncryptionModes) {
 /// @param type Its FileProtection Type Enum provided by Apple, user can pass any Protection case whatever they need to set on there files.
 -(void)encryptFile: (NSFileProtectionType _Nonnull)type;
 
-///  This function will help to set Encryption MODE. Set a mode according to your need.
+///  This function will help to set Protection level. Set a mode according to your need.
 /// @param mode - It's a ENUM value that users can set from predefined enum cases.
--(void)setEncryptionMode: (EncryptionModes)mode;
+-(void)setProtectionLevel: (OTFProtectionLevel)level;
 
 /// This funtion will return the current applied file protection policy on files.
 - (NSFileProtectionType _Nullable)appliedProtectionPolicyOnDb;

--- a/CDTDatastore/CDTDatastore.h
+++ b/CDTDatastore/CDTDatastore.h
@@ -16,7 +16,7 @@
 #import <Foundation/Foundation.h>
 #import "CDTDatastoreManager.h"
 #import "CDTNSURLSessionConfigurationDelegate.h"
-
+#import <OTFToolBoxCore/OTFToolBoxCore-Swift.h>
 @class CDTDocumentRevision;
 @class FMDatabase;
 
@@ -78,13 +78,14 @@ extern NSString * __nonnull const CDTDatastoreChangeNotification;
  *
  * @param BackgroundMode Apps need to periodically run in the background to do things such as automatic syncs. It will give 30 seconds timeframe to finish any operation  in the background. After 30 seconds it will be change to NSFileProtectionType to Complete automatically and any running operation won't be able to access Files because application is in background.
  *
-*/
+
 
 typedef NS_ENUM(NSUInteger, OTFProtectionLevel) {
     RunToCompletionWithin10Seconds = 1,
     RunToCompletionBeyond10Seconds = 2,
     BackgroundMode = 3
 };
+ */
 
 /**
  *

--- a/CDTDatastore/CDTDatastore.h
+++ b/CDTDatastore/CDTDatastore.h
@@ -95,7 +95,6 @@ typedef NS_ENUM(NSUInteger, OTFProtectionLevel) {
  * @param database the database where this datastore should save documents.
  *
  */
-//- (nullable instancetype)initWithManager:(nonnull CDTDatastoreManager *)manager database:(nonnull TD_Database *)database;
 - (nullable instancetype)initWithManager:(nonnull CDTDatastoreManager *)manager database:(nonnull TD_Database *)database directory: (nonnull NSString *)directory;
 /**
  * The number of document in the datastore.

--- a/CDTDatastore/CDTDatastore.m
+++ b/CDTDatastore/CDTDatastore.m
@@ -55,7 +55,6 @@ NSString *const CDTDatastoreChangeNotification = @"CDTDatastoreChangeNotificatio
 
 @synthesize database = _database;
 @synthesize directory = _directory;
-@synthesize delegate;
 
 + (NSString *)versionString { return @CLOUDANT_SYNC_VERSION; }
 
@@ -96,15 +95,6 @@ int runningProcess;
                                                      selector:@selector(TDdbChanged:)
                                                          name:TD_DatabaseChangeNotification
                                                        object:database];
-/*
-            [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(applicationProtectedDataDidBecomeAvailable:) name:UIApplicationProtectedDataDidBecomeAvailable object:nil];
-            [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(applicationProtectedDataWillBecomeUnavailable:) name:UIApplicationProtectedDataWillBecomeUnavailable object:nil];
-            [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(applicationWillTerminateNotification:) name:UIApplicationWillTerminateNotification object:nil];
-
-            [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(applicationDidEnterBackgroundNotification:) name:UIApplicationDidEnterBackgroundNotification object:nil];
-            [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(applicationWillEnterForegroundNotification:) name:UIApplicationWillEnterForegroundNotification object:nil];
-*/
-
             [self encryptFile:NSFileProtectionCompleteUnlessOpen];
         }
     }
@@ -227,11 +217,11 @@ int runningProcess;
     }];
 }
 
--(void)setMode1 {
+-(void)setRunToCompletionModeWithin10Sec {
     [self startTimerWithDuration: 10];
 }
 
--(void)setMode2 {
+-(void)setRunToCompletionBeyond10Sec {
     [self startTimerWithDuration: 20];
 }
 
@@ -241,9 +231,11 @@ int runningProcess;
 }
 
 -(void)startTimerWithDuration: (NSTimeInterval)seconds {
+    NSLog(@"Encryption mode changed NSFileProtectionCompleteUnlessOpen");
     [self encryptFile: NSFileProtectionCompleteUnlessOpen];
     [NSTimer scheduledTimerWithTimeInterval:seconds repeats:false block:^(NSTimer * _Nonnull timer) {
         [self encryptFile: NSFileProtectionComplete];
+        NSLog(@"Encryption mode changed NSFileProtectionComplete");
         [self endBackgroundTaskIfAny];
     }];
 }
@@ -252,13 +244,13 @@ int runningProcess;
 /// @param mode - It's a ENUM value that users can set from predefined enum cases.
 -(void)setProtectionLevel: (OTFProtectionLevel)level {
     switch(level) {
-        case mode1:
-            [self setMode1];
+        case RunToCompletionWithin10Seconds:
+            [self setRunToCompletionModeWithin10Sec];
             break;
-        case mode2:
-            [self setMode2];
+        case RunToCompletionBeyond10Seconds:
+            [self setRunToCompletionBeyond10Sec];
             break;
-        case background:
+        case BackgroundMode:
             [self setBackgroundMode];
             break;
     }

--- a/CDTDatastore/CDTDatastore.m
+++ b/CDTDatastore/CDTDatastore.m
@@ -244,13 +244,13 @@ int runningProcess;
 /// @param mode - It's a ENUM value that users can set from predefined enum cases.
 -(void)setProtectionLevel: (OTFProtectionLevel)level {
     switch(level) {
-        case RunToCompletionWithin10Seconds:
+        case OTFProtectionLevelRunToCompletionWithIn10Seconds:
             [self setRunToCompletionModeWithin10Sec];
             break;
-        case RunToCompletionBeyond10Seconds:
+        case OTFProtectionLevelRunToCompletionBeyond10Seconds:
             [self setRunToCompletionBeyond10Sec];
             break;
-        case BackgroundMode:
+        case OTFProtectionLevelBackgroundMode:
             [self setBackgroundMode];
             break;
     }

--- a/CDTDatastore/CDTDatastore.m
+++ b/CDTDatastore/CDTDatastore.m
@@ -250,8 +250,8 @@ int runningProcess;
 
 ///  This function will help to set Encryption MODE. Set a mode according to your need.
 /// @param mode - It's a ENUM value that users can set from predefined enum cases.
--(void)setEncryptionMode: (EncryptionModes)mode {
-    switch(mode) {
+-(void)setProtectionLevel: (OTFProtectionLevel)level {
+    switch(level) {
         case mode1:
             [self setMode1];
             break;

--- a/CDTDatastore/CDTDatastoreManager.m
+++ b/CDTDatastore/CDTDatastoreManager.m
@@ -71,8 +71,7 @@ NSString *const CDTExtensionsDirName = @"_extensions";
         NSString *errorReason = nil;
         TD_Database *db = [self.manager databaseNamed:name];
         if (db) {
-            datastore = [[CDTDatastore alloc] initWithManager:self database:db encryptionKeyProvider:provider];
-            
+            datastore = [[CDTDatastore alloc] initWithManager:self database:db encryptionKeyProvider:provider directory: [self.manager directory]];
             if (!datastore) {
                 errorReason = NSLocalizedString(@"Wrong key?", nil);
             }
@@ -140,7 +139,7 @@ NSString *const CDTExtensionsDirName = @"_extensions";
             // called on it _before_ we attempt to delete its underlying database
             CDTLogDebug(CDTDATASTORE_LOG_CONTEXT, @"calling close from delete %@", name);
             [_openDatastores removeObjectForKey:name];
-            NSString *dbPath = [self.manager pathForName:name];;
+            NSString *dbPath = [self.manager pathForName:name];
             NSString *extPath = [dbPath stringByDeletingLastPathComponent];
             extPath = [extPath
                        stringByAppendingPathComponent:[name stringByAppendingString:CDTExtensionsDirName]];

--- a/CDTDatastore/CDTReplicator/CDTDatastore+Replication.h
+++ b/CDTDatastore/CDTReplicator/CDTDatastore+Replication.h
@@ -100,15 +100,17 @@ NS_ASSUME_NONNULL_BEGIN
  Asynchronously pushes data in this datastore to the server.
 
  @param target            The URL of the remote database to push the data to.
- @param completionHandler A block to call when the replication completes or errors.
+ @param replicator            The replicator to push the replication with.
  @param username          The username to authenticate with.
  @param password          The password to authenticate with.
+ @param completionHandler A block to call when the replication completes or errors.
  */
-- (void) pushReplicationWithTarget:(NSURL*) target
-                          username:(nullable NSString*) username
-                          password:(nullable NSString*) password
-                 completionHandler:(void (^ __nonnull)(NSError* __nullable)) completionHandler
-NS_SWIFT_NAME(push(to:username:password:completionHandler:));
+- (void)pushReplicationWithTarget:(NSURL *)target
+                       replicator: (nullable CDTReplicator *)replicator
+                         username:(NSString *)username
+                         password:(NSString *)password
+                completionHandler:(void (^ __nonnull)(NSError *__nullable))completionHandler
+NS_SWIFT_NAME(push(to:replicator:username:password:completionHandler:));
 
 /**
  Asynchronously pushes data in this datastore to the server.
@@ -126,15 +128,17 @@ NS_SWIFT_NAME(push(to:IAMAPIKey:completionHandler:));
  Asynchronously pull data from a remote server to this local datastore.
 
  @param source            The URL of the remote database from which to pull data.
+ @param replicator            The replicator to pull the replication with. 
  @param completionHandler A block to call when the replication completes or errors.
  @param username          The username to authenticate with.
  @param password          The password to authenticate with.
  */
 - (void) pullReplicationWithSource:(NSURL*) source
+                        replicator: (nullable CDTReplicator *) replicator
                           username:(nullable NSString*) username
                           password:(nullable NSString*) password
                  completionHandler:(void (^ __nonnull)(NSError* __nullable)) completionHandler
-NS_SWIFT_NAME(pull(from:username:password:completionHandler:));
+NS_SWIFT_NAME(pull(from:replicator:username:password:completionHandler:));
 
 /**
  Asynchronously pull data from a remote server to this local datastore.

--- a/CDTDatastore/CDTReplicator/CDTDatastore+Replication.h
+++ b/CDTDatastore/CDTReplicator/CDTDatastore+Replication.h
@@ -105,10 +105,10 @@ NS_ASSUME_NONNULL_BEGIN
  @param password          The password to authenticate with.
  @param completionHandler A block to call when the replication completes or errors.
  */
-- (void)pushReplicationWithTarget:(NSURL *)target
+- (void)pushReplicationWithTarget:(NSURL * _Nullable)target
                        replicator: (nullable CDTReplicator *)replicator
-                         username:(NSString *)username
-                         password:(NSString *)password
+                         username:(NSString * _Nullable)username
+                         password:(NSString * _Nullable)password
                 completionHandler:(void (^ __nonnull)(NSError *__nullable))completionHandler
 NS_SWIFT_NAME(push(to:replicator:username:password:completionHandler:));
 

--- a/CDTDatastore/CDTReplicator/CDTDatastore+Replication.m
+++ b/CDTDatastore/CDTReplicator/CDTDatastore+Replication.m
@@ -49,6 +49,7 @@
 
 - (void)replicatorDidError:(CDTReplicator *)replicator info:(NSError *)info {
     self.error = info;
+    self.completionHandler(self.error);
 }
 
 @end
@@ -113,20 +114,28 @@
 - (void) pushReplicationWithTarget:(NSURL*) target
                  completionHandler:(void (^ __nonnull)(NSError* __nullable)) completionHandler
 {
-    [self pushReplicationWithTarget:target username:nil password:nil completionHandler:completionHandler];
+    [self pushReplicationWithTarget:target replicator:nil username:nil password:nil completionHandler:completionHandler];
 }
 
 - (void)pushReplicationWithTarget:(NSURL *)target
+                       replicator: (CDTReplicator *)replicator
                          username:(NSString *)username
                          password:(NSString *)password
                 completionHandler:(void (^ __nonnull)(NSError *__nullable))completionHandler
 {
     NSError* error = nil;
     CDTDatastoreReplicationDelegate* delegate = [[CDTDatastoreReplicationDelegate alloc] initWithCompletionHandler:completionHandler];
-    CDTReplicator* replicator = [self pushReplicationTarget:target
+    replicator.delegate = delegate;
+    /*
+     CDTReplicator* replicator = [self pushReplicationTarget:target
                                                       username:username
                                                       password:password
                                                   withDelegate:delegate error:&error];
+     */
+    if (self.sessionConfigDelegate != nil) {
+        replicator.sessionConfigDelegate = self.sessionConfigDelegate;
+    }
+
     if (!error){
         [replicator startWithError:&error];
     }
@@ -155,26 +164,31 @@
 }
 
 - (void) pullReplicationWithSource:(NSURL*) source
-                 completionHandler:(void (^ __nonnull)(NSError* __nullable)) completionHandler
-{
-    [self pullReplicationWithSource:source username:nil password:nil completionHandler:completionHandler];
+                 completionHandler:(void (^ __nonnull)(NSError* __nullable)) completionHandler {
+    [self pullReplicationWithSource:source replicator:nil username:nil password:nil completionHandler:completionHandler];
 }
 
-- (void)pullReplicationWithSource:(NSURL *)source
-                         username:(NSString *)username
-                         password:(NSString *)password
-                completionHandler:(void (^ __nonnull)(NSError *__nullable))completionHandler
+- (void) pullReplicationWithSource:(NSURL*) source
+                        replicator: (nullable CDTReplicator *) replicator
+                          username:(nullable NSString*) username
+                          password:(nullable NSString*) password
+                 completionHandler:(void (^ __nonnull)(NSError* __nullable)) completionHandler
 {
     NSError* error = nil;
-    CDTDatastoreReplicationDelegate* delegate = [[CDTDatastoreReplicationDelegate alloc] initWithCompletionHandler:^(NSError * err) {
- //       [self removeOneTask];
-        [self.delegate didRecieveResponseWith:err datastore:self];
-    }];
+    CDTDatastoreReplicationDelegate* delegate = [[CDTDatastoreReplicationDelegate alloc] initWithCompletionHandler:completionHandler];
 
-    CDTReplicator* replicator = [self pullReplicationSource:source
-                                                      username:username password:password withDelegate:delegate error:&error];
-    if (!error) { 
-//        [self addNewTask];
+    /*
+     CDTReplicator* replicator = [self pullReplicationSource:source
+                                                       username:username password:password withDelegate:delegate error:&error];
+     */
+
+    replicator.delegate = delegate;
+
+    if (self.sessionConfigDelegate != nil) {
+        replicator.sessionConfigDelegate = self.sessionConfigDelegate;
+    }
+
+    if (!error) {
         [replicator startWithError:&error];
     }
 

--- a/CDTDatastore/CDTReplicator/CDTDatastore+Replication.m
+++ b/CDTDatastore/CDTReplicator/CDTDatastore+Replication.m
@@ -126,12 +126,6 @@
     NSError* error = nil;
     CDTDatastoreReplicationDelegate* delegate = [[CDTDatastoreReplicationDelegate alloc] initWithCompletionHandler:completionHandler];
     replicator.delegate = delegate;
-    /*
-     CDTReplicator* replicator = [self pushReplicationTarget:target
-                                                      username:username
-                                                      password:password
-                                                  withDelegate:delegate error:&error];
-     */
     if (self.sessionConfigDelegate != nil) {
         replicator.sessionConfigDelegate = self.sessionConfigDelegate;
     }
@@ -176,12 +170,6 @@
 {
     NSError* error = nil;
     CDTDatastoreReplicationDelegate* delegate = [[CDTDatastoreReplicationDelegate alloc] initWithCompletionHandler:completionHandler];
-
-    /*
-     CDTReplicator* replicator = [self pullReplicationSource:source
-                                                       username:username password:password withDelegate:delegate error:&error];
-     */
-
     replicator.delegate = delegate;
 
     if (self.sessionConfigDelegate != nil) {

--- a/CDTDatastore/CDTReplicator/CDTDatastore+Replication.m
+++ b/CDTDatastore/CDTReplicator/CDTDatastore+Replication.m
@@ -117,10 +117,10 @@
     [self pushReplicationWithTarget:target replicator:nil username:nil password:nil completionHandler:completionHandler];
 }
 
-- (void)pushReplicationWithTarget:(NSURL *)target
+- (void)pushReplicationWithTarget:(NSURL *_Nullable)target
                        replicator: (CDTReplicator *)replicator
-                         username:(NSString *)username
-                         password:(NSString *)password
+                         username:(NSString *_Nullable)username
+                         password:(NSString *_Nullable)password
                 completionHandler:(void (^ __nonnull)(NSError *__nullable))completionHandler
 {
     NSError* error = nil;

--- a/CDTDatastore/CDTReplicator/CDTDatastore+Replication.m
+++ b/CDTDatastore/CDTReplicator/CDTDatastore+Replication.m
@@ -166,10 +166,17 @@
                 completionHandler:(void (^ __nonnull)(NSError *__nullable))completionHandler
 {
     NSError* error = nil;
-    CDTDatastoreReplicationDelegate* delegate = [[CDTDatastoreReplicationDelegate alloc] initWithCompletionHandler:completionHandler];
+    CDTDatastoreReplicationDelegate* delegate = [[CDTDatastoreReplicationDelegate alloc] initWithCompletionHandler:^(NSError * err) {
+        [self encryptFile:NSFileProtectionCompleteUnlessOpen];
+        [self removeOneTask];
+        [self.delegate didRecieveResponseWith:err datastore:self];
+    }];
+
     CDTReplicator* replicator = [self pullReplicationSource:source
                                                       username:username password:password withDelegate:delegate error:&error];
-    if (!error){
+    if (!error) {
+        [self encryptFile:NSFileProtectionComplete];
+        [self addNewTask];
         [replicator startWithError:&error];
     }
 

--- a/CDTDatastore/CDTReplicator/CDTDatastore+Replication.m
+++ b/CDTDatastore/CDTReplicator/CDTDatastore+Replication.m
@@ -167,16 +167,14 @@
 {
     NSError* error = nil;
     CDTDatastoreReplicationDelegate* delegate = [[CDTDatastoreReplicationDelegate alloc] initWithCompletionHandler:^(NSError * err) {
-        [self encryptFile:NSFileProtectionCompleteUnlessOpen];
-        [self removeOneTask];
+ //       [self removeOneTask];
         [self.delegate didRecieveResponseWith:err datastore:self];
     }];
 
     CDTReplicator* replicator = [self pullReplicationSource:source
                                                       username:username password:password withDelegate:delegate error:&error];
-    if (!error) {
-        [self encryptFile:NSFileProtectionComplete];
-        [self addNewTask];
+    if (!error) { 
+//        [self addNewTask];
         [replicator startWithError:&error];
     }
 

--- a/CDTDatastore/CDTReplicator/CDTReplicator.h
+++ b/CDTDatastore/CDTReplicator/CDTReplicator.h
@@ -289,4 +289,10 @@ typedef void(^ __nonnull ReplicatorTestCompletionHandler)(id __nullable response
  */
 -(void)testUploadBulkDocs: (ReplicatorTestCompletionHandler) completionHandler;
 
+/**
+ This test function will be used to test end point _local/{docId} .
+ We're assuming to get an response in return of this api. and not an error.
+ @param completionHandler A completion hanlder to return the response we got from the API call.
+ */
+-(void)testBulkGet:(NSDictionary* _Nullable)requestBody handler:(ReplicatorTestCompletionHandler) completionHandler;
 @end

--- a/CDTDatastore/CDTReplicator/CDTReplicator.h
+++ b/CDTDatastore/CDTReplicator/CDTReplicator.h
@@ -258,4 +258,35 @@ initWithTDDatabaseManager:(nonnull TD_DatabaseManager *)dbManager
  */
 @property (nullable, nonatomic, readonly) NSError *error;
 
+/** Completion Block to return results. It returns two values Response and Error. Both are optional objects and can have nil value.*/
+typedef void(^ __nonnull ReplicatorTestCompletionHandler)(id __nullable response, NSError* __nullable error);
+
+
+/**
+ This test function will be used to test end point _local/{docId} .
+ We're assuming to get an response in return of this api. and not an error.
+ @param completionHandler A completion hanlder to return the response we got from the API call.
+ */
+-(void)testEndPointLocal:(ReplicatorTestCompletionHandler) completionHandler;
+
+
+/**
+ This function is created to be used in Test Cases.
+ It simply tests the _revs_diff API call
+ and returns it's response in completion block.
+
+ @param completionHandler A completion handler to return the response we got from the API call.
+*/
+-(void)testRevsDiff: (ReplicatorTestCompletionHandler) completionHandler;
+
+
+/**
+ This function is created to be used in Test Cases.
+ It simply tests the _bulk_docs API call
+ and returns it's response in completion block.
+
+ @param completionHandler A completion handler to return the response we got from the API call.
+ */
+-(void)testUploadBulkDocs: (ReplicatorTestCompletionHandler) completionHandler;
+
 @end

--- a/CDTDatastore/CDTReplicator/CDTReplicator.m
+++ b/CDTDatastore/CDTReplicator/CDTReplicator.m
@@ -287,6 +287,81 @@ static NSString *const CDTReplicatorErrorDomain = @"CDTReplicatorErrorDomain";
     return YES;
 }
 
+// MARK: - DB Proxy API's functions for Test cases.
+- (void)testEndPointLocal:(ReplicatorTestCompletionHandler) completionHandler {
+    if (self.tdReplicator == nil) {
+        NSError *localError;
+        self.tdReplicator =
+            [self buildTDReplicatorFromConfiguration:&localError];
+        if (localError) {
+            completionHandler(nil, localError);
+            return;
+        }
+    }
+
+    if (!self.tdReplicator.isPush) {
+        self.tdReplicator.sessionConfigDelegate = self.sessionConfigDelegate;
+        [self.tdReplicator startReplicationThread: nil];
+        [self.tdReplicator testEndPointLocal: completionHandler];
+    } else {
+        NSMutableDictionary *details = [NSMutableDictionary dictionary];
+        [details setValue:@"⛔️ _local API is not implemented in Push Replication. Please use Pull Replication to test this API." forKey:NSLocalizedDescriptionKey];
+        NSError *error = [[NSError alloc] initWithDomain:@"com.cdtreplication" code:400 userInfo:details];
+        completionHandler(nil, error);
+    }
+
+}
+
+-(void)testRevsDiff: (ReplicatorTestCompletionHandler) completionHandler {
+    if (self.tdReplicator == nil) {
+        NSError *localError;
+        self.tdReplicator =
+            [self buildTDReplicatorFromConfiguration:&localError];
+        if (localError) {
+            completionHandler(nil, localError);
+            return;
+        }
+    }
+
+    if (self.tdReplicator.isPush) {
+        self.tdReplicator.sessionConfigDelegate = self.sessionConfigDelegate;
+        [self.tdReplicator startReplicationThread: nil];
+        TDPusher *tdpusher = (TDPusher *)self.tdReplicator;
+        [tdpusher testRevsDiff:completionHandler];
+    } else {
+        NSMutableDictionary* details = [NSMutableDictionary dictionary];
+        [details setValue:@"⛔️ _revs_diff API not implemented in Pull Replication. Please use Push Replication to test this API." forKey:NSLocalizedDescriptionKey];
+        NSError *error = [[NSError alloc] initWithDomain:@"com.cdtreplication" code:400 userInfo: details];
+        completionHandler(nil, error);
+    }
+
+}
+
+-(void) testUploadBulkDocs: (ReplicatorTestCompletionHandler) completionHandler {
+    if (self.tdReplicator == nil) {
+        NSError *localError;
+        self.tdReplicator = [self buildTDReplicatorFromConfiguration:&localError];
+        if (localError) {
+            completionHandler(nil, localError);
+            return;
+        }
+    }
+
+    if (self.tdReplicator.isPush) {
+        self.tdReplicator.sessionConfigDelegate = self.sessionConfigDelegate;
+        [self.tdReplicator startReplicationThread:nil];
+        TDPusher *tdpusher = (TDPusher*)self.tdReplicator;
+
+        [tdpusher testUploadBulkDocs:completionHandler];
+    } else {
+        NSMutableDictionary *details = [NSMutableDictionary dictionary];
+        [details setValue:@"⛔️ _bulk_docs API not implemented in Pull replication. Please use Push Replication to test this API." forKey:NSLocalizedDescriptionKey];
+        NSError *error = [[NSError alloc] initWithDomain:@"com.cdtreplication" code:400 userInfo:details];
+        completionHandler(nil, error);
+    }
+}
+// MARK: -
+
 /**
  Builds a TDReplicator object from a CDTPush/PullReplication configuration.
  */

--- a/CDTDatastore/Encryption/CDTDatastore+EncryptionKey.h
+++ b/CDTDatastore/Encryption/CDTDatastore+EncryptionKey.h
@@ -31,9 +31,14 @@
  */
 - (nullable instancetype)initWithManager:(nonnull CDTDatastoreManager *)manager
                        database:(nonnull TD_Database *)database
-          encryptionKeyProvider:(nullable id<CDTEncryptionKeyProvider>)provider;
+          encryptionKeyProvider:(nonnull id<CDTEncryptionKeyProvider>)provider
+                               directory: (nonnull NSString *)directory;
 
-/**
+/*- (nullable instancetype)initWithManager:(nonnull CDTDatastoreManager *)manager
+                       database:(nonnull TD_Database *)database
+          encryptionKeyProvider:(nullable id<CDTEncryptionKeyProvider>)provider;
+*/
+/*
  * Return the key provider used to encrypt the datastore
  */
 - (nullable id<CDTEncryptionKeyProvider>)encryptionKeyProvider;

--- a/CDTDatastore/touchdb/TDPuller.m
+++ b/CDTDatastore/touchdb/TDPuller.m
@@ -80,15 +80,20 @@ static NSString* joinQuotedEscaped(NSArray* strings);
 
 - (void)dealloc { [_changeTracker stop]; }
 
+- (void)testBulkGet:(NSDictionary* _Nullable )requestBody handler:(ReplicatorTestCompletionHandler) completionHandler {
+    [self sendAsyncRequest:@"POST" path:@"_bulk_get" body:requestBody onCompletion:completionHandler];
+}
 
 - (void)beginReplicating
 {
     __weak TDPuller* weakSelf = self;
     // check to see if _bulk_get endpoint is supported and then start replication
+    NSArray* keys = [NSArray array];
+    NSDictionary *requestBody = @{@"docs": keys};
     __block bool done = NO;
-    [self sendAsyncRequest:@"GET"
+    [self sendAsyncRequest:@"POST"
                       path:@"_bulk_get"
-                      body:nil
+                      body:requestBody
               onCompletion:^(id result, NSError* error) {
                   __strong TDPuller* strongSelf = weakSelf;
                   switch(error.code) {

--- a/CDTDatastore/touchdb/TDPusher.h
+++ b/CDTDatastore/touchdb/TDPusher.h
@@ -34,4 +34,27 @@
 /** Block called to filter document revisions that are pushed to the remote server. */
 @property (nonatomic, copy) TD_FilterBlock filter;
 
+/** Completion Block to return results. It returns two values Response and Error. Both are optional objects and can have nil value.*/
+typedef void(^ __nonnull ReplicatorTestCompletionHandler)(id __nullable response, NSError* __nullable error);
+
+
+/**
+ This function is created to be used in Test Cases.
+ It simply test the _revs_diff API call
+ and return it's response in completion block.
+
+ @param completionHandler A completion handler to return the response we got from the API call.
+*/
+- (void)testRevsDiff: (ReplicatorTestCompletionHandler) completionHandler;
+
+
+/**
+ This function is created to be used in Test Cases.
+ It simply test the _bulk_docs API call
+ and return it's response in completion block.
+
+ @param completionHandler A completion handler to return the response we got from the API call.
+ */
+-(void)testUploadBulkDocs: (ReplicatorTestCompletionHandler) completionHandler;
+
 @end

--- a/CDTDatastore/touchdb/TDPusher.h
+++ b/CDTDatastore/touchdb/TDPusher.h
@@ -32,7 +32,7 @@
 @property BOOL createTarget;
 
 /** Block called to filter document revisions that are pushed to the remote server. */
-@property (nonatomic, copy) TD_FilterBlock filter;
+@property (nonatomic, copy) TD_FilterBlock _Nullable filter;
 
 /** Completion Block to return results. It returns two values Response and Error. Both are optional objects and can have nil value.*/
 typedef void(^ __nonnull ReplicatorTestCompletionHandler)(id __nullable response, NSError* __nullable error);

--- a/CDTDatastore/touchdb/TDPusher.m
+++ b/CDTDatastore/touchdb/TDPusher.m
@@ -281,6 +281,19 @@
               }];
 }
 
+// MARK: - These are the testing functions to test DB Proxy API's, We're passing empty parameters here just to check if the API's are working fine and not giving any kind of errors.
+
+- (void)testRevsDiff: (ReplicatorTestCompletionHandler) completionHandler {
+    // We're passing empty dictionary in body parameter for testing purpose. It should return empty response in result but should not return an error.
+    [self sendAsyncRequest:@"POST" path:@"_revs_diff" body:$mdict() onCompletion:completionHandler];
+}
+
+-(void) testUploadBulkDocs: (ReplicatorTestCompletionHandler) completionHandler {
+    // We're passing an empty Array in body parameter for testing purpose only. It should return an empty response in result but should not return an error.
+    NSArray *docsToEdit = [[NSArray alloc] init];
+    [self sendAsyncRequest:@"POST" path:@"_bulk_docs" body:$dict({ @"docs", docsToEdit }, { @"new_edits", $false }) onCompletion:completionHandler];
+}
+
 /**
  Upload documents to the remote using _bulk_docs.
 

--- a/CDTDatastore/touchdb/TDReplicator.h
+++ b/CDTDatastore/touchdb/TDReplicator.h
@@ -15,13 +15,13 @@
 @protocol TDAuthorizer;
 
 /** Posted when replicator starts running. */
-extern NSString* TDReplicatorStartedNotification;
+extern NSString* _Nullable TDReplicatorStartedNotification;
 
 /** Posted when changesProcessed or changesTotal changes. */
-extern NSString* TDReplicatorProgressChangedNotification;
+extern NSString* _Nullable TDReplicatorProgressChangedNotification;
 
 /** Posted when replicator stops running. */
-extern NSString* TDReplicatorStoppedNotification;
+extern NSString* _Nullable TDReplicatorStoppedNotification;
 
 /** Abstract base class for push or pull replications. */
 @interface TDReplicator : NSObject {
@@ -52,31 +52,31 @@ extern NSString* TDReplicatorStoppedNotification;
     TDReachability* _host;
 }
 
-+ (NSString*)progressChangedNotification;
-+ (NSString*)stoppedNotification;
++ (NSString*_Nullable)progressChangedNotification;
++ (NSString*_Nullable)stoppedNotification;
 
-- (instancetype)initWithDB:(TD_Database*)db
-                    remote:(NSURL*)remote
+- (instancetype _Nullable )initWithDB:(TD_Database*_Nullable)db
+                               remote:(NSURL*_Nullable)remote
                       push:(BOOL)push
                 continuous:(BOOL)continuous
-              interceptors:(NSArray*)interceptors;
+                         interceptors:(NSArray*_Nullable)interceptors;
 
-@property (weak, readonly) TD_Database* db;
-@property (readonly) NSURL* remote;
+@property (weak, readonly) TD_Database* _Nullable db;
+@property (readonly) NSURL* _Nullable remote;
 @property (readonly) BOOL isPush;
 @property (readonly) BOOL continuous;
-@property (copy) NSString* filterName;
-@property (copy) NSDictionary* filterParameters;
-@property (copy) NSArray* docIDs;
+@property (copy) NSString* _Nullable filterName;
+@property (copy) NSDictionary* _Nullable filterParameters;
+@property (copy) NSArray* _Nullable docIDs;
 
 /** Whether to ignore saved changes feed checkpoints */
 @property (nonatomic) BOOL reset;
 
 /** Heartbeat value used for _changes requests during pull (in ms) */
-@property (nonatomic) NSNumber* heartbeat;
+@property (nonatomic) NSNumber* _Nullable heartbeat;
 
-@property (nonatomic, strong,readonly) CDTURLSession *session;
-@property (nonatomic, weak) NSObject<CDTNSURLSessionConfigurationDelegate> *sessionConfigDelegate;
+@property (nonatomic, strong,readonly) CDTURLSession * _Nullable session;
+@property (nonatomic, weak) NSObject<CDTNSURLSessionConfigurationDelegate> * _Nullable sessionConfigDelegate;
 
 /** Access to the replicator's NSThread execution state.*/
 /** NSThread.executing*/
@@ -87,12 +87,12 @@ extern NSString* TDReplicatorStoppedNotification;
 -(BOOL) threadCanceled;
 
 /** Optional dictionary of headers to be added to all requests to remote servers. */
-@property (copy) NSDictionary* requestHeaders;
+@property (copy) NSDictionary* _Nullable requestHeaders;
 
-@property (strong) id<TDAuthorizer> authorizer;
+@property (strong) id<TDAuthorizer> _Nullable authorizer;
 
 /** Do these two replicators have identical settings? */
-- (bool)hasSameSettingsAs:(TDReplicator*)other;
+- (bool)hasSameSettingsAs:(TDReplicator*_Nullable)other;
 
 /** Starts the replicator.
     Replicators run asynchronously so nothing will happen until later.
@@ -100,7 +100,7 @@ extern NSString* TDReplicatorStoppedNotification;
 
     @param taskGroup The dispatch_group_t to make the replicators part of.
  */
-- (void)startWithTaskGroup:(dispatch_group_t)taskGroup;
+- (void)startWithTaskGroup:(dispatch_group_t _Nullable )taskGroup;
 
 /** Request to stop the replicator.
     Any pending asynchronous operations will be canceled.
@@ -122,10 +122,10 @@ extern NSString* TDReplicatorStoppedNotification;
 /** Latest error encountered while replicating.
     This is set to nil when starting. It may also be set to nil by the client if desired.
     Not all errors are fatal; if .running is still true, the replicator will retry. */
-@property (strong, nonatomic) NSError* error;
+@property (strong, nonatomic) NSError* _Nullable error;
 
 /** A unique-per-process string identifying this replicator instance. */
-@property (copy, nonatomic) NSString* sessionID;
+@property (copy, nonatomic) NSString* _Nullable sessionID;
 
 /** Number of changes (docs or other metadata) transferred so far. */
 @property (readonly, nonatomic) NSUInteger changesProcessed;
@@ -135,10 +135,10 @@ extern NSString* TDReplicatorStoppedNotification;
 @property (readonly, nonatomic) NSUInteger changesTotal;
 
 /** JSON-compatible array of status info about active remote HTTP requests. */
-@property (readonly) NSArray* activeRequestsStatus;
+@property (readonly) NSArray* _Nullable activeRequestsStatus;
 
 /** Exposed for testing. Returns the doc ID for the checkpoint document. */
-- (NSString *)remoteCheckpointDocID;
+- (NSString *_Nullable)remoteCheckpointDocID;
 
 /** Completion Block to return results. It returns two values Response and Error. Both are optional objects and can have nil value.*/
 typedef void(^ __nonnull ReplicatorTestCompletionHandler)(id __nullable response, NSError* __nullable error);
@@ -151,6 +151,12 @@ typedef void(^ __nonnull ReplicatorTestCompletionHandler)(id __nullable response
  */
 - (void)testEndPointLocal:(ReplicatorTestCompletionHandler) completionHandler;
 
+/**
+ This test function will be used to test end point _bulk_get .
+ We're assuming to get an response in return of this api. and not an error.
+ @param completionHandler A completion hanlder to return the response we got from the API call.
+ */
+- (void)testBulkGet:(NSDictionary* _Nullable)requestBody handler:(ReplicatorTestCompletionHandler) completionHandler;
 
 -(void) startReplicationThread:(dispatch_group_t _Nonnull )taskGroup;
 @end

--- a/CDTDatastore/touchdb/TDReplicator.h
+++ b/CDTDatastore/touchdb/TDReplicator.h
@@ -140,4 +140,17 @@ extern NSString* TDReplicatorStoppedNotification;
 /** Exposed for testing. Returns the doc ID for the checkpoint document. */
 - (NSString *)remoteCheckpointDocID;
 
+/** Completion Block to return results. It returns two values Response and Error. Both are optional objects and can have nil value.*/
+typedef void(^ __nonnull ReplicatorTestCompletionHandler)(id __nullable response, NSError* __nullable error);
+
+
+/**
+ This test function will be used to test end point _local/{docId} .
+ We're assuming to get an response in return of this api. and not an error.
+ @param completionHandler A completion hanlder to return the response we got from the API call.
+ */
+- (void)testEndPointLocal:(ReplicatorTestCompletionHandler) completionHandler;
+
+
+-(void) startReplicationThread:(dispatch_group_t _Nonnull )taskGroup;
 @end

--- a/CDTDatastore/touchdb/TDReplicator.m
+++ b/CDTDatastore/touchdb/TDReplicator.m
@@ -222,12 +222,20 @@ NSString* TDReplicatorStartedNotification = @"TDReplicatorStarted";
 
 - (void) startWithTaskGroup:(dispatch_group_t)taskGroup {
     
+    [self startReplicationThread:taskGroup] ;
+    [self performSelector:@selector(checkIfNotCanceledThenStart)
+                 onThread:_replicatorThread
+               withObject:nil
+            waitUntilDone:NO];
+}
+
+-(void) startReplicationThread:(dispatch_group_t)taskGroup {
     if(_replicatorThread){
         return;
     }
-    
+
     self.running = YES;
-    
+
     if (taskGroup) {
         dispatch_group_enter(taskGroup);
     }
@@ -236,16 +244,10 @@ NSString* TDReplicatorStartedNotification = @"TDReplicatorStarted";
                                                   object: taskGroup];
     CDTLogInfo(CDTREPLICATION_LOG_CONTEXT, @"Starting TDReplicator thread %@ ...", _replicatorThread);
     [_replicatorThread start];
-    
+
     [[NSNotificationCenter defaultCenter] addObserver: self selector: @selector(databaseWasDeleted:)
                                                  name: TD_DatabaseWillBeDeletedNotification
                                                object: _db];
-
-    [self performSelector:@selector(checkIfNotCanceledThenStart)
-                 onThread:_replicatorThread
-               withObject:nil
-            waitUntilDone:NO];
-    
 }
 
 -(void) checkIfNotCanceledThenStart
@@ -675,6 +677,11 @@ NSString* TDReplicatorStartedNotification = @"TDReplicatorStarted";
     // could have undefined value).
     __weak TDReplicator* weakSelf = self;
     __block TDRemoteJSONRequest* req = nil;
+    if (!self.session) {
+        self.session = [[CDTURLSession alloc] initWithCallbackThread:_replicatorThread
+                                                 requestInterceptors:self.interceptors
+                                               sessionConfigDelegate:self.sessionConfigDelegate];
+    }
     req = [[TDRemoteJSONRequest alloc] initWithSession:self.session method:method
                                                   URL:url
                                                  body:body
@@ -744,8 +751,19 @@ NSString* TDReplicatorStartedNotification = @"TDReplicatorStarted";
     return TDHexSHA1Digest([TDCanonicalJSON canonicalData:spec]);
 }
 
-- (void)fetchRemoteCheckpointDoc
-{
+- (void)testEndPointLocal:(ReplicatorTestCompletionHandler) completionHandler {
+    NSString* checkpointID = self.remoteCheckpointDocID;
+    [self asyncTaskStarted];
+    [self sendAsyncRequest:@"GET" path:[@"_local/" stringByAppendingString:checkpointID]
+                      body:nil
+              onCompletion:^(id response, NSError* error) {
+        // Got the response:
+        completionHandler(response, error);
+        [self asyncTasksFinished:1];
+    }];
+}
+
+- (void)fetchRemoteCheckpointDoc {
     _lastSequenceChanged = NO;
     NSString* checkpointID = self.remoteCheckpointDocID;
     NSDictionary<NSString*, NSObject*>* localCheckpoint =

--- a/CDTDatastore/touchdb/TD_DatabaseManager.m
+++ b/CDTDatastore/touchdb/TD_DatabaseManager.m
@@ -75,11 +75,17 @@ static NSCharacterSet* kIllegalNameChars;
         _databases = [[NSMutableDictionary alloc] init];
         _options = options ? *options : kTD_DatabaseManagerDefaultOptions;
 
+        NSDictionary *attributes = nil;
+        #if TARGET_OS_IPHONE
+        if (@available(iOS 9.0, *)) {
+            attributes = @{NSFileProtectionKey : NSFileProtectionCompleteUnlessOpen};
+        }
+       #endif
         // Create the directory but don't fail if it already exists:
         NSError* error;
         if (![[NSFileManager defaultManager] createDirectoryAtPath:_dir
                                        withIntermediateDirectories:NO
-                                                        attributes:nil
+                                                        attributes:attributes
                                                              error:&error]) {
             BOOL isDir;
             if (!TDIsFileExistsError(error) ||

--- a/CDTDatastoreTestApp/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/CDTDatastoreTestApp/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -2,67 +2,97 @@
   "images" : [
     {
       "idiom" : "iphone",
-      "size" : "29x29",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "20x20"
     },
     {
       "idiom" : "iphone",
-      "size" : "29x29",
-      "scale" : "3x"
+      "scale" : "3x",
+      "size" : "20x20"
     },
     {
       "idiom" : "iphone",
-      "size" : "40x40",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "29x29"
     },
     {
       "idiom" : "iphone",
-      "size" : "40x40",
-      "scale" : "3x"
+      "scale" : "3x",
+      "size" : "29x29"
     },
     {
       "idiom" : "iphone",
-      "size" : "60x60",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "40x40"
     },
     {
       "idiom" : "iphone",
-      "size" : "60x60",
-      "scale" : "3x"
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
     },
     {
       "idiom" : "ipad",
-      "size" : "29x29",
-      "scale" : "1x"
+      "scale" : "1x",
+      "size" : "20x20"
     },
     {
       "idiom" : "ipad",
-      "size" : "29x29",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "20x20"
     },
     {
       "idiom" : "ipad",
-      "size" : "40x40",
-      "scale" : "1x"
+      "scale" : "1x",
+      "size" : "29x29"
     },
     {
       "idiom" : "ipad",
-      "size" : "40x40",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "29x29"
     },
     {
       "idiom" : "ipad",
-      "size" : "76x76",
-      "scale" : "1x"
+      "scale" : "1x",
+      "size" : "40x40"
     },
     {
       "idiom" : "ipad",
-      "size" : "76x76",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/PodFile
+++ b/PodFile
@@ -1,3 +1,5 @@
+source 'https://github.com/HippocratesTech/OTFCocoapodSpecs.git'
+
 use_frameworks!
 
 if ENV["encrypted"]
@@ -13,13 +15,14 @@ abstract_target 'base' do
     pod 'CocoaLumberjack', '~> 2.0'
     pod 'SQLCipher/fts', '~> 3.1.0' if ENV["encrypted"]
     pod 'GoogleToolboxForMac/NSData+zlib', '~> 2.1.1'
+    pod 'OTFToolBox/Core', '~> 0.0.1'
 
     target :CDTDatastore do
-        platform :ios, '8.0'
+        platform :ios, '13.0'
     end
-    target :CDTDatastoreOSX do
-        platform :osx, '10.9'
-    end
+#    target :CDTDatastoreOSX do
+#        platform :osx, '10.9'
+#    end
 
     abstract_target 'tests' do
 
@@ -31,12 +34,12 @@ abstract_target 'base' do
         pod MRDatabaseContentChecker, :git => 'https://github.com/rhyshort/MRDatabaseContentChecker.git'
 
         target :CDTDatastoreTests do
-            platform :ios, '8.0'
+            platform :ios, '13.0'
         end
 
-        target :CDTDatastoreTestsOSX do
-            platform :osx, '10.9'
-        end
+#        target :CDTDatastoreTestsOSX do
+#            platform :osx, '10.9'
+#        end
 
     end
 
@@ -45,12 +48,12 @@ abstract_target 'base' do
         pod 'TRVSMonitor'
         pod 'NSData+Base64'
 
-        target :CDTDatastoreReplicationAcceptanceTestsOSX do
-            platform :osx, '10.9'
-        end
+#        target :CDTDatastoreReplicationAcceptanceTestsOSX do
+#            platform :osx, '10.9'
+#        end
 
         target :CDTDatastoreReplicationAcceptanceTests do
-          platform :ios, '8.0'
+          platform :ios, '13.0'
         end
     end
 

--- a/PodFile
+++ b/PodFile
@@ -26,7 +26,7 @@ abstract_target 'base' do
         pod 'Specta'
         pod 'Expecta'
         pod 'OCMock'
-        pod 'OHHTTPStubs'
+        pod 'OHHTTPStubs', '~> 8.0.0'
         pod 'RSSwizzle'
         pod MRDatabaseContentChecker, :git => 'https://github.com/rhyshort/MRDatabaseContentChecker.git'
 

--- a/Project/Project.xcodeproj/project.pbxproj
+++ b/Project/Project.xcodeproj/project.pbxproj
@@ -238,7 +238,6 @@
 				ORGANIZATIONNAME = Cloudant;
 				TargetAttributes = {
 					27C1CDC2184E2D9C000604EF = {
-						DevelopmentTeam = BS4R9ZW87K;
 						ProvisioningStyle = Automatic;
 					};
 					27C1CDE3184E2D9C000604EF = {
@@ -478,12 +477,12 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = BS4R9ZW87K;
+				DEVELOPMENT_TEAM = "";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Project/Project-Prefix.pch";
 				INFOPLIST_FILE = "Project/Project-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				PRODUCT_BUNDLE_IDENTIFIER = imran.personal.team;
+				PRODUCT_BUNDLE_IDENTIFIER = "-com.cloudant.--PRODUCT-NAME-rfc1034identifier--";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				WRAPPER_EXTENSION = app;
@@ -497,12 +496,12 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = BS4R9ZW87K;
+				DEVELOPMENT_TEAM = "";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Project/Project-Prefix.pch";
 				INFOPLIST_FILE = "Project/Project-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				PRODUCT_BUNDLE_IDENTIFIER = imran.personal.team;
+				PRODUCT_BUNDLE_IDENTIFIER = "-com.cloudant.--PRODUCT-NAME-rfc1034identifier--";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				WRAPPER_EXTENSION = app;

--- a/Project/Project.xcodeproj/project.pbxproj
+++ b/Project/Project.xcodeproj/project.pbxproj
@@ -482,7 +482,7 @@
 				GCC_PREFIX_HEADER = "Project/Project-Prefix.pch";
 				INFOPLIST_FILE = "Project/Project-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "-com.cloudant.--PRODUCT-NAME-rfc1034identifier--";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.cloudant.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				WRAPPER_EXTENSION = app;
@@ -501,7 +501,7 @@
 				GCC_PREFIX_HEADER = "Project/Project-Prefix.pch";
 				INFOPLIST_FILE = "Project/Project-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "-com.cloudant.--PRODUCT-NAME-rfc1034identifier--";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.cloudant.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				WRAPPER_EXTENSION = app;

--- a/Project/Project.xcodeproj/project.pbxproj
+++ b/Project/Project.xcodeproj/project.pbxproj
@@ -199,7 +199,6 @@
 				27C1CDC0184E2D9C000604EF /* Frameworks */,
 				27C1CDC1184E2D9C000604EF /* Resources */,
 				0ACCC6334D2AE204A575DDD7 /* [CP] Embed Pods Frameworks */,
-				FAFE0C0908533A384F9323D2 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -238,6 +237,10 @@
 				LastUpgradeCheck = 0730;
 				ORGANIZATIONNAME = Cloudant;
 				TargetAttributes = {
+					27C1CDC2184E2D9C000604EF = {
+						DevelopmentTeam = BS4R9ZW87K;
+						ProvisioningStyle = Automatic;
+					};
 					27C1CDE3184E2D9C000604EF = {
 						TestTargetID = 27C1CDC2184E2D9C000604EF;
 					};
@@ -248,6 +251,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -291,7 +295,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-Project/Pods-Project-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-Project/Pods-Project-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/CDTDatastore/CDTDatastore.framework",
 				"${BUILT_PRODUCTS_DIR}/CocoaLumberjack/CocoaLumberjack.framework",
 				"${BUILT_PRODUCTS_DIR}/FMDB/FMDB.framework",
@@ -306,7 +310,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Project/Pods-Project-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Project/Pods-Project-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		F89A156CF8A2F5DE5C622ED1 /* [CP] Check Pods Manifest.lock */ = {
@@ -325,21 +329,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		FAFE0C0908533A384F9323D2 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Project/Pods-Project-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -487,12 +476,16 @@
 			baseConfigurationReference = 6CF7CD6E9CDD31FC50E9722B /* Pods-Project.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = BS4R9ZW87K;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Project/Project-Prefix.pch";
 				INFOPLIST_FILE = "Project/Project-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.cloudant.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_BUNDLE_IDENTIFIER = imran.personal.team;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
@@ -502,12 +495,16 @@
 			baseConfigurationReference = 621CD83AE51E6D0F61B20539 /* Pods-Project.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = BS4R9ZW87K;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Project/Project-Prefix.pch";
 				INFOPLIST_FILE = "Project/Project-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.cloudant.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_BUNDLE_IDENTIFIER = imran.personal.team;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Release;

--- a/Project/Project.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Project/Project.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Project/Project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Project/Project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Project/Project/CDTAppDelegate.m
+++ b/Project/Project/CDTAppDelegate.m
@@ -135,7 +135,6 @@
     }
 
     CDTDatastore *datastore = [self.manager datastoreNamed:@"todo_items" error:&outError];
-    [datastore setEncryptionBeforeStartingProcess:NSFileProtectionNone afterFinishProcess:NSFileProtectionCompleteUnlessOpen];
     if (nil != outError) {
         NSLog(@"Error creating datastore: %@", outError);
         exit(1);

--- a/Project/Project/CDTAppDelegate.m
+++ b/Project/Project/CDTAppDelegate.m
@@ -135,7 +135,7 @@
     }
 
     CDTDatastore *datastore = [self.manager datastoreNamed:@"todo_items" error:&outError];
-
+    [datastore setEncryptionBeforeStartingProcess:NSFileProtectionNone afterFinishProcess:NSFileProtectionCompleteUnlessOpen];
     if (nil != outError) {
         NSLog(@"Error creating datastore: %@", outError);
         exit(1);

--- a/Project/Project/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/Project/Project/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -2,22 +2,52 @@
   "images" : [
     {
       "idiom" : "iphone",
-      "size" : "29x29",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "20x20"
     },
     {
       "idiom" : "iphone",
-      "size" : "40x40",
-      "scale" : "2x"
+      "scale" : "3x",
+      "size" : "20x20"
     },
     {
       "idiom" : "iphone",
-      "size" : "60x60",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/README.md
+++ b/README.md
@@ -305,11 +305,11 @@ By Default value for **NSFileProtectionType** is **NSFileProtectionCompleteUntil
 
 In CDTDatastore framework, we have given 3 types of OTFProtectionLevels that will help to set encryption with some different behaviours. Below are the available modes -
 
-### **mode1** - User can use this mode in case Apps are guaranteed to complete syncing within 10 seconds, it will set NSFileProtectionType to CompleteUnlessOpen till 10 seconds finishes. After 10 seconds it will be change the NSFileProtectionType to Complete automatically and any running sycing  won't be able to access Files in background.
+### **RunToCompletionWithin10Seconds** - User can use this mode in case Apps are guaranteed to complete syncing within 10 seconds, it will set NSFileProtectionType to CompleteUnlessOpen till 10 seconds finishes. After 10 seconds it will be change the NSFileProtectionType to Complete automatically and any running sycing  won't be able to access Files in background.
 
-### **mode2** - User can use this mode in case Apps cannot finish syncing within 10 seconds and need more time. Mode2 will give 20 seconds timeframe to finish any running syncing. After 20 seconds it will be change to NSFileProtectionType to Complete automatically and any running syncing won't be able to access Files in background.
+### **RunToCompletionBeyond10Seconds** - User can use this mode in case Apps cannot finish syncing within 10 seconds and need more time. RunToCompletionBeyond10Seconds will give 20 seconds timeframe to finish any running syncing. After 20 seconds it will be change to NSFileProtectionType to Complete automatically and any running syncing won't be able to access Files in background.
 
-### **background** User can use this mode in case Apps need to periodically run in the background to do things such as automatic syncs. It will give 30 seconds timeframe to finish any operation in background. After 30 seconds it will be change NSFileProtectionType to Complete automatically and any running operation won't be able to access files after that.
+### **BackgroundMode** User can use this mode in case Apps need to periodically run in the background to do things such as automatic syncs. It will give 30 seconds timeframe to finish any operation in background. After 30 seconds it will be change NSFileProtectionType to Complete automatically and any running operation won't be able to access files after that.
 
 ## How to Use Encryption Modes
 To use encryption modes in application, user need to call below function with the help of CDTDatastore object - 
@@ -319,16 +319,16 @@ To use encryption modes in application, user need to call below function with th
 
 and you can call encryption function like this with the help of datastore object in OBJECTIVE C -
 
-# [datastore setProtectionLevel: mode1];
-You can replace mode1 with any other available mode.
+# [datastore setProtectionLevel: RunToCompletionWithin10Seconds];
+You can replace RunToCompletionWithin10Seconds with any other available mode.
 ```
 
 
 ```swift
 you can call encryption function like this with the help of datastore object in SWIFT -
 
-# dataStore.setProtectionLevel(.level)
-You can replace mode1 with any other available mode.
+# dataStore.setProtectionLevel(.RunToCompletionWithin10Seconds)
+You can replace RunToCompletionWithin10Seconds with any other available mode.
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -286,6 +286,52 @@ has more features than the previous implementation.  For details about
 migrating to a 0.16.0+ indexing and query version from a previous version
 see [Index and Querying Migration](https://github.com/cloudant/CDTDatastore/blob/master/doc/query-migration.md).
 
+
+### File Encryption Modes
+
+You can set a MODE from available options. Setting any mode will ensure the file protection that you want to apply on your files before starting and after finishing any operation on the files.
+There are 4 types of File protections available in iOS categorised by the key "NSFileProtectionType", and below are the different types of file protection -
+
+### **NSFileProtectionComplete** -  The file is stored in an encrypted format on disk and cannot be read from or written to while the device is locked or booting.
+
+### **NSFileProtectionCompleteUnlessOpen** - The file is stored in an encrypted format on disk after it is closed.
+
+### **NSFileProtectionCompleteUntilFirstUserAuthentication** - The file is an encrypted format on disk and cannot be accessed until after the device has booted.
+
+### **NSFIleProtectionNone** - The file has no special protections associated with it.
+
+By Default value for **NSFileProtectionType** is **NSFileProtectionCompleteUntilFirstUserAuthentication**, that user can change at any point of time.
+
+
+In CDTDatastore framework, we have given 3 types of MODES that will help to set encryptions with some different behaviours. Below are the available modes -
+
+### **mode1** - User can use this mode in case Apps are guaranteed to complete syncing within 10 seconds, it will set NSFileProtectionType to CompleteUnlessOpen till 10 seconds finishes. After 10 seconds it will be change the NSFileProtectionType to Complete automatically and any running sycing  won't be able to access Files in background.
+
+### **mode2** - User can use this mode in case Apps cannot finish syncing within 10 seconds and need more time. Mode2 will give 20 seconds timeframe to finish any running syncing. After 20 seconds it will be change to NSFileProtectionType to Complete automatically and any running syncing won't be able to access Files in background.
+
+### **background** User can use this mode in case Apps need to periodically run in the background to do things such as automatic syncs. It will give 30 seconds timeframe to finish any operation in background. After 30 seconds it will be change NSFileProtectionType to Complete automatically and any running operation won't be able to access files after that.
+
+## How to Use Encryption Modes
+To use encryption modes in application, user need to call below function with the help of CDTDatastore object - 
+
+```objc
+# -(void)setEncryptionMode: (EncryptionModes)mode;'
+
+and you can call encryption function like this with the help of datastore object in OBJECTIVE C -
+
+# [datastore setEncryptionMode: mode1];
+You can replace mode1 with any other available mode.
+```
+
+
+```swift
+you can call encryption function like this with the help of datastore object in SWIFT -
+
+# dataStore.setEncryptionMode(.mode1)
+You can replace mode1 with any other available mode.
+```
+
+
 ### Conflicts
 
 An obvious repercussion of being able to replicate documents about the place

--- a/README.md
+++ b/README.md
@@ -287,9 +287,9 @@ migrating to a 0.16.0+ indexing and query version from a previous version
 see [Index and Querying Migration](https://github.com/cloudant/CDTDatastore/blob/master/doc/query-migration.md).
 
 
-### File Encryption Modes
+### File Protection Levels
 
-You can set a MODE from available options. Setting any mode will ensure the file protection that you want to apply on your files before starting and after finishing any operation on the files.
+You can set a File Protection Level from available options. Setting any mode will ensure the file protection that you want to apply on your files before starting and after finishing any operation on the files.
 There are 4 types of File protections available in iOS categorised by the key "NSFileProtectionType", and below are the different types of file protection -
 
 ### **NSFileProtectionComplete** -  The file is stored in an encrypted format on disk and cannot be read from or written to while the device is locked or booting.
@@ -303,7 +303,7 @@ There are 4 types of File protections available in iOS categorised by the key "N
 By Default value for **NSFileProtectionType** is **NSFileProtectionCompleteUntilFirstUserAuthentication**, that user can change at any point of time.
 
 
-In CDTDatastore framework, we have given 3 types of MODES that will help to set encryptions with some different behaviours. Below are the available modes -
+In CDTDatastore framework, we have given 3 types of OTFProtectionLevels that will help to set encryption with some different behaviours. Below are the available modes -
 
 ### **mode1** - User can use this mode in case Apps are guaranteed to complete syncing within 10 seconds, it will set NSFileProtectionType to CompleteUnlessOpen till 10 seconds finishes. After 10 seconds it will be change the NSFileProtectionType to Complete automatically and any running sycing  won't be able to access Files in background.
 
@@ -315,11 +315,11 @@ In CDTDatastore framework, we have given 3 types of MODES that will help to set 
 To use encryption modes in application, user need to call below function with the help of CDTDatastore object - 
 
 ```objc
-# -(void)setEncryptionMode: (EncryptionModes)mode;'
+# -(void)setProtectionLevel: (OTFProtectionLevel)level;'
 
 and you can call encryption function like this with the help of datastore object in OBJECTIVE C -
 
-# [datastore setEncryptionMode: mode1];
+# [datastore setProtectionLevel: mode1];
 You can replace mode1 with any other available mode.
 ```
 
@@ -327,7 +327,7 @@ You can replace mode1 with any other available mode.
 ```swift
 you can call encryption function like this with the help of datastore object in SWIFT -
 
-# dataStore.setEncryptionMode(.mode1)
+# dataStore.setProtectionLevel(.level)
 You can replace mode1 with any other available mode.
 ```
 


### PR DESCRIPTION
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description
Integrated OTFToolBoxCore
Updated Nullability - it was missing at some places and giving warnings in Xcode.
_bulk_get is now a POST request - this change is in compliance with the CouchDB REST API.


## Schema & API Changes

CDTDatastore

/// Added the directory parameter. Directory is for setting the URL of database we want to protect.
- (nullable instancetype)initWithManager:(nonnull CDTDatastoreManager *)manager database:(nonnull TD_Database *)database directory: (nonnull NSString *)directory;

/// This function will help to set FILE Protection manually by users.
/// @param type Its FileProtection Type Enum provided by Apple, user can pass any Protection case whatever they need to set on there files.
-(void)encryptFile: (NSFileProtectionType _Nonnull)type;

///  This function will help to set Protection level. Set a mode according to your need.
/// @param mode - It's a ENUM value that users can set from predefined enum cases.
-(void)setProtectionLevel: (OTFProtectionLevel)level;

/// This funtion will return the current applied file protection policy on files.
- (NSFileProtectionType _Nullable)appliedProtectionPolicyOnDb;

/**
 * Set the delegate for handling customisation of the NSURLSession
 * used during replication.
 *
 * This allows the setting of specific options on the NSURLSessionConfiguration
 * to control the replication - e.g. replication only when on Wifi would be
 * achieved by setting the NSURLSessionConfiguration's allowsCellularAccess
 * attribute to 'NO'.
 *
 * @see CDTNSURLSessionConfigurationDelegate
 */

@property (nullable, nonatomic, weak) NSObject<CDTNSURLSessionConfigurationDelegate> *sessionConfigDelegate;


pushReplicationWithTarget method now contains the replicator parameter. That's so that 


## Security and Privacy

Added the encryption at rest protections levels.

## Testing

Added tests:

/**
 This test function will be used to test end point _local/{docId} .
 We're assuming to get an response in return of this api. and not an error.
 @param completionHandler A completion hanlder to return the response we got from the API call.
 */
-(void)testEndPointLocal:(ReplicatorTestCompletionHandler) completionHandler;


/**
 This function is created to be used in Test Cases.
 It simply tests the _revs_diff API call
 and returns it's response in completion block.
 @param completionHandler A completion handler to return the response we got from the API call.
*/
-(void)testRevsDiff: (ReplicatorTestCompletionHandler) completionHandler;


/**
 This function is created to be used in Test Cases.
 It simply tests the _bulk_docs API call
 and returns it's response in completion block.
 @param completionHandler A completion handler to return the response we got from the API call.
 */
-(void)testUploadBulkDocs: (ReplicatorTestCompletionHandler) completionHandler;

/**
 This test function will be used to test end point _local/{docId} .
 We're assuming to get an response in return of this api. and not an error.
 @param completionHandler A completion hanlder to return the response we got from the API call.
 */
-(void)testBulkGet:(NSDictionary* _Nullable)requestBody handler:(ReplicatorTestCompletionHandler) completionHandler;


So that we can test all the components more in detail.

## Monitoring and Logging
- "No change"
